### PR TITLE
fix: align acp output status

### DIFF
--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -18,7 +18,7 @@ fn styles_keep_acp_conversation_scoped() {
         "acp container should be flex and height constrained"
     );
     assert!(
-        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  flex: 1 1 auto;\n  display: flex;\n  flex-direction: column;\n}"),
+        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  flex: 1 1 auto;\n  display: flex;\n  flex-direction: column;\n  justify-content: flex-end;\n}"),
         "acp conversation should be scrollable and flex column"
     );
     assert!(

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -148,6 +148,7 @@ export function App() {
     [agents, activeAgent]
   );
   const activeAgentStatus = activeAgentRecord?.status ?? null;
+  const showAcpRuntime = activeAgentStatus === "running";
 
   const token = auth?.token ?? null;
   const mergeOutputs = (existing: OutputLine[], incoming: OutputLine[]) => {
@@ -577,8 +578,9 @@ export function App() {
         setActiveAgent(agent.id);
         setOutputs([]);
         await refreshAgents();
-      } catch {
-        // ignore start failure; keep created agent
+      } catch (err) {
+        const msg = parseApiErrorMessage(err) ?? String(err);
+        setError(`Start failed: ${msg}`);
       }
       setAgentName("");
       setAgentWorkdir("");
@@ -592,9 +594,8 @@ export function App() {
       const hint = formatWorktreeError(err);
       if (hint) {
         setWorktreeError(hint);
-      } else {
-        setError(String(err));
       }
+      setError(hint ?? parseApiErrorMessage(err) ?? String(err));
     }
   };
 
@@ -611,11 +612,7 @@ export function App() {
       await refreshAgents();
     } catch (err) {
       const hint = formatWorktreeError(err);
-      if (hint) {
-        setWorktreeError(hint);
-      } else {
-        setError(String(err));
-      }
+      setError(hint ?? parseApiErrorMessage(err) ?? String(err));
     }
   };
 
@@ -1071,14 +1068,14 @@ export function App() {
                             {activeSessionId.slice(0, 8)}
                           </span>
                         )}
-                        {acpView.runStatus?.status && (
+                        {showAcpRuntime && acpView.runStatus?.status && (
                           <span
                             className={`acp-run ${acpView.runStatus.status}`}
                           >
                             {acpView.runStatus.status}
                           </span>
                         )}
-                        {acpView.thinkingStartTs && (
+                        {showAcpRuntime && acpView.thinkingStartTs && (
                           <span className="acp-thinking">
                             thinking{" "}
                             {Math.max(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -423,6 +423,7 @@ button {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
 }
 
 .output-header {


### PR DESCRIPTION
## Summary

- Keep ACP conversation pinned to the bottom when content is short
- Hide ACP run status/thinking when the agent is not running
- Surface start failures in the global error banner

 
## Testing

- Not run (manual)