### PR TITLE
test(web): increase use_acp_conversation coverage

### DIFF
--- a/docs/features/2026-02-14-use-acp-conversation-coverage.md
+++ b/docs/features/2026-02-14-use-acp-conversation-coverage.md
@@ -1,0 +1,51 @@
+# use_acp_conversation Coverage Hardening
+
+## Summary
+
+Increase branch and line coverage for `use_acp_conversation` by extracting
+decision-heavy logic into pure helper functions and adding focused unit tests
+for each helper.
+
+## Background
+
+The conversation hook had many conditional paths (virtualization, history
+autoload, viewport updates, jump badge visibility, scroll restore) but low
+direct unit coverage. Most logic lived inside hook effects/callbacks, making
+branch-level verification expensive and brittle.
+
+## Scope
+
+- `web/src/hooks/use_acp_conversation.ts`
+- `web/src/hooks/use_acp_conversation.test.ts`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Keep hook behavior unchanged while extracting deterministic calculations.
+2. Export only decision/helper functions that do not depend on React runtime.
+3. Route existing hook branches through extracted helpers to preserve single
+   behavior source.
+4. Add targeted tests for:
+   - tail key generation
+   - history loading gate conditions
+   - virtualization threshold decision
+   - viewport clamping/update rules
+   - auto-load eligibility
+   - average height normalization
+   - scroll restoration fallback
+   - jump badge/jump button derivation
+
+## Validation
+
+```bash
+cd web
+npm run test -- src/hooks/use_acp_conversation.test.ts
+npm run lint -- src/hooks/use_acp_conversation.ts src/hooks/use_acp_conversation.test.ts
+npm run build
+npm run test:coverage
+```
+
+## Follow-ups
+
+- Confirm the extracted helper path keeps conversation scroll UX stable on long
+  real-world sessions (desktop + mobile).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -9,8 +9,10 @@
 - [x] Add input history privacy guard to avoid persisting obvious secret-like commands in localStorage (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Move ACP `Interrupt` control into input dock top row and colocate with `History` actions (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
 - [x] Increase unit coverage for input dock interaction branches and ACP tab interaction callbacks (`input_dock.tsx`, `acp_panel.tsx`) (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
+- [x] Increase unit coverage for `use_acp_conversation` by extracting deterministic helper decisions into pure functions and testing branch-heavy paths (see `docs/features/2026-02-14-use-acp-conversation-coverage.md`).
 - [ ] Verify input dock command history menu and arrow-key recall behavior on desktop/mobile IME (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
+- [ ] Verify `use_acp_conversation` helper extraction keeps scroll restoration and jump-badge behavior unchanged across long sessions (see `docs/features/2026-02-14-use-acp-conversation-coverage.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).

--- a/web/src/hooks/use_acp_conversation.test.ts
+++ b/web/src/hooks/use_acp_conversation.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { ConversationItem } from "../conversation";
-import { buildVirtualConversationSlice } from "./use_acp_conversation";
+import {
+  buildConversationTailKey,
+  buildVirtualConversationSlice,
+  deriveConversationJumpState,
+  nextConversationViewport,
+  normalizeConversationAvgHeightEstimate,
+  restoreConversationScrollTop,
+  shouldAutoLoadConversationHistory,
+  shouldLoadOlderFromMeta,
+  shouldUseConversationVirtualization,
+} from "./use_acp_conversation";
 
 function makeItems(count: number): ConversationItem[] {
   return Array.from({ length: count }, (_, idx) => ({
@@ -28,5 +38,144 @@ describe("buildVirtualConversationSlice", () => {
     expect(slice.offset).toBeGreaterThan(200);
     expect(slice.topSpacer).toBeGreaterThan(0);
     expect(slice.bottomSpacer).toBeGreaterThan(0);
+  });
+
+  it("falls back to default item height for invalid estimates", () => {
+    const items = makeItems(300);
+    const slice = buildVirtualConversationSlice(items, 0, -80, 0, 0);
+    expect(slice.offset).toBe(0);
+    expect(slice.items.length).toBeGreaterThan(0);
+    expect(slice.items.length).toBeLessThanOrEqual(300);
+    expect(slice.topSpacer).toBe(0);
+  });
+});
+
+describe("buildConversationTailKey", () => {
+  it("handles empty conversations", () => {
+    expect(buildConversationTailKey([])).toBe("empty");
+  });
+
+  it("builds key for plain message item", () => {
+    const key = buildConversationTailKey([
+      {
+        kind: "agent_message",
+        text: "hello",
+        event_id: 42,
+      },
+    ]);
+    expect(key).toBe("agent_message:42:5");
+  });
+
+  it("builds key for tool call including payload lengths", () => {
+    const key = buildConversationTailKey([
+      {
+        kind: "tool_call",
+        id: "call-1",
+        title: "search",
+        content: "abc",
+        terminal_output: "ok",
+        raw_input: { q: "hello" },
+        raw_output: { done: true },
+        event_id: 7,
+      },
+    ]);
+    expect(key).toContain("tool_call:7:3:2:");
+  });
+});
+
+describe("shouldLoadOlderFromMeta", () => {
+  const meta = {
+    "agent-1:latest": {
+      oldestId: 1,
+      hasMore: true,
+      loading: false,
+      loaded: true,
+    },
+  };
+
+  it("returns false without active agent", () => {
+    expect(shouldLoadOlderFromMeta(null, null, meta)).toBe(false);
+  });
+
+  it("returns false when meta is missing or not eligible", () => {
+    expect(shouldLoadOlderFromMeta("agent-x", null, meta)).toBe(false);
+    expect(
+      shouldLoadOlderFromMeta("agent-1", null, {
+        "agent-1:latest": { ...meta["agent-1:latest"], loading: true },
+      })
+    ).toBe(false);
+    expect(
+      shouldLoadOlderFromMeta("agent-1", null, {
+        "agent-1:latest": { ...meta["agent-1:latest"], hasMore: false },
+      })
+    ).toBe(false);
+    expect(
+      shouldLoadOlderFromMeta("agent-1", null, {
+        "agent-1:latest": { ...meta["agent-1:latest"], oldestId: null },
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when metadata indicates older events are available", () => {
+    expect(shouldLoadOlderFromMeta("agent-1", null, meta)).toBe(true);
+  });
+});
+
+describe("conversation helper decisions", () => {
+  it("derives virtualization eligibility", () => {
+    expect(shouldUseConversationVirtualization(true, 500)).toBe(false);
+    expect(shouldUseConversationVirtualization(false, 50)).toBe(false);
+    expect(shouldUseConversationVirtualization(false, 180)).toBe(true);
+  });
+
+  it("computes next viewport state and reuses previous object when unchanged", () => {
+    const prev = { top: 10, height: 400 };
+    expect(nextConversationViewport(prev, 10, 400)).toBe(prev);
+    expect(nextConversationViewport(prev, 20, 420)).toEqual({ top: 20, height: 420 });
+  });
+
+  it("derives auto-load eligibility for short conversation windows", () => {
+    expect(shouldAutoLoadConversationHistory("debug", "agent-1", true, 2)).toBe(false);
+    expect(shouldAutoLoadConversationHistory("conversation", null, true, 2)).toBe(false);
+    expect(
+      shouldAutoLoadConversationHistory("conversation", "agent-1", false, 2)
+    ).toBe(false);
+    expect(
+      shouldAutoLoadConversationHistory("conversation", "agent-1", true, 20)
+    ).toBe(false);
+    expect(
+      shouldAutoLoadConversationHistory("conversation", "agent-1", true, 4)
+    ).toBe(true);
+  });
+
+  it("normalizes average height estimates with bounds and jitter guard", () => {
+    expect(normalizeConversationAvgHeightEstimate(48, 0, 4)).toBe(48);
+    expect(normalizeConversationAvgHeightEstimate(48, 96, 2)).toBe(48);
+    expect(normalizeConversationAvgHeightEstimate(48, 960, 4)).toBe(220);
+    expect(normalizeConversationAvgHeightEstimate(48, 8, 10)).toBe(24);
+  });
+
+  it("restores scroll top within available scroll range", () => {
+    expect(restoreConversationScrollTop(400, 800, 300)).toBe(400);
+    expect(restoreConversationScrollTop(900, 800, 300)).toBe(500);
+  });
+
+  it("derives jump/badge visibility from tab and stick state", () => {
+    expect(deriveConversationJumpState("debug", false, 3)).toEqual({
+      showConversationJump: false,
+      showConversationBadge: false,
+    });
+    expect(deriveConversationJumpState("conversation", true, 3)).toEqual({
+      showConversationJump: false,
+      showConversationBadge: false,
+    });
+    expect(deriveConversationJumpState("conversation", false, 0)).toEqual({
+      showConversationJump: true,
+      showConversationBadge: false,
+    });
+    expect(deriveConversationJumpState("conversation", false, 2)).toEqual({
+      showConversationJump: true,
+      showConversationBadge: true,
+    });
   });
 });

--- a/web/src/hooks/use_acp_conversation.ts
+++ b/web/src/hooks/use_acp_conversation.ts
@@ -60,8 +60,114 @@ type ConversationVirtualSlice = {
   bottomSpacer: number;
 };
 
+type ConversationViewport = {
+  top: number;
+  height: number;
+};
+
 const VIRTUALIZATION_MIN_ITEMS = 140;
 const VIRTUALIZATION_OVERSCAN = 14;
+
+export function buildConversationTailKey(conversationMessages: ConversationItem[]): string {
+  if (conversationMessages.length === 0) return "empty";
+  const last = conversationMessages[conversationMessages.length - 1];
+  const base = `${last.kind}:${last.event_id ?? last.seq ?? "na"}`;
+  if (last.kind === "tool_call") {
+    const contentLen = last.content?.length ?? 0;
+    const terminalLen = last.terminal_output?.length ?? 0;
+    const rawInLen = last.raw_input
+      ? JSON.stringify(last.raw_input).length
+      : 0;
+    const rawOutLen = last.raw_output
+      ? JSON.stringify(last.raw_output).length
+      : 0;
+    return `${base}:${contentLen}:${terminalLen}:${rawInLen}:${rawOutLen}`;
+  }
+  return `${base}:${last.text?.length ?? 0}`;
+}
+
+export function shouldLoadOlderFromMeta(
+  activeAgent: string | null,
+  activeSessionId: string | null,
+  eventMeta: Record<string, EventMeta>
+): boolean {
+  if (!activeAgent) return false;
+  const key = `${activeAgent}:${activeSessionId ?? "latest"}`;
+  const meta = eventMeta[key];
+  if (!meta || meta.loading || !meta.hasMore || meta.oldestId == null) {
+    return false;
+  }
+  return true;
+}
+
+export function shouldUseConversationVirtualization(
+  conversationStickToBottom: boolean,
+  sourceItemsLength: number
+): boolean {
+  return !conversationStickToBottom && sourceItemsLength >= VIRTUALIZATION_MIN_ITEMS;
+}
+
+export function nextConversationViewport(
+  prev: ConversationViewport,
+  nextTop: number,
+  nextHeight: number
+): ConversationViewport {
+  if (prev.top === nextTop && prev.height === nextHeight) {
+    return prev;
+  }
+  return {
+    top: nextTop,
+    height: nextHeight,
+  };
+}
+
+export function shouldAutoLoadConversationHistory(
+  acpTab: "conversation" | "debug",
+  activeAgent: string | null,
+  canLoadOlder: boolean,
+  conversationMessageCount: number,
+  minMessages: number = 12
+): boolean {
+  if (acpTab !== "conversation") return false;
+  if (!activeAgent) return false;
+  if (!canLoadOlder) return false;
+  return conversationMessageCount < minMessages;
+}
+
+export function normalizeConversationAvgHeightEstimate(
+  previous: number,
+  scrollHeight: number,
+  messageCount: number
+): number {
+  const count = Math.max(1, messageCount);
+  const estimate = scrollHeight / count;
+  if (!Number.isFinite(estimate) || estimate <= 0) return previous;
+  const normalized = Math.min(220, Math.max(24, estimate));
+  if (Math.abs(previous - normalized) < 1) return previous;
+  return normalized;
+}
+
+export function restoreConversationScrollTop(
+  savedTop: number,
+  scrollHeight: number,
+  clientHeight: number
+): number {
+  const maxTop = Math.max(0, scrollHeight - clientHeight);
+  return Math.min(savedTop, maxTop);
+}
+
+export function deriveConversationJumpState(
+  acpTab: "conversation" | "debug",
+  conversationStickToBottom: boolean,
+  conversationPendingCount: number
+): { showConversationJump: boolean; showConversationBadge: boolean } {
+  const showConversationJump =
+    acpTab === "conversation" && !conversationStickToBottom;
+  return {
+    showConversationJump,
+    showConversationBadge: showConversationJump && conversationPendingCount > 0,
+  };
+}
 
 export function buildVirtualConversationSlice(
   sourceItems: ConversationItem[],
@@ -149,31 +255,19 @@ export function useAcpConversation({
     () => windowConversation(conversationMessages, conversationStickToBottom, 200),
     [conversationMessages, conversationStickToBottom]
   );
-  const conversationTailKey = useMemo(() => {
-    if (conversationMessages.length === 0) return "empty";
-    const last = conversationMessages[conversationMessages.length - 1];
-    const base = `${last.kind}:${last.event_id ?? last.seq ?? "na"}`;
-    if (last.kind === "tool_call") {
-      const contentLen = last.content?.length ?? 0;
-      const terminalLen = last.terminal_output?.length ?? 0;
-      const rawInLen = last.raw_input
-        ? JSON.stringify(last.raw_input).length
-        : 0;
-      const rawOutLen = last.raw_output
-        ? JSON.stringify(last.raw_output).length
-        : 0;
-      return `${base}:${contentLen}:${terminalLen}:${rawInLen}:${rawOutLen}`;
-    }
-    return `${base}:${last.text?.length ?? 0}`;
-  }, [conversationMessages]);
+  const conversationTailKey = useMemo(
+    () => buildConversationTailKey(conversationMessages),
+    [conversationMessages]
+  );
   const isFrozenView = conversationFrozen && conversationFrozenItems.length > 0;
   const conversationSourceItems = isFrozenView
     ? conversationFrozenItems
     : conversationWindow.items;
   const conversationSourceOffset = isFrozenView ? 0 : conversationWindow.offset;
-  const shouldVirtualizeConversation =
-    !conversationStickToBottom &&
-    conversationSourceItems.length >= VIRTUALIZATION_MIN_ITEMS;
+  const shouldVirtualizeConversation = shouldUseConversationVirtualization(
+    conversationStickToBottom,
+    conversationSourceItems.length
+  );
   const conversationVirtualSlice = useMemo(() => {
     if (!shouldVirtualizeConversation) {
       return {
@@ -203,13 +297,7 @@ export function useAcpConversation({
   const shouldAutoCollapse = conversationMessages.length > 50;
 
   const shouldLoadOlder = useCallback(() => {
-    if (!activeAgent) return false;
-    const key = `${activeAgent}:${activeSessionId ?? "latest"}`;
-    const meta = eventMeta[key];
-    if (!meta || meta.loading || !meta.hasMore || meta.oldestId == null) {
-      return false;
-    }
-    return true;
+    return shouldLoadOlderFromMeta(activeAgent, activeSessionId, eventMeta);
   }, [activeAgent, activeSessionId, eventMeta]);
 
   const syncConversationViewport = useCallback(() => {
@@ -218,13 +306,7 @@ export function useAcpConversation({
     setConversationViewport((prev) => {
       const nextTop = el.scrollTop;
       const nextHeight = el.clientHeight;
-      if (prev.top === nextTop && prev.height === nextHeight) {
-        return prev;
-      }
-      return {
-        top: nextTop,
-        height: nextHeight,
-      };
+      return nextConversationViewport(prev, nextTop, nextHeight);
     });
   }, []);
 
@@ -319,11 +401,16 @@ export function useAcpConversation({
   }, [handleConversationScrollNow]);
 
   useEffect(() => {
-    if (acpTab !== "conversation") return;
-    if (!activeAgent) return;
-    if (!shouldLoadOlder()) return;
-    const minMessages = 12;
-    if (conversationMessages.length >= minMessages) return;
+    if (
+      !shouldAutoLoadConversationHistory(
+        acpTab,
+        activeAgent,
+        shouldLoadOlder(),
+        conversationMessages.length
+      )
+    ) {
+      return;
+    }
     prepareForLoadOlder();
     onLoadOlder();
   }, [
@@ -388,8 +475,11 @@ export function useAcpConversation({
     }
     acpStickToBottomRef.current = false;
     setConversationStickToBottom(false);
-    const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
-    el.scrollTop = Math.min(saved.top, maxTop);
+    el.scrollTop = restoreConversationScrollTop(
+      saved.top,
+      el.scrollHeight,
+      el.clientHeight
+    );
   }, [acpTab, conversationStickToBottom, conversationTailKey, jumpToConversationBottom]);
 
   useEffect(() => {
@@ -397,14 +487,13 @@ export function useAcpConversation({
     if (!conversationStickToBottom) return;
     const el = acpConversationRef.current;
     if (!el) return;
-    const count = Math.max(1, conversationMessages.length);
-    const estimate = el.scrollHeight / count;
-    if (Number.isFinite(estimate) && estimate > 0) {
-      const normalized = Math.min(220, Math.max(24, estimate));
-      setConversationAvgHeight((prev) =>
-        Math.abs(prev - normalized) >= 1 ? normalized : prev
-      );
-    }
+    setConversationAvgHeight((prev) =>
+      normalizeConversationAvgHeightEstimate(
+        prev,
+        el.scrollHeight,
+        conversationMessages.length
+      )
+    );
   }, [conversationMessages.length, acpTab, conversationStickToBottom]);
 
   useEffect(() => {
@@ -457,10 +546,11 @@ export function useAcpConversation({
     jumpToConversationBottom,
   ]);
 
-  const showConversationJump =
-    acpTab === "conversation" && !conversationStickToBottom;
-  const showConversationBadge =
-    showConversationJump && conversationPendingCount > 0;
+  const { showConversationJump, showConversationBadge } = deriveConversationJumpState(
+    acpTab,
+    conversationStickToBottom,
+    conversationPendingCount
+  );
 
   return {
     acpConversationRef,


### PR DESCRIPTION
## Summary

This PR increases test coverage for `web/src/hooks/use_acp_conversation.ts` by extracting deterministic branch-heavy logic into pure helper functions and adding focused unit tests.

## What Changed

- Extracted decision and normalization helpers from `use_acp_conversation`:
  - `buildConversationTailKey`
  - `shouldLoadOlderFromMeta`
  - `shouldUseConversationVirtualization`
  - `nextConversationViewport`
  - `shouldAutoLoadConversationHistory`
  - `normalizeConversationAvgHeightEstimate`
  - `restoreConversationScrollTop`
  - `deriveConversationJumpState`
- Rewired existing hook branches to use these helpers without changing feature behavior.
- Expanded `use_acp_conversation.test.ts` with helper-level branch tests.
- Added feature note and TODO updates:
  - `docs/features/2026-02-14-use-acp-conversation-coverage.md`
  - `docs/todo.md`

## Coverage Focus

- Target file: `src/hooks/use_acp_conversation.ts`
- Coverage report snapshot from local `lcov.info` after this change:
  - lines: `45/209 (21.53%)`
  - branches: `49/143 (34.27%)`

## Validation

```bash
cd web
npm run test -- src/hooks/use_acp_conversation.test.ts
npm run lint -- src/hooks/use_acp_conversation.ts src/hooks/use_acp_conversation.test.ts
npm run build
npm run test:coverage
```

## Completed

- [x] Increase unit coverage for `use_acp_conversation` by extracting deterministic helper decisions into pure functions and adding branch-heavy tests.
- [x] Document the change and follow-up checks.

## TODO / Follow-ups

- [ ] Verify scroll restoration, jump-button visibility, and history auto-load behavior in long real sessions (desktop + mobile).
- [ ] Continue coverage hardening for other ACP interaction surfaces with low branch coverage.

## Related

- Base branch: `main`
- Branch: `test/use-acp-conversation-coverage`
