### PR TITLE
feat: add hourly log_path output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "toml 0.8.23",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -7141,6 +7142,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "sy
 tokio-util = { version = "0.7", features = ["compat"] }
 tower-http = { version = "0.5", features = ["fs", "trace", "cors", "compression-gzip"] }
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 web-push = "0.10"

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -412,10 +412,7 @@ impl PromptState {
     fn build_chunk_meta(&mut self, kind: &str, item_id: &str) -> Meta {
         let mut meta = Meta::new();
         let index = self.next_chunk_index(kind, item_id);
-        meta.insert(
-            "message_id".to_string(),
-            Value::String(item_id.to_string()),
-        );
+        meta.insert("message_id".to_string(), Value::String(item_id.to_string()));
         meta.insert(
             "chunk_index".to_string(),
             Value::Number(Number::from(index)),

--- a/docs/features/2026-02-09-hourly-log-path.md
+++ b/docs/features/2026-02-09-hourly-log-path.md
@@ -1,0 +1,33 @@
+---
+title: Hourly Log Files via log_path
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+Add `log_path` configuration to write all logs to hourly-rotated files.
+
+## Background
+
+When running locally or on a server, it is useful to persist logs without
+relying on stdout. This change allows operators to configure a directory
+for log files while keeping the default stdout behavior for simple setups.
+
+## Decision
+
+- Introduce a top-level `log_path` configuration key.
+- If set, log output goes to `log_path/agenthub.log.YYYY-MM-DD-HH`.
+- If unset, logs continue to go to stdout.
+- Logs are written without ANSI color codes.
+
+## Scope
+
+- `Cargo.toml`
+- `src/config.rs`
+- `src/main.rs`
+
+## Validation
+
+- Configure `log_path` and confirm log files are created hourly.
+- Start the server and verify stdout is quiet when `log_path` is set.

--- a/docs/features/2026-02-09-hourly-log-path.md
+++ b/docs/features/2026-02-09-hourly-log-path.md
@@ -6,7 +6,8 @@ status: implemented
 
 ## Summary
 
-Add `log_path` configuration to write all logs to hourly-rotated files.
+Add `log_path` configuration to write all logs to hourly-rotated files. The
+path can point to a directory or a file prefix.
 
 ## Background
 
@@ -17,7 +18,10 @@ for log files while keeping the default stdout behavior for simple setups.
 ## Decision
 
 - Introduce a top-level `log_path` configuration key.
-- If set, log output goes to `log_path/agenthub.log.YYYY-MM-DD-HH`.
+- If set to a directory, log output goes to `log_path/agenthub.log.YYYY-MM-DD-HH`.
+- If set to a file path (for example `/var/log/agenthub.log`), the parent
+  directory is used and the file name becomes the log prefix
+  (`agenthub.log.YYYY-MM-DD-HH`).
 - If unset, logs continue to go to stdout.
 - Logs are written without ANSI color codes.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -35,6 +35,7 @@
 - [ ] Verify global event ordering uses `event_id` across API/SSE/polling and pagination (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify compareEventOrder is deterministic when `event_id` or `ts` is missing (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify gzip compression for static assets and JSON responses (see `docs/features/2026-02-08-gzip-compression.md`).
+- [ ] Verify hourly `log_path` output and stdout suppression when configured (see `docs/features/2026-02-09-hourly-log-path.md`).
 - [ ] Verify debug builds serve `web/dist` and release builds force embedded assets (see `docs/features/2026-02-09-web-dir-debug-embedded-release.md`).
 - [ ] Verify db init warns on index creation failures and unexpected ALTER errors (see `docs/features/2026-02-08-db-init-index-logging.md`).
 - [ ] Verify output ordering remains stable with mixed legacy numeric and UUIDv7 seq values (see `docs/features/2026-02-08-output-ordering-mixed-seq.md`).

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -386,13 +386,13 @@ fn json_message(kind: &str, chunk: &ContentChunk) -> Value {
     obj.insert("chunk".to_string(), Value::Bool(true));
     if let Some(meta) = &chunk.meta {
         if let Some(Value::String(message_id)) = meta.get("message_id") {
-            obj.insert(
-                "message_id".to_string(),
-                Value::String(message_id.clone()),
-            );
+            obj.insert("message_id".to_string(), Value::String(message_id.clone()));
         }
         if let Some(Value::Number(chunk_index)) = meta.get("chunk_index") {
-            obj.insert("chunk_index".to_string(), Value::Number(chunk_index.clone()));
+            obj.insert(
+                "chunk_index".to_string(),
+                Value::Number(chunk_index.clone()),
+            );
         } else if let Some(Value::String(chunk_index)) = meta.get("chunk_index") {
             if let Ok(value) = chunk_index.parse::<u64>() {
                 obj.insert(

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct AppConfig {
     pub push: Option<PushConfig>,
     pub safe_paths: Option<Vec<String>>,
     pub web_dir: Option<String>,
+    pub log_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -118,6 +119,14 @@ impl AppConfig {
         self.safe_paths.clone().unwrap_or_default()
     }
 
+    pub fn log_path(&self) -> Option<String> {
+        self.log_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_tilde)
+    }
+
     pub fn codex_acp_binary(&self) -> String {
         self.codex_acp
             .as_ref()
@@ -168,6 +177,7 @@ fn detect_env_overrides() -> Vec<String> {
         "AGENTHUB_RP_NAME",
         "AGENTHUB_SAFE_PATHS",
         "AGENTHUB_WEB_DIR",
+        "AGENTHUB_LOG_PATH",
         "AGENTHUB_CODEX_ACP_BINARY",
         "AGENTHUB_HTTP_PROXY",
         "AGENTHUB_HTTPS_PROXY",
@@ -180,4 +190,15 @@ fn detect_env_overrides() -> Vec<String> {
         .filter(|key| std::env::var(key).ok().filter(|v| !v.is_empty()).is_some())
         .map(|key| key.to_string())
         .collect()
+}
+
+fn expand_tilde(path: &str) -> String {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        return std::path::Path::new(&home)
+            .join(stripped)
+            .to_string_lossy()
+            .to_string();
+    }
+    path.to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,12 +193,18 @@ fn detect_env_overrides() -> Vec<String> {
 }
 
 fn expand_tilde(path: &str) -> String {
-    if let Some(stripped) = path.strip_prefix("~/") {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        return std::path::Path::new(&home)
-            .join(stripped)
-            .to_string_lossy()
-            .to_string();
+    if path == "~" {
+        std::env::var("HOME").unwrap_or_else(|_| path.to_string())
+    } else if let Some(stripped) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            std::path::Path::new(&home)
+                .join(stripped)
+                .to_string_lossy()
+                .to_string()
+        } else {
+            path.to_string()
+        }
+    } else {
+        path.to_string()
     }
-    path.to_string()
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -195,7 +195,10 @@ pub async fn init_db() -> anyhow::Result<SqlitePool> {
     .execute(&pool)
     .await
     {
-        tracing::warn!("db init: failed to create idx_agent_events_agent_seq: {}", err);
+        tracing::warn!(
+            "db init: failed to create idx_agent_events_agent_seq: {}",
+            err
+        );
     }
     if let Err(err) = sqlx::query(
         r#"
@@ -220,7 +223,10 @@ pub async fn init_db() -> anyhow::Result<SqlitePool> {
     .execute(&pool)
     .await
     {
-        tracing::warn!("db init: failed to create idx_agent_events_agent_id: {}", err);
+        tracing::warn!(
+            "db init: failed to create idx_agent_events_agent_id: {}",
+            err
+        );
     }
     if let Err(err) = sqlx::query(
         r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,31 @@ mod sse;
 mod state;
 mod web;
 
+fn split_log_path(path: &str) -> (std::path::PathBuf, String) {
+    let path_buf = std::path::Path::new(path);
+    if path_buf.extension().is_some() {
+        let file_name = path_buf
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("agenthub.log")
+            .to_string();
+        let dir = path_buf
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        return (dir.to_path_buf(), file_name);
+    }
+    (path_buf.to_path_buf(), "agenthub.log".to_string())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let (config, info) = config::AppConfig::load_with_info()?;
     let log_path = config.log_path();
-    let _log_guard = if let Some(path) = &log_path {
-        std::fs::create_dir_all(path)?;
-        let file_appender = tracing_appender::rolling::hourly(path, "agenthub.log");
+    let log_spec = log_path.as_deref().map(split_log_path);
+    let _log_guard = if let Some((dir, file_name)) = log_spec.as_ref() {
+        std::fs::create_dir_all(dir)?;
+        let file_appender = tracing_appender::rolling::hourly(dir, file_name.as_str());
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         tracing_subscriber::fmt()
             .with_env_filter(filter)
@@ -48,10 +65,16 @@ async fn main() -> anyhow::Result<()> {
         tracing::warn!("env overrides ignored: {}", info.env_overrides.join(", "));
     }
     tracing::info!("config listen: {}", config.listen_addr());
-    tracing::info!(
-        "config log_path: {}",
-        log_path.as_deref().unwrap_or("<stdout>")
-    );
+    if let Some((dir, file_name)) = log_spec.as_ref() {
+        tracing::info!(
+            "config log_path: {} (dir {}, file {})",
+            log_path.as_deref().unwrap_or("<stdout>"),
+            dir.display(),
+            file_name
+        );
+    } else {
+        tracing::info!("config log_path: <stdout>");
+    }
     tracing::info!("config rp_id: {}", config.rp_id());
     tracing::info!("config rp_origin: {}", config.rp_origin());
     tracing::info!("config rp_name: {}", config.rp_name());

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,22 @@ mod web;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    tracing_subscriber::fmt().with_env_filter(filter).init();
-
     let (config, info) = config::AppConfig::load_with_info()?;
+    let log_path = config.log_path();
+    let _log_guard = if let Some(path) = &log_path {
+        std::fs::create_dir_all(path)?;
+        let file_appender = tracing_appender::rolling::hourly(path, "agenthub.log");
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .init();
+        Some(guard)
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+        None
+    };
     if info.file_exists {
         tracing::info!("config source: file");
         tracing::info!("config path: {}", info.path.display());
@@ -35,6 +48,10 @@ async fn main() -> anyhow::Result<()> {
         tracing::warn!("env overrides ignored: {}", info.env_overrides.join(", "));
     }
     tracing::info!("config listen: {}", config.listen_addr());
+    tracing::info!(
+        "config log_path: {}",
+        log_path.as_deref().unwrap_or("<stdout>")
+    );
     tracing::info!("config rp_id: {}", config.rp_id());
     tracing::info!("config rp_origin: {}", config.rp_origin());
     tracing::info!("config rp_name: {}", config.rp_name());


### PR DESCRIPTION
## Summary
- add `log_path` config for hourly-rotated log files
- write logs to file when configured, otherwise stdout
- document behavior and add TODO

## Testing
- not run (config/logging change)