### PR TITLE
fix(web): stabilize ACP fold, markdown, and mobile alignment

### DIFF
--- a/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
+++ b/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
@@ -1,0 +1,46 @@
+# ACP UI Fold, Markdown, and Mobile Alignment Fixes
+
+## Background
+
+Three regressions were observed in ACP conversation UI:
+
+- Some tool call blocks did not auto-collapse reliably when live execution ended.
+- Markdown rendering looked inconsistent, especially for list and code typography.
+- Mobile layout alignment was unstable around safe-area and ACP header actions.
+
+## Scope
+
+- Fix tool call fold state transitions in conversation rendering.
+- Improve markdown typography and prevent admin list styles from leaking into ACP markdown.
+- Improve mobile layout alignment for ACP controls and panel safe-area behavior.
+
+## Key Decisions
+
+- Add a tool call fold state transition helper to ensure:
+  - live tool calls stay open,
+  - live-to-finished transitions auto-collapse,
+  - manual toggles for finished calls remain respected.
+- Use stable conversation keys (tool call ID / event cursor) to avoid fold state drift during list updates.
+- Scope admin list styles to `.admin .card` only, so markdown list items keep semantic layout.
+- Add `100dvh` support and safe-area padding/offset handling for mobile viewport alignment.
+- Stack ACP header controls on narrow screens to prevent action bar overflow.
+
+## Validation
+
+```bash
+cd web
+npm run test
+```
+
+- Expect all Vitest suites to pass, including:
+  - `src/acp_conversation.test.ts`
+  - `src/conversation.test.ts`
+
+```bash
+cargo test --test web_assets
+```
+
+- Expect CSS guard assertions to pass, including:
+  - mobile `100dvh` support
+  - admin list style scoping
+  - mobile ACP header stacking rule

--- a/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
+++ b/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
@@ -23,7 +23,7 @@ Three regressions were observed in ACP conversation UI:
 - Use stable conversation keys (tool call ID / event cursor) to avoid fold state drift during list updates.
 - Scope admin list styles to `.admin .card` only, so markdown list items keep semantic layout.
 - Disable raw HTML in markdown-it rendering (`html: false`) to prevent HTML injection from untrusted output.
-- Sanitize ANSI-rendered terminal HTML in tool call bubbles to allow only expected `<span style>` tags.
+- Replace `dangerouslySetInnerHTML` for tool call terminal rendering with a safe parser that only recognizes ANSI `<span style>` tags and renders them as React nodes.
 - Add `100dvh` support and safe-area padding/offset handling for mobile viewport alignment.
 - Stack ACP header controls on narrow screens to prevent action bar overflow.
 

--- a/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
+++ b/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
@@ -22,6 +22,8 @@ Three regressions were observed in ACP conversation UI:
   - manual toggles for finished calls remain respected.
 - Use stable conversation keys (tool call ID / event cursor) to avoid fold state drift during list updates.
 - Scope admin list styles to `.admin .card` only, so markdown list items keep semantic layout.
+- Disable raw HTML in markdown-it rendering (`html: false`) to prevent HTML injection from untrusted output.
+- Sanitize ANSI-rendered terminal HTML in tool call bubbles to allow only expected `<span style>` tags.
 - Add `100dvh` support and safe-area padding/offset handling for mobile viewport alignment.
 - Stack ACP header controls on narrow screens to prevent action bar overflow.
 

--- a/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
+++ b/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
@@ -34,6 +34,7 @@ npm run test
 
 - Expect all Vitest suites to pass, including:
   - `src/acp_conversation.test.ts`
+  - `src/acp_conversation_render.test.tsx`
   - `src/conversation.test.ts`
 
 ```bash

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,6 +3,7 @@
 - [ ] Verify tool call fold behavior auto-collapses after live status ends while still allowing manual expand/collapse (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [ ] Verify mobile workspace alignment with safe-area insets and ACP header action wrapping (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
+- [ ] Verify tool call terminal output keeps ANSI styling and escapes raw HTML payloads after review hardening (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [ ] Verify Rust Codecov upload appears with the `rust` flag on push and pull request runs (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
 - [ ] Add Web test coverage upload to Codecov after enabling Vitest coverage dependency management in CI (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
 - [ ] Verify Gemini preset event streaming and session clearing (see `docs/features/2026-02-10-acp-gemini-kimi.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,8 @@
 # TODO
 
+- [ ] Verify tool call fold behavior auto-collapses after live status ends while still allowing manual expand/collapse (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
+- [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
+- [ ] Verify mobile workspace alignment with safe-area insets and ACP header action wrapping (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [ ] Verify Rust Codecov upload appears with the `rust` flag on push and pull request runs (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
 - [ ] Add Web test coverage upload to Codecov after enabling Vitest coverage dependency management in CI (see `docs/features/2026-02-13-codecov-rust-coverage.md`).
 - [ ] Verify Gemini preset event streaming and session clearing (see `docs/features/2026-02-10-acp-gemini-kimi.md`).

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -57,4 +57,16 @@ fn styles_keep_acp_conversation_scoped() {
         css.contains(".input.docked {\n  background: #fff;\n  border: 1px solid #e0e0e0;\n  border-radius: 12px;\n  padding: 10px;\n  box-shadow: var(--shadow);\n  margin-top: auto;\n  position: relative;\n}"),
         "input docked should stick to bottom"
     );
+    assert!(
+        css.contains("@supports (height: 100dvh)"),
+        "styles.css should use dynamic viewport height fallback for mobile browsers"
+    );
+    assert!(
+        css.contains(".admin .card li:not([class*=\"mantine-\"])"),
+        "admin list layout styles should be scoped and not override markdown lists"
+    );
+    assert!(
+        css.contains(".acp-head.minimal {\n    flex-direction: column;\n    align-items: stretch;\n    gap: 8px;\n  }"),
+        "mobile ACP head should stack controls for narrow screens"
+    );
 }

--- a/web/src/acp_conversation.test.ts
+++ b/web/src/acp_conversation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { deriveToolCallOpenState } from "./components/acp_conversation";
+
+describe("deriveToolCallOpenState", () => {
+  it("keeps details open while tool call is live", () => {
+    expect(deriveToolCallOpenState(false, false, true)).toBe(true);
+    expect(deriveToolCallOpenState(true, true, true)).toBe(true);
+  });
+
+  it("auto-collapses when a live tool call transitions to finished", () => {
+    expect(deriveToolCallOpenState(true, true, false)).toBe(false);
+  });
+
+  it("preserves manual toggle state for non-live tool calls", () => {
+    expect(deriveToolCallOpenState(true, false, false)).toBe(true);
+    expect(deriveToolCallOpenState(false, false, false)).toBe(false);
+  });
+});

--- a/web/src/acp_conversation_render.test.tsx
+++ b/web/src/acp_conversation_render.test.tsx
@@ -51,6 +51,28 @@ describe("AcpConversation rendering", () => {
     expect(html).toContain("stdout");
   });
 
+  it("sanitizes terminal html while keeping allowed ansi span tags", () => {
+    const html = renderConversation(
+      [
+        {
+          kind: "tool_call",
+          id: "call-unsafe",
+          title: "Shell",
+          status: "in_progress",
+          terminal_output: "ignored",
+        },
+      ],
+      {
+        ansi: () =>
+          '<span style="color:#e06c75">safe</span><img src=x onerror=alert(1)>',
+      }
+    );
+
+    expect(html).toContain("<span style=\"color:#e06c75\">safe</span>");
+    expect(html).toContain("&lt;img");
+    expect(html).not.toContain("<img");
+  });
+
   it("renders finished tool calls collapsed by default", () => {
     const html = renderConversation([
       {
@@ -62,7 +84,7 @@ describe("AcpConversation rendering", () => {
     ]);
 
     expect(html).toContain("Tool Call: Read");
-    expect(html).not.toMatch(/acp-tool-fold\" open/);
+    expect(html).not.toMatch(/acp-tool-fold" open/);
   });
 
   it("renders auto-collapsed summaries for thinking and plan", () => {

--- a/web/src/acp_conversation_render.test.tsx
+++ b/web/src/acp_conversation_render.test.tsx
@@ -73,6 +73,52 @@ describe("AcpConversation rendering", () => {
     expect(html).not.toContain("<img");
   });
 
+  it("keeps nested ansi style spans and combines inherited styles", () => {
+    const html = renderConversation(
+      [
+        {
+          kind: "tool_call",
+          id: "call-nested-ansi",
+          title: "Shell",
+          status: "completed",
+          terminal_output: "ignored",
+        },
+      ],
+      {
+        ansi: () =>
+          '<span style="color:#123456">outer <span style="font-weight:700">inner</span> tail</span>',
+      }
+    );
+
+    expect(html).toContain("outer");
+    expect(html).toContain("inner");
+    expect(html).toContain("tail");
+    expect(html).toContain("style=\"color:#123456\"");
+    expect(html).toContain("style=\"color:#123456;font-weight:700\"");
+  });
+
+  it("drops unsupported ansi styles and escapes non-whitelisted span tags", () => {
+    const html = renderConversation(
+      [
+        {
+          kind: "tool_call",
+          id: "call-style-filter",
+          title: "Shell",
+          status: "completed",
+          terminal_output: "ignored",
+        },
+      ],
+      {
+        ansi: () =>
+          '<span style="position:absolute;color:#111111">safe</span><span class="ansi-out">literal</span>',
+      }
+    );
+
+    expect(html).toContain("<span style=\"color:#111111\">safe</span>");
+    expect(html).not.toContain("position:absolute");
+    expect(html).toContain("&lt;span class=&quot;ansi-out&quot;&gt;literal&lt;/span&gt;");
+  });
+
   it("renders finished tool calls collapsed by default", () => {
     const html = renderConversation([
       {

--- a/web/src/acp_conversation_render.test.tsx
+++ b/web/src/acp_conversation_render.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AcpConversation } from "./components/acp_conversation";
+import { ConversationItem } from "./conversation";
+
+function renderConversation(
+  items: ConversationItem[],
+  override?: Partial<React.ComponentProps<typeof AcpConversation>>
+): string {
+  return renderToStaticMarkup(
+    <AcpConversation
+      items={items}
+      windowOffset={0}
+      isFrozenView={false}
+      shouldAutoCollapse={false}
+      collapseCutoff={0}
+      stickToBottom={true}
+      pendingCount={0}
+      avgHeight={40}
+      onScroll={() => {}}
+      containerRef={React.createRef<HTMLDivElement>()}
+      ansi={(input) => `<span class="ansi-out">${input}</span>`}
+      {...override}
+    />
+  );
+}
+
+describe("AcpConversation rendering", () => {
+  it("renders live tool calls expanded and terminal output through ansi renderer", () => {
+    const html = renderConversation([
+      {
+        kind: "tool_call",
+        id: "call-1",
+        title: "Shell",
+        status: "in_progress",
+        content: "line1\\nline2",
+        raw_input: { cmd: "ls" },
+        terminal_output: "stdout\\nline",
+      },
+    ]);
+
+    expect(html).toContain("Tool Call: Shell");
+    expect(html).toContain("in_progress");
+    expect(html).toContain("acp-tool-fold");
+    expect(html).toContain("open");
+    expect(html).toContain("line1");
+    expect(html).toContain("line2");
+    expect(html).toContain("cmd");
+    expect(html).toContain("ansi-out");
+    expect(html).toContain("stdout");
+  });
+
+  it("renders finished tool calls collapsed by default", () => {
+    const html = renderConversation([
+      {
+        kind: "tool_call",
+        id: "call-2",
+        title: "Read",
+        status: "completed",
+      },
+    ]);
+
+    expect(html).toContain("Tool Call: Read");
+    expect(html).not.toMatch(/acp-tool-fold\" open/);
+  });
+
+  it("renders auto-collapsed summaries for thinking and plan", () => {
+    const html = renderConversation(
+      [
+        {
+          kind: "agent_thinking",
+          text: "thinking details for summary",
+          live: false,
+          event_id: 1,
+        },
+        {
+          kind: "agent_plan",
+          text: "1. do this",
+          live: false,
+          event_id: 2,
+        },
+      ],
+      {
+        shouldAutoCollapse: true,
+        collapseCutoff: 10,
+      }
+    );
+
+    expect(html).toContain("Thinking:");
+    expect(html).toContain("Plan:");
+  });
+
+  it("renders markdown bubbles and pending spacer", () => {
+    const html = renderConversation(
+      [
+        {
+          kind: "agent_message",
+          text: "**bold** message",
+          event_id: 1,
+        },
+        {
+          kind: "user_message",
+          text: "plain user text",
+          event_id: 2,
+        },
+      ],
+      {
+        stickToBottom: false,
+        pendingCount: 3,
+        avgHeight: 40,
+      }
+    );
+
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("plain user text");
+    expect(html).toContain("acp-conversation-spacer");
+    expect(html).toContain("height:120px");
+  });
+});

--- a/web/src/components/acp_conversation.tsx
+++ b/web/src/components/acp_conversation.tsx
@@ -33,8 +33,8 @@ export function AcpConversation({
     <div className="acp-conversation" ref={containerRef} onScroll={onScroll}>
       <div className="acp-conversation-inner">
         {items.map((msg, idx) => {
-          const key = `${windowOffset + idx}-${msg.kind}`;
           const globalIndex = isFrozenView ? idx : windowOffset + idx;
+          const key = getConversationItemKey(msg, globalIndex);
           const autoCollapse = shouldAutoCollapse && globalIndex < collapseCutoff;
           if (msg.kind === "agent_thinking") {
             const preview = autoCollapse
@@ -75,47 +75,8 @@ export function AcpConversation({
             );
           }
           if (msg.kind === "tool_call") {
-            const isLive = isToolCallLive(msg.status);
             return (
-              <div key={key} className="acp-bubble tool_call">
-                <details
-                  className="acp-tool-fold"
-                  {...(isLive ? { open: true } : {})}
-                >
-                  <summary>
-                    <span className="acp-tool-title">
-                      Tool Call
-                      {msg.title ? `: ${msg.title}` : ""}
-                    </span>
-                    {msg.status && (
-                      <span className="acp-tool-status">{msg.status}</span>
-                    )}
-                  </summary>
-                  {msg.content && (
-                    <div className="acp-text">
-                      <pre>{unescapeLineBreaks(msg.content)}</pre>
-                    </div>
-                  )}
-                  {msg.raw_input && (
-                    <pre className="acp-content">
-                      {formatToolCallPayload(msg.raw_input)}
-                    </pre>
-                  )}
-                  {msg.raw_output && (
-                    <pre className="acp-content">
-                      {formatToolCallPayload(msg.raw_output)}
-                    </pre>
-                  )}
-                  {msg.terminal_output && (
-                    <pre
-                      className="acp-content"
-                      dangerouslySetInnerHTML={{
-                        __html: ansi(unescapeLineBreaks(msg.terminal_output)),
-                      }}
-                    />
-                  )}
-                </details>
-              </div>
+              <ToolCallBubble key={key} msg={msg} ansi={ansi} />
             );
           }
           if (msg.kind === "agent_message") {
@@ -154,6 +115,77 @@ export function AcpConversation({
 
 export type { AcpConversationProps };
 
+type ToolCallBubbleProps = {
+  msg: Extract<ConversationItem, { kind: "tool_call" }>;
+  ansi: (input: string) => string;
+};
+
+function ToolCallBubble({ msg, ansi }: ToolCallBubbleProps) {
+  const isLive = isToolCallLive(msg.status);
+  const [open, setOpen] = React.useState(isLive);
+  const wasLiveRef = React.useRef(isLive);
+
+  React.useEffect(() => {
+    setOpen((prevOpen) => deriveToolCallOpenState(prevOpen, wasLiveRef.current, isLive));
+    wasLiveRef.current = isLive;
+  }, [isLive]);
+
+  return (
+    <div className="acp-bubble tool_call">
+      <details
+        className="acp-tool-fold"
+        open={open}
+        onToggle={(event) => {
+          setOpen(event.currentTarget.open);
+        }}
+      >
+        <summary>
+          <span className="acp-tool-title">
+            Tool Call
+            {msg.title ? `: ${msg.title}` : ""}
+          </span>
+          {msg.status && (
+            <span className="acp-tool-status">{msg.status}</span>
+          )}
+        </summary>
+        {msg.content && (
+          <div className="acp-text">
+            <pre>{unescapeLineBreaks(msg.content)}</pre>
+          </div>
+        )}
+        {msg.raw_input && (
+          <pre className="acp-content">
+            {formatToolCallPayload(msg.raw_input)}
+          </pre>
+        )}
+        {msg.raw_output && (
+          <pre className="acp-content">
+            {formatToolCallPayload(msg.raw_output)}
+          </pre>
+        )}
+        {msg.terminal_output && (
+          <pre
+            className="acp-content"
+            dangerouslySetInnerHTML={{
+              __html: ansi(unescapeLineBreaks(msg.terminal_output)),
+            }}
+          />
+        )}
+      </details>
+    </div>
+  );
+}
+
+export function deriveToolCallOpenState(
+  prevOpen: boolean,
+  wasLive: boolean,
+  isLive: boolean
+): boolean {
+  if (isLive) return true;
+  if (wasLive) return false;
+  return prevOpen;
+}
+
 function unescapeLineBreaks(text: string): string {
   return text
     .replace(/\\r\\n/g, "\n")
@@ -166,4 +198,11 @@ function formatToolCallPayload(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "string") return unescapeLineBreaks(value);
   return unescapeLineBreaks(JSON.stringify(value, null, 2));
+}
+
+function getConversationItemKey(msg: ConversationItem, fallback: number): string {
+  if (msg.kind === "tool_call") return `tool_call:${msg.id}`;
+  if (msg.event_id != null) return `${msg.kind}:event:${msg.event_id}`;
+  if (msg.seq) return `${msg.kind}:seq:${msg.seq}`;
+  return `${msg.kind}:idx:${fallback}`;
 }

--- a/web/src/components/acp_conversation.tsx
+++ b/web/src/components/acp_conversation.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ConversationItem, formatConversationPreview, isToolCallLive } from "../conversation";
-import { escapeHtml, renderMarkdown } from "../markdown";
+import { renderMarkdown } from "../markdown";
 
 type AcpConversationProps = {
   items: ConversationItem[];
@@ -164,14 +164,11 @@ function ToolCallBubble({ msg, ansi }: ToolCallBubbleProps) {
           </pre>
         )}
         {msg.terminal_output && (
-          <pre
-            className="acp-content"
-            dangerouslySetInnerHTML={{
-              __html: sanitizeAnsiHtml(
-                ansi(unescapeLineBreaks(msg.terminal_output))
-              ),
-            }}
-          />
+          <pre className="acp-content">
+            {renderAnsiTerminalOutput(
+              ansi(unescapeLineBreaks(msg.terminal_output))
+            )}
+          </pre>
         )}
       </details>
     </div>
@@ -202,28 +199,100 @@ function formatToolCallPayload(value: unknown): string {
   return unescapeLineBreaks(JSON.stringify(value, null, 2));
 }
 
-function sanitizeAnsiHtml(input: string): string {
-  let tokenId = 0;
-  const tokenMap = new Map<string, string>();
-  const preserved = input.replace(
-    /<\/?span(?: style="[a-zA-Z0-9:#;(),.%\s-]*")?>/g,
-    (tag) => {
-      const token = `__agenthub_ansi_token_${tokenId}__`;
-      tokenId += 1;
-      tokenMap.set(token, tag);
-      return token;
-    }
-  );
-  let escaped = escapeHtml(preserved);
-  for (const [token, tag] of tokenMap.entries()) {
-    escaped = escaped.replaceAll(token, tag);
-  }
-  return escaped;
-}
-
 function getConversationItemKey(msg: ConversationItem, fallback: number): string {
   if (msg.kind === "tool_call") return `tool_call:${msg.id}`;
   if (msg.event_id != null) return `${msg.kind}:event:${msg.event_id}`;
   if (msg.seq) return `${msg.kind}:seq:${msg.seq}`;
   return `${msg.kind}:idx:${fallback}`;
+}
+
+const ANSI_SPAN_TAG_PATTERN = /<\/?span(?: style="([a-zA-Z0-9:#;(),.%\s-]*)")?>/g;
+const ANSI_STYLE_VALUE_PATTERN = /^[a-zA-Z0-9#(),.%\s-]+$/;
+const ANSI_ALLOWED_STYLE_PROPERTIES: Record<string, keyof React.CSSProperties> = {
+  color: "color",
+  "background-color": "backgroundColor",
+  "font-weight": "fontWeight",
+  "font-style": "fontStyle",
+  "text-decoration": "textDecoration",
+  "text-decoration-line": "textDecorationLine",
+  "text-decoration-style": "textDecorationStyle",
+};
+
+type AnsiSegment = {
+  text: string;
+  style?: React.CSSProperties;
+};
+
+function renderAnsiTerminalOutput(input: string): React.ReactNode[] {
+  return parseAnsiSegments(input).map((segment, index) => {
+    if (segment.style) {
+      return (
+        <span key={index} style={segment.style}>
+          {segment.text}
+        </span>
+      );
+    }
+    return <React.Fragment key={index}>{segment.text}</React.Fragment>;
+  });
+}
+
+function parseAnsiSegments(input: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = [];
+  const styleStack: React.CSSProperties[] = [];
+  let cursor = 0;
+  ANSI_SPAN_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ANSI_SPAN_TAG_PATTERN.exec(input)) != null) {
+    if (match.index > cursor) {
+      pushAnsiSegment(segments, input.slice(cursor, match.index), styleStack);
+    }
+    if (match[0].startsWith("</")) {
+      if (styleStack.length > 0) {
+        styleStack.pop();
+      } else {
+        pushAnsiSegment(segments, match[0], styleStack);
+      }
+    } else {
+      styleStack.push(parseAnsiStyle(match[1] ?? ""));
+    }
+    cursor = ANSI_SPAN_TAG_PATTERN.lastIndex;
+  }
+  if (cursor < input.length) {
+    pushAnsiSegment(segments, input.slice(cursor), styleStack);
+  }
+  return segments;
+}
+
+function pushAnsiSegment(
+  segments: AnsiSegment[],
+  text: string,
+  styleStack: React.CSSProperties[]
+): void {
+  if (!text) return;
+  const style = mergeAnsiStyles(styleStack);
+  segments.push(style ? { text, style } : { text });
+}
+
+function mergeAnsiStyles(styleStack: React.CSSProperties[]): React.CSSProperties | undefined {
+  if (styleStack.length === 0) return undefined;
+  const merged: React.CSSProperties = {};
+  for (const style of styleStack) {
+    Object.assign(merged, style);
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function parseAnsiStyle(rawStyle: string): React.CSSProperties {
+  const parsed: React.CSSProperties = {};
+  for (const entry of rawStyle.split(";")) {
+    const separator = entry.indexOf(":");
+    if (separator < 0) continue;
+    const rawKey = entry.slice(0, separator).trim().toLowerCase();
+    const rawValue = entry.slice(separator + 1).trim();
+    const targetKey = ANSI_ALLOWED_STYLE_PROPERTIES[rawKey];
+    if (!targetKey) continue;
+    if (!rawValue || !ANSI_STYLE_VALUE_PATTERN.test(rawValue)) continue;
+    (parsed as Record<string, string>)[targetKey] = rawValue;
+  }
+  return parsed;
 }

--- a/web/src/components/acp_conversation.tsx
+++ b/web/src/components/acp_conversation.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ConversationItem, formatConversationPreview, isToolCallLive } from "../conversation";
-import { renderMarkdown } from "../markdown";
+import { escapeHtml, renderMarkdown } from "../markdown";
 
 type AcpConversationProps = {
   items: ConversationItem[];
@@ -167,7 +167,9 @@ function ToolCallBubble({ msg, ansi }: ToolCallBubbleProps) {
           <pre
             className="acp-content"
             dangerouslySetInnerHTML={{
-              __html: ansi(unescapeLineBreaks(msg.terminal_output)),
+              __html: sanitizeAnsiHtml(
+                ansi(unescapeLineBreaks(msg.terminal_output))
+              ),
             }}
           />
         )}
@@ -198,6 +200,25 @@ function formatToolCallPayload(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "string") return unescapeLineBreaks(value);
   return unescapeLineBreaks(JSON.stringify(value, null, 2));
+}
+
+function sanitizeAnsiHtml(input: string): string {
+  let tokenId = 0;
+  const tokenMap = new Map<string, string>();
+  const preserved = input.replace(
+    /<\/?span(?: style="[a-zA-Z0-9:#;(),.%\s-]*")?>/g,
+    (tag) => {
+      const token = `__agenthub_ansi_token_${tokenId}__`;
+      tokenId += 1;
+      tokenMap.set(token, tag);
+      return token;
+    }
+  );
+  let escaped = escapeHtml(preserved);
+  for (const [token, tag] of tokenMap.entries()) {
+    escaped = escaped.replaceAll(token, tag);
+  }
+  return escaped;
 }
 
 function getConversationItemKey(msg: ConversationItem, fallback: number): string {

--- a/web/src/components/output_error_boundary.tsx
+++ b/web/src/components/output_error_boundary.tsx
@@ -20,7 +20,7 @@ export class OutputErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: unknown, info: unknown) {
-    console.error("Output render failed", error, info);
+    reportRenderError(error, info);
   }
 
   handleReset = () => {
@@ -36,12 +36,34 @@ export class OutputErrorBoundary extends React.Component<
       <div className="output-body">
         <div className="output-error">
           <div className="title">Output failed to render</div>
-          <div className="meta">Check the console for details.</div>
+          <div className="meta">Retry rendering the latest output.</div>
           <button className="ghost" onClick={this.handleReset}>
             Retry
           </button>
         </div>
       </div>
     );
+  }
+}
+
+function reportRenderError(error: unknown, info: unknown) {
+  const detail = {
+    source: "output_error_boundary",
+    error,
+    info,
+  };
+  if (
+    "dispatchEvent" in globalThis &&
+    typeof globalThis.dispatchEvent === "function" &&
+    typeof CustomEvent === "function"
+  ) {
+    globalThis.dispatchEvent(
+      new CustomEvent("agenthub:output-render-error", {
+        detail,
+      })
+    );
+  }
+  if ("reportError" in globalThis && typeof globalThis.reportError === "function") {
+    globalThis.reportError(error);
   }
 }

--- a/web/src/conversation.test.ts
+++ b/web/src/conversation.test.ts
@@ -235,9 +235,12 @@ describe("conversation freeze helpers", () => {
 });
 
 describe("tool call status helpers", () => {
-  it("treats pending and in_progress as live", () => {
+  it("treats pending, in_progress, and running as live", () => {
     expect(isToolCallLive("pending")).toBe(true);
     expect(isToolCallLive("in_progress")).toBe(true);
+    expect(isToolCallLive("running")).toBe(true);
+    expect(isToolCallLive("in-progress")).toBe(true);
+    expect(isToolCallLive("IN PROGRESS")).toBe(true);
   });
 
   it("treats other statuses as not live", () => {

--- a/web/src/conversation.test.ts
+++ b/web/src/conversation.test.ts
@@ -128,6 +128,9 @@ describe("buildConversationMessages", () => {
     expect(items[0].kind).toBe("user_message");
     expect(items[1].kind).toBe("agent_thinking");
     expect(items[2].kind).toBe("tool_call");
+    if (items[2].kind === "tool_call") {
+      expect(items[2].id).toBe("c1");
+    }
     expect(items[3].kind).toBe("agent_message");
   });
 

--- a/web/src/conversation.ts
+++ b/web/src/conversation.ts
@@ -12,6 +12,7 @@ export type ConversationItem =
     }
   | {
       kind: "tool_call";
+      id: string;
       title: string;
       status?: string;
       content?: string;
@@ -31,8 +32,12 @@ export type ConversationWindow = {
 
 export function isToolCallLive(status?: string): boolean {
   if (!status) return false;
-  const normalized = status.toLowerCase();
-  return normalized === "pending" || normalized === "in_progress";
+  const normalized = status.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return (
+    normalized === "pending" ||
+    normalized === "in_progress" ||
+    normalized === "running"
+  );
 }
 
 export function formatConversationPreview(text: string, limit: number): string {
@@ -109,7 +114,7 @@ export function buildConversationMessages(
     });
     order += 1;
   }
-    entries.sort((a, b) => {
+  entries.sort((a, b) => {
     const base = compareEventOrder(
       { event_id: a.event_id ?? null, ts: a.ts ?? null },
       { event_id: b.event_id ?? null, ts: b.ts ?? null }
@@ -209,6 +214,7 @@ export function buildConversationMessages(
     }
     items.push({
       kind: "tool_call",
+      id: call.id,
       title: call.title,
       status: call.status,
       content: call.content,
@@ -220,16 +226,16 @@ export function buildConversationMessages(
       ts: call.ts,
     });
   }
-    if (pendingThought) {
-      items.push({
-        kind: "agent_thinking",
-        text: pendingThought,
-        live: true,
-        seq: pendingThoughtSeq ?? undefined,
-        event_id: pendingThoughtEventId ?? undefined,
-        ts: pendingThoughtTs ?? undefined,
-      });
-    }
+  if (pendingThought) {
+    items.push({
+      kind: "agent_thinking",
+      text: pendingThought,
+      live: true,
+      seq: pendingThoughtSeq ?? undefined,
+      event_id: pendingThoughtEventId ?? undefined,
+      ts: pendingThoughtTs ?? undefined,
+    });
+  }
   return items;
 }
 

--- a/web/src/markdown.test.ts
+++ b/web/src/markdown.test.ts
@@ -47,4 +47,11 @@ describe("renderMarkdown", () => {
     expect(html).toContain("<pre");
     expect(html).toContain("<code");
   });
+
+  it("escapes raw html blocks", () => {
+    const html = renderMarkdown('<img src=x onerror="alert(1)"><b>safe</b>');
+    expect(html).toContain("&lt;img");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("<b>safe</b>");
+  });
 });

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -73,7 +73,7 @@ let markdownRenderer: MarkdownIt | null = null;
 function getMarkdownRenderer(): MarkdownIt {
   if (markdownRenderer) return markdownRenderer;
   const renderer = new MarkdownIt({
-    html: true,
+    html: false,
     linkify: false,
     typographer: true,
     highlight: (code: string, lang: string) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -56,6 +56,18 @@ body {
   flex: 1;
 }
 
+@supports (height: 100dvh) {
+  body {
+    min-height: 100dvh;
+    height: 100dvh;
+  }
+
+  .app {
+    min-height: 100dvh;
+    height: 100dvh;
+  }
+}
+
 header {
   display: flex;
   justify-content: space-between;
@@ -1306,7 +1318,6 @@ select:not([class*="mantine-"]):focus-visible {
   padding: 10px 12px;
   line-height: 1.6;
   max-width: 100%;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
@@ -1314,7 +1325,8 @@ select:not([class*="mantine-"]):focus-visible {
   word-break: break-word;
   white-space: normal;
   font-size: 14px;
-  line-height: 1.65;
+  line-height: 1.72;
+  letter-spacing: 0.01em;
   color: #1b1f23;
 }
 
@@ -1334,6 +1346,8 @@ select:not([class*="mantine-"]):focus-visible {
 
 .acp-text li {
   display: list-item;
+  align-items: initial;
+  gap: 0;
   margin: 0;
 }
 
@@ -1378,6 +1392,7 @@ select:not([class*="mantine-"]):focus-visible {
 .acp-text pre {
   line-height: 1.45;
   white-space: pre;
+  overflow-x: auto;
   tab-size: 2;
 }
 
@@ -1489,7 +1504,8 @@ select:not([class*="mantine-"]):focus-visible {
   color: #295d52;
 }
 
-.acp-bubble code {
+.acp-content code,
+.acp-terminal code {
   background: #0e1116;
   color: #d9e1ee;
   padding: 2px 6px;
@@ -1505,10 +1521,15 @@ select:not([class*="mantine-"]):focus-visible {
   border-radius: 8px;
   overflow: auto;
   margin: 8px 0;
+}
+
+.acp-bubble.agent_thinking pre,
+.acp-bubble.agent_plan pre {
   white-space: pre-wrap;
 }
 
-.acp-bubble pre code {
+.acp-content pre code,
+.acp-terminal pre code {
   background: transparent;
   padding: 0;
   color: inherit;
@@ -1622,7 +1643,7 @@ select:not([class*="mantine-"]):focus-visible {
 
 @media (max-width: 720px) {
   .app {
-    padding: 2px 4px 0;
+    padding: calc(2px + env(safe-area-inset-top, 0px)) 4px calc(4px + env(safe-area-inset-bottom, 0px));
   }
 
   header {
@@ -1681,13 +1702,36 @@ select:not([class*="mantine-"]):focus-visible {
 
   .workspace-left {
     position: fixed;
-    top: 64px;
+    top: calc(56px + env(safe-area-inset-top, 0px));
     left: 8px;
     right: 8px;
-    bottom: 8px;
+    bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     z-index: 30;
     overflow: auto;
     box-shadow: 0 24px 60px rgba(15, 20, 30, 0.35);
+  }
+
+  .acp-head.minimal {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .acp-actions {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .acp-tabs {
+    flex: 1 1 auto;
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .acp-interrupt-button {
+    flex: 0 0 auto;
   }
 
   .agents-backdrop {
@@ -1746,11 +1790,11 @@ select:not([class*="mantine-"]):focus-visible {
   min-height: 220px;
 }
 
-ul:not([class*="mantine-"]) {
+.admin .card ul:not([class*="mantine-"]) {
   padding-left: 18px;
 }
 
-li:not([class*="mantine-"]) {
+.admin .card li:not([class*="mantine-"]) {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1804,7 +1848,7 @@ li:not([class*="mantine-"]) {
   grid-template-columns: 1fr;
 }
 
-li:not([class*="mantine-"]) button:not([class*="mantine-"]) {
+.admin .card li:not([class*="mantine-"]) button:not([class*="mantine-"]) {
   background: #444;
   padding: 4px 8px;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1346,8 +1346,6 @@ select:not([class*="mantine-"]):focus-visible {
 
 .acp-text li {
   display: list-item;
-  align-items: initial;
-  gap: 0;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- fix ACP tool call fold behavior with deterministic open/close transitions
- keep tool call fold state stable across list updates by using stable conversation keys
- broaden live-status detection for tool calls (`pending`, `in_progress`, `running`, and normalized variants)
- improve ACP markdown readability and prevent admin list styles from leaking into conversation markdown
- improve mobile alignment with `100dvh`, safe-area offsets, and wrapped ACP header actions
- add tests for fold transition logic and status normalization
- extend CSS guard test coverage for mobile/layout style contracts
- document the change and add TODO verification entries

## Purpose
Resolve three user-facing UI regressions in ACP conversation view:
1. some tool calls not auto-collapsing after execution
2. markdown typography/layout looking inconsistent
3. mobile layout alignment issues on narrow screens and safe-area devices

## Related Issue
- N/A

## Validation
```bash
cd web
npm run test

cargo test --test web_assets
```

## Notes
- this PR focuses on behavior and style correctness without changing backend ACP event schema
- follow-up verification items were added in `docs/todo.md`
