### PR TITLE
fix: keep acp conversation scrollable

### DIFF
--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -18,8 +18,12 @@ fn styles_keep_acp_conversation_scoped() {
         "acp container should be flex and height constrained"
     );
     assert!(
-        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  flex: 1 1 auto;\n  display: flex;\n  flex-direction: column;\n  justify-content: flex-end;\n}"),
-        "acp conversation should be scrollable and flex column"
+        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  flex: 1 1 auto;\n  display: block;\n}"),
+        "acp conversation should be scrollable container"
+    );
+    assert!(
+        css.contains(".acp-conversation-inner {\n  min-height: 100%;\n  display: flex;\n  flex-direction: column;\n  justify-content: flex-end;\n}"),
+        "acp conversation inner should bottom-align short content"
     );
     assert!(
         css.contains(".acp-plan {\n  overflow: auto;\n  min-height: 0;\n  max-height: 100%;\n}"),

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -24,6 +24,7 @@ import {
   windowConversation,
 } from "./conversation";
 import { isNearBottom } from "./scroll";
+import { renderMarkdown } from "./markdown";
 
 type AuthState = {
   token: string;
@@ -2183,39 +2184,6 @@ function createAnsiRenderer(): (input: string) => string {
     }
     return out;
   };
-}
-
-function escapeHtml(input: string): string {
-  return input
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function renderMarkdown(input: string): string {
-  const stripped = input.replace(/cite[^]+/g, "").replace(/[]/g, "");
-  const blocks = stripped.split("```");
-  let out = "";
-  blocks.forEach((part, idx) => {
-    if (idx % 2 === 1) {
-      const safe = escapeHtml(part.replace(/^\n/, "").replace(/\n$/, ""));
-      out += `<pre><code>${safe}</code></pre>`;
-      return;
-    }
-    let safe = escapeHtml(part);
-    safe = safe.replace(
-      /\[([^\]]+)\]\(([^)]+)\)/g,
-      (_m, text, href) =>
-        `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${text}</a>`
-    );
-    safe = safe.replace(/`([^`]+)`/g, "<code>$1</code>");
-    safe = safe.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-    safe = safe.replace(/\*([^*]+)\*/g, "<em>$1</em>");
-    out += safe;
-  });
-  return out;
 }
 
 function parseRunStatus(message: string): string | null {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -24,7 +24,7 @@ import {
   windowConversation,
 } from "./conversation";
 import { isNearBottom } from "./scroll";
-import { renderMarkdown } from "./markdown";
+import { escapeHtml, renderMarkdown } from "./markdown";
 
 type AuthState = {
   token: string;

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -23,6 +23,7 @@ import {
   ConversationItem,
   windowConversation,
 } from "./conversation";
+import { isNearBottom } from "./scroll";
 
 type AuthState = {
   token: string;
@@ -431,8 +432,7 @@ export function App() {
   useEffect(() => {
     const el = outputRef.current;
     if (!el) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distance < 120) {
+    if (isNearBottom(el.scrollHeight, el.scrollTop, el.clientHeight)) {
       el.scrollTop = el.scrollHeight;
     }
   }, [outputs, acpView.hasAcp]);
@@ -1203,9 +1203,11 @@ export function App() {
                         onScroll={() => {
                           const el = acpConversationRef.current;
                           if (!el) return;
-                          const distance =
-                            el.scrollHeight - el.scrollTop - el.clientHeight;
-                          const stick = distance < 120;
+                          const stick = isNearBottom(
+                            el.scrollHeight,
+                            el.scrollTop,
+                            el.clientHeight
+                          );
                           acpStickToBottomRef.current = stick;
                           setConversationStickToBottom(stick);
                           if (el.scrollTop < 80) {
@@ -1213,25 +1215,39 @@ export function App() {
                           }
                         }}
                       >
-                        {conversationWindow.items.map((msg, idx) => {
-                          const key = `${conversationWindow.offset + idx}-${msg.kind}`;
-                          if (msg.kind === "agent_thinking") {
+                        <div className="acp-conversation-inner">
+                          {conversationWindow.items.map((msg, idx) => {
+                            const key = `${conversationWindow.offset + idx}-${msg.kind}`;
+                            if (msg.kind === "agent_thinking") {
+                              return (
+                                <div key={key} className="acp-bubble agent_thinking">
+                                  <details className="acp-thought-fold" open={msg.live}>
+                                    <summary>
+                                      {msg.live
+                                        ? "Thinking (live)"
+                                        : "Thinking (collapsed)"}
+                                    </summary>
+                                    <div className="acp-text">
+                                      <pre>{msg.text}</pre>
+                                    </div>
+                                  </details>
+                                </div>
+                              );
+                            }
+                            if (msg.kind === "agent_message") {
+                              return (
+                                <div key={key} className="acp-bubble agent_message">
+                                  <div
+                                    className="acp-text"
+                                    dangerouslySetInnerHTML={{
+                                      __html: renderMarkdown(msg.text),
+                                    }}
+                                  />
+                                </div>
+                              );
+                            }
                             return (
-                              <div key={key} className="acp-bubble agent_thinking">
-                                <details className="acp-thought-fold" open={msg.live}>
-                                  <summary>
-                                    {msg.live ? "Thinking (live)" : "Thinking (collapsed)"}
-                                  </summary>
-                                  <div className="acp-text">
-                                    <pre>{msg.text}</pre>
-                                  </div>
-                                </details>
-                              </div>
-                            );
-                          }
-                          if (msg.kind === "agent_message") {
-                            return (
-                              <div key={key} className="acp-bubble agent_message">
+                              <div key={key} className="acp-bubble user_message">
                                 <div
                                   className="acp-text"
                                   dangerouslySetInnerHTML={{
@@ -1240,18 +1256,8 @@ export function App() {
                                 />
                               </div>
                             );
-                          }
-                          return (
-                            <div key={key} className="acp-bubble user_message">
-                              <div
-                                className="acp-text"
-                                dangerouslySetInnerHTML={{
-                                  __html: renderMarkdown(msg.text),
-                                }}
-                              />
-                            </div>
-                          );
-                        })}
+                          })}
+                        </div>
                       </div>
                     )}
                     {acpTab === "tools" && (

--- a/web/src/markdown.test.ts
+++ b/web/src/markdown.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown";
+
+describe("renderMarkdown", () => {
+  it("renders safe links", () => {
+    const html = renderMarkdown("[link](https://example.com)");
+    expect(html).toContain("href=\"https://example.com\"");
+    expect(html).toContain(">link</a>");
+  });
+
+  it("drops javascript links", () => {
+    const html = renderMarkdown("[x](javascript:alert(1))");
+    expect(html).not.toContain("href=");
+    expect(html).toContain("x");
+  });
+
+  it("drops encoded javascript links", () => {
+    const html = renderMarkdown("[x](jav&#97;script:alert(1))");
+    expect(html).not.toContain("href=");
+  });
+
+  it("allows relative links", () => {
+    const html = renderMarkdown("[x](/path)");
+    expect(html).toContain("href=\"/path\"");
+  });
+});

--- a/web/src/markdown.test.ts
+++ b/web/src/markdown.test.ts
@@ -19,6 +19,12 @@ describe("renderMarkdown", () => {
     expect(html).not.toContain("href=");
   });
 
+  it("keeps query strings without double escaping", () => {
+    const html = renderMarkdown("[x](/path?a=1&b=2)");
+    expect(html).toContain("href=\"/path?a=1&amp;b=2\"");
+    expect(html).not.toContain("&amp;amp;");
+  });
+
   it("allows relative links", () => {
     const html = renderMarkdown("[x](/path)");
     expect(html).toContain("href=\"/path\"");

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -1,0 +1,84 @@
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function decodeHtmlEntities(input: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    colon: ":",
+    tab: "\t",
+    newline: "\n",
+  };
+  let out = input;
+  for (let i = 0; i < 2; i += 1) {
+    out = out.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (_m, body) => {
+      const key = String(body).toLowerCase();
+      if (key in named) return named[key];
+      if (key.startsWith("#x")) {
+        const code = Number.parseInt(key.slice(2), 16);
+        if (Number.isNaN(code)) return "";
+        return String.fromCharCode(code);
+      }
+      if (key.startsWith("#")) {
+        const code = Number.parseInt(key.slice(1), 10);
+        if (Number.isNaN(code)) return "";
+        return String.fromCharCode(code);
+      }
+      return "";
+    });
+  }
+  return out;
+}
+
+function sanitizeHref(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const decoded = decodeHtmlEntities(trimmed);
+  const normalized = decoded.replace(/[\u0000-\u001F\u007F\s]+/g, "").toLowerCase();
+  if (
+    normalized.startsWith("http://") ||
+    normalized.startsWith("https://") ||
+    normalized.startsWith("mailto:") ||
+    normalized.startsWith("tel:")
+  ) {
+    return trimmed;
+  }
+  if (
+    normalized.startsWith("/") ||
+    normalized.startsWith("./") ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("#")
+  ) {
+    return trimmed;
+  }
+  return null;
+}
+
+export function renderMarkdown(input: string): string {
+  const stripped = input.replace(/cite[^]+/g, "").replace(/[]/g, "");
+  const blocks = stripped.split("```");
+  let out = "";
+  blocks.forEach((part, idx) => {
+    if (idx % 2 === 1) {
+      const safe = escapeHtml(part.replace(/^\n/, "").replace(/\n$/, ""));
+      out += `<pre><code>${safe}</code></pre>`;
+      return;
+    }
+    let safe = escapeHtml(part);
+    safe = safe.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, text, href) => {
+      const safeHref = sanitizeHref(href);
+      if (!safeHref) return text;
+      return `<a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+    });
+    safe = safe.replace(/`([^`]+)`/g, "<code>$1</code>");
+    safe = safe.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    safe = safe.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+    out += safe;
+  });
+  return out;
+}

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -1,4 +1,4 @@
-function escapeHtml(input: string): string {
+export function escapeHtml(input: string): string {
   return input
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -73,7 +73,7 @@ export function renderMarkdown(input: string): string {
     safe = safe.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, text, href) => {
       const safeHref = sanitizeHref(href);
       if (!safeHref) return text;
-      return `<a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+      return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer">${text}</a>`;
     });
     safe = safe.replace(/`([^`]+)`/g, "<code>$1</code>");
     safe = safe.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");

--- a/web/src/scroll.test.ts
+++ b/web/src/scroll.test.ts
@@ -10,6 +10,10 @@ describe("isNearBottom", () => {
     expect(isNearBottom(1000, 600, 100)).toBe(false);
   });
 
+  it("returns true when at the bottom", () => {
+    expect(isNearBottom(1000, 900, 100)).toBe(true);
+  });
+
   it("treats equality as not near", () => {
     expect(isNearBottom(1000, 780, 100, 120)).toBe(false);
   });

--- a/web/src/scroll.test.ts
+++ b/web/src/scroll.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isNearBottom } from "./scroll";
+
+describe("isNearBottom", () => {
+  it("returns true when distance is below threshold", () => {
+    expect(isNearBottom(1000, 880, 100)).toBe(true);
+  });
+
+  it("returns false when distance is above threshold", () => {
+    expect(isNearBottom(1000, 600, 100)).toBe(false);
+  });
+
+  it("treats equality as not near", () => {
+    expect(isNearBottom(1000, 780, 100, 120)).toBe(false);
+  });
+});

--- a/web/src/scroll.ts
+++ b/web/src/scroll.ts
@@ -1,0 +1,8 @@
+export function isNearBottom(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  threshold = 120
+): boolean {
+  return scrollHeight - scrollTop - clientHeight < threshold;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -421,6 +421,11 @@ button {
   height: 100%;
   max-height: 100%;
   flex: 1 1 auto;
+  display: block;
+}
+
+.acp-conversation-inner {
+  min-height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- make ACP conversation scrollable by moving bottom-alignment to an inner wrapper
- centralize stick-to-bottom detection in `isNearBottom` with tests
- harden markdown rendering to block unsafe link protocols and add tests
- update ACP CSS assertions to guard the new layout

## Testing
- not run (not requested)
