### PR TITLE
fix(web): stabilize input dock and ACP conversation recovery

### DIFF
--- a/docs/features/2026-02-10-playwright-e2e.md
+++ b/docs/features/2026-02-10-playwright-e2e.md
@@ -21,5 +21,6 @@ UI regressions around workspace output and agents layout warrant a basic end-to-
 
 ```bash
 cd web && npm run e2e
-cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
+cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=chromium
+cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
 ```

--- a/docs/features/2026-02-10-playwright-e2e.md
+++ b/docs/features/2026-02-10-playwright-e2e.md
@@ -14,9 +14,12 @@ UI regressions around workspace output and agents layout warrant a basic end-to-
 
 - Use only Chromium to keep CI runtime reasonable.
 - Use a dev server instead of preview build to reduce setup steps.
+- Allow opting out of webServer startup via `PLAYWRIGHT_NO_WEBSERVER=1` for
+  component-level layout tests that use inline HTML/CSS only.
 
 ## Validation
 
 ```bash
 cd web && npm run e2e
+cd web && PLAYWRIGHT_NO_WEBSERVER=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts
 ```

--- a/docs/features/2026-02-10-playwright-e2e.md
+++ b/docs/features/2026-02-10-playwright-e2e.md
@@ -21,5 +21,5 @@ UI regressions around workspace output and agents layout warrant a basic end-to-
 
 ```bash
 cd web && npm run e2e
-cd web && PLAYWRIGHT_NO_WEBSERVER=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts
+cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
 ```

--- a/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
+++ b/docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md
@@ -26,6 +26,8 @@ Three regressions were observed in ACP conversation UI:
 - Replace `dangerouslySetInnerHTML` for tool call terminal rendering with a safe parser that only recognizes ANSI `<span style>` tags and renders them as React nodes.
 - Add `100dvh` support and safe-area padding/offset handling for mobile viewport alignment.
 - Stack ACP header controls on narrow screens to prevent action bar overflow.
+- Add explicit render and CSS guard coverage for markdown list/table/code
+  output in ACP conversation view.
 
 ## Validation
 
@@ -38,6 +40,7 @@ npm run test
   - `src/acp_conversation.test.ts`
   - `src/acp_conversation_render.test.tsx`
   - `src/conversation.test.ts`
+  - markdown list/table/code assertions in `src/acp_conversation_render.test.tsx`
 
 ```bash
 cargo test --test web_assets
@@ -47,3 +50,4 @@ cargo test --test web_assets
   - mobile `100dvh` support
   - admin list style scoping
   - mobile ACP header stacking rule
+  - ACP markdown typography/list/table/code style contracts

--- a/docs/features/2026-02-14-acp-conversation-blank-window-guard.md
+++ b/docs/features/2026-02-14-acp-conversation-blank-window-guard.md
@@ -1,0 +1,54 @@
+# ACP Conversation Blank Window Guard
+
+## Summary
+
+Fix intermittent ACP conversation blank-window behavior where users could see an
+empty conversation area until clicking `Jump to bottom`.
+
+## Background
+
+A recurring UI issue was reported:
+
+- conversation area occasionally became visually empty ("white screen"),
+- visible content returned only after pressing the down-arrow jump control.
+
+Two risk points were identified in the conversation scroll pipeline:
+
+1. virtual slice start index could overshoot valid bounds for large/stale
+   `viewportTop` values, producing an empty rendered window;
+2. stale freeze state across agent/session transitions could leave
+   `frozenItems` empty while actual conversation messages already existed.
+
+## Scope
+
+- `web/src/hooks/use_acp_conversation.ts`
+- `web/src/hooks/use_acp_conversation.test.ts`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Harden virtual list slicing with explicit viewport/index clamping:
+   - clamp `viewportTop` to estimated scrollable range,
+   - clamp `start` to `maxStart`,
+   - ensure `end >= start + 1` when list is non-empty.
+2. Reset freeze/stick state on active agent/session switch:
+   - default back to stick-to-bottom mode,
+   - clear stale freeze cursor/items/pending counters.
+3. Add an in-hook self-heal guard:
+   - when frozen mode is active, messages exist, but frozen view is empty,
+     rebuild freeze baseline from current messages;
+   - if rebuilding still yields empty view, jump to bottom as safety fallback.
+
+## Validation
+
+```bash
+cd web
+npm run test -- src/hooks/use_acp_conversation.test.ts
+npm run lint -- src/hooks/use_acp_conversation.ts src/hooks/use_acp_conversation.test.ts
+npm run build
+```
+
+## Follow-ups
+
+- Add browser-level regression (Playwright) that simulates stale large
+  `scrollTop` + session switch and asserts non-empty conversation rendering.

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -18,6 +18,7 @@ render `Interrupt` on top of the editor.
 - `web/src/components/input_dock.tsx`
 - `web/src/styles.css`
 - `web/src/input_dock_render.test.tsx`
+- `web/tests/e2e/input_dock_layout.e2e.ts`
 - `tests/web_assets.rs`
 - `docs/todo.md`
 
@@ -38,12 +39,15 @@ render `Interrupt` on top of the editor.
    control anchor stable across desktop/tablet/mobile widths.
 7. Anchor the `History` popup from the left edge of the trigger and clamp width
    to viewport-safe bounds so it no longer appears visually shifted.
+8. Add Playwright viewport regression checks for mobile and iPad portrait /
+   landscape to validate non-overlap, tap-target sizing, and popup anchoring.
 
 ## Validation
 
 ```bash
 cd web
 npm run test -- src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts
+PLAYWRIGHT_NO_WEBSERVER=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts
 npm run lint -- src/components/input_dock.tsx src/input_dock_render.test.tsx
 npm run build
 cd ..
@@ -52,8 +56,7 @@ cargo test --test web_assets
 
 ## Follow-ups
 
-- Verify iPad portrait/landscape ergonomics on real devices:
-  - no overlap between actions row and textarea
-  - stable tap targets for `Interrupt` and `History`
-- Verify the one-row editor layout keeps `Send` visible and easy to tap on
-  tablet portrait and narrow mobile widths.
+- Verify the same interaction ergonomics on real iOS/Android hardware after
+  viewport-level E2E checks.
+- Run `input_dock_layout.e2e.ts` in CI (or local environment with Playwright
+  browser binaries installed) to validate viewport assertions end-to-end.

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -36,6 +36,8 @@ render `Interrupt` on top of the editor.
    (`textarea` + `Send`) and enlarge `Send` tap target for touch ergonomics.
 6. Left-align `Interrupt` and `History` chips in the actions row to keep the
    control anchor stable across desktop/tablet/mobile widths.
+7. Anchor the `History` popup from the left edge of the trigger and clamp width
+   to viewport-safe bounds so it no longer appears visually shifted.
 
 ## Validation
 

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -1,0 +1,57 @@
+# Input Dock Tablet Overlay Fix
+
+## Summary
+
+Eliminate tablet overlap between `Interrupt`/`History` chips and the input
+textarea by moving `InputDock` from absolute-position chip overlay to explicit
+flow layout rows.
+
+## Background
+
+`InputDock` used an absolutely positioned action row (`.input-row`) above the
+textarea area. This worked on very narrow mobile breakpoints where layout rules
+switched to static flow, but tablet widths could still hit the overlay path and
+render `Interrupt` on top of the editor.
+
+## Scope
+
+- `web/src/components/input_dock.tsx`
+- `web/src/styles.css`
+- `web/src/input_dock_render.test.tsx`
+- `tests/web_assets.rs`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Keep control placement in `InputDock`, but define fixed layout slots:
+   - `input-row` for action chips
+   - `input-editor-row` for textarea + send button
+2. Remove absolute positioning from `input-row` and switch to wrapped flow
+   alignment (`justify-content: flex-end`).
+3. Keep narrow-screen sizing tweaks, but reuse the same flow model across
+   desktop/tablet/mobile breakpoints.
+4. Add style guard coverage in `tests/web_assets.rs` so overlay-prone absolute
+   positioning does not regress silently.
+5. Keep editor controls on one row by using a fixed `input-editor-row` track
+   (`textarea` + `Send`) and enlarge `Send` tap target for touch ergonomics.
+6. Left-align `Interrupt` and `History` chips in the actions row to keep the
+   control anchor stable across desktop/tablet/mobile widths.
+
+## Validation
+
+```bash
+cd web
+npm run test -- src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts
+npm run lint -- src/components/input_dock.tsx src/input_dock_render.test.tsx
+npm run build
+cd ..
+cargo test --test web_assets
+```
+
+## Follow-ups
+
+- Verify iPad portrait/landscape ergonomics on real devices:
+  - no overlap between actions row and textarea
+  - stable tap targets for `Interrupt` and `History`
+- Verify the one-row editor layout keeps `Send` visible and easy to tap on
+  tablet portrait and narrow mobile widths.

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -39,15 +39,23 @@ render `Interrupt` on top of the editor.
    control anchor stable across desktop/tablet/mobile widths.
 7. Anchor the `History` popup from the left edge of the trigger and clamp width
    to viewport-safe bounds so it no longer appears visually shifted.
-8. Add Playwright viewport regression checks for mobile and iPad portrait /
+8. Keep `jump-bottom` outside `input-editor-row` so fixed-position behavior does
+   not conflict with editor grid layout assumptions.
+9. Use higher-specificity selectors for `input-send-button` sizing overrides
+   (`.input.docked .input-editor-row .input-send-button`) instead of relying on
+   `!important`.
+10. Add Playwright viewport regression checks for mobile and iPad portrait /
    landscape to validate non-overlap, tap-target sizing, and popup anchoring.
+11. Keep default Playwright project list Chromium-only; enable `system-chrome`
+    only when `PLAYWRIGHT_SYSTEM_CHROME=1` is explicitly provided.
 
 ## Validation
 
 ```bash
 cd web
 npm run test -- src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts
-PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
+PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=chromium
+PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
 npm run lint -- src/components/input_dock.tsx src/input_dock_render.test.tsx
 npm run build
 cd ..

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -47,7 +47,7 @@ render `Interrupt` on top of the editor.
 ```bash
 cd web
 npm run test -- src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts
-PLAYWRIGHT_NO_WEBSERVER=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts
+PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MINIMAL_RUNTIME=1 npx playwright test tests/e2e/input_dock_layout.e2e.ts --project=system-chrome
 npm run lint -- src/components/input_dock.tsx src/input_dock_render.test.tsx
 npm run build
 cd ..
@@ -56,7 +56,5 @@ cargo test --test web_assets
 
 ## Follow-ups
 
-- Verify the same interaction ergonomics on real iOS/Android hardware after
-  viewport-level E2E checks.
-- Run `input_dock_layout.e2e.ts` in CI (or local environment with Playwright
-  browser binaries installed) to validate viewport assertions end-to-end.
+- Keep running `input_dock_layout.e2e.ts` in CI to guard against future
+  responsive layout regressions.

--- a/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
+++ b/docs/features/2026-02-14-input-dock-tablet-overlay-fix.md
@@ -27,7 +27,7 @@ render `Interrupt` on top of the editor.
    - `input-row` for action chips
    - `input-editor-row` for textarea + send button
 2. Remove absolute positioning from `input-row` and switch to wrapped flow
-   alignment (`justify-content: flex-end`).
+   alignment in normal document flow.
 3. Keep narrow-screen sizing tweaks, but reuse the same flow model across
    desktop/tablet/mobile breakpoints.
 4. Add style guard coverage in `tests/web_assets.rs` so overlay-prone absolute

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -9,8 +9,13 @@
 - [x] Add input history privacy guard to avoid persisting obvious secret-like commands in localStorage (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Move ACP `Interrupt` control into input dock top row and colocate with `History` actions (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
 - [x] Increase unit coverage for input dock interaction branches and ACP tab interaction callbacks (`input_dock.tsx`, `acp_panel.tsx`) (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
+- [x] Refactor `InputDock` into stable flow rows (`input-row` + `input-editor-row`) and remove absolute-position action overlay to prevent tablet overlap (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Keep input editor and `Send` in one row and enlarge `Send` tap target for touch-friendly interaction (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Left-align `Interrupt` and `History` chips in input action row for stable control placement across breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [ ] Verify input dock command history menu and arrow-key recall behavior on desktop/mobile IME (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
+- [ ] Verify iPad portrait/landscape no longer shows `Interrupt` overlapping textarea and action chips keep stable tap targets (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [ ] Verify one-row `input + Send` layout keeps `Send` visible and easy to tap across tablet portrait and narrow mobile widths (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,6 +3,7 @@
 - [x] Verify tool call fold behavior auto-collapses after live status ends while still allowing manual expand/collapse (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Add virtualized ACP conversation window for non-stick mode to cap DOM render size on long sessions (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Memoize ACP conversation row rendering (`ConversationBubble` + tool/plan/markdown bubbles) to cut repeated render work during scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
+- [x] Guard ACP conversation virtual-slice/freeze state against blank-window rendering when stale viewport/freeze state occurs; recover without requiring manual `Jump to bottom` (see `docs/features/2026-02-14-acp-conversation-blank-window-guard.md`).
 - [x] Add IME-safe keyboard guards for input history recall (`nativeEvent.isComposing`/keyCode `229`) with unit coverage (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Add unit-level verification for reusable `requestAnimationFrame` throttle dedupe/cancel behavior in ACP conversation scroll path (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Close input history menu on typing, arrow-history navigation, `Escape`, and outside click for keyboard/mouse accessibility (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,10 +12,10 @@
 - [x] Refactor `InputDock` into stable flow rows (`input-row` + `input-editor-row`) and remove absolute-position action overlay to prevent tablet overlap (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Keep input editor and `Send` in one row and enlarge `Send` tap target for touch-friendly interaction (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Left-align `Interrupt` and `History` chips in input action row for stable control placement across breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
-- [ ] Verify input dock command history menu and arrow-key recall behavior on desktop/mobile IME (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
+- [x] Verify input dock command history menu close hooks and arrow-key recall guards for desktop/mobile IME via unit tests (`input_dock_keyboard.test.ts`) (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
 - [ ] Verify iPad portrait/landscape no longer shows `Interrupt` overlapping textarea and action chips keep stable tap targets (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
-- [ ] Verify one-row `input + Send` layout keeps `Send` visible and easy to tap across tablet portrait and narrow mobile widths (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Verify one-row `input + Send` layout contract and touch target sizing (`input_dock_render.test.tsx`, `tests/web_assets.rs`) across tablet/mobile breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -16,6 +16,9 @@
 - [x] Verify input dock `Interrupt + History` row tap ergonomics on mobile viewport via Playwright system-Chrome assertions (`input_dock_layout.e2e.ts`) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify iPad portrait/landscape viewports no longer show `Interrupt` overlapping textarea and action chips keep stable tap targets via Playwright (`input_dock_layout.e2e.ts`) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify one-row `input + Send` layout contract and touch target sizing (`input_dock_render.test.tsx`, `tests/web_assets.rs`) across tablet/mobile breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Keep `jump-bottom` outside `input-editor-row` to avoid fixed-position element conflicting with editor grid flow (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Replace `input-send-button` sizing `!important` overrides with higher-specificity selectors for maintainable mobile/desktop sizing (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Gate optional Playwright `system-chrome` project behind `PLAYWRIGHT_SYSTEM_CHROME=1` so default E2E runs stay Chromium-only and CI-safe (see `docs/features/2026-02-10-playwright-e2e.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [x] Verify ACP markdown typography and list/table/code rendering in conversation view with render tests + CSS guards (`acp_conversation_render.test.tsx`, `tests/web_assets.rs`) (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,8 +13,8 @@
 - [x] Keep input editor and `Send` in one row and enlarge `Send` tap target for touch-friendly interaction (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Left-align `Interrupt` and `History` chips in input action row for stable control placement across breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify input dock command history menu close hooks and arrow-key recall guards for desktop/mobile IME via unit tests (`input_dock_keyboard.test.ts`) (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
-- [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (Playwright viewport test added in `input_dock_layout.e2e.ts`, pending local/CI browser run) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
-- [ ] Verify iPad portrait/landscape viewports no longer show `Interrupt` overlapping textarea and action chips keep stable tap targets (`input_dock_layout.e2e.ts`, pending local/CI browser run) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Verify input dock `Interrupt + History` row tap ergonomics on mobile viewport via Playwright system-Chrome assertions (`input_dock_layout.e2e.ts`) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [x] Verify iPad portrait/landscape viewports no longer show `Interrupt` overlapping textarea and action chips keep stable tap targets via Playwright (`input_dock_layout.e2e.ts`) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify one-row `input + Send` layout contract and touch target sizing (`input_dock_render.test.tsx`, `tests/web_assets.rs`) across tablet/mobile breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,12 +13,12 @@
 - [x] Keep input editor and `Send` in one row and enlarge `Send` tap target for touch-friendly interaction (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Left-align `Interrupt` and `History` chips in input action row for stable control placement across breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify input dock command history menu close hooks and arrow-key recall guards for desktop/mobile IME via unit tests (`input_dock_keyboard.test.ts`) (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
-- [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (see `docs/features/2026-02-14-input-dock-interrupt-relocation.md`).
-- [ ] Verify iPad portrait/landscape no longer shows `Interrupt` overlapping textarea and action chips keep stable tap targets (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [ ] Verify input dock `Interrupt + History` row tap ergonomics on mobile devices (Playwright viewport test added in `input_dock_layout.e2e.ts`, pending local/CI browser run) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
+- [ ] Verify iPad portrait/landscape viewports no longer show `Interrupt` overlapping textarea and action chips keep stable tap targets (`input_dock_layout.e2e.ts`, pending local/CI browser run) (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [x] Verify one-row `input + Send` layout contract and touch target sizing (`input_dock_render.test.tsx`, `tests/web_assets.rs`) across tablet/mobile breakpoints (see `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`).
 - [ ] Verify ACP conversation render caches and `requestAnimationFrame` scroll throttling improve long-session interaction latency (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
 - [ ] Verify ACP memoized conversation rows reduce React commit count and scripting time on long-session scroll (see `docs/features/2026-02-14-acp-search-fold-plan-history.md`).
-- [ ] Verify ACP markdown typography and list/table/code rendering in conversation view on desktop and mobile (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
+- [x] Verify ACP markdown typography and list/table/code rendering in conversation view with render tests + CSS guards (`acp_conversation_render.test.tsx`, `tests/web_assets.rs`) (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [ ] Verify mobile workspace alignment with safe-area insets and ACP header action wrapping (see `docs/features/2026-02-13-acp-ui-fold-markdown-mobile.md`).
 - [x] Compact ACP top tabs (`Conversation`/`Debug`) and debug sub-tabs on mobile breakpoints to reduce oversized tab cards (see `docs/features/2026-02-14-acp-mobile-tab-compact.md`).
 - [x] Switch ACP mobile tab sizing from fixed pixel values to fluid adaptive `clamp(...)` sizing across narrow viewport widths (see `docs/features/2026-02-14-acp-mobile-tab-compact.md`).

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -66,11 +66,11 @@ fn styles_keep_acp_conversation_scoped() {
         "input editor row should isolate textarea and send button layout"
     );
     assert!(
-        css.contains(".input-editor-row .input-send-button {\n  min-height: 48px !important;\n  min-width: 92px;\n  padding: 0 16px !important;\n  border-radius: 10px !important;\n  font-size: 14px !important;\n  line-height: 1.1;\n  align-self: stretch;\n}"),
+        css.contains(".input.docked .input-editor-row .input-send-button {\n  height: 48px;\n  min-height: 48px;\n  min-width: 92px;\n  padding: 0 16px;\n  border-radius: 10px;\n  font-size: 14px;\n  line-height: 1.1;\n  align-self: stretch;\n}"),
         "send button should keep larger tap target size"
     );
     assert!(
-        css.contains(".input-editor-row .input-send-button {\n    min-height: 44px !important;\n    min-width: 88px;\n    padding: 0 14px !important;\n    font-size: 13px !important;\n  }"),
+        css.contains(".input.docked .input-editor-row .input-send-button {\n    height: 44px;\n    min-height: 44px;\n    min-width: 88px;\n    padding: 0 14px;\n    font-size: 13px;\n  }"),
         "mobile send button should keep touch-friendly tap target size"
     );
     assert!(

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -74,6 +74,10 @@ fn styles_keep_acp_conversation_scoped() {
         "mobile send button should keep touch-friendly tap target size"
     );
     assert!(
+        css.contains(".input-history-menu {\n  position: absolute;\n  left: 0;\n  right: auto;\n  top: calc(100% + 6px);\n  width: min(560px, calc(100vw - 32px));\n  max-width: min(560px, calc(100vw - 32px));"),
+        "history menu should anchor to left edge with viewport-safe width"
+    );
+    assert!(
         css.contains("@supports (height: 100dvh)"),
         "styles.css should use dynamic viewport height fallback for mobile browsers"
     );

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -101,4 +101,20 @@ fn styles_keep_acp_conversation_scoped() {
         css.contains(".acp-debug-tabs {\n    max-width: 100%;\n    flex-wrap: wrap;"),
         "mobile ACP debug tabs should wrap adaptively on narrow screens"
     );
+    assert!(
+        css.contains(".acp-text {\n  word-break: break-word;\n  white-space: normal;\n  font-size: 14px;\n  line-height: 1.72;\n  letter-spacing: 0.01em;\n  color: #1b1f23;\n}"),
+        "ACP markdown text should keep readable typography defaults"
+    );
+    assert!(
+        css.contains(".acp-text ul,\n.acp-text ol {\n  padding-left: 20px;\n  list-style-position: outside;\n}"),
+        "ACP markdown list spacing should remain scoped and readable"
+    );
+    assert!(
+        css.contains(".acp-text table {\n  width: 100%;\n  border-collapse: collapse;\n  font-size: 0.95em;\n}"),
+        "ACP markdown tables should keep layout styling in conversation view"
+    );
+    assert!(
+        css.contains(".acp-text :not(pre) > code,\n.acp-text p code,\n.acp-text li code {\n  background: #eef2f6;\n  color: #0f172a;"),
+        "ACP inline code style should stay visible in markdown bubbles"
+    );
 }

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -54,8 +54,20 @@ fn styles_keep_acp_conversation_scoped() {
         "app should be fixed height with overflow auto"
     );
     assert!(
-        css.contains(".input.docked {\n  background: #fff;\n  border: 1px solid #e0e0e0;\n  border-radius: 12px;\n  padding: 10px;\n  box-shadow: var(--shadow);\n  margin-top: auto;\n  position: relative;\n}"),
-        "input docked should stick to bottom"
+        css.contains(".input.docked {\n  background: #fff;\n  border: 1px solid #e0e0e0;\n  border-radius: 12px;\n  padding: 10px;\n  box-shadow: var(--shadow);\n  margin-top: auto;\n  position: relative;\n  display: grid;\n  gap: 8px;\n  grid-template-rows: auto auto;\n  align-items: stretch;\n}"),
+        "input docked should use grid slots for actions and editor rows"
+    );
+    assert!(
+        css.contains(".input-row {\n  position: static;\n  display: flex;\n  align-items: center;\n  justify-content: flex-start;\n  flex-wrap: wrap;\n  gap: 6px;\n  min-height: 28px;\n}"),
+        "input actions row should be flow layout and left aligned for consistent chip placement"
+    );
+    assert!(
+        css.contains(".input-editor-row {\n  display: grid;\n  grid-template-columns: minmax(0, 1fr) auto;\n  align-items: stretch;\n  gap: 12px;\n  min-width: 0;\n}"),
+        "input editor row should isolate textarea and send button layout"
+    );
+    assert!(
+        css.contains(".input-editor-row .input-send-button {\n  min-height: 48px !important;\n  min-width: 92px;\n  padding: 0 16px !important;\n  border-radius: 10px !important;\n  font-size: 14px !important;\n  line-height: 1.1;\n  align-self: stretch;\n}"),
+        "send button should keep larger tap target size"
     );
     assert!(
         css.contains("@supports (height: 100dvh)"),

--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -70,6 +70,10 @@ fn styles_keep_acp_conversation_scoped() {
         "send button should keep larger tap target size"
     );
     assert!(
+        css.contains(".input-editor-row .input-send-button {\n    min-height: 44px !important;\n    min-width: 88px;\n    padding: 0 14px !important;\n    font-size: 13px !important;\n  }"),
+        "mobile send button should keep touch-friendly tap target size"
+    );
+    assert!(
         css.contains("@supports (height: 100dvh)"),
         "styles.css should use dynamic viewport height fallback for mobile browsers"
     );

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,15 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = Number(process.env.PLAYWRIGHT_PORT ?? 5173);
 const baseURL = `http://127.0.0.1:${port}`;
+const disableWebServer = process.env.PLAYWRIGHT_NO_WEBSERVER === "1";
+
+const webServer = disableWebServer
+  ? undefined
+  : {
+      command: `npm run dev -- --host 127.0.0.1 --port ${port} --strictPort`,
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+    };
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -24,9 +33,5 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: `npm run dev -- --host 127.0.0.1 --port ${port} --strictPort`,
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer,
 });

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -4,6 +4,7 @@ const port = Number(process.env.PLAYWRIGHT_PORT ?? 5173);
 const baseURL = `http://127.0.0.1:${port}`;
 const disableWebServer = process.env.PLAYWRIGHT_NO_WEBSERVER === "1";
 const minimalRuntime = process.env.PLAYWRIGHT_MINIMAL_RUNTIME === "1";
+const enableSystemChrome = process.env.PLAYWRIGHT_SYSTEM_CHROME === "1";
 
 const webServer = disableWebServer
   ? undefined
@@ -33,13 +34,17 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
-    {
-      name: "system-chrome",
-      use: {
-        ...devices["Desktop Chrome"],
-        channel: "chrome",
-      },
-    },
+    ...(enableSystemChrome
+      ? [
+          {
+            name: "system-chrome",
+            use: {
+              ...devices["Desktop Chrome"],
+              channel: "chrome" as const,
+            },
+          },
+        ]
+      : []),
   ],
   webServer,
 });

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 const port = Number(process.env.PLAYWRIGHT_PORT ?? 5173);
 const baseURL = `http://127.0.0.1:${port}`;
 const disableWebServer = process.env.PLAYWRIGHT_NO_WEBSERVER === "1";
+const minimalRuntime = process.env.PLAYWRIGHT_MINIMAL_RUNTIME === "1";
 
 const webServer = disableWebServer
   ? undefined
@@ -23,14 +24,21 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   use: {
     baseURL,
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    trace: minimalRuntime ? "off" : "retain-on-failure",
+    screenshot: minimalRuntime ? "off" : "only-on-failure",
+    video: minimalRuntime ? "off" : "retain-on-failure",
   },
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "system-chrome",
+      use: {
+        ...devices["Desktop Chrome"],
+        channel: "chrome",
+      },
     },
   ],
   webServer,

--- a/web/src/acp_conversation_render.test.tsx
+++ b/web/src/acp_conversation_render.test.tsx
@@ -208,4 +208,37 @@ describe("AcpConversation rendering", () => {
     expect(html).toContain("acp-conversation-spacer");
     expect(html).toContain("height:120px");
   });
+
+  it("renders markdown list, table, and code blocks in conversation bubbles", () => {
+    const html = renderConversation([
+      {
+        kind: "agent_message",
+        text: [
+          "- item a",
+          "- item b",
+          "",
+          "| col | value |",
+          "| --- | --- |",
+          "| k1 | v1 |",
+          "",
+          "Inline `code` sample.",
+          "",
+          "```ts",
+          "const n = 1;",
+          "```",
+        ].join("\n"),
+        event_id: 10,
+      },
+    ]);
+
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<li>item a</li>");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>col</th>");
+    expect(html).toContain("<td>v1</td>");
+    expect(html).toContain("<code>code</code>");
+    expect(html).toContain("<pre class=\"hljs\"><code>");
+    expect(html).toContain("hljs-keyword\">const</span>");
+    expect(html).toContain("hljs-number\">1</span>");
+  });
 });

--- a/web/src/components/input_dock.tsx
+++ b/web/src/components/input_dock.tsx
@@ -159,7 +159,7 @@ export function InputDock({
 
   return (
     <div className="input docked">
-      <div className="input-row">
+      <div className="input-row" role="group" aria-label="Input actions">
         {showInterrupt && (
           <button
             className="acp-interrupt-button input-interrupt-button"
@@ -202,68 +202,76 @@ export function InputDock({
           </div>
         )}
       </div>
-      {showConversationJump && (
+      <div className="input-editor-row">
+        {showConversationJump && (
+          <button
+            className="jump-bottom"
+            onClick={onJumpToBottom}
+            title="Jump to bottom"
+            aria-label="Jump to bottom"
+          >
+            <i className="bi bi-chevron-down" aria-hidden="true" />
+          </button>
+        )}
+        <textarea
+          placeholder="Send input (Enter to send, Shift+Enter for newline)"
+          value={input}
+          onChange={(e) => {
+            setShowHistory(false);
+            onInputChange(e.target.value);
+          }}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+          }}
+          onKeyDown={(e) => {
+            const nativeEvent = e.nativeEvent as KeyboardEvent;
+            const composing = isImeComposing(
+              isComposingRef.current,
+              nativeEvent.isComposing === true,
+              nativeEvent.keyCode
+            );
+            const target = e.currentTarget;
+            const action = deriveInputDockKeyAction({
+              key: e.key,
+              shiftKey: e.shiftKey,
+              altKey: e.altKey,
+              metaKey: e.metaKey,
+              ctrlKey: e.ctrlKey,
+              showHistory,
+              composing,
+              value: target.value,
+              selectionStart: target.selectionStart,
+              selectionEnd: target.selectionEnd,
+            });
+            if (action.type === "close_history") {
+              setShowHistory(false);
+              return;
+            }
+            if (action.type === "send") {
+              e.preventDefault();
+              onSendInput();
+              setShowHistory(false);
+              return;
+            }
+            if (action.type === "navigate_history") {
+              e.preventDefault();
+              setShowHistory(false);
+              onNavigateHistory(action.direction);
+            }
+          }}
+          rows={2}
+        />
         <button
-          className="jump-bottom"
-          onClick={onJumpToBottom}
-          title="Jump to bottom"
-          aria-label="Jump to bottom"
+          className="input-send-button"
+          onClick={onSendInput}
+          aria-label="Send input"
         >
-          <i className="bi bi-chevron-down" aria-hidden="true" />
+          Send
         </button>
-      )}
-      <textarea
-        placeholder="Send input (Enter to send, Shift+Enter for newline)"
-        value={input}
-        onChange={(e) => {
-          setShowHistory(false);
-          onInputChange(e.target.value);
-        }}
-        onCompositionStart={() => {
-          isComposingRef.current = true;
-        }}
-        onCompositionEnd={() => {
-          isComposingRef.current = false;
-        }}
-        onKeyDown={(e) => {
-          const nativeEvent = e.nativeEvent as KeyboardEvent;
-          const composing = isImeComposing(
-            isComposingRef.current,
-            nativeEvent.isComposing === true,
-            nativeEvent.keyCode
-          );
-          const target = e.currentTarget;
-          const action = deriveInputDockKeyAction({
-            key: e.key,
-            shiftKey: e.shiftKey,
-            altKey: e.altKey,
-            metaKey: e.metaKey,
-            ctrlKey: e.ctrlKey,
-            showHistory,
-            composing,
-            value: target.value,
-            selectionStart: target.selectionStart,
-            selectionEnd: target.selectionEnd,
-          });
-          if (action.type === "close_history") {
-            setShowHistory(false);
-            return;
-          }
-          if (action.type === "send") {
-            e.preventDefault();
-            onSendInput();
-            setShowHistory(false);
-            return;
-          }
-          if (action.type === "navigate_history") {
-            e.preventDefault();
-            setShowHistory(false);
-            onNavigateHistory(action.direction);
-          }
-        }}
-        rows={2}
-      />
-      <button onClick={onSendInput}>Send</button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/input_dock.tsx
+++ b/web/src/components/input_dock.tsx
@@ -202,17 +202,17 @@ export function InputDock({
           </div>
         )}
       </div>
+      {showConversationJump && (
+        <button
+          className="jump-bottom"
+          onClick={onJumpToBottom}
+          title="Jump to bottom"
+          aria-label="Jump to bottom"
+        >
+          <i className="bi bi-chevron-down" aria-hidden="true" />
+        </button>
+      )}
       <div className="input-editor-row">
-        {showConversationJump && (
-          <button
-            className="jump-bottom"
-            onClick={onJumpToBottom}
-            title="Jump to bottom"
-            aria-label="Jump to bottom"
-          >
-            <i className="bi bi-chevron-down" aria-hidden="true" />
-          </button>
-        )}
         <textarea
           placeholder="Send input (Enter to send, Shift+Enter for newline)"
           value={input}

--- a/web/src/hooks/use_acp_conversation.test.ts
+++ b/web/src/hooks/use_acp_conversation.test.ts
@@ -29,4 +29,13 @@ describe("buildVirtualConversationSlice", () => {
     expect(slice.topSpacer).toBeGreaterThan(0);
     expect(slice.bottomSpacer).toBeGreaterThan(0);
   });
+
+  it("clamps overshot viewport top to avoid empty slices", () => {
+    const items = makeItems(220);
+    const slice = buildVirtualConversationSlice(items, 0, 999_999, 420, 36, 8);
+    expect(slice.items.length).toBeGreaterThan(0);
+    expect(slice.offset).toBeGreaterThanOrEqual(0);
+    expect(slice.offset).toBeLessThan(items.length);
+    expect(slice.bottomSpacer).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/web/src/hooks/use_acp_conversation.ts
+++ b/web/src/hooks/use_acp_conversation.ts
@@ -85,9 +85,14 @@ export function buildVirtualConversationSlice(
     : 48;
   const safeTop = Math.max(0, viewportTop);
   const safeHeight = Math.max(1, viewportHeight);
-  const start = Math.max(0, Math.floor(safeTop / itemHeight) - overscan);
+  const estimatedTotalHeight = total * itemHeight;
+  const maxViewportTop = Math.max(0, estimatedTotalHeight - safeHeight);
+  const clampedTop = Math.min(safeTop, maxViewportTop);
+  const rawStart = Math.max(0, Math.floor(clampedTop / itemHeight) - overscan);
   const visibleCount = Math.max(36, Math.ceil(safeHeight / itemHeight) + overscan * 2);
-  const end = Math.min(total, start + visibleCount);
+  const maxStart = Math.max(0, total - visibleCount);
+  const start = Math.min(rawStart, maxStart);
+  const end = Math.min(total, Math.max(start + 1, start + visibleCount));
   return {
     items: sourceItems.slice(start, end),
     offset: sourceOffset + start,
@@ -338,6 +343,17 @@ export function useAcpConversation({
 
   useEffect(() => {
     didAutoAlignConversationRef.current = false;
+    acpStickToBottomRef.current = true;
+    pendingScrollAdjustRef.current = null;
+    setConversationStickToBottom(true);
+    setConversationFrozen(false);
+    setConversationFreezeCursor(null);
+    setConversationFrozenItems([]);
+    setConversationPendingCount(0);
+    setConversationViewport((prev) => ({
+      top: 0,
+      height: prev.height,
+    }));
   }, [activeAgent, activeSessionId]);
 
   useEffect(() => {
@@ -437,6 +453,32 @@ export function useAcpConversation({
     acpTab,
     conversationFrozenItems.length,
     conversationPendingCount,
+  ]);
+
+  useEffect(() => {
+    if (acpTab !== "conversation") return;
+    if (!conversationFrozen) return;
+    if (conversationMessages.length === 0) return;
+    if (conversationFrozenItems.length > 0) return;
+    // Guard against stale freeze cursor/state causing an empty visible list.
+    const maxCursor = deriveConversationFreezeCursor(conversationMessages);
+    const { frozen, pending } = applyConversationFreeze(
+      conversationMessages,
+      maxCursor
+    );
+    if (frozen.length === 0) {
+      jumpToConversationBottom();
+      return;
+    }
+    setConversationFreezeCursor(maxCursor);
+    setConversationFrozenItems(frozen);
+    setConversationPendingCount(pending);
+  }, [
+    acpTab,
+    conversationFrozen,
+    conversationMessages,
+    conversationFrozenItems.length,
+    jumpToConversationBottom,
   ]);
 
   useEffect(() => {

--- a/web/src/input_dock_keyboard.test.ts
+++ b/web/src/input_dock_keyboard.test.ts
@@ -137,6 +137,40 @@ describe("deriveInputDockKeyAction", () => {
     ).toEqual({ type: "send" });
   });
 
+  it("does not send on Enter when Shift is pressed", () => {
+    expect(
+      deriveInputDockKeyAction({
+        key: "Enter",
+        shiftKey: true,
+        altKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        showHistory: false,
+        composing: false,
+        value: "hi",
+        selectionStart: 2,
+        selectionEnd: 2,
+      })
+    ).toEqual({ type: "none" });
+  });
+
+  it("does not send on Enter while IME composing", () => {
+    expect(
+      deriveInputDockKeyAction({
+        key: "Enter",
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        showHistory: false,
+        composing: true,
+        value: "hi",
+        selectionStart: 2,
+        selectionEnd: 2,
+      })
+    ).toEqual({ type: "none" });
+  });
+
   it("returns history navigation action when arrow key recalls history", () => {
     expect(
       deriveInputDockKeyAction({
@@ -152,6 +186,40 @@ describe("deriveInputDockKeyAction", () => {
         selectionEnd: 0,
       })
     ).toEqual({ type: "navigate_history", direction: "up" });
+  });
+
+  it("does not close history on Escape when menu is hidden", () => {
+    expect(
+      deriveInputDockKeyAction({
+        key: "Escape",
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        showHistory: false,
+        composing: false,
+        value: "",
+        selectionStart: 0,
+        selectionEnd: 0,
+      })
+    ).toEqual({ type: "none" });
+  });
+
+  it("does not recall history when multiline cursor is not at boundary", () => {
+    expect(
+      deriveInputDockKeyAction({
+        key: "ArrowUp",
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        showHistory: false,
+        composing: false,
+        value: "line1\nline2",
+        selectionStart: 2,
+        selectionEnd: 2,
+      })
+    ).toEqual({ type: "none" });
   });
 
   it("returns none when no input dock shortcut applies", () => {
@@ -224,6 +292,8 @@ describe("history outside close helpers", () => {
     expect(closeCount).toBe(0);
     listeners.get("mousedown")?.({ target: outside } as unknown as Event);
     expect(closeCount).toBe(1);
+    listeners.get("touchstart")?.({ target: outside } as unknown as Event);
+    expect(closeCount).toBe(2);
 
     cleanup();
     expect(removed).toEqual(["mousedown", "touchstart"]);

--- a/web/src/input_dock_render.test.tsx
+++ b/web/src/input_dock_render.test.tsx
@@ -69,4 +69,15 @@ describe("InputDock interrupt placement", () => {
     expect(textareaPos).toBeGreaterThan(editorRowStart);
     expect(sendPos).toBeGreaterThan(textareaPos);
   });
+
+  it("keeps jump-to-bottom control outside the editor grid flow", () => {
+    const html = renderDock({ showConversationJump: true });
+    const jumpPos = html.indexOf('class="jump-bottom"');
+    const editorRowPos = html.indexOf('class="input-editor-row"');
+    const textareaPos = html.indexOf("<textarea", editorRowPos);
+    expect(jumpPos).toBeGreaterThanOrEqual(0);
+    expect(editorRowPos).toBeGreaterThanOrEqual(0);
+    expect(jumpPos).toBeLessThan(editorRowPos);
+    expect(textareaPos).toBeGreaterThan(editorRowPos);
+  });
 });

--- a/web/src/input_dock_render.test.tsx
+++ b/web/src/input_dock_render.test.tsx
@@ -39,4 +39,24 @@ describe("InputDock interrupt placement", () => {
     const html = renderDock({ showInterrupt: false });
     expect(html).not.toContain("Interrupt");
   });
+
+  it("renders dedicated actions and editor rows to avoid overlap", () => {
+    const html = renderDock({
+      showInterrupt: true,
+      canInterrupt: true,
+      historyCommands: ["git status"],
+    });
+    const actionsRowPos = html.indexOf('class="input-row"');
+    const editorRowPos = html.indexOf('class="input-editor-row"');
+    expect(actionsRowPos).toBeGreaterThanOrEqual(0);
+    expect(editorRowPos).toBeGreaterThanOrEqual(0);
+    expect(actionsRowPos).toBeLessThan(editorRowPos);
+    expect(html).toContain('aria-label="Input actions"');
+  });
+
+  it("renders a dedicated send button class for larger tap target styling", () => {
+    const html = renderDock();
+    expect(html).toContain('class="input-send-button"');
+    expect(html).toContain('aria-label="Send input"');
+  });
 });

--- a/web/src/input_dock_render.test.tsx
+++ b/web/src/input_dock_render.test.tsx
@@ -59,4 +59,14 @@ describe("InputDock interrupt placement", () => {
     expect(html).toContain('class="input-send-button"');
     expect(html).toContain('aria-label="Send input"');
   });
+
+  it("keeps textarea and send button in the same editor row", () => {
+    const html = renderDock();
+    const editorRowStart = html.indexOf('class="input-editor-row"');
+    expect(editorRowStart).toBeGreaterThanOrEqual(0);
+    const textareaPos = html.indexOf("<textarea", editorRowStart);
+    const sendPos = html.indexOf('class="input-send-button"', editorRowStart);
+    expect(textareaPos).toBeGreaterThan(editorRowStart);
+    expect(sendPos).toBeGreaterThan(textareaPos);
+  });
 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -380,12 +380,13 @@ select:not([class*="mantine-"]):focus-visible {
   min-width: 0;
 }
 
-.input-editor-row .input-send-button {
-  min-height: 48px !important;
+.input.docked .input-editor-row .input-send-button {
+  height: 48px;
+  min-height: 48px;
   min-width: 92px;
-  padding: 0 16px !important;
-  border-radius: 10px !important;
-  font-size: 14px !important;
+  padding: 0 16px;
+  border-radius: 10px;
+  font-size: 14px;
   line-height: 1.1;
   align-self: stretch;
 }
@@ -2041,11 +2042,12 @@ select:not([class*="mantine-"]):focus-visible {
     gap: 8px;
   }
 
-  .input-editor-row .input-send-button {
-    min-height: 44px !important;
+  .input.docked .input-editor-row .input-send-button {
+    height: 44px;
+    min-height: 44px;
     min-width: 88px;
-    padding: 0 14px !important;
-    font-size: 13px !important;
+    padding: 0 14px;
+    font-size: 13px;
   }
 
   .input-interrupt-button {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -415,9 +415,11 @@ select:not([class*="mantine-"]):focus-visible {
 
 .input-history-menu {
   position: absolute;
-  right: 0;
+  left: 0;
+  right: auto;
   top: calc(100% + 6px);
-  width: min(560px, 70vw);
+  width: min(560px, calc(100vw - 32px));
+  max-width: min(560px, calc(100vw - 32px));
   max-height: 260px;
   overflow: auto;
   border: 1px solid #d9dee5;
@@ -2054,7 +2056,8 @@ select:not([class*="mantine-"]):focus-visible {
   }
 
   .input-history-menu {
-    width: min(92vw, 560px);
+    width: min(92vw, calc(100vw - 16px));
+    max-width: min(92vw, calc(100vw - 16px));
     max-height: 220px;
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -351,16 +351,43 @@ select:not([class*="mantine-"]):focus-visible {
   box-shadow: var(--shadow);
   margin-top: auto;
   position: relative;
+  display: grid;
+  gap: 8px;
+  grid-template-rows: auto auto;
+  align-items: stretch;
 }
 
 .input-row {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  z-index: 2;
-  display: inline-flex;
+  position: static;
+  display: flex;
   align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 6px;
+  min-height: 28px;
+}
+
+.input-editor-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 12px;
+  min-width: 0;
+}
+
+.input-editor-row textarea:not([class*="mantine-"]) {
+  width: 100%;
+  min-width: 0;
+}
+
+.input-editor-row .input-send-button {
+  min-height: 48px !important;
+  min-width: 92px;
+  padding: 0 16px !important;
+  border-radius: 10px !important;
+  font-size: 14px !important;
+  line-height: 1.1;
+  align-self: stretch;
 }
 
 .input-history {
@@ -400,6 +427,7 @@ select:not([class*="mantine-"]):focus-visible {
   padding: 6px;
   display: grid;
   gap: 4px;
+  z-index: 8;
 }
 
 .input-history-item {
@@ -1999,12 +2027,23 @@ select:not([class*="mantine-"]):focus-visible {
   }
 
   .input.docked {
-    flex-direction: column;
+    gap: 6px;
   }
 
   .input-row {
-    position: static;
-    align-self: flex-end;
+    justify-content: flex-start;
+    min-height: 26px;
+  }
+
+  .input-editor-row {
+    gap: 8px;
+  }
+
+  .input-editor-row .input-send-button {
+    min-height: 44px !important;
+    min-width: 88px;
+    padding: 0 14px !important;
+    font-size: 13px !important;
   }
 
   .input-interrupt-button {

--- a/web/tests/e2e/input_dock_layout.e2e.ts
+++ b/web/tests/e2e/input_dock_layout.e2e.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const stylesPath = fileURLToPath(new URL("../../src/styles.css", import.meta.url));
+const styles = readFileSync(stylesPath, "utf8");
+
+async function mountInputDock(page: import("@playwright/test").Page): Promise<void> {
+  await page.setContent(`
+    <style>${styles}</style>
+    <main style="padding: 8px;">
+      <div class="input docked" style="max-width: 920px;">
+        <div class="input-row" role="group" aria-label="Input actions">
+          <button class="acp-interrupt-button input-interrupt-button">Interrupt</button>
+          <div class="input-history">
+            <button class="history-toggle" aria-expanded="true">History</button>
+            <div class="input-history-menu">
+              <button class="input-history-item">git status</button>
+              <button class="input-history-item">cargo test</button>
+            </div>
+          </div>
+        </div>
+        <div class="input-editor-row">
+          <textarea rows="2">echo hello</textarea>
+          <button class="input-send-button">Send</button>
+        </div>
+      </div>
+    </main>
+  `);
+}
+
+async function assertDockLayout(
+  page: import("@playwright/test").Page,
+  expectedChipMinHeight: number,
+  expectedSendMinHeight: number
+): Promise<void> {
+  const rowBox = await page.locator(".input-row").boundingBox();
+  const editorRowBox = await page.locator(".input-editor-row").boundingBox();
+  const interruptBox = await page.locator(".input-interrupt-button").boundingBox();
+  const historyBox = await page.locator(".history-toggle").boundingBox();
+  const menuBox = await page.locator(".input-history-menu").boundingBox();
+  const sendBox = await page.locator(".input-send-button").boundingBox();
+  const textareaBox = await page.locator("textarea").boundingBox();
+
+  expect(rowBox).not.toBeNull();
+  expect(editorRowBox).not.toBeNull();
+  expect(interruptBox).not.toBeNull();
+  expect(historyBox).not.toBeNull();
+  expect(menuBox).not.toBeNull();
+  expect(sendBox).not.toBeNull();
+  expect(textareaBox).not.toBeNull();
+
+  const row = rowBox!;
+  const editor = editorRowBox!;
+  const interrupt = interruptBox!;
+  const history = historyBox!;
+  const menu = menuBox!;
+  const send = sendBox!;
+  const textarea = textareaBox!;
+
+  // Action row should stay above editor row and never overlap textarea.
+  expect(row.y + row.height).toBeLessThanOrEqual(editor.y + 0.5);
+  expect(row.y + row.height).toBeLessThanOrEqual(textarea.y + 0.5);
+
+  // Left-aligned chips keep a stable anchor at the start of the row.
+  expect(history.x).toBeGreaterThanOrEqual(row.x - 0.5);
+  expect(history.x).toBeLessThanOrEqual(row.x + 2.5);
+
+  // History popup should be left-anchored to the History trigger.
+  expect(menu.x).toBeGreaterThanOrEqual(history.x - 1);
+  expect(menu.x).toBeLessThanOrEqual(history.x + 2);
+
+  // Tap target sizes for touch ergonomics.
+  expect(interrupt.height).toBeGreaterThanOrEqual(expectedChipMinHeight);
+  expect(history.height).toBeGreaterThanOrEqual(expectedChipMinHeight);
+  expect(send.height).toBeGreaterThanOrEqual(expectedSendMinHeight);
+}
+
+test("keeps input dock controls touch-friendly on mobile viewport", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mountInputDock(page);
+  await assertDockLayout(page, 26, 44);
+});
+
+test("keeps input dock controls non-overlapping on tablet viewports", async ({
+  page,
+}) => {
+  for (const viewport of [
+    { width: 820, height: 1180 },
+    { width: 1180, height: 820 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await mountInputDock(page);
+    await assertDockLayout(page, 28, 48);
+  }
+});

--- a/web/tests/e2e/input_dock_layout.e2e.ts
+++ b/web/tests/e2e/input_dock_layout.e2e.ts
@@ -63,8 +63,9 @@ async function assertDockLayout(
   expect(row.y + row.height).toBeLessThanOrEqual(textarea.y + 0.5);
 
   // Left-aligned chips keep a stable anchor at the start of the row.
-  expect(history.x).toBeGreaterThanOrEqual(row.x - 0.5);
-  expect(history.x).toBeLessThanOrEqual(row.x + 2.5);
+  expect(interrupt.x).toBeGreaterThanOrEqual(row.x - 0.5);
+  expect(interrupt.x).toBeLessThanOrEqual(row.x + 2.5);
+  expect(history.x).toBeGreaterThanOrEqual(interrupt.x + interrupt.width - 1);
 
   // History popup should be left-anchored to the History trigger.
   expect(menu.x).toBeGreaterThanOrEqual(history.x - 1);


### PR DESCRIPTION
## Summary

This PR now includes **two related frontend stability tracks**:

1. InputDock tablet/mobile layout hardening.
2. ACP conversation blank-window recovery hardening.

Both changes target the same user-facing workspace reliability goal under long-running sessions and responsive breakpoints.

## What Changed

### A) InputDock Layout Stabilization

- Refactored dock layout into explicit flow rows:
  - `input-row` for `Interrupt` + `History`
  - `input-editor-row` for `textarea` + `Send`
- Removed action-row absolute overlay behavior that could overlap textarea on tablet widths.
- Kept `input + Send` on one row; enlarged `Send` tap target.
- Left-aligned action chips for stable control anchor across breakpoints.
- Moved `jump-bottom` outside editor grid flow.
- Replaced `!important` send sizing overrides with higher-specificity selector-based rules.
- Made Playwright `system-chrome` project opt-in via `PLAYWRIGHT_SYSTEM_CHROME=1`.

### B) ACP Conversation Blank-Window Guard

- Hardened virtual slice bounds in `use_acp_conversation`:
  - clamp viewport top and virtual start/end indices,
  - guarantee non-empty render window for non-empty source lists.
- Reset freeze/stick state on active agent/session switch.
- Added self-heal guard for stale freeze state (`frozenItems=[]` while messages exist), with fallback to jump-bottom recovery.

## Key Files

- `web/src/components/input_dock.tsx`
- `web/src/styles.css`
- `web/playwright.config.ts`
- `web/src/hooks/use_acp_conversation.ts`
- `web/src/input_dock_render.test.tsx`
- `web/src/hooks/use_acp_conversation.test.ts`
- `tests/web_assets.rs`
- `docs/features/2026-02-14-input-dock-tablet-overlay-fix.md`
- `docs/features/2026-02-14-acp-conversation-blank-window-guard.md`
- `docs/features/2026-02-10-playwright-e2e.md`
- `docs/todo.md`

## Validation

```bash
cd web
npm run test -- src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts
npm run test -- src/hooks/use_acp_conversation.test.ts
npm run lint -- src/components/input_dock.tsx src/input_dock_render.test.tsx playwright.config.ts
npm run lint -- src/hooks/use_acp_conversation.ts src/hooks/use_acp_conversation.test.ts
npm run build
cd ..
cargo test --test web_assets
cargo build
```

## TODO / Follow-ups

- [ ] Verify iPad portrait/landscape and narrow mobile ergonomics on real devices.
- [ ] Add a Playwright regression that reproduces stale large `scrollTop` + session switch for ACP blank-window prevention.
