### PR TITLE
feat: add Mantine UI library POC

### DIFF
--- a/docs/features/2026-02-09-mantine-ui-library.md
+++ b/docs/features/2026-02-09-mantine-ui-library.md
@@ -1,0 +1,43 @@
+---
+title: Mantine UI Library POC
+date: 2026-02-09
+status: implemented
+---
+
+## Summary
+
+Introduce Mantine as the first UI library experiment for AgentHub, adding a
+shared theme and migrating key modals to Mantine components to standardize
+inputs, buttons, and layout primitives.
+
+## Background
+
+The web UI relies on bespoke HTML and CSS. Adding new flows requires repeating
+form styles and modal layouts. A component library should reduce duplication and
+make UI development more consistent.
+
+## Decision
+
+- Add `@mantine/core` and `@mantine/hooks` to the web dependencies.
+- Wrap the app in `MantineProvider` with a theme aligned to existing typography
+  and radius tokens.
+- Migrate the Create Agent and Permission Requests modals to Mantine components.
+- Keep existing layout CSS while scoping base element styles to avoid overriding
+  Mantine styling.
+
+## Scope
+
+- `web/package.json`
+- `web/src/main.tsx`
+- `web/src/ui/mantine_theme.ts`
+- `web/src/components/create_agent_modal.tsx`
+- `web/src/components/permission_modal.tsx`
+- `web/src/styles.css`
+- `web/src/permission_modal.test.tsx`
+
+## Validation
+
+- Run `npm install` in `web/` to refresh dependencies.
+- Run `npm run dev` and confirm the Create Agent and Permission modals render
+  with Mantine styling.
+- Verify permission options with empty `option_id` remain disabled.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify Mantine UI library POC styling and modal behavior (see `docs/features/2026-02-09-mantine-ui-library.md`).
 - [ ] Refresh codex git dependencies and `Cargo.lock` after ACP protocol sync (see `docs/features/2026-02-09-codex-acp-protocol-sync.md`).
 - [ ] Verify ACP debug layout, interrupt gating, permission debug events, and tool output logging (see `docs/features/2026-02-09-acp-debug-layout-fixes.md`).
 - [ ] Verify single-instance agent start, ACP timeout cleanup, and SQLite WAL settings (see `docs/features/2026-02-08-backend-stability-hardening.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,9 @@
 # TODO
 
 - [ ] Verify Mantine UI library POC styling and modal behavior (see `docs/features/2026-02-09-mantine-ui-library.md`).
+- [ ] Decide and document MCP configuration source for ACP sessions (Codex config vs AgentHub config).
+- [ ] Investigate ACP output formatting for large chunked messages (e.g., shiro sessions) and fix cache retention/rendering.
+- [ ] Add ACP support for Gemini and Kimi providers, including config wiring and documentation.
 - [ ] Refresh codex git dependencies and `Cargo.lock` after ACP protocol sync (see `docs/features/2026-02-09-codex-acp-protocol-sync.md`).
 - [ ] Verify ACP debug layout, interrupt gating, permission debug events, and tool output logging (see `docs/features/2026-02-09-acp-debug-layout-fixes.md`).
 - [ ] Verify single-instance agent start, ACP timeout cleanup, and SQLite WAL settings (see `docs/features/2026-02-08-backend-stability-hardening.md`).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,8 +8,8 @@
       "name": "agenthub-web",
       "version": "0.1.0",
       "dependencies": {
-        "@mantine/core": "^7.0.0",
-        "@mantine/hooks": "^7.0.0",
+        "@mantine/core": "7.17.8",
+        "@mantine/hooks": "7.17.8",
         "bootstrap-icons": "^1.11.3",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.1.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "agenthub-web",
       "version": "0.1.0",
       "dependencies": {
+        "@mantine/core": "^7.0.0",
+        "@mantine/hooks": "^7.0.0",
         "bootstrap-icons": "^1.11.3",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.1.0",
@@ -263,6 +265,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -866,6 +877,59 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -976,6 +1040,34 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mantine/core": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.28",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.3",
+        "react-remove-scroll": "^2.6.2",
+        "react-textarea-autosize": "8.5.9",
+        "type-fest": "^4.27.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "7.17.8",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
+      "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1479,14 +1571,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2319,6 +2411,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2370,7 +2471,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2496,6 +2597,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -3474,6 +3581,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -4940,6 +5056,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-number-format": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
+      "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4948,6 +5074,92 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5608,6 +5820,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5685,6 +5903,12 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5696,6 +5920,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -5854,6 +6090,94 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/uuidv7": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@mantine/core": "^7.0.0",
-    "@mantine/hooks": "^7.0.0",
+    "@mantine/core": "7.17.8",
+    "@mantine/hooks": "7.17.8",
     "bootstrap-icons": "^1.11.3",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mantine/core": "^7.0.0",
+    "@mantine/hooks": "^7.0.0",
     "bootstrap-icons": "^1.11.3",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.0",

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Button,
   Group,
+  List,
   Modal,
   Select,
   SimpleGrid,
@@ -140,11 +141,15 @@ export function CreateAgentModal({
         {worktreeError ? (
           <Alert color="red" title="Worktree Setup Failed" variant="light">
             <Text size="sm">{worktreeError}</Text>
-            <ul>
-              <li>Check Safe Paths for the workdir and repo path.</li>
-              <li>Ensure the workdir is empty when creating a worktree.</li>
-              <li>Verify the git repo exists and the ref is valid.</li>
-            </ul>
+            <List size="sm" spacing="xs" mt="xs" withPadding>
+              <List.Item>Check Safe Paths for the workdir and repo path.</List.Item>
+              <List.Item>
+                Ensure the workdir is empty when creating a worktree.
+              </List.Item>
+              <List.Item>
+                Verify the git repo exists and the ref is valid.
+              </List.Item>
+            </List>
           </Alert>
         ) : null}
 

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -62,7 +62,7 @@ export function CreateAgentModal({
   codeMode,
   setCodeMode,
   worktreeError,
-  withinPortal,
+  withinPortal = true,
   onCreateAgent,
   onClose,
 }: CreateAgentModalProps) {

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -73,6 +73,9 @@ export function CreateAgentModal({
       title="Create Agent"
       size="lg"
       radius="md"
+      withCloseButton={false}
+      closeOnEscape={false}
+      closeOnClickOutside={false}
       withinPortal={withinPortal}
       overlayProps={{ backgroundOpacity: 0.35, blur: 2 }}
     >
@@ -95,6 +98,7 @@ export function CreateAgentModal({
             placeholder="Select worktree mode"
             value={worktreeMode}
             data={worktreeOptions}
+            allowDeselect={false}
             onChange={(value) => {
               if (
                 value === "use_existing" ||
@@ -127,6 +131,7 @@ export function CreateAgentModal({
             placeholder="Select command"
             value={agentCommand}
             data={commandOptions}
+            allowDeselect={false}
             onChange={(value) => {
               if (value) {
                 setAgentCommand(value);

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -1,4 +1,16 @@
 import React from "react";
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  Select,
+  SimpleGrid,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
 
 type CreateAgentModalProps = {
   agentName: string;
@@ -22,6 +34,16 @@ type CreateAgentModalProps = {
   onClose: () => void;
 };
 
+const worktreeOptions = [
+  { value: "use_existing", label: "Use existing workdir" },
+  { value: "create_worktree", label: "Create git worktree" },
+  { value: "reuse_worktree", label: "Reuse git worktree" },
+];
+
+const commandOptions = [
+  { value: "agenthub-codex-acp", label: "agenthub-codex-acp" },
+];
+
 export function CreateAgentModal({
   agentName,
   setAgentName,
@@ -42,92 +64,95 @@ export function CreateAgentModal({
   onClose,
 }: CreateAgentModalProps) {
   return (
-    <div className="modal-backdrop">
-      <div className="modal">
-        <div className="modal-head">
-          <h3>Create Agent</h3>
-          <button className="ghost" onClick={onClose}>
-            Close
-          </button>
-        </div>
-        <div className="modal-body">
-          <div className="form-grid">
-            <input
-              placeholder="Agent name"
-              value={agentName}
-              onChange={(e) => setAgentName(e.target.value)}
-            />
-            <input
-              placeholder="Workdir"
-              value={agentWorkdir}
-              onChange={(e) => setAgentWorkdir(e.target.value)}
-            />
-            <select
-              value={worktreeMode}
-              onChange={(e) =>
+    <Modal
+      opened
+      onClose={onClose}
+      title="Create Agent"
+      size="lg"
+      radius="md"
+      overlayProps={{ backgroundOpacity: 0.35, blur: 2 }}
+    >
+      <Stack gap="sm">
+        <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+          <TextInput
+            label="Agent name"
+            placeholder="Agent name"
+            value={agentName}
+            onChange={(event) => setAgentName(event.currentTarget.value)}
+          />
+          <TextInput
+            label="Workdir"
+            placeholder="Workdir"
+            value={agentWorkdir}
+            onChange={(event) => setAgentWorkdir(event.currentTarget.value)}
+          />
+          <Select
+            label="Worktree mode"
+            placeholder="Select worktree mode"
+            value={worktreeMode}
+            data={worktreeOptions}
+            onChange={(value) => {
+              if (value) {
                 setWorktreeMode(
-                  e.target.value as
-                    | "use_existing"
-                    | "create_worktree"
-                    | "reuse_worktree"
-                )
+                  value as "use_existing" | "create_worktree" | "reuse_worktree"
+                );
               }
-            >
-              <option value="use_existing">Use existing workdir</option>
-              <option value="create_worktree">Create git worktree</option>
-              <option value="reuse_worktree">Reuse git worktree</option>
-            </select>
-            {(worktreeMode === "create_worktree" ||
-              worktreeMode === "reuse_worktree") && (
-              <input
-                placeholder="Worktree repo path"
-                value={worktreeRepo}
-                onChange={(e) => setWorktreeRepo(e.target.value)}
-              />
-            )}
-            {worktreeMode === "create_worktree" && (
-              <input
-                placeholder="Worktree ref (branch or commit)"
-                value={worktreeRef}
-                onChange={(e) => setWorktreeRef(e.target.value)}
-              />
-            )}
-            <select
-              value={agentCommand}
-              onChange={(e) => setAgentCommand(e.target.value)}
-            >
-              <option value="agenthub-codex-acp">agenthub-codex-acp</option>
-            </select>
-          </div>
-          <div className="checkbox-row">
-            <label className="checkbox">
-              <input
-                type="checkbox"
-                checked={codeMode}
-                onChange={(e) => setCodeMode(e.target.checked)}
-              />
-              <span>Code mode</span>
-            </label>
-          </div>
-          {worktreeError && (
-            <div className="worktree-error">
-              <h4>Worktree Setup Failed</h4>
-              <p>{worktreeError}</p>
-              <ul>
-                <li>Check Safe Paths for the workdir and repo path.</li>
-                <li>Ensure the workdir is empty when creating a worktree.</li>
-                <li>Verify the git repo exists and the ref is valid.</li>
-              </ul>
-            </div>
-          )}
-        </div>
-        <div className="modal-actions">
-          <button onClick={onCreateAgent}>Create Agent</button>
-          <button className="ghost" onClick={onClose}>
+            }}
+          />
+          {worktreeMode === "create_worktree" ||
+          worktreeMode === "reuse_worktree" ? (
+            <TextInput
+              label="Worktree repo path"
+              placeholder="Worktree repo path"
+              value={worktreeRepo}
+              onChange={(event) => setWorktreeRepo(event.currentTarget.value)}
+            />
+          ) : null}
+          {worktreeMode === "create_worktree" ? (
+            <TextInput
+              label="Worktree ref"
+              placeholder="Worktree ref (branch or commit)"
+              value={worktreeRef}
+              onChange={(event) => setWorktreeRef(event.currentTarget.value)}
+            />
+          ) : null}
+          <Select
+            label="Agent command"
+            placeholder="Select command"
+            value={agentCommand}
+            data={commandOptions}
+            onChange={(value) => {
+              if (value) {
+                setAgentCommand(value);
+              }
+            }}
+          />
+        </SimpleGrid>
+
+        <Switch
+          label="Code mode"
+          checked={codeMode}
+          onChange={(event) => setCodeMode(event.currentTarget.checked)}
+        />
+
+        {worktreeError ? (
+          <Alert color="red" title="Worktree Setup Failed" variant="light">
+            <Text size="sm">{worktreeError}</Text>
+            <ul>
+              <li>Check Safe Paths for the workdir and repo path.</li>
+              <li>Ensure the workdir is empty when creating a worktree.</li>
+              <li>Verify the git repo exists and the ref is valid.</li>
+            </ul>
+          </Alert>
+        ) : null}
+
+        <Group justify="flex-end" mt="xs">
+          <Button onClick={onCreateAgent}>Create Agent</Button>
+          <Button variant="default" onClick={onClose}>
             Cancel
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -92,10 +92,12 @@ export function CreateAgentModal({
             value={worktreeMode}
             data={worktreeOptions}
             onChange={(value) => {
-              if (value) {
-                setWorktreeMode(
-                  value as "use_existing" | "create_worktree" | "reuse_worktree"
-                );
+              if (
+                value === "use_existing" ||
+                value === "create_worktree" ||
+                value === "reuse_worktree"
+              ) {
+                setWorktreeMode(value);
               }
             }}
           />

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -31,6 +31,7 @@ type CreateAgentModalProps = {
   codeMode: boolean;
   setCodeMode: (value: boolean) => void;
   worktreeError: string | null;
+  withinPortal?: boolean;
   onCreateAgent: () => void;
   onClose: () => void;
 };
@@ -61,6 +62,7 @@ export function CreateAgentModal({
   codeMode,
   setCodeMode,
   worktreeError,
+  withinPortal,
   onCreateAgent,
   onClose,
 }: CreateAgentModalProps) {
@@ -71,6 +73,7 @@ export function CreateAgentModal({
       title="Create Agent"
       size="lg"
       radius="md"
+      withinPortal={withinPortal}
       overlayProps={{ backgroundOpacity: 0.35, blur: 2 }}
     >
       <Stack gap="sm">

--- a/web/src/components/permission_modal.tsx
+++ b/web/src/components/permission_modal.tsx
@@ -1,65 +1,83 @@
 import React from "react";
+import { Badge, Button, Card, Group, Modal, Stack, Text } from "@mantine/core";
 import { AcpPermissionRecord } from "../api";
 
 type PermissionModalProps = {
   permissions: AcpPermissionRecord[];
   permissionBusy: string | null;
   onRespond: (agentId: string, permissionId: string, optionId?: string) => void;
+  withinPortal?: boolean;
 };
 
 export function PermissionModal({
   permissions,
   permissionBusy,
   onRespond,
+  withinPortal = true,
 }: PermissionModalProps) {
   return (
-    <div className="modal-backdrop">
-      <div className="modal">
-        <div className="modal-head">
-          <h3>Permission Requests</h3>
-          <span className="badge">{permissions.length}</span>
-        </div>
-        <div className="modal-body">
-          {permissions.map((perm) => {
-            const toolCall = perm.tool_call as {
-              title?: string;
-              tool_call_id?: string;
-            } | null;
-            const title =
-              toolCall?.title ?? perm.tool_call_id ?? "Permission Request";
-            return (
-              <div key={perm.id} className="acp-permission">
-                <div className="head">
-                  <div className="title">{title}</div>
-                  <div className="meta">{perm.status}</div>
-                </div>
-                <div className="options">
-                  {perm.options.map((opt, idx) => {
-                    const optionId = opt.option_id.trim();
-                    return (
-                      <button
-                        key={optionId || `${perm.id}-${idx}`}
-                        disabled={permissionBusy === perm.id || !optionId}
-                        onClick={() =>
-                          onRespond(perm.agent_id, perm.id, optionId)
-                        }
-                      >
-                        {opt.name}
-                      </button>
-                    );
-                  })}
-                  <button
-                    disabled={permissionBusy === perm.id}
-                    onClick={() => onRespond(perm.agent_id, perm.id)}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
+    <Modal
+      opened
+      onClose={() => {}}
+      withCloseButton={false}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      withinPortal={withinPortal}
+      title={
+        <Group gap="xs">
+          <Text fw={600}>Permission Requests</Text>
+          <Badge variant="light">{permissions.length}</Badge>
+        </Group>
+      }
+      size="lg"
+      radius="md"
+      overlayProps={{ backgroundOpacity: 0.35, blur: 2 }}
+    >
+      <Stack gap="sm">
+        {permissions.map((perm) => {
+          const toolCall = perm.tool_call as {
+            title?: string;
+            tool_call_id?: string;
+          } | null;
+          const title =
+            toolCall?.title ?? perm.tool_call_id ?? "Permission Request";
+          return (
+            <Card key={perm.id} withBorder radius="md" padding="sm">
+              <Group justify="space-between" align="center">
+                <Text fw={600}>{title}</Text>
+                <Badge variant="outline" size="sm">
+                  {perm.status}
+                </Badge>
+              </Group>
+              <Group gap="xs" mt="sm" wrap="wrap">
+                {perm.options.map((opt, idx) => {
+                  const optionId = opt.option_id.trim();
+                  return (
+                    <Button
+                      key={optionId || `${perm.id}-${idx}`}
+                      size="xs"
+                      disabled={permissionBusy === perm.id || !optionId}
+                      onClick={() =>
+                        onRespond(perm.agent_id, perm.id, optionId)
+                      }
+                    >
+                      {opt.name}
+                    </Button>
+                  );
+                })}
+                <Button
+                  size="xs"
+                  variant="default"
+                  disabled={permissionBusy === perm.id}
+                  onClick={() => onRespond(perm.agent_id, perm.id)}
+                >
+                  Cancel
+                </Button>
+              </Group>
+            </Card>
+          );
+        })}
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/create_agent_modal.test.tsx
+++ b/web/src/create_agent_modal.test.tsx
@@ -20,6 +20,7 @@ const baseProps = {
   codeMode: false,
   setCodeMode: () => {},
   worktreeError: null as string | null,
+  withinPortal: false,
   onCreateAgent: () => {},
   onClose: () => {},
 };

--- a/web/src/create_agent_modal.test.tsx
+++ b/web/src/create_agent_modal.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { CreateAgentModal } from "./components/create_agent_modal";
+
+const baseProps = {
+  agentName: "",
+  setAgentName: () => {},
+  agentWorkdir: "",
+  setAgentWorkdir: () => {},
+  agentCommand: "agenthub-codex-acp",
+  setAgentCommand: () => {},
+  worktreeMode: "use_existing" as const,
+  setWorktreeMode: () => {},
+  worktreeRepo: "",
+  setWorktreeRepo: () => {},
+  worktreeRef: "",
+  setWorktreeRef: () => {},
+  codeMode: false,
+  setCodeMode: () => {},
+  worktreeError: null as string | null,
+  onCreateAgent: () => {},
+  onClose: () => {},
+};
+
+const renderModal = (overrides?: Partial<typeof baseProps>) =>
+  renderToStaticMarkup(
+    <MantineProvider>
+      <CreateAgentModal {...baseProps} {...overrides} />
+    </MantineProvider>
+  );
+
+describe("CreateAgentModal", () => {
+  it("renders repo and ref inputs for create_worktree", () => {
+    const html = renderModal({ worktreeMode: "create_worktree" });
+    expect(html).toContain("Worktree repo path");
+    expect(html).toContain("Worktree ref");
+  });
+
+  it("renders repo input only for reuse_worktree", () => {
+    const html = renderModal({ worktreeMode: "reuse_worktree" });
+    expect(html).toContain("Worktree repo path");
+    expect(html).not.toContain("Worktree ref");
+  });
+
+  it("hides worktree inputs for use_existing", () => {
+    const html = renderModal({ worktreeMode: "use_existing" });
+    expect(html).not.toContain("Worktree repo path");
+    expect(html).not.toContain("Worktree ref");
+  });
+
+  it("renders error alert and guidance list when worktreeError is set", () => {
+    const html = renderModal({ worktreeError: "Worktree missing" });
+    expect(html).toContain("Worktree Setup Failed");
+    expect(html).toContain("Worktree missing");
+    expect(html).toContain("Check Safe Paths for the workdir and repo path.");
+  });
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
 import { App } from "./app";
 import "highlight.js/styles/github-dark.css";
-import "./styles.css";
+import "@mantine/core/styles.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
+import "./styles.css";
+import { mantineTheme } from "./ui/mantine_theme";
 
 const root = document.getElementById("root");
 if (!root) {
@@ -12,6 +15,8 @@ if (!root) {
 
 createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <MantineProvider theme={mantineTheme}>
+      <App />
+    </MantineProvider>
   </React.StrictMode>
 );

--- a/web/src/permission_modal.test.tsx
+++ b/web/src/permission_modal.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
 import { PermissionModal } from "./components/permission_modal";
 import { AcpPermissionRecord } from "./api";
 
@@ -15,18 +16,40 @@ const basePermission: AcpPermissionRecord = {
 
 const renderModal = (permissions: AcpPermissionRecord[]) =>
   renderToStaticMarkup(
-    <PermissionModal
-      permissions={permissions}
-      permissionBusy={null}
-      onRespond={() => {}}
-    />
+    <MantineProvider>
+      <PermissionModal
+        permissions={permissions}
+        permissionBusy={null}
+        onRespond={() => {}}
+        withinPortal={false}
+      />
+    </MantineProvider>
   );
 
-const hasEnabledButton = (html: string, label: string) =>
-  new RegExp(`<button(?![^>]*disabled)[^>]*>${label}</button>`).test(html);
+const findButtonHtml = (html: string, label: string) => {
+  const labelIndex = html.indexOf(label);
+  if (labelIndex < 0) return null;
+  const start = html.lastIndexOf("<button", labelIndex);
+  if (start < 0) return null;
+  const end = html.indexOf("</button>", labelIndex);
+  if (end < 0) return null;
+  return html.slice(start, end + "</button>".length);
+};
 
-const hasDisabledButton = (html: string, label: string) =>
-  new RegExp(`<button[^>]*disabled[^>]*>${label}</button>`).test(html);
+const isDisabledButton = (buttonHtml: string) =>
+  /(?:\s|^)disabled(?:\s|=|>)/.test(buttonHtml) ||
+  /aria-disabled=["']true["']/.test(buttonHtml) ||
+  /data-disabled=["']true["']/.test(buttonHtml);
+
+const hasEnabledButton = (html: string, label: string) => {
+  const button = findButtonHtml(html, label);
+  return Boolean(button) && !isDisabledButton(button);
+};
+
+const hasDisabledButton = (html: string, label: string) => {
+  const button = findButtonHtml(html, label);
+  return Boolean(button) && isDisabledButton(button);
+};
 
 describe("PermissionModal option id handling", () => {
   it("renders enabled buttons when option_id is present", () => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -205,7 +205,7 @@ section {
   min-height: 0;
 }
 
-input {
+input:not([class*="mantine-"]) {
   width: 100%;
   padding: 10px;
   border-radius: var(--radius-sm);
@@ -217,7 +217,7 @@ input {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-textarea {
+textarea:not([class*="mantine-"]) {
   width: 100%;
   padding: 12px;
   border-radius: var(--radius-sm);
@@ -232,7 +232,7 @@ textarea {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-select {
+select:not([class*="mantine-"]) {
   width: 100%;
   padding: 10px;
   border-radius: var(--radius-sm);
@@ -244,7 +244,7 @@ select {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-button {
+button:not([class*="mantine-"]) {
   border: none;
   background: var(--ink);
   color: white;
@@ -290,7 +290,7 @@ select:focus-visible {
   position: relative;
 }
 
-.input button {
+.input button:not([class*="mantine-"]) {
   height: 44px;
 }
 
@@ -1463,11 +1463,11 @@ select:focus-visible {
     flex-direction: column;
   }
 
-  .input.docked textarea {
+  .input.docked textarea:not([class*="mantine-"]) {
     min-height: 80px;
   }
 
-  .input.docked button {
+  .input.docked button:not([class*="mantine-"]) {
     height: 38px;
     font-size: 12px;
     padding: 6px 10px;
@@ -1495,11 +1495,11 @@ select:focus-visible {
   min-height: 220px;
 }
 
-ul {
+ul:not([class*="mantine-"]) {
   padding-left: 18px;
 }
 
-li {
+li:not([class*="mantine-"]) {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1553,7 +1553,7 @@ li {
   grid-template-columns: 1fr;
 }
 
-li button {
+li:not([class*="mantine-"]) button:not([class*="mantine-"]) {
   background: #444;
   padding: 4px 8px;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -256,19 +256,19 @@ button:not([class*="mantine-"]) {
   transition: transform 0.1s ease, box-shadow 0.15s ease;
 }
 
-button:active {
+button:not([class*="mantine-"]):active {
   transform: translateY(1px);
 }
 
-button:disabled {
+button:not([class*="mantine-"]):disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible {
+button:not([class*="mantine-"]):focus-visible,
+input:not([class*="mantine-"]):focus-visible,
+textarea:not([class*="mantine-"]):focus-visible,
+select:not([class*="mantine-"]):focus-visible {
   outline: none;
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
@@ -1342,29 +1342,6 @@ select:focus-visible {
 
 .mono {
   font-family: "Source Code Pro", monospace;
-}
-
-.worktree-error {
-  margin-top: 16px;
-  padding: 14px 16px;
-  border-radius: 12px;
-  background: #fff3f3;
-  border: 1px solid #f2b1b1;
-  color: #7b1c1c;
-}
-
-.worktree-error h4 {
-  margin: 0 0 6px;
-  font-size: 14px;
-}
-
-.worktree-error p {
-  margin: 0 0 8px;
-}
-
-.worktree-error ul {
-  margin: 0;
-  padding-left: 18px;
 }
 
 .checkbox-row.compact {

--- a/web/src/ui/mantine_theme.ts
+++ b/web/src/ui/mantine_theme.ts
@@ -1,4 +1,4 @@
-import { MantineThemeOverride } from "@mantine/core";
+import type { MantineThemeOverride } from "@mantine/core";
 
 export const mantineTheme: MantineThemeOverride = {
   fontFamily: '"Space Grotesk", system-ui, sans-serif',

--- a/web/src/ui/mantine_theme.ts
+++ b/web/src/ui/mantine_theme.ts
@@ -1,0 +1,33 @@
+import { MantineThemeOverride } from "@mantine/core";
+
+export const mantineTheme: MantineThemeOverride = {
+  fontFamily: '"Space Grotesk", system-ui, sans-serif',
+  fontFamilyMonospace:
+    '"Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  primaryColor: "brand",
+  primaryShade: 6,
+  defaultRadius: "sm",
+  radius: {
+    sm: "8px",
+    md: "10px",
+    lg: "16px",
+  },
+  colors: {
+    brand: [
+      "#eef4f8",
+      "#d9e7f2",
+      "#b3cde4",
+      "#8cb3d5",
+      "#669ac7",
+      "#3f80b8",
+      "#24689f",
+      "#1b3a57",
+      "#143045",
+      "#0f2435",
+    ],
+  },
+  headings: {
+    fontFamily: '"Space Grotesk", system-ui, sans-serif',
+    fontWeight: "600",
+  },
+};


### PR DESCRIPTION
## Summary
- add Mantine provider + theme
- migrate Create Agent and Permission modals to Mantine components
- scope legacy global styles to avoid overriding Mantine

## Testing
- npm run build
- npm run test
- npm run lint
