### PR TITLE
ui: improve ACP debug scrolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ agenthub/
 - Add a TODO entry in `docs/todo.md` for follow-up or verification items.
 - Add a feature note under `docs/features/` describing background, scope, key decisions, and validation.
 - Feature notes should use `YYYY-MM-DD-topic.md` naming for easy lookup.
+- API naming conventions live in `docs/api_naming.md` and must be followed for all AgentHub-owned payloads.
 
 ## 12. Change Log
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,6 @@ dependencies = [
  "codex-protocol",
  "heck",
  "itertools 0.14.0",
- "mcp-types",
  "regex-lite",
  "serde",
  "serde_json",
@@ -247,6 +246,15 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -819,6 +827,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "codex-api"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1003,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "codex-app-server-protocol"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1011,7 +1038,6 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "inventory",
- "mcp-types",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1024,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "codex-apply-patch"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "similar",
@@ -1036,7 +1062,7 @@ dependencies = [
 [[package]]
 name = "codex-arg0"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1050,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "codex-async-utils"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1060,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "codex-client"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1082,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "codex-common"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "clap",
  "codex-core",
@@ -1096,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "codex-core"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1126,6 +1152,7 @@ dependencies = [
  "codex-utils-string",
  "codex-windows-sandbox",
  "core-foundation 0.9.4",
+ "dirs",
  "dunce",
  "encoding_rs",
  "env-flags",
@@ -1138,8 +1165,8 @@ dependencies = [
  "keyring",
  "landlock",
  "libc",
- "mcp-types",
  "multimap",
+ "notify",
  "once_cell",
  "openssl-sys",
  "os_info",
@@ -1147,6 +1174,7 @@ dependencies = [
  "regex",
  "regex-lite",
  "reqwest",
+ "rmcp",
  "schemars 0.8.22",
  "seccompiler",
  "serde",
@@ -1174,12 +1202,13 @@ dependencies = [
  "uuid",
  "which",
  "wildmatch",
+ "zip",
 ]
 
 [[package]]
 name = "codex-execpolicy"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1194,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "codex-experimental-api-macros"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1204,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "codex-file-search"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1219,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "codex-git"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "once_cell",
  "regex",
@@ -1234,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "codex-keyring-store"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "keyring",
  "tracing",
@@ -1243,20 +1272,23 @@ dependencies = [
 [[package]]
 name = "codex-linux-sandbox"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
+ "cc",
  "clap",
  "codex-core",
  "codex-utils-absolute-path",
  "landlock",
  "libc",
+ "pkg-config",
  "seccompiler",
+ "serde_json",
 ]
 
 [[package]]
 name = "codex-lmstudio"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "codex-core",
  "reqwest",
@@ -1269,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "codex-login"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1291,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "codex-mcp-server"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -1299,7 +1331,7 @@ dependencies = [
  "codex-core",
  "codex-protocol",
  "codex-utils-json-to-toml",
- "mcp-types",
+ "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1312,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "codex-ollama"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "async-stream",
  "bytes",
@@ -1329,13 +1361,13 @@ dependencies = [
 [[package]]
 name = "codex-otel"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "chrono",
  "codex-api",
- "codex-app-server-protocol",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-string",
  "eventsource-stream",
  "http 1.4.0",
  "opentelemetry",
@@ -1343,6 +1375,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "os_info",
  "reqwest",
  "serde",
  "serde_json",
@@ -1358,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "codex-protocol"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "codex-execpolicy",
  "codex-git",
@@ -1367,7 +1400,6 @@ dependencies = [
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
- "mcp-types",
  "mime_guess",
  "schemars 0.8.22",
  "serde",
@@ -1384,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "codex-rmcp-client"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -1393,7 +1425,6 @@ dependencies = [
  "codex-utils-home-dir",
  "futures",
  "keyring",
- "mcp-types",
  "oauth2",
  "reqwest",
  "rmcp",
@@ -1412,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "codex-state"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1420,6 +1451,7 @@ dependencies = [
  "codex-otel",
  "codex-protocol",
  "dirs",
+ "log",
  "owo-colors",
  "serde",
  "serde_json",
@@ -1433,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-absolute-path"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "dirs",
  "path-absolutize",
@@ -1445,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-cache"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "lru",
  "sha1",
@@ -1455,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-home-dir"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "dirs",
 ]
@@ -1463,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-image"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -1475,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-json-to-toml"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "serde_json",
  "toml 0.9.11+spec-1.1.0",
@@ -1484,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-pty"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -1500,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-readiness"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -1511,12 +1543,12 @@ dependencies = [
 [[package]]
 name = "codex-utils-string"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 
 [[package]]
 name = "codex-windows-sandbox"
 version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
+source = "git+https://github.com/zed-industries/codex?branch=acp#785c0c43df941e6997ff3a9e8a9dd48da2661f20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1599,6 +1631,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1929,6 +1967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
 name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2049,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2563,6 +2618,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3329,6 +3393,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3634,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3858,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,17 +3904,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "mcp-types"
-version = "0.0.0"
-source = "git+https://github.com/zed-industries/codex?branch=acp#6a06fefad7b3529e8cacb465a6ffa61d52ad4b31"
-dependencies = [
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "ts-rs",
-]
 
 [[package]]
 name = "md-5"
@@ -3864,6 +3978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3970,6 +4085,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4121,7 +4263,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -4604,6 +4746,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -8372,6 +8524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8552,10 +8713,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.13.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -30,7 +30,6 @@ codex-mcp-server = { git = "https://github.com/zed-industries/codex", branch = "
 codex-protocol = { git = "https://github.com/zed-industries/codex", branch = "acp" }
 heck = "0.5.0"
 itertools = "0.14.0"
-mcp-types = { git = "https://github.com/zed-industries/codex", branch = "acp" }
 regex-lite = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -10,17 +10,17 @@ use agent_client_protocol::{
 };
 use codex_core::auth::AuthMode;
 use codex_core::{
-    NewThread, ResponseItem, RolloutRecorder, ThreadManager, ThreadSortKey,
+    NewThread, RolloutRecorder, ThreadManager, ThreadSortKey,
     auth::{AuthManager, read_codex_api_key_from_env, read_openai_api_key_from_env},
     config::{
         Config,
         types::{McpServerConfig, McpServerTransportConfig},
     },
-    find_thread_path_by_id_str, parse_cursor, parse_turn_item,
+    find_thread_path_by_id_str, parse_cursor,
     protocol::{InitialHistory, SessionSource},
 };
 use codex_login::{CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR};
-use codex_protocol::{ThreadId, protocol::SessionMetaLine};
+use codex_protocol::ThreadId;
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -252,7 +252,7 @@ impl Agent for CodexAgent {
 
         // Check before starting login flow if already authenticated with the same method
         if let Some(auth) = self.auth_manager.auth().await {
-            match (auth.internal_auth_mode(), auth_method) {
+            match (auth.auth_mode(), auth_method) {
                 (
                     AuthMode::ApiKey,
                     CodexAuthMethod::CodexApiKey | CodexAuthMethod::OpenAiApiKey,
@@ -460,39 +460,25 @@ impl Agent for CodexAgent {
             .items
             .into_iter()
             .filter_map(|item| {
-                // Codex rollout summaries put the SessionMetaLine first in the head.
-                let session_meta_line = item.head.first().and_then(|first| {
-                    serde_json::from_value::<SessionMetaLine>(first.clone()).ok()
-                })?;
+                let thread_id = item.thread_id?;
+                let item_cwd = item.cwd?;
 
                 if let Some(filter_cwd) = cwd.as_ref()
-                    && session_meta_line.meta.cwd != *filter_cwd
+                    && item_cwd != *filter_cwd
                 {
                     return None;
                 }
 
-                let mut title = None;
-                for value in item.head {
-                    if let Ok(response_item) = serde_json::from_value::<ResponseItem>(value)
-                        && let Some(turn_item) = parse_turn_item(&response_item)
-                        && let codex_protocol::items::TurnItem::UserMessage(user) = turn_item
-                    {
-                        if let Some(formatted) = format_session_title(&user.message()) {
-                            title = Some(formatted);
-                        }
-                        break;
-                    }
-                }
-
-                let updated_at = item.updated_at.clone().or(item.created_at.clone());
+                let title = item
+                    .first_user_message
+                    .as_deref()
+                    .and_then(format_session_title);
+                let updated_at = item.updated_at.or(item.created_at);
 
                 Some(
-                    SessionInfo::new(
-                        SessionId::new(session_meta_line.meta.id.to_string()),
-                        session_meta_line.meta.cwd.clone(),
-                    )
-                    .title(title)
-                    .updated_at(updated_at),
+                    SessionInfo::new(SessionId::new(thread_id.to_string()), item_cwd)
+                        .title(title)
+                        .updated_at(updated_at),
                 )
             })
             .collect::<Vec<_>>();

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -7,21 +7,20 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-use codex_apply_patch::parse_patch;
-
 use agent_client_protocol::{
-    Annotations, AudioContent, AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate,
-    BlobResourceContents, Client, ClientCapabilities, ConfigOptionUpdate, Content, ContentBlock,
-    ContentChunk, Diff, EmbeddedResource, EmbeddedResourceResource, Error, ImageContent,
-    LoadSessionResponse, Meta, ModelId, ModelInfo, PermissionOption, PermissionOptionKind, Plan,
-    PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
-    SessionConfigValueId, SessionId, SessionMode, SessionModeId, SessionModeState,
-    SessionModelState, SessionNotification, SessionUpdate, StopReason, Terminal, TextContent,
-    TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+    AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, Client, ClientCapabilities,
+    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, Diff, EmbeddedResource,
+    EmbeddedResourceResource, Error, LoadSessionResponse, Meta, ModelId, ModelInfo,
+    PermissionOption, PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus,
+    PromptRequest, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    ResourceLink, SelectedPermissionOutcome, SessionConfigId, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOption, SessionConfigValueId, SessionId,
+    SessionMode, SessionModeId, SessionModeState, SessionModelState, SessionNotification,
+    SessionUpdate, StopReason, Terminal, TextResourceContents, ToolCall, ToolCallContent,
+    ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    UnstructuredCommandInput,
 };
+use codex_apply_patch::parse_patch;
 use codex_common::approval_presets::{ApprovalPreset, builtin_approval_presets};
 use codex_core::{
     AuthManager, CodexThread,
@@ -50,6 +49,7 @@ use codex_protocol::{
     approvals::ElicitationRequestEvent,
     config_types::TrustLevel,
     custom_prompts::CustomPrompt,
+    mcp::CallToolResult,
     models::ResponseItem,
     openai_models::{ModelPreset, ReasoningEffort},
     parse_command::ParsedCommand,
@@ -59,7 +59,6 @@ use codex_protocol::{
 };
 use heck::ToTitleCase;
 use itertools::Itertools;
-use mcp_types::{CallToolResult, RequestId};
 use serde_json::{Number, Value, json};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
@@ -700,8 +699,10 @@ impl PromptState {
             // Used for returning a single history entry
             | EventMsg::GetHistoryEntryResponse(..)
             | EventMsg::DeprecationNotice(..)
-            |  EventMsg::RequestUserInput(..)
+            | EventMsg::RequestUserInput(..)
             | EventMsg::DynamicToolCallRequest(..)
+            | EventMsg::ListRemoteSkillsResponse(..)
+            | EventMsg::RemoteSkillDownloaded(..)
             ) => {
                 warn!("Unexpected event: {:?}", e);
             }
@@ -720,8 +721,8 @@ impl PromptState {
             message,
         } = event;
         let tool_call_id = ToolCallId::new(match &id {
-            RequestId::String(s) => s.clone(),
-            RequestId::Integer(i) => i.to_string(),
+            codex_protocol::mcp::RequestId::String(s) => s.clone(),
+            codex_protocol::mcp::RequestId::Integer(i) => i.to_string(),
         });
         let response = client
             .request_permission(
@@ -981,7 +982,10 @@ impl PromptState {
                             result
                                 .content
                                 .into_iter()
-                                .map(codex_content_to_acp_content)
+                                .filter_map(|content| {
+                                    serde_json::from_value::<ContentBlock>(content).ok()
+                                })
+                                .map(|content| ToolCallContent::Content(Content::new(content)))
                                 .collect()
                         },
                     )),
@@ -1566,7 +1570,9 @@ impl TaskState {
             | EventMsg::DeprecationNotice(..)
             | EventMsg::ElicitationRequest(..)
             | EventMsg::RequestUserInput(..)
-            | EventMsg::DynamicToolCallRequest(..)) => {
+            | EventMsg::DynamicToolCallRequest(..)
+            | EventMsg::ListRemoteSkillsResponse(..)
+            | EventMsg::RemoteSkillDownloaded(..)) => {
                 warn!("Unexpected event: {:?}", e);
             }
         }
@@ -2759,10 +2765,7 @@ impl<A: Auth> ThreadActor<A> {
             }
             ResponseItem::FunctionCallOutput { call_id, output } => {
                 self.client
-                    .send_tool_call_completed(
-                        call_id.clone(),
-                        serde_json::to_value(&output.content).ok(),
-                    )
+                    .send_tool_call_completed(call_id.clone(), serde_json::to_value(output).ok())
                     .await;
             }
             ResponseItem::LocalShellCall {
@@ -2926,98 +2929,6 @@ fn format_uri_as_link(name: Option<String>, uri: String) -> String {
     }
 }
 
-fn codex_content_to_acp_content(content: mcp_types::ContentBlock) -> ToolCallContent {
-    ToolCallContent::Content(Content::new(match content {
-        mcp_types::ContentBlock::TextContent(mcp_types::TextContent {
-            annotations, text, ..
-        }) => ContentBlock::Text(
-            TextContent::new(text).annotations(annotations.map(convert_annotations)),
-        ),
-        mcp_types::ContentBlock::ImageContent(mcp_types::ImageContent {
-            annotations,
-            data,
-            mime_type,
-            ..
-        }) => ContentBlock::Image(
-            ImageContent::new(data, mime_type).annotations(annotations.map(convert_annotations)),
-        ),
-        mcp_types::ContentBlock::AudioContent(mcp_types::AudioContent {
-            annotations,
-            data,
-            mime_type,
-            ..
-        }) => ContentBlock::Audio(
-            AudioContent::new(data, mime_type).annotations(annotations.map(convert_annotations)),
-        ),
-        mcp_types::ContentBlock::ResourceLink(mcp_types::ResourceLink {
-            annotations,
-            description,
-            mime_type,
-            name,
-            size,
-            title,
-            uri,
-            ..
-        }) => ContentBlock::ResourceLink(
-            ResourceLink::new(name, uri)
-                .annotations(annotations.map(convert_annotations))
-                .description(description)
-                .mime_type(mime_type)
-                .size(size)
-                .title(title),
-        ),
-        mcp_types::ContentBlock::EmbeddedResource(mcp_types::EmbeddedResource {
-            annotations,
-            resource,
-            ..
-        }) => {
-            let resource = match resource {
-                mcp_types::EmbeddedResourceResource::TextResourceContents(
-                    mcp_types::TextResourceContents {
-                        mime_type,
-                        text,
-                        uri,
-                    },
-                ) => EmbeddedResourceResource::TextResourceContents(
-                    TextResourceContents::new(text, uri).mime_type(mime_type),
-                ),
-                mcp_types::EmbeddedResourceResource::BlobResourceContents(
-                    mcp_types::BlobResourceContents {
-                        blob,
-                        mime_type,
-                        uri,
-                    },
-                ) => EmbeddedResourceResource::BlobResourceContents(
-                    BlobResourceContents::new(blob, uri).mime_type(mime_type),
-                ),
-            };
-            ContentBlock::Resource(
-                EmbeddedResource::new(resource).annotations(annotations.map(convert_annotations)),
-            )
-        }
-    }))
-}
-
-fn convert_annotations(
-    mcp_types::Annotations {
-        audience,
-        last_modified,
-        priority,
-    }: mcp_types::Annotations,
-) -> Annotations {
-    Annotations::new()
-        .audience(audience.map(|a| {
-            a.into_iter()
-                .map(|audience| match audience {
-                    mcp_types::Role::Assistant => agent_client_protocol::Role::Assistant,
-                    mcp_types::Role::User => agent_client_protocol::Role::User,
-                })
-                .collect::<Vec<_>>()
-        }))
-        .last_modified(last_modified)
-        .priority(priority)
-}
-
 fn extract_tool_call_content_from_changes(
     changes: HashMap<PathBuf, FileChange>,
 ) -> (
@@ -3103,6 +3014,7 @@ fn extract_slash_command(content: &[UserInput]) -> Option<(&str, &str)> {
 mod tests {
     use std::sync::atomic::AtomicUsize;
 
+    use agent_client_protocol::TextContent;
     use codex_core::{
         config::ConfigOverrides, models_manager::model_presets::all_model_presets,
         protocol::AgentMessageEvent,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1367,6 +1367,10 @@ fn map_tool_output_content(contents: Vec<Value>) -> Vec<ToolCallContent> {
         .collect()
 }
 
+fn is_permission_demo_allowed(option_id: &str) -> bool {
+    matches!(option_id, "allow_once" | "allow_always")
+}
+
 fn parse_command_tool_call(parsed_cmd: Vec<ParsedCommand>, cwd: &Path) -> ParseCommandToolCall {
     let mut titles = Vec::new();
     let mut locations = Vec::new();
@@ -2463,10 +2467,6 @@ impl<A: Auth> ThreadActor<A> {
 
         Ok(())
     }
-
-fn is_permission_demo_allowed(option_id: &str) -> bool {
-    matches!(option_id, "allow_once" | "allow_always")
-}
 
     async fn handle_set_mode(&mut self, mode: SessionModeId) -> Result<(), Error> {
         let preset = APPROVAL_PRESETS

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -2408,6 +2408,11 @@ impl<A: Auth> ThreadActor<A> {
                 .await;
 
             let options = vec![
+                PermissionOption::new(
+                    "allow_always",
+                    "Always",
+                    PermissionOptionKind::AllowAlways,
+                ),
                 PermissionOption::new("allow_once", "Allow once", PermissionOptionKind::AllowOnce),
                 PermissionOption::new("reject_once", "Reject", PermissionOptionKind::RejectOnce),
             ];
@@ -2426,7 +2431,9 @@ impl<A: Auth> ThreadActor<A> {
                     RequestPermissionOutcome::Selected(SelectedPermissionOutcome {
                         option_id,
                         ..
-                    }) if option_id.0.as_ref() == "allow_once" => {
+                    }) if option_id.0.as_ref() == "allow_once"
+                        || option_id.0.as_ref() == "allow_always" =>
+                    {
                         client.send_agent_text("Permission granted.").await;
                         client
                             .send_tool_call_completed(call_id, Some(json!({ "result": "allowed" })))

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -982,8 +982,18 @@ impl PromptState {
                             result
                                 .content
                                 .into_iter()
-                                .filter_map(|content| {
-                                    serde_json::from_value::<ContentBlock>(content).ok()
+                                .filter_map(|content| match serde_json::from_value::<ContentBlock>(
+                                    content.clone(),
+                                ) {
+                                    Ok(block) => Some(block),
+                                    Err(err) => {
+                                        warn!(
+                                            ?err,
+                                            raw = ?content,
+                                            "Failed to deserialize tool output content block"
+                                        );
+                                        None
+                                    }
                                 })
                                 .map(|content| ToolCallContent::Content(Content::new(content)))
                                 .collect()

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -977,28 +977,12 @@ impl PromptState {
                         ToolCallStatus::Completed
                     })
                     .raw_output(raw_output)
-                    .content(result.ok().filter(|result| !result.content.is_empty()).map(
-                        |result| {
-                            result
-                                .content
-                                .into_iter()
-                                .filter_map(|content| match serde_json::from_value::<ContentBlock>(
-                                    content.clone(),
-                                ) {
-                                    Ok(block) => Some(block),
-                                    Err(err) => {
-                                        warn!(
-                                            ?err,
-                                            raw = ?content,
-                                            "Failed to deserialize tool output content block"
-                                        );
-                                        None
-                                    }
-                                })
-                                .map(|content| ToolCallContent::Content(Content::new(content)))
-                                .collect()
-                        },
-                    )),
+                    .content(
+                        result
+                            .ok()
+                            .filter(|result| !result.content.is_empty())
+                            .map(|result| map_tool_output_content(result.content)),
+                    ),
             ))
             .await;
     }
@@ -1364,6 +1348,23 @@ struct ParseCommandToolCall {
     terminal_output: bool,
     locations: Vec<ToolCallLocation>,
     kind: ToolKind,
+}
+
+fn map_tool_output_content(contents: Vec<Value>) -> Vec<ToolCallContent> {
+    contents
+        .into_iter()
+        .filter_map(|content| match serde_json::from_value::<ContentBlock>(content.clone()) {
+            Ok(block) => Some(ToolCallContent::Content(Content::new(block))),
+            Err(err) => {
+                warn!(
+                    ?err,
+                    raw = ?content,
+                    "Failed to deserialize tool output content block"
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 fn parse_command_tool_call(parsed_cmd: Vec<ParsedCommand>, cwd: &Path) -> ParseCommandToolCall {
@@ -2431,9 +2432,7 @@ impl<A: Auth> ThreadActor<A> {
                     RequestPermissionOutcome::Selected(SelectedPermissionOutcome {
                         option_id,
                         ..
-                    }) if option_id.0.as_ref() == "allow_once"
-                        || option_id.0.as_ref() == "allow_always" =>
-                    {
+                    }) if is_permission_demo_allowed(option_id.0.as_ref()) => {
                         client.send_agent_text("Permission granted.").await;
                         client
                             .send_tool_call_completed(call_id, Some(json!({ "result": "allowed" })))
@@ -2464,6 +2463,10 @@ impl<A: Auth> ThreadActor<A> {
 
         Ok(())
     }
+
+fn is_permission_demo_allowed(option_id: &str) -> bool {
+    matches!(option_id, "allow_once" | "allow_always")
+}
 
     async fn handle_set_mode(&mut self, mode: SessionModeId) -> Result<(), Error> {
         let preset = APPROVAL_PRESETS
@@ -3165,6 +3168,28 @@ mod tests {
         assert_eq!(ops.as_slice(), &[Op::Undo]);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_permission_demo_allows_always() {
+        assert!(is_permission_demo_allowed("allow_always"));
+        assert!(is_permission_demo_allowed("allow_once"));
+        assert!(!is_permission_demo_allowed("reject_once"));
+    }
+
+    #[test]
+    fn test_map_tool_output_content_filters_invalid() {
+        let valid = serde_json::to_value(ContentBlock::Text(TextContent::new("ok"))).unwrap();
+        let invalid = serde_json::json!({ "bad": true });
+        let mapped = map_tool_output_content(vec![valid, invalid]);
+        assert_eq!(mapped.len(), 1);
+        match &mapped[0] {
+            ToolCallContent::Content(Content { content, .. }) => match content {
+                ContentBlock::Text(TextContent { text, .. }) => assert_eq!(text, "ok"),
+                _ => panic!("expected text content block"),
+            },
+            _ => panic!("expected content tool call entry"),
+        }
     }
 
     #[tokio::test]

--- a/docs/api_naming.md
+++ b/docs/api_naming.md
@@ -1,0 +1,16 @@
+# API Naming Conventions
+
+## Canonical Casing
+AgentHub-owned JSON payloads (HTTP API + SSE) use `snake_case`.
+
+## Boundary Normalization
+Upstream protocols may emit `camelCase`. Normalize at the boundary:
+- Parse `camelCase` input via serde aliases.
+- Re-emit only `snake_case`.
+- Store JSON blobs in `snake_case` (avoid dual-casing in storage).
+
+## UI Types
+Frontend types must only expose `snake_case` fields. Do not keep both casings in public interfaces.
+
+## Example
+`optionId` (upstream) -> `option_id` (AgentHub API/UI/storage).

--- a/docs/features/2026-02-09-acp-debug-layout-fixes.md
+++ b/docs/features/2026-02-09-acp-debug-layout-fixes.md
@@ -1,0 +1,23 @@
+# ACP Debug Layout Fixes
+
+## Background
+The ACP debug panel still failed to scroll reliably after recent layout refactors, and review feedback highlighted grid/flex mismatches and missing height constraints. Additional feedback covered interrupt gating, permission event serialization, and lock usage in agent input handling.
+
+## Scope
+- Define ACP container as a two-row grid (`auto` + `minmax(0, 1fr)`) so the active panel can scroll.
+- Ensure `.acp-debug` has explicit height constraints and scroll behavior.
+- Gate Interrupt to active runs only (running or tool call in progress).
+- Emit permission debug events without moving `args.options` or outcomes.
+- Release agent manager locks before performing async DB updates.
+- Log tool output content deserialization failures instead of silently dropping them.
+
+## Key Decisions
+- Prefer a grid layout for ACP to keep header sizing stable while panels consume remaining space.
+- Keep `runStatusLabel` for badge rendering, but restrict `canInterrupt` to active statuses.
+- Log JSON deserialization errors with the raw value to aid protocol debugging.
+
+## Validation
+- Open ACP Debug and confirm Raw Events scrolls within the Output panel.
+- Trigger a permission request and verify debug events emit without panics.
+- Confirm Interrupt is disabled for completed/failed runs but enabled during in-progress tool calls.
+- Run `cargo check` to ensure the agent manager and ACP handler compile.

--- a/docs/features/2026-02-09-acp-default-mode.md
+++ b/docs/features/2026-02-09-acp-default-mode.md
@@ -1,0 +1,26 @@
+# ACP Default Mode
+
+## Background
+ACP permission UI does not appear when sessions run under a full-access approval preset. We need a consistent way to apply a non-full-access preset on ACP session start so permission requests surface in the UI.
+
+## Scope
+- Add `codex_acp.default_mode` to the config schema.
+- Apply the configured mode immediately after ACP session creation.
+- Log the configured mode at startup and warn if applying it fails.
+
+## Key Decisions
+- Use a simple string mode ID from configuration; no database migration required.
+- Apply the mode for each ACP session start; on failure, keep the session running and log a warning.
+- Users should set `default_mode` to a mode ID exposed by Codex ACP (e.g., via Debug -> Raw Events `current_mode` / config options).
+
+## Configuration
+```toml
+[codex_acp]
+default_mode = "auto"
+```
+
+## Validation
+- Restart agenthub after updating `~/.agenthub/config.toml`.
+- Start a new ACP agent session.
+- Confirm Debug -> Raw Events shows `current_mode` reflecting the configured mode.
+- Trigger a tool permission (or `/permission-demo`) and verify the permission entry appears in Debug and the permission modal.

--- a/docs/features/2026-02-09-acp-interrupt-in-progress.md
+++ b/docs/features/2026-02-09-acp-interrupt-in-progress.md
@@ -1,0 +1,32 @@
+---
+title: ACP Interrupt Enabled During In-Progress Tool Calls
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+Enable the Interrupt button and runtime badge when ACP tool calls are in progress,
+even if an explicit `run_status` event is missing.
+
+## Background
+
+Some ACP clients do not emit `run_status` events for tool execution. The UI
+was gating the Interrupt button and runtime badge on `run_status`, which
+left the controls disabled while tool calls were actively running.
+
+## Decision
+
+- Derive a `runStatusLabel` from `run_status` when available.
+- Fall back to `in_progress` when any tool call is running.
+- Use the derived label to enable Interrupt and display a status badge.
+
+## Scope
+
+- `web/src/components/acp_panel.tsx`
+- `web/src/styles.css`
+
+## Validation
+
+- Trigger a tool call that stays `in_progress`; confirm Interrupt is enabled.
+- Confirm the ACP status badge shows `in_progress` without `run_status`.

--- a/docs/features/2026-02-09-acp-interrupt-in-progress.md
+++ b/docs/features/2026-02-09-acp-interrupt-in-progress.md
@@ -30,3 +30,4 @@ left the controls disabled while tool calls were actively running.
 
 - Trigger a tool call that stays `in_progress`; confirm Interrupt is enabled.
 - Confirm the ACP status badge shows `in_progress` without `run_status`.
+- Run `pnpm test` (or `npm test`) and confirm `acp_panel.test.tsx` passes.

--- a/docs/features/2026-02-09-acp-permission-events.md
+++ b/docs/features/2026-02-09-acp-permission-events.md
@@ -1,0 +1,32 @@
+---
+title: ACP Permission Events In Debug Stream
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+Emit explicit ACP debug events when permission requests are created, resolved,
+or timed out, so the Debug tab can show the full permission lifecycle.
+
+## Background
+
+Operators could not see permission prompts in the Debug stream, making it
+difficult to understand why a tool call was blocked or timed out.
+
+## Decision
+
+- Emit `permission_request` when a permission prompt is created.
+- Emit `permission_response` when the outcome is decided.
+- Emit `permission_timeout` when a request expires and the fallback is applied.
+- Include `permission_id`, `session_id`, `tool_call_id`, outcome, and timestamps.
+
+## Scope
+
+- `src/acp.rs`
+
+## Validation
+
+- Trigger a permissioned tool call and verify the Debug raw events list shows
+  request/response entries with matching IDs.
+- Force a timeout and confirm a `permission_timeout` event is recorded.

--- a/docs/features/2026-02-09-acp-permission-option-id.md
+++ b/docs/features/2026-02-09-acp-permission-option-id.md
@@ -4,13 +4,16 @@
 ACP permission options are serialized from the server using camelCase (`optionId`), but the frontend expects `option_id`. This mismatch results in the UI sending `null` option IDs, which the backend interprets as `cancelled`, so approvals are always rejected.
 
 ## Scope
-- Accept both `option_id` and `optionId` in the frontend permission UI.
-- Disable option buttons when no option ID is present to avoid accidental cancellation.
+- Normalize permission options to `option_id` on the server for new requests.
+- Normalize legacy stored payloads so the API always returns `option_id`.
+- Keep the frontend UI `option_id`-only and disable buttons when the ID is missing.
 
 ## Key Decisions
-- Normalize the option ID in the UI layer to keep API responses backward compatible.
-- Keep the server payload unchanged to avoid breaking existing ACP clients.
+- Emit `option_id` in server permission payloads to align with the API and UI.
+- Allow legacy `optionId` data to deserialize server-side, then re-serialize as `option_id`.
+- Add a UI test that rejects empty option IDs.
 
 ## Validation
 - Trigger `/permission-demo` and click **Allow once** or **Always**.
 - Verify the permission response outcome is `selected` and the tool call completes successfully.
+- Run `pnpm test` (or `npm test`) and confirm `permission_modal.test.tsx` passes.

--- a/docs/features/2026-02-09-acp-permission-option-id.md
+++ b/docs/features/2026-02-09-acp-permission-option-id.md
@@ -1,0 +1,16 @@
+# ACP Permission Option ID Mapping
+
+## Background
+ACP permission options are serialized from the server using camelCase (`optionId`), but the frontend expects `option_id`. This mismatch results in the UI sending `null` option IDs, which the backend interprets as `cancelled`, so approvals are always rejected.
+
+## Scope
+- Accept both `option_id` and `optionId` in the frontend permission UI.
+- Disable option buttons when no option ID is present to avoid accidental cancellation.
+
+## Key Decisions
+- Normalize the option ID in the UI layer to keep API responses backward compatible.
+- Keep the server payload unchanged to avoid breaking existing ACP clients.
+
+## Validation
+- Trigger `/permission-demo` and click **Allow once** or **Always**.
+- Verify the permission response outcome is `selected` and the tool call completes successfully.

--- a/docs/features/2026-02-09-acp-permission-session-id.md
+++ b/docs/features/2026-02-09-acp-permission-session-id.md
@@ -1,0 +1,18 @@
+# ACP Permission Session IDs
+
+## Background
+ACP permission requests were persisted with the ACP session ID in the `session_id` column, but the database enforces a foreign key to `agent_sessions(id)`. This mismatch causes foreign key failures and drops permission requests.
+
+## Scope
+- Store the AgentHub agent session ID in `acp_permission_requests.session_id`.
+- Add `acp_session_id` to preserve the ACP session ID for debugging.
+- Keep API responses backward compatible by making the new field optional.
+
+## Key Decisions
+- Keep the foreign key constraint intact for consistency.
+- Add a nullable `acp_session_id` column via `ALTER TABLE` and include it in new inserts.
+
+## Validation
+- Start a new ACP session and trigger `/permission-demo`.
+- Confirm the permission request persists without foreign key errors.
+- Verify Debug -> Raw Events and the permission modal show the pending request.

--- a/docs/features/2026-02-09-acp-tool-output-content-filter.md
+++ b/docs/features/2026-02-09-acp-tool-output-content-filter.md
@@ -1,0 +1,15 @@
+# ACP Tool Output Content Filtering
+
+## Background
+Tool call results may include content blocks that cannot be deserialized into ACP `ContentBlock` values. These invalid blocks are skipped to avoid crashing the client, but the behavior needs coverage to prevent regressions.
+
+## Scope
+- Factor tool output content mapping into a helper function.
+- Add a unit test that keeps valid blocks and skips invalid ones.
+
+## Key Decisions
+- Preserve the existing warn-level logging when deserialization fails.
+- Keep the filtering behavior consistent with current runtime handling.
+
+## Validation
+- Run `cargo test -p agenthub-codex-acp` and confirm the new unit test passes.

--- a/docs/features/2026-02-09-agent-not-running-refresh.md
+++ b/docs/features/2026-02-09-agent-not-running-refresh.md
@@ -1,0 +1,30 @@
+---
+title: Refresh Agent Status When Input Fails
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+When sending input fails with `agent not running`, refresh agent status to
+avoid stale UI state.
+
+## Background
+
+The UI can show `running` while the agent process has already exited. Sending
+input in this state fails, but the UI continues to display a running status.
+
+## Decision
+
+- On `agent not running` errors, trigger `refreshAgents()` to sync UI.
+- On the backend, mark running sessions as exited if the in-memory handle is
+  missing when input arrives.
+
+## Scope
+
+- `src/agent/manager.rs`
+- `web/src/app.tsx`
+
+## Validation
+
+- Kill an agent process, then try sending input; UI should refresh to non-running.

--- a/docs/features/2026-02-09-api-naming-conventions.md
+++ b/docs/features/2026-02-09-api-naming-conventions.md
@@ -1,0 +1,20 @@
+# API Naming Conventions
+
+## Background
+We observed inconsistent casing for the same field (`option_id` vs `optionId`) across ACP events, database storage, and web API responses. This caused client-side mismatches and approvals being treated as cancelled.
+
+## Scope
+- Define a single canonical casing for AgentHub-owned JSON payloads.
+- Clarify how to handle upstream protocols (e.g., ACP) that use different casing.
+- Document boundary mapping rules and expectations for storage and UI types.
+
+## Key Decisions
+- AgentHub public API and SSE payloads use `snake_case`.
+- Database JSON blobs store `snake_case` fields to keep consistency with the API.
+- Upstream protocols that emit `camelCase` must be normalized at the boundary (parse aliases, then re-emit `snake_case`).
+- UI types only expose `snake_case` fields; do not carry dual-casing in public interfaces.
+
+## Validation
+- Review new API fields to ensure they follow `snake_case`.
+- Confirm legacy `camelCase` payloads are normalized server-side.
+- Run UI tests that validate permission option IDs use `option_id`.

--- a/docs/features/2026-02-09-codex-acp-protocol-sync.md
+++ b/docs/features/2026-02-09-codex-acp-protocol-sync.md
@@ -1,0 +1,22 @@
+# Codex ACP Protocol Sync
+
+## Background
+AgentHub's Codex ACP adapter needs to track protocol updates from the upstream codex-acp integration.
+The current changes align session listing and tool call payload handling with the latest ACP types.
+
+## Scope
+- Use rollout summary fields (`thread_id`, `cwd`, `first_user_message`, `updated_at`) when listing sessions.
+- Remove `mcp-types` usage and rely on `codex_protocol::mcp` for tool call results and request IDs.
+- Deserialize tool call content blocks directly into ACP `ContentBlock` values.
+- Emit full tool call outputs for `FunctionCallOutput` events.
+- Handle new remote skill events without spurious warnings.
+
+## Key Decisions
+- Trust rollout summary fields instead of parsing `SessionMetaLine` from head items.
+- Treat tool call content as JSON-encoded ACP blocks, not bespoke conversions.
+- Remove the `mcp-types` dependency to stay aligned with upstream codex.
+
+## Validation
+- Run `cargo check -p agenthub-codex-acp`.
+- Run `cargo test -p agenthub-codex-acp`.
+- Update `Cargo.lock` after refreshing codex git dependencies (`cargo update -p codex-protocol`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,7 @@
 # TODO
 
 - [ ] Refresh codex git dependencies and `Cargo.lock` after ACP protocol sync (see `docs/features/2026-02-09-codex-acp-protocol-sync.md`).
+- [ ] Verify ACP debug layout, interrupt gating, permission debug events, and tool output logging (see `docs/features/2026-02-09-acp-debug-layout-fixes.md`).
 - [ ] Verify single-instance agent start, ACP timeout cleanup, and SQLite WAL settings (see `docs/features/2026-02-08-backend-stability-hardening.md`).
 - [ ] Verify ACP output cache isolation and UI stability (see `docs/features/2026-02-07-acp-output-cache-and-polling.md`).
 - [ ] Verify admin/join flows and focus ring styling after frontend refactor (see `docs/features/2026-02-08-frontend-quality-refactor.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,6 +24,7 @@
 - [ ] Verify ACP details caret indicator renders for tool calls and thinking folds (see `docs/features/2026-02-08-acp-details-caret.md`).
 - [ ] Verify ACP chunk ordering metadata fixes token-level stream ordering under SSE/polling (see `docs/features/2026-02-08-acp-chunk-ordering.md`).
 - [ ] Verify ACP interrupt button appears next to Conversation tab, Debug hides input dock, and raw events list scrolls (see `docs/features/2026-02-08-acp-debug-interrupt.md`).
+- [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
 - [ ] Review raw HTML handling in markdown-it renderer and add sanitization if ACP output becomes untrusted (see `docs/features/2026-02-08-markdown-renderer.md`).
 - [ ] Validate SSE streaming output under proxy/load balancer conditions (see `docs/features/2026-02-08-sse-streaming.md`).
 - [ ] Verify SSE heartbeat events are emitted and ignored by the client (see `docs/features/2026-02-08-sse-streaming.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,6 +31,7 @@
 - [ ] Verify ACP permission option IDs map correctly in the UI and approvals are accepted (see `docs/features/2026-02-09-acp-permission-option-id.md`).
 - [ ] Verify ACP permission demo allows `allow_always` options after approval (see `docs/features/2026-02-09-acp-permission-option-id.md`).
 - [ ] Verify ACP default_mode config applies to new sessions and triggers permission requests when required (see `docs/features/2026-02-09-acp-default-mode.md`).
+- [ ] Verify API payload naming remains `snake_case` after new endpoint additions (see `docs/features/2026-02-09-api-naming-conventions.md`).
 - [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
 - [ ] Verify ACP tool output content filtering test coverage (see `docs/features/2026-02-09-acp-tool-output-content-filter.md`).
 - [ ] Verify UI refreshes agent status when input fails with `agent not running` (see `docs/features/2026-02-09-agent-not-running-refresh.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,6 +24,7 @@
 - [ ] Verify ACP details caret indicator renders for tool calls and thinking folds (see `docs/features/2026-02-08-acp-details-caret.md`).
 - [ ] Verify ACP chunk ordering metadata fixes token-level stream ordering under SSE/polling (see `docs/features/2026-02-08-acp-chunk-ordering.md`).
 - [ ] Verify ACP interrupt button appears next to Conversation tab, Debug hides input dock, and raw events list scrolls (see `docs/features/2026-02-08-acp-debug-interrupt.md`).
+- [ ] Verify ACP permission request/response/timeout events appear in Debug raw events (see `docs/features/2026-02-09-acp-permission-events.md`).
 - [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
 - [ ] Verify UI refreshes agent status when input fails with `agent not running` (see `docs/features/2026-02-09-agent-not-running-refresh.md`).
 - [ ] Review raw HTML handling in markdown-it renderer and add sanitization if ACP output becomes untrusted (see `docs/features/2026-02-08-markdown-renderer.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -29,8 +29,10 @@
 - [ ] Verify ACP permission request/response/timeout events appear in Debug raw events (see `docs/features/2026-02-09-acp-permission-events.md`).
 - [ ] Verify ACP permission requests persist with AgentHub session IDs and capture ACP session IDs (see `docs/features/2026-02-09-acp-permission-session-id.md`).
 - [ ] Verify ACP permission option IDs map correctly in the UI and approvals are accepted (see `docs/features/2026-02-09-acp-permission-option-id.md`).
+- [ ] Verify ACP permission demo allows `allow_always` options after approval (see `docs/features/2026-02-09-acp-permission-option-id.md`).
 - [ ] Verify ACP default_mode config applies to new sessions and triggers permission requests when required (see `docs/features/2026-02-09-acp-default-mode.md`).
 - [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
+- [ ] Verify ACP tool output content filtering test coverage (see `docs/features/2026-02-09-acp-tool-output-content-filter.md`).
 - [ ] Verify UI refreshes agent status when input fails with `agent not running` (see `docs/features/2026-02-09-agent-not-running-refresh.md`).
 - [ ] Review raw HTML handling in markdown-it renderer and add sanitization if ACP output becomes untrusted (see `docs/features/2026-02-08-markdown-renderer.md`).
 - [ ] Validate SSE streaming output under proxy/load balancer conditions (see `docs/features/2026-02-08-sse-streaming.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -25,6 +25,7 @@
 - [ ] Verify ACP chunk ordering metadata fixes token-level stream ordering under SSE/polling (see `docs/features/2026-02-08-acp-chunk-ordering.md`).
 - [ ] Verify ACP interrupt button appears next to Conversation tab, Debug hides input dock, and raw events list scrolls (see `docs/features/2026-02-08-acp-debug-interrupt.md`).
 - [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
+- [ ] Verify UI refreshes agent status when input fails with `agent not running` (see `docs/features/2026-02-09-agent-not-running-refresh.md`).
 - [ ] Review raw HTML handling in markdown-it renderer and add sanitization if ACP output becomes untrusted (see `docs/features/2026-02-08-markdown-renderer.md`).
 - [ ] Validate SSE streaming output under proxy/load balancer conditions (see `docs/features/2026-02-08-sse-streaming.md`).
 - [ ] Verify SSE heartbeat events are emitted and ignored by the client (see `docs/features/2026-02-08-sse-streaming.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,6 +27,9 @@
 - [ ] Verify ACP chunk ordering metadata fixes token-level stream ordering under SSE/polling (see `docs/features/2026-02-08-acp-chunk-ordering.md`).
 - [ ] Verify ACP interrupt button appears next to Conversation tab, Debug hides input dock, and raw events list scrolls (see `docs/features/2026-02-08-acp-debug-interrupt.md`).
 - [ ] Verify ACP permission request/response/timeout events appear in Debug raw events (see `docs/features/2026-02-09-acp-permission-events.md`).
+- [ ] Verify ACP permission requests persist with AgentHub session IDs and capture ACP session IDs (see `docs/features/2026-02-09-acp-permission-session-id.md`).
+- [ ] Verify ACP permission option IDs map correctly in the UI and approvals are accepted (see `docs/features/2026-02-09-acp-permission-option-id.md`).
+- [ ] Verify ACP default_mode config applies to new sessions and triggers permission requests when required (see `docs/features/2026-02-09-acp-default-mode.md`).
 - [ ] Verify ACP Interrupt enables when tool calls are in progress and status badge shows `in_progress` (see `docs/features/2026-02-09-acp-interrupt-in-progress.md`).
 - [ ] Verify UI refreshes agent status when input fails with `agent not running` (see `docs/features/2026-02-09-agent-not-running-refresh.md`).
 - [ ] Review raw HTML handling in markdown-it renderer and add sanitization if ACP output becomes untrusted (see `docs/features/2026-02-08-markdown-renderer.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Refresh codex git dependencies and `Cargo.lock` after ACP protocol sync (see `docs/features/2026-02-09-codex-acp-protocol-sync.md`).
 - [ ] Verify single-instance agent start, ACP timeout cleanup, and SQLite WAL settings (see `docs/features/2026-02-08-backend-stability-hardening.md`).
 - [ ] Verify ACP output cache isolation and UI stability (see `docs/features/2026-02-07-acp-output-cache-and-polling.md`).
 - [ ] Verify admin/join flows and focus ring styling after frontend refactor (see `docs/features/2026-02-08-frontend-quality-refactor.md`).

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use agent_client_protocol::{
     Agent, CancelNotification, Client, ClientCapabilities, ClientSideConnection, ContentBlock,
     ContentChunk, Implementation, InitializeRequest, LoadSessionRequest, NewSessionRequest,
-    PromptRequest, ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest,
+    PermissionOption, PermissionOptionKind, PromptRequest, ProtocolVersion,
+    RequestPermissionOutcome, RequestPermissionRequest,
     RequestPermissionResponse, SelectedPermissionOutcome, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, ToolCall,
     ToolCallUpdate, ToolCallUpdateFields,
@@ -110,6 +111,11 @@ impl Client for AcpClient {
         &self,
         args: RequestPermissionRequest,
     ) -> Result<RequestPermissionResponse, agent_client_protocol::Error> {
+        let options = args
+            .options
+            .iter()
+            .map(AcpPermissionOption::from)
+            .collect::<Vec<_>>();
         let (request_id, response_rx) = self
             .permissions
             .create_request(
@@ -125,7 +131,7 @@ impl Client for AcpClient {
                 "permission_id": request_id,
                 "session_id": args.session_id.to_string(),
                 "tool_call_id": args.tool_call.tool_call_id.to_string(),
-                "options": &args.options,
+                "options": &options,
                 "created_at": Utc::now().timestamp(),
             }))
             .await;
@@ -539,12 +545,30 @@ pub struct AcpPermissionRecord {
     pub session_id: String,
     pub acp_session_id: Option<String>,
     pub tool_call_id: Option<String>,
-    pub options: Vec<agent_client_protocol::PermissionOption>,
+    pub options: Vec<AcpPermissionOption>,
     pub tool_call: Option<Value>,
     pub status: String,
     pub selected_option_id: Option<String>,
     pub created_at: i64,
     pub responded_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AcpPermissionOption {
+    #[serde(alias = "optionId")]
+    pub option_id: String,
+    pub name: String,
+    pub kind: PermissionOptionKind,
+}
+
+impl From<&PermissionOption> for AcpPermissionOption {
+    fn from(option: &PermissionOption) -> Self {
+        Self {
+            option_id: option.option_id.0.to_string(),
+            name: option.name.clone(),
+            kind: option.kind,
+        }
+    }
 }
 
 impl AcpPermissionService {
@@ -562,7 +586,12 @@ impl AcpPermissionService {
         args: &RequestPermissionRequest,
     ) -> anyhow::Result<(String, oneshot::Receiver<RequestPermissionOutcome>)> {
         let id = uuid::Uuid::new_v4().to_string();
-        let options_json = serde_json::to_string(&args.options)?;
+        let options = args
+            .options
+            .iter()
+            .map(AcpPermissionOption::from)
+            .collect::<Vec<_>>();
+        let options_json = serde_json::to_string(&options)?;
         let tool_call_json = serde_json::to_string(&args.tool_call)?;
         let now = Utc::now().timestamp();
         sqlx::query(
@@ -685,7 +714,8 @@ impl AcpPermissionService {
         for row in rows {
             let options_json: String = row.get("options_json");
             let tool_call_json: Option<String> = row.try_get("tool_call_json").ok();
-            let options = serde_json::from_str(&options_json).unwrap_or_default();
+            let options = serde_json::from_str::<Vec<AcpPermissionOption>>(&options_json)
+                .unwrap_or_default();
             let tool_call = tool_call_json.and_then(|raw| serde_json::from_str(&raw).ok());
             out.push(AcpPermissionRecord {
                 id: row.get("id"),

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -115,6 +115,16 @@ impl Client for AcpClient {
             .create_request(&self.sink.agent_id, &args)
             .await
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
+        self.sink
+            .emit_json(serde_json::json!({
+                "type": "permission_request",
+                "permission_id": request_id,
+                "session_id": args.session_id.to_string(),
+                "tool_call_id": args.tool_call.tool_call_id.to_string(),
+                "options": args.options,
+                "created_at": Utc::now().timestamp(),
+            }))
+            .await;
 
         let outcome =
             match tokio::time::timeout(std::time::Duration::from_secs(300), response_rx).await {
@@ -126,9 +136,30 @@ impl Client for AcpClient {
                         .permissions
                         .mark_timeout(&request_id, Some(&fallback))
                         .await;
+                    self.sink
+                        .emit_json(serde_json::json!({
+                            "type": "permission_timeout",
+                            "permission_id": request_id,
+                            "session_id": args.session_id.to_string(),
+                            "tool_call_id": args.tool_call.tool_call_id.to_string(),
+                            "outcome": fallback,
+                            "responded_at": Utc::now().timestamp(),
+                        }))
+                        .await;
                     fallback
                 }
             };
+
+        self.sink
+            .emit_json(serde_json::json!({
+                "type": "permission_response",
+                "permission_id": request_id,
+                "session_id": args.session_id.to_string(),
+                "tool_call_id": args.tool_call.tool_call_id.to_string(),
+                "outcome": outcome,
+                "responded_at": Utc::now().timestamp(),
+            }))
+            .await;
 
         Ok(RequestPermissionResponse::new(outcome))
     }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -121,7 +121,7 @@ impl Client for AcpClient {
                 "permission_id": request_id,
                 "session_id": args.session_id.to_string(),
                 "tool_call_id": args.tool_call.tool_call_id.to_string(),
-                "options": args.options,
+                "options": &args.options,
                 "created_at": Utc::now().timestamp(),
             }))
             .await;
@@ -142,7 +142,7 @@ impl Client for AcpClient {
                             "permission_id": request_id,
                             "session_id": args.session_id.to_string(),
                             "tool_call_id": args.tool_call.tool_call_id.to_string(),
-                            "outcome": fallback,
+                            "outcome": &fallback,
                             "responded_at": Utc::now().timestamp(),
                         }))
                         .await;
@@ -156,7 +156,7 @@ impl Client for AcpClient {
                 "permission_id": request_id,
                 "session_id": args.session_id.to_string(),
                 "tool_call_id": args.tool_call.tool_call_id.to_string(),
-                "outcome": outcome,
+                "outcome": &outcome,
                 "responded_at": Utc::now().timestamp(),
             }))
             .await;

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -112,7 +112,11 @@ impl Client for AcpClient {
     ) -> Result<RequestPermissionResponse, agent_client_protocol::Error> {
         let (request_id, response_rx) = self
             .permissions
-            .create_request(&self.sink.agent_id, &args)
+            .create_request(
+                &self.sink.agent_id,
+                &self.sink.session_id,
+                &args,
+            )
             .await
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
         self.sink
@@ -533,6 +537,7 @@ pub struct AcpPermissionRecord {
     pub id: String,
     pub agent_id: String,
     pub session_id: String,
+    pub acp_session_id: Option<String>,
     pub tool_call_id: Option<String>,
     pub options: Vec<agent_client_protocol::PermissionOption>,
     pub tool_call: Option<Value>,
@@ -553,6 +558,7 @@ impl AcpPermissionService {
     pub async fn create_request(
         &self,
         agent_id: &str,
+        agent_session_id: &str,
         args: &RequestPermissionRequest,
     ) -> anyhow::Result<(String, oneshot::Receiver<RequestPermissionOutcome>)> {
         let id = uuid::Uuid::new_v4().to_string();
@@ -562,14 +568,15 @@ impl AcpPermissionService {
         sqlx::query(
             r#"
             INSERT INTO acp_permission_requests (
-                id, agent_id, session_id, tool_call_id, options_json, tool_call_json,
+                id, agent_id, session_id, acp_session_id, tool_call_id, options_json, tool_call_json,
                 status, created_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'pending', ?8)
             "#,
         )
         .bind(&id)
         .bind(agent_id)
+        .bind(agent_session_id)
         .bind(args.session_id.to_string())
         .bind(args.tool_call.tool_call_id.to_string())
         .bind(options_json)
@@ -648,7 +655,7 @@ impl AcpPermissionService {
         let rows = if let Some(status) = status {
             sqlx::query(
                 r#"
-                SELECT id, agent_id, session_id, tool_call_id, options_json, tool_call_json,
+                SELECT id, agent_id, session_id, acp_session_id, tool_call_id, options_json, tool_call_json,
                        status, selected_option_id, created_at, responded_at
                 FROM acp_permission_requests
                 WHERE agent_id = ?1 AND status = ?2
@@ -662,7 +669,7 @@ impl AcpPermissionService {
         } else {
             sqlx::query(
                 r#"
-                SELECT id, agent_id, session_id, tool_call_id, options_json, tool_call_json,
+                SELECT id, agent_id, session_id, acp_session_id, tool_call_id, options_json, tool_call_json,
                        status, selected_option_id, created_at, responded_at
                 FROM acp_permission_requests
                 WHERE agent_id = ?1
@@ -684,6 +691,7 @@ impl AcpPermissionService {
                 id: row.get("id"),
                 agent_id: row.get("agent_id"),
                 session_id: row.get("session_id"),
+                acp_session_id: row.try_get("acp_session_id").ok(),
                 tool_call_id: row.try_get("tool_call_id").ok(),
                 options,
                 tool_call,

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -24,6 +24,7 @@ pub struct AgentManager {
     auth: Arc<AuthService>,
     proxy_env: Vec<(String, String)>,
     codex_acp_binary: String,
+    acp_default_mode: Option<String>,
     permissions: Arc<AcpPermissionService>,
     starting: Arc<Mutex<HashSet<String>>>,
     inner: Arc<RwLock<HashMap<String, AgentHandle>>>,
@@ -49,6 +50,7 @@ impl AgentManager {
         push: Arc<PushService>,
         proxy_env: Vec<(String, String)>,
         codex_acp_binary: String,
+        acp_default_mode: Option<String>,
         permissions: Arc<AcpPermissionService>,
         auth: Arc<AuthService>,
     ) -> Self {
@@ -58,6 +60,7 @@ impl AgentManager {
             auth,
             proxy_env,
             codex_acp_binary,
+            acp_default_mode,
             permissions,
             starting: Arc::new(Mutex::new(HashSet::new())),
             inner: Arc::new(RwLock::new(HashMap::new())),
@@ -562,6 +565,16 @@ impl AgentManager {
                 .await
             {
                 tracing::error!("persist acp session failed: {}", err);
+            }
+            if let Some(mode_id) = self.acp_default_mode.as_deref() {
+                if let Err(err) = handle.set_mode(mode_id.to_string()).await {
+                    tracing::warn!(
+                        "set acp default mode failed: agent_id={}, mode_id={}, error={}",
+                        agent.id,
+                        mode_id,
+                        err
+                    );
+                }
             }
             AgentInput::Acp(handle.clone())
         } else {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -739,37 +739,9 @@ impl AgentManager {
         message_id: Option<&str>,
     ) -> anyhow::Result<()> {
         let now = Utc::now().timestamp();
-        let (stdin, acp, output_tx, session_id) = {
+        let handle_snapshot = {
             let guard = self.inner.read().await;
-            let handle = match guard.get(agent_id) {
-                Some(handle) => handle,
-                None => {
-                    let _ = sqlx::query(
-                        r#"
-                        UPDATE agent_sessions
-                        SET status = 'exited', ended_at = ?1
-                        WHERE agent_id = ?2 AND status = 'running' AND ended_at IS NULL
-                        "#,
-                    )
-                    .bind(now)
-                    .bind(agent_id)
-                    .execute(&self.db)
-                    .await;
-                    let _ = sqlx::query(
-                        r#"
-                        UPDATE agents
-                        SET status = 'exited', updated_at = ?1
-                        WHERE id = ?2 AND status = 'running'
-                        "#,
-                    )
-                    .bind(now)
-                    .bind(agent_id)
-                    .execute(&self.db)
-                    .await;
-                    return Err(anyhow::anyhow!("agent not running"));
-                }
-            };
-            match &handle.input {
+            guard.get(agent_id).map(|handle| match &handle.input {
                 AgentInput::Stdin(stdin) => (Some(stdin.clone()), None, None, None),
                 AgentInput::Acp(acp) => (
                     None,
@@ -777,6 +749,34 @@ impl AgentManager {
                     Some(handle.output_tx.clone()),
                     Some(handle.session_id.clone()),
                 ),
+            })
+        };
+        let (stdin, acp, output_tx, session_id) = match handle_snapshot {
+            Some(snapshot) => snapshot,
+            None => {
+                let _ = sqlx::query(
+                    r#"
+                    UPDATE agent_sessions
+                    SET status = 'exited', ended_at = ?1
+                    WHERE agent_id = ?2 AND status = 'running' AND ended_at IS NULL
+                    "#,
+                )
+                .bind(now)
+                .bind(agent_id)
+                .execute(&self.db)
+                .await;
+                let _ = sqlx::query(
+                    r#"
+                    UPDATE agents
+                    SET status = 'exited', updated_at = ?1
+                    WHERE id = ?2 AND status = 'running'
+                    "#,
+                )
+                .bind(now)
+                .bind(agent_id)
+                .execute(&self.db)
+                .await;
+                return Err(anyhow::anyhow!("agent not running"));
             }
         };
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -738,11 +738,37 @@ impl AgentManager {
         input: &str,
         message_id: Option<&str>,
     ) -> anyhow::Result<()> {
+        let now = Utc::now().timestamp();
         let (stdin, acp, output_tx, session_id) = {
             let guard = self.inner.read().await;
-            let handle = guard
-                .get(agent_id)
-                .ok_or_else(|| anyhow::anyhow!("agent not running"))?;
+            let handle = match guard.get(agent_id) {
+                Some(handle) => handle,
+                None => {
+                    let _ = sqlx::query(
+                        r#"
+                        UPDATE agent_sessions
+                        SET status = 'exited', ended_at = ?1
+                        WHERE agent_id = ?2 AND status = 'running' AND ended_at IS NULL
+                        "#,
+                    )
+                    .bind(now)
+                    .bind(agent_id)
+                    .execute(&self.db)
+                    .await;
+                    let _ = sqlx::query(
+                        r#"
+                        UPDATE agents
+                        SET status = 'exited', updated_at = ?1
+                        WHERE id = ?2 AND status = 'running'
+                        "#,
+                    )
+                    .bind(now)
+                    .bind(agent_id)
+                    .execute(&self.db)
+                    .await;
+                    return Err(anyhow::anyhow!("agent not running"));
+                }
+            };
             match &handle.input {
                 AgentInput::Stdin(stdin) => (Some(stdin.clone()), None, None, None),
                 AgentInput::Acp(acp) => (

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct ProxyConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CodexAcpConfig {
     pub binary: Option<String>,
+    pub default_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -134,6 +135,15 @@ impl AppConfig {
             .unwrap_or_else(|| "agenthub-codex-acp".to_string())
     }
 
+    pub fn codex_acp_default_mode(&self) -> Option<String> {
+        self.codex_acp
+            .as_ref()
+            .and_then(|c| c.default_mode.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string())
+    }
+
     pub fn proxy_env(&self) -> Vec<(String, String)> {
         let mut items = Vec::new();
         if let Some(proxy) = &self.proxy {
@@ -179,6 +189,7 @@ fn detect_env_overrides() -> Vec<String> {
         "AGENTHUB_WEB_DIR",
         "AGENTHUB_LOG_PATH",
         "AGENTHUB_CODEX_ACP_BINARY",
+        "AGENTHUB_CODEX_ACP_DEFAULT_MODE",
         "AGENTHUB_HTTP_PROXY",
         "AGENTHUB_HTTPS_PROXY",
         "AGENTHUB_ALL_PROXY",

--- a/src/db.rs
+++ b/src/db.rs
@@ -264,6 +264,7 @@ pub async fn init_db() -> anyhow::Result<SqlitePool> {
             id TEXT PRIMARY KEY,
             agent_id TEXT NOT NULL,
             session_id TEXT NOT NULL,
+            acp_session_id TEXT,
             tool_call_id TEXT,
             options_json TEXT NOT NULL,
             tool_call_json TEXT,
@@ -304,6 +305,9 @@ pub async fn init_db() -> anyhow::Result<SqlitePool> {
         .execute(&pool)
         .await;
     let _ = sqlx::query("ALTER TABLE agents ADD COLUMN code_mode INTEGER")
+        .execute(&pool)
+        .await;
+    let _ = sqlx::query("ALTER TABLE acp_permission_requests ADD COLUMN acp_session_id TEXT")
         .execute(&pool)
         .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,13 @@ async fn main() -> anyhow::Result<()> {
         web_dir.as_deref().unwrap_or("embedded")
     );
     tracing::info!("config codex_acp_binary: {}", config.codex_acp_binary());
+    tracing::info!(
+        "config codex_acp_default_mode: {}",
+        config
+            .codex_acp_default_mode()
+            .as_deref()
+            .unwrap_or("<unset>")
+    );
     tracing::info!("config vapid_subject: {}", config.vapid_subject());
     tracing::info!(
         "config vapid_keys_path: {}",

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,6 +28,7 @@ impl AppState {
             push.clone(),
             config.proxy_env(),
             config.codex_acp_binary(),
+            config.codex_acp_default_mode(),
             acp_permissions.clone(),
             auth.clone(),
         ));

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -14,11 +14,11 @@ fn styles_keep_acp_conversation_scoped() {
         "styles.css should define .acp-conversation"
     );
     assert!(
-        css.contains(".acp {\n  height: 100%;\n  min-height: 0;\n  display: flex;\n  flex-direction: column;\n  flex: 1;\n  overflow: hidden;\n}"),
-        "acp container should be flex and height constrained"
+        css.contains(".acp {\n  height: 100%;\n  min-height: 0;\n  display: grid;\n  gap: 12px;\n  grid-template-columns: minmax(0, 1fr);\n  grid-template-rows: auto minmax(0, 1fr);\n  flex: 1;\n  overflow: hidden;\n}"),
+        "acp container should be grid and height constrained"
     );
     assert!(
-        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  flex: 1 1 auto;\n  display: block;\n}"),
+        css.contains(".acp-conversation {\n  overflow: auto;\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;\n  display: block;\n}"),
         "acp conversation should be scrollable container"
     );
     assert!(

--- a/web/src/acp_panel.test.tsx
+++ b/web/src/acp_panel.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AcpPanel, AcpPanelProps } from "./components/acp_panel";
+import { AcpView } from "./acp";
+
+const baseView: AcpView = {
+  hasAcp: true,
+  toolCalls: [],
+  messages: [],
+  rawEvents: [],
+  plan: null,
+  commands: [],
+  currentMode: null,
+  runStatus: null,
+  thinkingStartTs: null,
+};
+
+const baseProps: AcpPanelProps = {
+  acpView: baseView,
+  activeSessionId: null,
+  showAcpRuntime: true,
+  thinkingStartTs: null,
+  acpTab: "conversation",
+  onSelectTab: () => {},
+  showConversationBadge: false,
+  canControlAcp: true,
+  onAcpCancel: () => {},
+  conversation: {
+    items: [],
+    windowOffset: 0,
+    isFrozenView: false,
+    shouldAutoCollapse: false,
+    collapseCutoff: 0,
+    stickToBottom: true,
+    pendingCount: 0,
+    avgHeight: 40,
+    onScroll: () => {},
+    containerRef: React.createRef<HTMLDivElement>(),
+    ansi: (input) => input,
+  },
+  debug: {
+    currentMode: null,
+    rawEvents: [],
+    acpPermissionHistory: [],
+    acpModeId: "",
+    acpModelId: "",
+    acpConfigId: "",
+    acpConfigValue: "",
+    onAcpModeIdChange: () => {},
+    onAcpModelIdChange: () => {},
+    onAcpConfigIdChange: () => {},
+    onAcpConfigValueChange: () => {},
+    canControlAcp: false,
+    onAcpSetMode: () => {},
+    onAcpSetModel: () => {},
+    onAcpSetConfig: () => {},
+    onAcpCancel: () => {},
+    onAcpClearSession: () => {},
+  },
+};
+
+const renderPanel = (override: Partial<AcpView>) =>
+  renderToStaticMarkup(
+    <AcpPanel {...baseProps} acpView={{ ...baseView, ...override }} />
+  );
+
+const interruptDisabled = (html: string) =>
+  /acp-interrupt-button[^>]*disabled/.test(html);
+
+describe("AcpPanel interrupt gating", () => {
+  it("enables interrupt when a tool call is in progress without run status", () => {
+    const html = renderPanel({
+      toolCalls: [{ id: "call-1", title: "Tool", status: "in_progress" }],
+    });
+    expect(interruptDisabled(html)).toBe(false);
+  });
+
+  it("disables interrupt when run status is non-running and no tool call active", () => {
+    const html = renderPanel({
+      runStatus: { status: "completed" },
+    });
+    expect(interruptDisabled(html)).toBe(true);
+  });
+});

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -40,7 +40,8 @@ export type AgentEvent = {
 };
 
 export type AcpPermissionOption = {
-  option_id: string;
+  option_id?: string;
+  optionId?: string;
   name: string;
   kind: string;
 };
@@ -49,6 +50,7 @@ export type AcpPermissionRecord = {
   id: string;
   agent_id: string;
   session_id: string;
+  acp_session_id?: string | null;
   tool_call_id?: string | null;
   options: AcpPermissionOption[];
   tool_call?: unknown;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -40,8 +40,7 @@ export type AgentEvent = {
 };
 
 export type AcpPermissionOption = {
-  option_id?: string;
-  optionId?: string;
+  option_id: string;
   name: string;
   kind: string;
 };

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1071,7 +1071,11 @@ export function App() {
       await api.sendInput(token, activeAgent, text, messageId ?? undefined);
       setInput("");
     } catch (err) {
-      setError(String(err || "websocket not connected"));
+      const msg = String(err || "websocket not connected");
+      setError(msg);
+      if (msg.includes(AGENT_NOT_RUNNING_ERROR)) {
+        await refreshAgents();
+      }
     }
   };
 

--- a/web/src/components/acp_panel.tsx
+++ b/web/src/components/acp_panel.tsx
@@ -30,8 +30,12 @@ export function AcpPanel({
   conversation,
   debug,
 }: AcpPanelProps) {
-  const canInterrupt =
-    canControlAcp && acpView.runStatus?.status === "running";
+  const hasInProgressToolCall = acpView.toolCalls.some(
+    (call) => call.status === "in_progress"
+  );
+  const runStatusLabel =
+    acpView.runStatus?.status ?? (hasInProgressToolCall ? "in_progress" : null);
+  const canInterrupt = canControlAcp && Boolean(runStatusLabel);
   return (
     <div className="acp">
       <div className="acp-head">
@@ -40,10 +44,8 @@ export function AcpPanel({
           {activeSessionId && (
             <span className="acp-session">{activeSessionId.slice(0, 8)}</span>
           )}
-          {showAcpRuntime && acpView.runStatus?.status && (
-            <span className={`acp-run ${acpView.runStatus.status}`}>
-              {acpView.runStatus.status}
-            </span>
+          {showAcpRuntime && runStatusLabel && (
+            <span className={`acp-run ${runStatusLabel}`}>{runStatusLabel}</span>
           )}
           {showAcpRuntime && thinkingStartTs && (
             <span className="acp-thinking">

--- a/web/src/components/acp_panel.tsx
+++ b/web/src/components/acp_panel.tsx
@@ -30,12 +30,14 @@ export function AcpPanel({
   conversation,
   debug,
 }: AcpPanelProps) {
+  const runStatus = acpView.runStatus?.status ?? null;
   const hasInProgressToolCall = acpView.toolCalls.some(
     (call) => call.status === "in_progress"
   );
   const runStatusLabel =
-    acpView.runStatus?.status ?? (hasInProgressToolCall ? "in_progress" : null);
-  const canInterrupt = canControlAcp && Boolean(runStatusLabel);
+    runStatus ?? (hasInProgressToolCall ? "in_progress" : null);
+  const isActiveRun = runStatus === "running" || hasInProgressToolCall;
+  const canInterrupt = canControlAcp && isActiveRun;
   return (
     <div className="acp">
       <div className="acp-head">

--- a/web/src/components/permission_modal.tsx
+++ b/web/src/components/permission_modal.tsx
@@ -35,7 +35,7 @@ export function PermissionModal({
                 </div>
                 <div className="options">
                   {perm.options.map((opt, idx) => {
-                    const optionId = opt.option_id ?? opt.optionId ?? "";
+                    const optionId = opt.option_id.trim();
                     return (
                       <button
                         key={optionId || `${perm.id}-${idx}`}

--- a/web/src/components/permission_modal.tsx
+++ b/web/src/components/permission_modal.tsx
@@ -34,17 +34,20 @@ export function PermissionModal({
                   <div className="meta">{perm.status}</div>
                 </div>
                 <div className="options">
-                  {perm.options.map((opt) => (
-                    <button
-                      key={opt.option_id}
-                      disabled={permissionBusy === perm.id}
-                      onClick={() =>
-                        onRespond(perm.agent_id, perm.id, opt.option_id)
-                      }
-                    >
-                      {opt.name}
-                    </button>
-                  ))}
+                  {perm.options.map((opt, idx) => {
+                    const optionId = opt.option_id ?? opt.optionId ?? "";
+                    return (
+                      <button
+                        key={optionId || `${perm.id}-${idx}`}
+                        disabled={permissionBusy === perm.id || !optionId}
+                        onClick={() =>
+                          onRespond(perm.agent_id, perm.id, optionId)
+                        }
+                      >
+                        {opt.name}
+                      </button>
+                    );
+                  })}
                   <button
                     disabled={permissionBusy === perm.id}
                     onClick={() => onRespond(perm.agent_id, perm.id)}

--- a/web/src/permission_modal.test.tsx
+++ b/web/src/permission_modal.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PermissionModal } from "./components/permission_modal";
+import { AcpPermissionRecord } from "./api";
+
+const basePermission: AcpPermissionRecord = {
+  id: "perm-1",
+  agent_id: "agent-1",
+  session_id: "session-1",
+  options: [],
+  status: "pending",
+  created_at: 1,
+};
+
+const renderModal = (permissions: AcpPermissionRecord[]) =>
+  renderToStaticMarkup(
+    <PermissionModal
+      permissions={permissions}
+      permissionBusy={null}
+      onRespond={() => {}}
+    />
+  );
+
+const hasEnabledButton = (html: string, label: string) =>
+  new RegExp(`<button(?![^>]*disabled)[^>]*>${label}</button>`).test(html);
+
+const hasDisabledButton = (html: string, label: string) =>
+  new RegExp(`<button[^>]*disabled[^>]*>${label}</button>`).test(html);
+
+describe("PermissionModal option id handling", () => {
+  it("renders enabled buttons when option_id is present", () => {
+    const html = renderModal([
+      {
+        ...basePermission,
+        options: [{ option_id: "allow_once", name: "Allow once", kind: "allow_once" }],
+      },
+    ]);
+    expect(hasEnabledButton(html, "Allow once")).toBe(true);
+  });
+
+  it("disables options with empty option IDs", () => {
+    const html = renderModal([
+      {
+        ...basePermission,
+        options: [{ option_id: "", name: "Allow once", kind: "allow_once" }],
+      },
+    ]);
+    expect(hasDisabledButton(html, "Allow once")).toBe(true);
+  });
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -502,8 +502,10 @@ select:focus-visible {
 .acp {
   height: 100%;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   flex: 1;
   overflow: hidden;
 }
@@ -513,7 +515,6 @@ select:focus-visible {
   min-height: 0;
   height: 100%;
   max-height: 100%;
-  flex: 1 1 auto;
   display: block;
 }
 
@@ -589,13 +590,6 @@ select:focus-visible {
   to {
     transform: rotate(360deg);
   }
-}
-
-
-.acp {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: minmax(0, 1fr);
 }
 
 
@@ -1015,8 +1009,9 @@ select:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  flex: 1 1 auto;
   min-height: 0;
+  height: 100%;
+  max-height: 100%;
   overflow: auto;
   padding-right: 6px;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -892,6 +892,11 @@ select:focus-visible {
   color: #1c6bb8;
 }
 
+.acp-run.in_progress {
+  background: #e7f5ff;
+  color: #1c6bb8;
+}
+
 .acp-run.completed {
   background: #def3e3;
   color: #246b38;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1065,6 +1065,19 @@ select:focus-visible {
   margin: 0 0 8px;
 }
 
+.acp-raw-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-height: 240px;
+}
+
+.acp-raw {
+  overflow: auto;
+  padding-right: 4px;
+}
+
 .acp-raw .meta {
   display: flex;
   gap: 8px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1006,6 +1006,16 @@ select:focus-visible {
   max-height: 100%;
 }
 
+.acp-debug {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 6px;
+}
+
 .acp-commands ul,
 .acp-debug ul {
   list-style: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1023,20 +1023,12 @@ select:focus-visible {
   margin: 0;
 }
 
-.acp-debug {
+.acp-raw-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  min-height: 0;
+  gap: 8px;
   flex: 1 1 auto;
-  overflow: hidden;
-}
-
-.acp-raw-wrapper {
-  min-height: 0;
-  flex: 1 1 auto;
-  overflow: auto;
-  padding-right: 6px;
+  min-height: 240px;
 }
 
 .acp-commands li,
@@ -1065,17 +1057,11 @@ select:focus-visible {
   margin: 0 0 8px;
 }
 
-.acp-raw-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  flex: 1 1 auto;
-  min-height: 240px;
-}
-
 .acp-raw {
   overflow: auto;
   padding-right: 4px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .acp-raw .meta {


### PR DESCRIPTION
## Summary
- fix ACP debug layout by using a two-row grid and explicit scroll constraints
- gate Interrupt to active runs while keeping the status badge behavior
- avoid moving permission request options/outcomes in debug events
- release agent manager locks before async DB updates on missing agents
- log ACP tool output deserialization failures instead of dropping silently
- align Codex ACP protocol handling (session list fields, tool outputs, remove `mcp-types`)
- document the changes and add verification TODOs

## Testing
- not run (UI + logic changes)