### PR TITLE
ci: upload Rust coverage report to Codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,10 +5,6 @@ on:
     branches: ["main"]
   pull_request:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   rust:
     name: Rust
@@ -40,11 +36,11 @@ jobs:
         working-directory: web
       - name: Generate Rust coverage report
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
-      - name: Upload Rust coverage to Codecov
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           flags: rust
           name: rust-coverage
-          use_oidc: true
           fail_ci_if_error: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   rust:
     name: Rust
@@ -16,6 +20,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install LLVM tools
+        run: rustup component add llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Setup Node
@@ -30,5 +38,13 @@ jobs:
       - name: Build web dist
         run: npm run build
         working-directory: web
-      - name: Test
-        run: cargo test --all
+      - name: Generate Rust coverage report
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Upload Rust coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: rust
+          name: rust-coverage
+          use_oidc: true
+          fail_ci_if_error: false

--- a/docs/features/2026-02-13-codecov-rust-coverage.md
+++ b/docs/features/2026-02-13-codecov-rust-coverage.md
@@ -13,7 +13,7 @@ Coverage trends were not visible in CI because the Rust pipeline only ran tests 
 ## Key Decisions
 
 - Use `cargo-llvm-cov` to generate coverage in `lcov` format from the Rust workspace.
-- Upload with `codecov/codecov-action@v5` using OIDC (`use_oidc: true`) to avoid hard-coding tokens in workflow config.
+- Upload with `codecov/codecov-action@v5` using repository secret `CODECOV_TOKEN`.
 - Keep `fail_ci_if_error: false` initially so CI remains usable while Codecov permissions are being verified.
 
 ## Validation

--- a/docs/features/2026-02-13-codecov-rust-coverage.md
+++ b/docs/features/2026-02-13-codecov-rust-coverage.md
@@ -1,0 +1,28 @@
+# Codecov Rust Coverage Upload
+
+## Background
+
+Coverage trends were not visible in CI because the Rust pipeline only ran tests and did not publish a coverage report.
+
+## Scope
+
+- Generate an `lcov` report from Rust tests in the existing Rust workflow.
+- Upload the generated report to Codecov so coverage can be tracked per run.
+- Keep the workflow split model (`Rust`/`Web`/`Web E2E`) unchanged.
+
+## Key Decisions
+
+- Use `cargo-llvm-cov` to generate coverage in `lcov` format from the Rust workspace.
+- Upload with `codecov/codecov-action@v5` using OIDC (`use_oidc: true`) to avoid hard-coding tokens in workflow config.
+- Keep `fail_ci_if_error: false` initially so CI remains usable while Codecov permissions are being verified.
+
+## Validation
+
+- In GitHub Actions `Rust` workflow:
+  - `Generate Rust coverage report` should produce `lcov.info`.
+  - `Upload Rust coverage to Codecov` should complete and publish the report with the `rust` flag.
+
+## Follow-ups
+
+- Add Web coverage upload once `vitest` coverage dependencies are available in CI and lockfile updates can be committed.
+- Consider changing `fail_ci_if_error` to `true` after Codecov integration is stable.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,7 @@
 # TODO
 
+- [ ] Verify Rust Codecov upload appears with the `rust` flag on push and pull request runs (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
+- [ ] Add Web test coverage upload to Codecov after enabling Vitest coverage dependency management in CI (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
 - [ ] Verify Gemini preset event streaming and session clearing (see `docs/features/2026-02-10-acp-gemini-kimi.md`).
 - [ ] Verify Kimi preset event streaming and session clearing (see `docs/features/2026-02-10-acp-gemini-kimi.md`).
 - [ ] Verify `acp/session/clear` defaults provider based on agent command when omitted (see `docs/features/2026-02-10-acp-gemini-kimi.md`).


### PR DESCRIPTION
## Summary
- add Rust CI coverage generation via `cargo llvm-cov` and emit `lcov.info`
- upload coverage to Codecov with `codecov-action@v5` using OIDC and `rust` flag
- document the change in `docs/features/2026-02-13-codecov-rust-coverage.md`
- add follow-up TODOs for verifying upload and adding Web coverage upload

## Purpose
Enable visible Rust coverage tracking in CI while keeping current Rust/Web/E2E workflow split unchanged.

## Related Issue
- N/A

## Testing
- Not run locally (workflow-only changes)
- Validation path: GitHub Actions `Rust` workflow should generate `lcov.info` and upload to Codecov

## Notes
- Web coverage upload is intentionally deferred until Vitest coverage dependency management is available in CI.