### PR TITLE
fix: repair acp session id type

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -278,7 +278,7 @@ pub async fn spawn_acp_session(
                         return;
                     }
                 };
-                session_id = Some(session.session_id.clone());
+                session_id = Some(session.session_id.to_string());
             }
 
             let session_id = session_id.unwrap_or_else(|| "unknown".to_string());

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use sqlx::{Row, SqlitePool};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use uuid::Uuid;
 
 use super::{


### PR DESCRIPTION
## Summary
- remove unused `mpsc` import in agent manager
- convert ACP `SessionId` to `String` when storing session id

## Testing
- not run (not requested)
