### PR TITLE
feat: use web_dir in debug builds

### DIFF
--- a/docs/features/2026-02-09-web-dir-debug-embedded-release.md
+++ b/docs/features/2026-02-09-web-dir-debug-embedded-release.md
@@ -1,0 +1,36 @@
+---
+title: Debug Uses web_dir, Release Forces Embedded Assets
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+Serve frontend assets from `web/dist` during debug builds to reflect local
+changes without forcing a Rust rebuild. Release builds always serve embedded
+assets to ensure a self-contained binary.
+
+## Background
+
+Developers often run `make run` and expect frontend changes to appear
+immediately. When assets are embedded, the Rust binary may not rebuild if only
+`web/dist` changes. This leads to confusing stale UI behavior. In production
+we still want a single binary with embedded assets.
+
+## Decision
+
+- Debug builds resolve `web_dir` to `web/dist` by default (or the configured
+  `web_dir` when provided).
+- Release builds ignore `web_dir` and always use embedded assets.
+
+## Scope
+
+- `src/config.rs`
+- `src/main.rs`
+
+## Validation
+
+- Debug: run `make run`, update a frontend file, rebuild `web/dist`, and refresh
+  the browser to confirm updates appear without rebuilding Rust.
+- Release: run a release build and confirm logs show embedded assets while the
+  UI still loads.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -35,6 +35,7 @@
 - [ ] Verify global event ordering uses `event_id` across API/SSE/polling and pagination (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify compareEventOrder is deterministic when `event_id` or `ts` is missing (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify gzip compression for static assets and JSON responses (see `docs/features/2026-02-08-gzip-compression.md`).
+- [ ] Verify debug builds serve `web/dist` and release builds force embedded assets (see `docs/features/2026-02-09-web-dir-debug-embedded-release.md`).
 - [ ] Verify db init warns on index creation failures and unexpected ALTER errors (see `docs/features/2026-02-08-db-init-index-logging.md`).
 - [ ] Verify output ordering remains stable with mixed legacy numeric and UUIDv7 seq values (see `docs/features/2026-02-08-output-ordering-mixed-seq.md`).
 - [ ] Decide whether to serialize `event_id` as a string in the web API once IDs approach JS safe integer limits (see `docs/features/2026-02-08-output-ordering-mixed-seq.md`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,13 +75,13 @@ pub fn config_path() -> std::path::PathBuf {
 impl AppConfig {
     pub fn effective_web_dir(&self) -> Option<String> {
         if cfg!(debug_assertions) {
-            let configured = self
+            let dir = self
                 .web_dir
-                .as_ref()
-                .map(|value| value.trim())
+                .as_deref()
+                .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .map(|value| value.to_string());
-            return Some(configured.unwrap_or_else(|| "web/dist".to_string()));
+                .unwrap_or("web/dist");
+            return Some(dir.to_string());
         }
         None
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,19 @@ pub fn config_path() -> std::path::PathBuf {
 }
 
 impl AppConfig {
+    pub fn effective_web_dir(&self) -> Option<String> {
+        if cfg!(debug_assertions) {
+            let configured = self
+                .web_dir
+                .as_ref()
+                .map(|value| value.trim())
+                .filter(|value| !value.is_empty())
+                .map(|value| value.to_string());
+            return Some(configured.unwrap_or_else(|| "web/dist".to_string()));
+        }
+        None
+    }
+
     pub fn listen_addr(&self) -> String {
         self.server
             .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,16 +40,20 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("config rp_name: {}", config.rp_name());
     let configured_web_dir = config
         .web_dir
-        .clone()
-        .unwrap_or_else(|| "embedded".to_string());
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     let web_dir = config.effective_web_dir();
     if !cfg!(debug_assertions) && config.web_dir.is_some() {
         tracing::info!("config web_dir ignored in release build");
     }
-    tracing::info!("config web_dir: {}", configured_web_dir);
+    tracing::info!(
+        "config web_dir: {}",
+        configured_web_dir.unwrap_or("<unset>")
+    );
     tracing::info!(
         "effective web_dir: {}",
-        web_dir.clone().unwrap_or_else(|| "embedded".to_string())
+        web_dir.as_deref().unwrap_or("embedded")
     );
     tracing::info!("config codex_acp_binary: {}", config.codex_acp_binary());
     tracing::info!("config vapid_subject: {}", config.vapid_subject());

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,12 +38,18 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("config rp_id: {}", config.rp_id());
     tracing::info!("config rp_origin: {}", config.rp_origin());
     tracing::info!("config rp_name: {}", config.rp_name());
+    let configured_web_dir = config
+        .web_dir
+        .clone()
+        .unwrap_or_else(|| "embedded".to_string());
+    let web_dir = config.effective_web_dir();
+    if !cfg!(debug_assertions) && config.web_dir.is_some() {
+        tracing::info!("config web_dir ignored in release build");
+    }
+    tracing::info!("config web_dir: {}", configured_web_dir);
     tracing::info!(
-        "config web_dir: {}",
-        config
-            .web_dir
-            .clone()
-            .unwrap_or_else(|| "embedded".to_string())
+        "effective web_dir: {}",
+        web_dir.clone().unwrap_or_else(|| "embedded".to_string())
     );
     tracing::info!("config codex_acp_binary: {}", config.codex_acp_binary());
     tracing::info!("config vapid_subject: {}", config.vapid_subject());
@@ -55,8 +61,6 @@ async fn main() -> anyhow::Result<()> {
     let state = state::AppState::init(config.clone()).await?;
 
     let api_router = api::router(state.clone());
-
-    let web_dir = config.web_dir.clone();
 
     let trace = TraceLayer::new_for_http()
         .make_span_with(DefaultMakeSpan::new().level(Level::INFO))


### PR DESCRIPTION
## Summary
- serve assets from web_dir during debug builds (default to web/dist)
- force embedded assets in release builds
- add documentation and TODO entry

## Testing
- not run (config behavior)