### PR TITLE
feat: support multi-agent SSE subscription stream

### DIFF
--- a/docs/features/2026-02-15-sse-bounded-fan-in-and-connection-status-followups.md
+++ b/docs/features/2026-02-15-sse-bounded-fan-in-and-connection-status-followups.md
@@ -1,0 +1,57 @@
+# SSE Bounded Fan-In And Connection Status Follow-Ups
+
+## Background
+
+Review feedback highlighted two stability risks in the SSE path:
+
+- backend fan-in used `mpsc::unbounded_channel`, which can grow without bound for
+  slow/disconnected clients under bursty multi-agent output;
+- frontend status/error handling had duplicated constants and a few edge-case
+  correctness gaps (auth-error detection order, stale offline banner, and
+  unnecessary ACP cache work on non-ACP lines).
+
+## Scope
+
+- Replace SSE fan-in queue with a bounded channel in `src/sse.rs`.
+- Keep live stream bounded and rely on persisted DB history + polling/reconnect
+  for catch-up semantics.
+- Align frontend connection/error constants usage and remove duplicated literals.
+- Improve frontend SSE error handling and connection badge accessibility.
+- Reduce avoidable ACP cache updates for non-ACP stream lines.
+- Expand unit tests for connection status helpers.
+
+## Key Decisions
+
+- Use `tokio::sync::mpsc::channel(512)` instead of `unbounded_channel` for
+  output fan-in.
+- Forwarder tasks use timeout-guarded async send:
+  - if queue pressure clears quickly, continue streaming;
+  - if queue stays full past timeout (`2s`), mark stream as backpressured and
+    close the SSE stream.
+- On stream close, frontend reconnect + polling/DB replay fills any missed
+  events instead of keeping unbounded in-memory buffers.
+- Keep `broadcast::RecvError::Lagged` behavior as-is; missed live events are
+  acceptable because events are persisted and can be replayed.
+- Export shared connectivity constants from `web/src/connection_status.ts` and
+  reuse them from `web/src/app.tsx`.
+- Check `isInvalidTokenMessage` against raw SSE payload before sanitization.
+- Update ACP cache only for `stream === "acp"` entries.
+
+## Validation
+
+```bash
+cargo test sse::tests
+cd web
+npm run test -- connection_status.test.ts
+npm run build
+```
+
+Expected outcomes:
+
+- SSE output fan-in remains bounded under slow clients;
+- sustained queue pressure closes the current SSE stream and recovers through
+  reconnect + persisted history replay;
+- frontend connection badge/error banner states are consistent;
+- auth redirect detection remains correct on SSE error payloads;
+- connection-status helper coverage includes connecting/empty/whitespace and
+  false-positive guard cases.

--- a/docs/features/2026-02-15-sse-connection-indicator-and-error-sanitization.md
+++ b/docs/features/2026-02-15-sse-connection-indicator-and-error-sanitization.md
@@ -1,0 +1,45 @@
+# SSE Connection Indicator And Error Sanitization
+
+## Background
+
+When AgentHub runs behind Cloudflare, stream interruptions can surface gateway HTML
+responses in the UI error banner. This is noisy and confusing for users.
+At the same time, the header did not expose whether the client is online or whether
+the SSE stream is currently connected.
+
+## Scope
+
+- Add a header connection badge near the authenticated username.
+- Surface network + SSE state transitions in a compact user-facing label.
+- Sanitize error-banner messages so HTML/gateway responses are mapped to stable
+  connectivity messages instead of rendering raw HTML payload text.
+
+## Key Decisions
+
+- Introduce a dedicated frontend helper module:
+  - `deriveConnectionBadge(networkOnline, hasStreamTarget, sseState)`
+  - `sanitizeErrorBannerMessage(rawMessage, networkOnline)`
+- Keep SSE lifecycle states explicit in app state:
+  - `idle`, `connecting`, `connected`, `reconnecting`.
+- Drive network awareness from browser `online`/`offline` events plus runtime
+  checks on SSE error callbacks.
+- Keep sanitization at the error banner source layer (in `App`) so all error paths
+  benefit from the same normalization.
+
+## Validation
+
+```bash
+cd web
+npm run test -- src/connection_status.test.ts src/agent_ws.test.ts
+npm run build
+```
+
+- Expect:
+  - connection badge labels/tone map correctly for offline/idle/connected/reconnecting;
+  - HTML-like gateway payloads are normalized to a compact reconnecting message;
+  - offline mode always shows a stable cannot-connect message.
+
+## Follow-up
+
+- Optionally expose a tooltip with last successful SSE open timestamp and retry
+  backoff seconds for deeper operational troubleshooting.

--- a/docs/features/2026-02-15-sse-multi-agent-subscription.md
+++ b/docs/features/2026-02-15-sse-multi-agent-subscription.md
@@ -1,0 +1,51 @@
+# SSE Multi-Agent Subscription
+
+## Background
+
+The previous SSE implementation subscribed only to the currently selected agent
+(`activeAgent`) through `/sse/agents/:id`.
+When users switched between agents, the client closed and reopened the stream,
+causing temporary `connecting/reconnecting` state flips in the header badge.
+
+For multi-agent workflows, this behavior is noisy and does not represent the
+actual platform connectivity state.
+
+## Scope
+
+- Add a multi-agent SSE endpoint: `/sse/agents?ids=a,b,c`.
+- Keep existing `/sse/agents/:id` endpoint for backward compatibility.
+- Update frontend SSE target selection to subscribe once to all currently
+  stream-eligible agents (`running` or `idle`).
+- Keep conversation rendering filtered by current active agent/session while
+  still updating background caches and status for other agents.
+
+## Key Decisions
+
+- Backend accepts a comma-separated `ids` query and deduplicates/normalizes IDs.
+- Backend ignores non-running IDs during multi-agent subscribe and streams from
+  all currently available agent output channels.
+- Stream fan-in is implemented via per-agent forwarder tasks into a single mpsc
+  channel, with heartbeat unchanged.
+- Frontend computes SSE targets from the current agent list and keeps one
+  EventSource connection for the whole target set.
+- Frontend uses refs for `activeAgent`/`activeSessionId` to avoid reconnect on
+  UI selection changes and only appends visible lines for the active view.
+
+## Validation
+
+```bash
+cargo test sse::tests
+npm --prefix web run test -- sse_targets.test.ts connection_status.test.ts
+npm --prefix web run build
+```
+
+- Expect:
+  - switching active agent no longer forces SSE reconnect when target set is unchanged;
+  - header badge reflects global stream state instead of selected-agent-only state;
+  - active conversation still shows only active agent/session content;
+  - background agent status changes are still reflected in the agent list.
+
+## Follow-up
+
+- Add an end-to-end web test that runs two active agents simultaneously and
+  verifies no reconnect is triggered when switching active tabs.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -166,6 +166,7 @@
 - [x] Verify SSE auto-reconnect and polling fallback after network interruption (see `docs/features/2026-02-08-sse-retry.md`).
 - [ ] Verify polling pauses while SSE is OPEN and resumes on disconnect (see `docs/features/2026-02-08-sse-retry.md`).
 - [ ] Verify SSE headers prevent proxy buffering and caching (see `docs/features/2026-02-08-sse-streaming.md`).
+- [ ] Verify header network/SSE badge state transitions and Cloudflare HTML stream errors are normalized to compact connectivity messages (see `docs/features/2026-02-15-sse-connection-indicator-and-error-sanitization.md`).
 - [ ] Verify UUIDv7 ordering and pagination across API/SSE (see `docs/features/2026-02-08-event-seq-uuidv7.md`).
 - [ ] Verify global event ordering uses `event_id` across API/SSE/polling and pagination (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify compareEventOrder is deterministic when `event_id` or `ts` is missing (see `docs/features/2026-02-08-global-event-ordering.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -167,6 +167,7 @@
 - [ ] Verify polling pauses while SSE is OPEN and resumes on disconnect (see `docs/features/2026-02-08-sse-retry.md`).
 - [ ] Verify SSE headers prevent proxy buffering and caching (see `docs/features/2026-02-08-sse-streaming.md`).
 - [ ] Verify header network/SSE badge state transitions and Cloudflare HTML stream errors are normalized to compact connectivity messages (see `docs/features/2026-02-15-sse-connection-indicator-and-error-sanitization.md`).
+- [ ] Verify bounded SSE fan-in channel behavior under burst output and slow/disconnected clients, ensuring memory does not grow unbounded and polling/history catch-up remains correct (see `docs/features/2026-02-15-sse-bounded-fan-in-and-connection-status-followups.md`).
 - [ ] Verify multi-agent SSE subscription keeps a stable single connection across active-agent switches and updates agent status in background (see `docs/features/2026-02-15-sse-multi-agent-subscription.md`).
 - [ ] Verify UUIDv7 ordering and pagination across API/SSE (see `docs/features/2026-02-08-event-seq-uuidv7.md`).
 - [ ] Verify global event ordering uses `event_id` across API/SSE/polling and pagination (see `docs/features/2026-02-08-global-event-ordering.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -167,6 +167,7 @@
 - [ ] Verify polling pauses while SSE is OPEN and resumes on disconnect (see `docs/features/2026-02-08-sse-retry.md`).
 - [ ] Verify SSE headers prevent proxy buffering and caching (see `docs/features/2026-02-08-sse-streaming.md`).
 - [ ] Verify header network/SSE badge state transitions and Cloudflare HTML stream errors are normalized to compact connectivity messages (see `docs/features/2026-02-15-sse-connection-indicator-and-error-sanitization.md`).
+- [ ] Verify multi-agent SSE subscription keeps a stable single connection across active-agent switches and updates agent status in background (see `docs/features/2026-02-15-sse-multi-agent-subscription.md`).
 - [ ] Verify UUIDv7 ordering and pagination across API/SSE (see `docs/features/2026-02-08-event-seq-uuidv7.md`).
 - [ ] Verify global event ordering uses `event_id` across API/SSE/polling and pagination (see `docs/features/2026-02-08-global-event-ordering.md`).
 - [ ] Verify compareEventOrder is deterministic when `event_id` or `ts` is missing (see `docs/features/2026-02-08-global-event-ordering.md`).

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -107,16 +107,42 @@ fn parse_agent_ids(raw_ids: &str) -> Vec<String> {
     ids
 }
 
+const OUTPUT_STREAM_BUFFER_CAPACITY: usize = 512;
+const OUTPUT_STREAM_SEND_TIMEOUT: Duration = Duration::from_secs(2);
+
 fn output_stream(
     output_rxs: Vec<broadcast::Receiver<AgentOutput>>,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
-    let (output_tx, output_rx) = mpsc::unbounded_channel::<AgentOutput>();
+    output_stream_with_limits(
+        output_rxs,
+        OUTPUT_STREAM_BUFFER_CAPACITY,
+        OUTPUT_STREAM_SEND_TIMEOUT,
+    )
+}
+
+fn output_stream_with_limits(
+    output_rxs: Vec<broadcast::Receiver<AgentOutput>>,
+    buffer_capacity: usize,
+    send_timeout: Duration,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    let (output_tx, output_rx) = mpsc::channel::<AgentOutput>(buffer_capacity);
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (disconnect_tx, disconnect_rx) = watch::channel(false);
     let forwarders = output_rxs
         .into_iter()
-        .map(|rx| spawn_output_forwarder(rx, output_tx.clone(), shutdown_rx.clone()))
+        .map(|rx| {
+            spawn_output_forwarder(
+                rx,
+                output_tx.clone(),
+                shutdown_rx.clone(),
+                disconnect_tx.clone(),
+                send_timeout,
+                buffer_capacity,
+            )
+        })
         .collect::<Vec<_>>();
     drop(output_tx);
+    drop(disconnect_tx);
 
     let heartbeat_interval = Duration::from_secs(15);
     futures::stream::unfold(
@@ -124,14 +150,23 @@ fn output_stream(
             output_rx,
             heartbeat: tokio::time::interval(heartbeat_interval),
             shutdown_tx,
+            disconnect_rx,
             forwarders,
         },
         |mut state| async move {
             loop {
+                if *state.disconnect_rx.borrow() {
+                    return None;
+                }
                 tokio::select! {
                     _ = state.heartbeat.tick() => {
                         let event = Event::default().data("heartbeat");
                         return Some((Ok(event), state));
+                    }
+                    changed = state.disconnect_rx.changed() => {
+                        if changed.is_err() || *state.disconnect_rx.borrow() {
+                            return None;
+                        }
                     }
                     msg = state.output_rx.recv() => {
                         match msg {
@@ -151,9 +186,10 @@ fn output_stream(
 }
 
 struct OutputStreamState {
-    output_rx: mpsc::UnboundedReceiver<AgentOutput>,
+    output_rx: mpsc::Receiver<AgentOutput>,
     heartbeat: tokio::time::Interval,
     shutdown_tx: watch::Sender<bool>,
+    disconnect_rx: watch::Receiver<bool>,
     forwarders: Vec<JoinHandle<()>>,
 }
 
@@ -168,8 +204,11 @@ impl Drop for OutputStreamState {
 
 fn spawn_output_forwarder(
     mut output_rx: broadcast::Receiver<AgentOutput>,
-    output_tx: mpsc::UnboundedSender<AgentOutput>,
+    output_tx: mpsc::Sender<AgentOutput>,
     mut shutdown_rx: watch::Receiver<bool>,
+    disconnect_tx: watch::Sender<bool>,
+    send_timeout: Duration,
+    buffer_capacity: usize,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -182,8 +221,20 @@ fn spawn_output_forwarder(
                 msg = output_rx.recv() => {
                     match msg {
                         Ok(output) => {
-                            if output_tx.send(output).is_err() {
-                                break;
+                            // Bounded fan-in avoids unbounded memory growth for slow/disconnected SSE clients.
+                            // On sustained backpressure we close this SSE stream and let reconnect + DB replay catch up.
+                            match tokio::time::timeout(send_timeout, output_tx.send(output)).await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(_)) => break,
+                                Err(_) => {
+                                    let _ = disconnect_tx.send(true);
+                                    tracing::warn!(
+                                        ?send_timeout,
+                                        buffer_capacity,
+                                        "sse output stream backpressure timeout; closing stream"
+                                    );
+                                    break;
+                                }
                             }
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
@@ -559,5 +610,39 @@ mod tests {
             .expect("receive second event")
             .expect("stream should not end")
             .expect("stream event should be ok");
+    }
+
+    #[tokio::test]
+    async fn output_stream_closes_after_backpressure_timeout() {
+        use futures::StreamExt;
+
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let mut stream = std::pin::pin!(super::output_stream_with_limits(
+            vec![rx],
+            1,
+            std::time::Duration::from_millis(30),
+        ));
+
+        let first = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("receive first event")
+            .expect("stream should not end")
+            .expect("stream event should be ok");
+        assert!(format!("{first:?}").contains("heartbeat"));
+
+        tx.send(sample_output(OutputStream::Stdout))
+            .expect("send first output");
+        tx.send(sample_output(OutputStream::Stdout))
+            .expect("send second output");
+
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+        let next = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("poll stream after backpressure");
+        assert!(
+            next.is_none(),
+            "stream should close after sustained backpressure timeout"
+        );
     }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -151,6 +151,7 @@ fn output_stream_with_limits(
             heartbeat: tokio::time::interval(heartbeat_interval),
             shutdown_tx,
             disconnect_rx,
+            disconnect_watch_active: true,
             forwarders,
         },
         |mut state| async move {
@@ -163,9 +164,18 @@ fn output_stream_with_limits(
                         let event = Event::default().data("heartbeat");
                         return Some((Ok(event), state));
                     }
-                    changed = state.disconnect_rx.changed() => {
-                        if changed.is_err() || *state.disconnect_rx.borrow() {
-                            return None;
+                    changed = state.disconnect_rx.changed(), if state.disconnect_watch_active => {
+                        match changed {
+                            Ok(()) => {
+                                if *state.disconnect_rx.borrow() {
+                                    return None;
+                                }
+                            }
+                            Err(_) => {
+                                // All disconnect senders are dropped. Keep draining output_rx
+                                // until it is naturally exhausted.
+                                state.disconnect_watch_active = false;
+                            }
                         }
                     }
                     msg = state.output_rx.recv() => {
@@ -190,6 +200,7 @@ struct OutputStreamState {
     heartbeat: tokio::time::Interval,
     shutdown_tx: watch::Sender<bool>,
     disconnect_rx: watch::Receiver<bool>,
+    disconnect_watch_active: bool,
     forwarders: Vec<JoinHandle<()>>,
 }
 
@@ -643,6 +654,37 @@ mod tests {
         assert!(
             next.is_none(),
             "stream should close after sustained backpressure timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn output_stream_drains_buffered_messages_after_forwarder_shutdown() {
+        use futures::StreamExt;
+
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let mut stream = std::pin::pin!(super::output_stream_with_limits(
+            vec![rx],
+            8,
+            std::time::Duration::from_secs(1),
+        ));
+
+        let first = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("receive first event")
+            .expect("stream should not end")
+            .expect("stream event should be ok");
+        assert!(format!("{first:?}").contains("heartbeat"));
+
+        tx.send(sample_output(OutputStream::Stdout))
+            .expect("send output");
+        drop(tx);
+
+        let second = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("receive buffered output after forwarder shutdown");
+        assert!(
+            second.is_some(),
+            "stream should emit buffered output before termination"
         );
     }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, time::Duration};
+use std::{collections::BTreeSet, convert::Infallible, time::Duration};
 
 use axum::response::sse::Event;
 use axum::{
@@ -9,17 +9,28 @@ use axum::{
     routing::get,
 };
 use futures::stream::Stream;
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::JoinHandle,
+};
 
 use crate::agent::AgentOutput;
 use crate::state::AppState;
 
 #[derive(Debug, serde::Deserialize)]
-struct SseQuery {
+struct SseTokenQuery {
     token: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SseAgentsQuery {
+    token: String,
+    ids: String,
 }
 
 pub fn router(state: AppState) -> Router {
     Router::new()
+        .route("/agents", get(sse_agents))
         .route("/agents/:id", get(sse_agent))
         .with_state(state)
 }
@@ -27,7 +38,7 @@ pub fn router(state: AppState) -> Router {
 async fn sse_agent(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
-    Query(query): Query<SseQuery>,
+    Query(query): Query<SseTokenQuery>,
 ) -> impl IntoResponse {
     if state.auth.validate_session(&query.token).await.is_err() {
         return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
@@ -38,7 +49,38 @@ async fn sse_agent(
         Err(err) => return (StatusCode::NOT_FOUND, err.to_string()).into_response(),
     };
 
-    let stream = output_stream(output_rx);
+    sse_response(vec![output_rx])
+}
+
+async fn sse_agents(
+    State(state): State<AppState>,
+    Query(query): Query<SseAgentsQuery>,
+) -> impl IntoResponse {
+    if state.auth.validate_session(&query.token).await.is_err() {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+
+    let agent_ids = parse_agent_ids(&query.ids);
+    if agent_ids.is_empty() {
+        return (StatusCode::BAD_REQUEST, "at least one agent id is required").into_response();
+    }
+
+    let mut output_rxs = Vec::with_capacity(agent_ids.len());
+    for agent_id in agent_ids {
+        if let Ok(rx) = state.agents.subscribe_output(&agent_id).await {
+            output_rxs.push(rx);
+        }
+    }
+
+    if output_rxs.is_empty() {
+        return (StatusCode::NOT_FOUND, "agent not running").into_response();
+    }
+
+    sse_response(output_rxs)
+}
+
+fn sse_response(output_rxs: Vec<broadcast::Receiver<AgentOutput>>) -> axum::response::Response {
+    let stream = output_stream(output_rxs);
     let mut response = Sse::new(stream).into_response();
     let headers = response.headers_mut();
     headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
@@ -50,37 +92,107 @@ async fn sse_agent(
     response
 }
 
+fn parse_agent_ids(raw_ids: &str) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut ids = Vec::new();
+    for raw in raw_ids.split(',') {
+        let id = raw.trim();
+        if id.is_empty() {
+            continue;
+        }
+        if seen.insert(id.to_string()) {
+            ids.push(id.to_string());
+        }
+    }
+    ids
+}
+
 fn output_stream(
-    output_rx: tokio::sync::broadcast::Receiver<AgentOutput>,
+    output_rxs: Vec<broadcast::Receiver<AgentOutput>>,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
+    let (output_tx, output_rx) = mpsc::unbounded_channel::<AgentOutput>();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let forwarders = output_rxs
+        .into_iter()
+        .map(|rx| spawn_output_forwarder(rx, output_tx.clone(), shutdown_rx.clone()))
+        .collect::<Vec<_>>();
+    drop(output_tx);
+
     let heartbeat_interval = Duration::from_secs(15);
     futures::stream::unfold(
-        (output_rx, tokio::time::interval(heartbeat_interval)),
-        |(mut rx, mut heartbeat)| async move {
+        OutputStreamState {
+            output_rx,
+            heartbeat: tokio::time::interval(heartbeat_interval),
+            shutdown_tx,
+            forwarders,
+        },
+        |mut state| async move {
             loop {
                 tokio::select! {
-                    _ = heartbeat.tick() => {
+                    _ = state.heartbeat.tick() => {
                         let event = Event::default().data("heartbeat");
-                        return Some((Ok(event), (rx, heartbeat)));
+                        return Some((Ok(event), state));
                     }
-                    msg = rx.recv() => {
+                    msg = state.output_rx.recv() => {
                         match msg {
-                            Ok(output) => {
+                            Some(output) => {
                                 if let Ok(text) = serde_json::to_string(&output_to_message(&output)) {
                                     let event = Event::default().data(text);
-                                    return Some((Ok(event), (rx, heartbeat)));
+                                    return Some((Ok(event), state));
                                 }
                             }
-                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                                continue;
-                            }
-                            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                            None => return None,
                         }
                     }
                 }
             }
         },
     )
+}
+
+struct OutputStreamState {
+    output_rx: mpsc::UnboundedReceiver<AgentOutput>,
+    heartbeat: tokio::time::Interval,
+    shutdown_tx: watch::Sender<bool>,
+    forwarders: Vec<JoinHandle<()>>,
+}
+
+impl Drop for OutputStreamState {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        for task in &self.forwarders {
+            task.abort();
+        }
+    }
+}
+
+fn spawn_output_forwarder(
+    mut output_rx: broadcast::Receiver<AgentOutput>,
+    output_tx: mpsc::UnboundedSender<AgentOutput>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                shutdown = shutdown_rx.changed() => {
+                    if shutdown.is_err() || *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+                msg = output_rx.recv() => {
+                    match msg {
+                        Ok(output) => {
+                            if output_tx.send(output).is_err() {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        }
+    })
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -98,5 +210,22 @@ fn output_to_message(output: &AgentOutput) -> SseServerMessage {
     SseServerMessage {
         r#type: msg_type.to_string(),
         payload: serde_json::json!(output),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_agent_ids;
+
+    #[test]
+    fn parse_agent_ids_dedupes_and_trims() {
+        let parsed = parse_agent_ids(" alpha, beta ,alpha,, gamma ");
+        assert_eq!(parsed, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn parse_agent_ids_ignores_empty_values() {
+        let parsed = parse_agent_ids(" , , ");
+        assert!(parsed.is_empty());
     }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -215,7 +215,253 @@ fn output_to_message(output: &AgentOutput) -> SseServerMessage {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use chrono::Utc;
+    use sqlx::SqlitePool;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use tower::util::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::{
+        acp::AcpPermissionService,
+        agent::{AgentOutput, OutputStream},
+        auth::AuthService,
+        config::{AppConfig, PushConfig, WebConfig},
+        push::PushService,
+        state::AppState,
+        team::TeamManager,
+    };
+
     use super::parse_agent_ids;
+
+    fn build_sse_request(path: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::GET)
+            .uri(path)
+            .body(Body::empty())
+            .expect("build sse request")
+    }
+
+    async fn create_test_db() -> SqlitePool {
+        let options = SqliteConnectOptions::new()
+            .filename(":memory:")
+            .create_if_missing(true)
+            .foreign_keys(true);
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("connect sqlite")
+    }
+
+    async fn init_test_schema(db: &SqlitePool) {
+        sqlx::query(
+            r#"
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                role TEXT NOT NULL,
+                password_hash TEXT,
+                created_at INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create users");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE auth_sessions (
+                token TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                revoked_at INTEGER,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create auth_sessions");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE devices (
+                id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                user_agent TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_login_at INTEGER,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create devices");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                workdir TEXT NOT NULL,
+                command TEXT NOT NULL,
+                args TEXT NOT NULL,
+                worktree_mode TEXT NOT NULL,
+                worktree_repo TEXT,
+                worktree_ref TEXT,
+                code_mode INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create agents");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE safe_paths (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT NOT NULL UNIQUE,
+                created_at INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create safe_paths");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE agent_sessions (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                started_at INTEGER NOT NULL,
+                ended_at INTEGER,
+                FOREIGN KEY(agent_id) REFERENCES agents(id)
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create agent_sessions");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE agent_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                seq TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                stream TEXT NOT NULL,
+                message TEXT NOT NULL,
+                FOREIGN KEY(agent_id) REFERENCES agents(id),
+                FOREIGN KEY(session_id) REFERENCES agent_sessions(id)
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create agent_events");
+    }
+
+    async fn build_test_state() -> AppState {
+        let db = create_test_db().await;
+        init_test_schema(&db).await;
+        let keys_dir = std::env::temp_dir().join(format!("agenthub-sse-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&keys_dir).expect("create keys dir");
+        let keys_path = keys_dir.join("vapid.json");
+        let config = AppConfig {
+            web: Some(WebConfig {
+                rp_id: Some("localhost".to_string()),
+                rp_origin: Some("http://localhost:8080".to_string()),
+                rp_name: Some("AgentHub Test".to_string()),
+            }),
+            push: Some(PushConfig {
+                subject: Some("mailto:test@example.com".to_string()),
+                keys_path: Some(keys_path.to_string_lossy().to_string()),
+            }),
+            ..Default::default()
+        };
+        let push = Arc::new(PushService::new(db.clone(), &config).expect("create push service"));
+        let _ = std::fs::remove_dir_all(&keys_dir);
+        let auth = Arc::new(
+            AuthService::new(db.clone(), &config)
+                .await
+                .expect("create auth"),
+        );
+        let permissions = Arc::new(AcpPermissionService::new(db.clone()));
+        let agents = Arc::new(crate::agent::AgentManager::new(
+            db.clone(),
+            push.clone(),
+            Vec::new(),
+            "agenthub-codex-acp".to_string(),
+            None,
+            permissions.clone(),
+            auth.clone(),
+        ));
+        let teams = Arc::new(TeamManager::new(db.clone()));
+        AppState {
+            db,
+            agents,
+            teams,
+            push,
+            auth,
+            acp_permissions: permissions,
+            default_worktree_root: config.default_worktree_root(),
+        }
+    }
+
+    async fn create_auth_token(state: &AppState) -> String {
+        let user_id = Uuid::new_v4().to_string();
+        let now = Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT INTO users (id, username, display_name, role, password_hash, created_at)
+            VALUES (?1, ?2, ?3, 'root', NULL, ?4)
+            "#,
+        )
+        .bind(&user_id)
+        .bind(format!("root-{}", Uuid::new_v4()))
+        .bind("Root")
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert user");
+        state
+            .auth
+            .create_session(&user_id)
+            .await
+            .expect("create token")
+    }
+
+    fn sample_output(stream: OutputStream) -> AgentOutput {
+        AgentOutput {
+            event_id: 42,
+            agent_id: "agent-x".to_string(),
+            session_id: "session-x".to_string(),
+            seq: "0001".to_string(),
+            ts: 123,
+            stream,
+            message: "hello".to_string(),
+        }
+    }
 
     #[test]
     fn parse_agent_ids_dedupes_and_trims() {
@@ -227,5 +473,91 @@ mod tests {
     fn parse_agent_ids_ignores_empty_values() {
         let parsed = parse_agent_ids(" , , ");
         assert!(parsed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sse_agents_requires_valid_token() {
+        let state = build_test_state().await;
+        let app = super::router(state);
+        let response = app
+            .oneshot(build_sse_request("/agents?ids=a&token=bad-token"))
+            .await
+            .expect("execute request");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn sse_agents_rejects_empty_ids() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = super::router(state);
+        let response = app
+            .oneshot(build_sse_request(&format!("/agents?ids=,,,&token={token}")))
+            .await
+            .expect("execute request");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn sse_agents_returns_not_found_when_no_running_agents_match() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = super::router(state);
+        let response = app
+            .oneshot(build_sse_request(&format!(
+                "/agents?ids=missing-agent&token={token}"
+            )))
+            .await
+            .expect("execute request");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn legacy_sse_agent_route_returns_not_found_when_agent_is_not_running() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = super::router(state);
+        let response = app
+            .oneshot(build_sse_request(&format!(
+                "/agents/missing-agent?token={token}"
+            )))
+            .await
+            .expect("execute request");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn output_to_message_uses_output_type_for_non_acp_streams() {
+        let msg = super::output_to_message(&sample_output(OutputStream::Stdout));
+        assert_eq!(msg.r#type, "output");
+    }
+
+    #[test]
+    fn output_to_message_uses_acp_type_for_acp_streams() {
+        let msg = super::output_to_message(&sample_output(OutputStream::Acp));
+        assert_eq!(msg.r#type, "acp");
+    }
+
+    #[tokio::test]
+    async fn output_stream_emits_events_from_forwarders() {
+        use futures::StreamExt;
+
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let mut stream = std::pin::pin!(super::output_stream(vec![rx]));
+
+        let first = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("receive first event")
+            .expect("stream should not end")
+            .expect("stream event should be ok");
+        assert!(format!("{first:?}").contains("heartbeat"));
+
+        tx.send(sample_output(OutputStream::Stdout))
+            .expect("send broadcast output");
+        let _second = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
+            .await
+            .expect("receive second event")
+            .expect("stream should not end")
+            .expect("stream event should be ok");
     }
 }

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -13,7 +13,6 @@ import { buildAcpView } from "./acp";
 import {
   AGENT_NOT_RUNNING_ERROR,
   shouldIgnoreAgentWsError,
-  shouldOpenAgentSocket,
   sanitizeAgentError,
   isAgentActiveStatus,
 } from "./agent_ws";
@@ -82,6 +81,7 @@ import {
   resolveWorkdirForModeChange,
   resolveWorkdirForModalOpen,
 } from "./worktree_defaults";
+import { buildSseTargetAgentIds, encodeSseTargetAgentIds } from "./sse_targets";
 
 const DEFAULT_WORKTREE_ROOT = "~/.agenthub/worktrees";
 
@@ -210,6 +210,9 @@ export function App() {
     null
   );
   const outputPersistTimerRef = useRef<number | null>(null);
+  const activeAgentRef = useRef<string | null>(null);
+  const activeSessionIdRef = useRef<string | null>(null);
+  const activeAgentStatusRef = useRef<string | null>(null);
   useEffect(() => {
     outputsRef.current = outputs;
   }, [outputs]);
@@ -295,9 +298,12 @@ export function App() {
   }, [activeAgentRecord]);
   const activeAgentStatus = activeAgentRecord?.status ?? null;
   const isAgentActive = isAgentActiveStatus(activeAgentStatus);
-  const hasSseTarget = Boolean(
-    activeAgent && shouldOpenAgentSocket(activeAgentStatus)
+  const streamAgentIds = useMemo(() => buildSseTargetAgentIds(agents), [agents]);
+  const streamAgentIdsQuery = useMemo(
+    () => encodeSseTargetAgentIds(streamAgentIds),
+    [streamAgentIds]
   );
+  const hasSseTarget = streamAgentIds.length > 0;
   const connectionBadge = useMemo(
     () => deriveConnectionBadge(networkOnline, hasSseTarget, sseState),
     [networkOnline, hasSseTarget, sseState]
@@ -322,6 +328,16 @@ export function App() {
     Boolean(activeEventKey) && eventMeta[activeEventKey]?.loaded !== true;
 
   const token = auth?.token ?? null;
+  useEffect(() => {
+    activeAgentRef.current = activeAgent;
+  }, [activeAgent]);
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId;
+  }, [activeSessionId]);
+  useEffect(() => {
+    activeAgentStatusRef.current = activeAgentStatus;
+  }, [activeAgentStatus]);
+
   useEffect(() => {
     setInputHistoryCursor(-1);
     inputHistoryDraftRef.current = "";
@@ -722,17 +738,22 @@ export function App() {
   }, [activeAgentStatus]);
 
   useEffect(() => {
-    if (!token || !activeAgent) {
+    if (!token || !activeAgent) return;
+    loadAgentEvents(activeAgent, activeSessionId);
+  }, [token, activeAgent, activeSessionId, loadAgentEvents]);
+
+  useEffect(() => {
+    if (!token) {
+      setSseState("idle");
+      return;
+    }
+    const streamTarget = streamAgentIdsQuery;
+    if (!hasSseTarget || streamTarget.length === 0) {
       setSseState("idle");
       return;
     }
     let cancelled = false;
     const pollState = eventPollRef.current;
-    loadAgentEvents(activeAgent, activeSessionId);
-    if (!shouldOpenAgentSocket(activeAgentStatus)) {
-      setSseState("idle");
-      return;
-    }
     let reconnectTimer: number | null = null;
     let reconnectAttempt = 0;
     const clearReconnectTimer = () => {
@@ -740,6 +761,13 @@ export function App() {
         window.clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+    };
+    const pollActiveAgent = async (): Promise<boolean> => {
+      const currentActive = activeAgentRef.current;
+      if (!currentActive) return false;
+      return (
+        (await loadAgentEvents(currentActive, activeSessionIdRef.current)) === true
+      );
     };
     const scheduleReconnect = () => {
       if (cancelled) return;
@@ -756,9 +784,9 @@ export function App() {
       if (cancelled) return;
       setSseState((prev) => (prev === "reconnecting" ? "reconnecting" : "connecting"));
       const source = new EventSource(
-        `${location.origin}/sse/agents/${encodeURIComponent(
-          activeAgent
-        )}?token=${encodeURIComponent(token)}`
+        `${location.origin}/sse/agents?ids=${encodeURIComponent(
+          streamTarget
+        )}&token=${encodeURIComponent(token)}`
       );
       sseRef.current = source;
       source.onopen = () => {
@@ -777,12 +805,6 @@ export function App() {
           if (parsed.type === "output" || parsed.type === "acp") {
             const payload = parsed.payload;
             if (!isValidOutputPayload(payload)) {
-              return;
-            }
-            if (payload.agent_id !== activeAgent) {
-              return;
-            }
-            if (activeSessionId && payload.session_id !== activeSessionId) {
               return;
             }
             const line: OutputLine = {
@@ -808,11 +830,19 @@ export function App() {
                 );
               }
             }
-            setOutputs((prev) => appendOutputLine(prev, line));
             updateOutputCacheEntry(key, [line]);
+            updateAcpOutputCacheEntry(key, [line]);
+            const currentActive = activeAgentRef.current;
+            if (payload.agent_id !== currentActive) {
+              return;
+            }
+            const currentSessionId = activeSessionIdRef.current;
+            if (currentSessionId && payload.session_id !== currentSessionId) {
+              return;
+            }
+            setOutputs((prev) => appendOutputLine(prev, line));
             if (line.stream === "acp") {
               setAcpOutputs((prev) => appendOutputLine(prev, line));
-              updateAcpOutputCacheEntry(key, [line]);
             }
           }
         } catch {
@@ -825,7 +855,12 @@ export function App() {
               clearAuthAndRedirect();
               return;
             }
-            if (shouldIgnoreAgentWsError(normalizedStreamError, activeAgentStatus)) {
+            if (
+              shouldIgnoreAgentWsError(
+                normalizedStreamError,
+                activeAgentStatusRef.current
+              )
+            ) {
               return;
             }
             setError(normalizedStreamError);
@@ -872,8 +907,7 @@ export function App() {
           current != null && current.readyState === EventSource.OPEN;
         let hasNew = false;
         if (!isOpen) {
-          hasNew =
-            (await loadAgentEvents(activeAgent, activeSessionId)) === true;
+          hasNew = (await pollActiveAgent()) === true;
         } else {
           pollState.idleCount = 0;
         }
@@ -907,9 +941,8 @@ export function App() {
     };
   }, [
     token,
-    activeAgent,
-    activeSessionId,
-    activeAgentStatus,
+    hasSseTarget,
+    streamAgentIdsQuery,
     loadAgentEvents,
     updateOutputCacheEntry,
     updateAcpOutputCacheEntry,

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -20,6 +20,11 @@ import {
 import { ErrorBanner } from "./error_banner";
 import { clearAuthAndRedirect, isInvalidTokenMessage } from "./auth_redirect";
 import {
+  deriveConnectionBadge,
+  sanitizeErrorBannerMessage,
+  type SseConnectionState,
+} from "./connection_status";
+import {
   getAdaptivePollInterval,
   EventCursor,
   getMaxEventCursor,
@@ -122,6 +127,8 @@ export function App() {
   const [joinToken, setJoinToken] = useState<string | null>(null);
   const [vapidInfo, setVapidInfo] = useState<VapidInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [networkOnline, setNetworkOnline] = useState<boolean>(getNavigatorOnline);
+  const [sseState, setSseState] = useState<SseConnectionState>("idle");
   const [worktreeError, setWorktreeError] = useState<string | null>(null);
   const [activeAgent, setActiveAgent] = useState<string | null>(null);
   const [outputs, setOutputs] = useState<OutputLine[]>([]);
@@ -219,6 +226,24 @@ export function App() {
     localStorage.setItem(INPUT_HISTORY_STORAGE_KEY, JSON.stringify(inputHistory));
   }, [inputHistory]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onOnline = () => {
+      setNetworkOnline(true);
+    };
+    const onOffline = () => {
+      setNetworkOnline(false);
+      setSseState((prev) => (prev === "idle" ? "idle" : "reconnecting"));
+      setError("Offline. Unable to connect to server.");
+    };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
+  }, []);
+
   const handleTerminalScroll = useCallback(() => {
     const el = terminalRef.current;
     if (!el) return;
@@ -270,6 +295,17 @@ export function App() {
   }, [activeAgentRecord]);
   const activeAgentStatus = activeAgentRecord?.status ?? null;
   const isAgentActive = isAgentActiveStatus(activeAgentStatus);
+  const hasSseTarget = Boolean(
+    activeAgent && shouldOpenAgentSocket(activeAgentStatus)
+  );
+  const connectionBadge = useMemo(
+    () => deriveConnectionBadge(networkOnline, hasSseTarget, sseState),
+    [networkOnline, hasSseTarget, sseState]
+  );
+  const normalizedError = useMemo(
+    () => (error ? sanitizeErrorBannerMessage(error, networkOnline) : null),
+    [error, networkOnline]
+  );
   const thinkingStartTs =
     activeAgentStatus === "running" ? acpView.thinkingStartTs : null;
   const canControlAcp = Boolean(activeAgent && isAgentActive);
@@ -686,11 +722,17 @@ export function App() {
   }, [activeAgentStatus]);
 
   useEffect(() => {
-    if (!token || !activeAgent) return;
+    if (!token || !activeAgent) {
+      setSseState("idle");
+      return;
+    }
     let cancelled = false;
     const pollState = eventPollRef.current;
     loadAgentEvents(activeAgent, activeSessionId);
-    if (!shouldOpenAgentSocket(activeAgentStatus)) return;
+    if (!shouldOpenAgentSocket(activeAgentStatus)) {
+      setSseState("idle");
+      return;
+    }
     let reconnectTimer: number | null = null;
     let reconnectAttempt = 0;
     const clearReconnectTimer = () => {
@@ -702,6 +744,7 @@ export function App() {
     const scheduleReconnect = () => {
       if (cancelled) return;
       clearReconnectTimer();
+      setSseState("reconnecting");
       const delay = Math.min(30_000, 1000 * 2 ** reconnectAttempt);
       reconnectAttempt = Math.min(reconnectAttempt + 1, 6);
       reconnectTimer = window.setTimeout(() => {
@@ -711,6 +754,7 @@ export function App() {
     };
     const openSource = () => {
       if (cancelled) return;
+      setSseState((prev) => (prev === "reconnecting" ? "reconnecting" : "connecting"));
       const source = new EventSource(
         `${location.origin}/sse/agents/${encodeURIComponent(
           activeAgent
@@ -719,6 +763,8 @@ export function App() {
       sseRef.current = source;
       source.onopen = () => {
         reconnectAttempt = 0;
+        setNetworkOnline(true);
+        setSseState("connected");
         if (pollState.timer) {
           window.clearTimeout(pollState.timer);
           pollState.timer = null;
@@ -771,14 +817,18 @@ export function App() {
           }
         } catch {
           if (typeof event.data === "string") {
-            if (isInvalidTokenMessage(event.data)) {
+            const normalizedStreamError = sanitizeErrorBannerMessage(
+              event.data,
+              getNavigatorOnline()
+            );
+            if (isInvalidTokenMessage(normalizedStreamError)) {
               clearAuthAndRedirect();
               return;
             }
-            if (shouldIgnoreAgentWsError(event.data, activeAgentStatus)) {
+            if (shouldIgnoreAgentWsError(normalizedStreamError, activeAgentStatus)) {
               return;
             }
-            setError(event.data);
+            setError(normalizedStreamError);
           }
         }
       };
@@ -787,6 +837,14 @@ export function App() {
           source.close();
           return;
         }
+        const online = getNavigatorOnline();
+        setNetworkOnline(online);
+        setSseState("reconnecting");
+        setError(
+          online
+            ? "Connection unavailable (gateway response). Reconnecting..."
+            : "Offline. Unable to connect to server."
+        );
         source.close();
         sseRef.current = null;
         schedulePoll(getAdaptivePollInterval(pollState.idleCount));
@@ -845,6 +903,7 @@ export function App() {
         sseRef.current.close();
         sseRef.current = null;
       }
+      setSseState("idle");
     };
   }, [
     token,
@@ -1433,7 +1492,7 @@ export function App() {
     return (
       <AdminPage
         auth={auth}
-        error={error}
+        error={normalizedError}
         setError={setError}
         safePaths={safePaths}
         selectedSafePaths={selectedSafePaths}
@@ -1463,6 +1522,13 @@ export function App() {
         <h1>AgentHub</h1>
         {auth && (
           <div className="session">
+            <span
+              className={`session-connection ${connectionBadge.tone}`}
+              title={connectionBadge.title}
+            >
+              <span className="session-connection-dot" aria-hidden="true" />
+              <span>{connectionBadge.label}</span>
+            </span>
             <span>{auth.username}</span>
             {auth.role === "root" && (
               <a
@@ -1479,7 +1545,9 @@ export function App() {
         )}
       </header>
 
-      {error && <ErrorBanner message={error} onClose={() => setError(null)} />}
+      {normalizedError && (
+        <ErrorBanner message={normalizedError} onClose={() => setError(null)} />
+      )}
 
       {!auth && (
         <section className="auth">
@@ -1693,6 +1761,11 @@ function parseApiErrorMessage(err: unknown): string | null {
     return raw;
   }
   return null;
+}
+
+function getNavigatorOnline(): boolean {
+  if (typeof navigator === "undefined") return true;
+  return navigator.onLine;
 }
 
 function createAnsiRenderer(): (input: string) => string {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -790,7 +790,7 @@ export function App() {
     };
     const openSource = () => {
       if (cancelled) return;
-      setSseState((prev) => (prev === "reconnecting" ? "reconnecting" : "connecting"));
+      setSseState("connecting");
       const source = new EventSource(
         `${location.origin}/sse/agents?ids=${encodeURIComponent(
           streamTarget

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -20,8 +20,10 @@ import { ErrorBanner } from "./error_banner";
 import { clearAuthAndRedirect, isInvalidTokenMessage } from "./auth_redirect";
 import {
   deriveConnectionBadge,
+  OFFLINE_MESSAGE,
   sanitizeErrorBannerMessage,
   type SseConnectionState,
+  UPSTREAM_HTML_MESSAGE,
 } from "./connection_status";
 import {
   getAdaptivePollInterval,
@@ -233,11 +235,14 @@ export function App() {
     if (typeof window === "undefined") return;
     const onOnline = () => {
       setNetworkOnline(true);
+      setError((prev) =>
+        prev === OFFLINE_MESSAGE || prev === UPSTREAM_HTML_MESSAGE ? null : prev
+      );
     };
     const onOffline = () => {
       setNetworkOnline(false);
       setSseState((prev) => (prev === "idle" ? "idle" : "reconnecting"));
-      setError("Offline. Unable to connect to server.");
+      setError(OFFLINE_MESSAGE);
     };
     window.addEventListener("online", onOnline);
     window.addEventListener("offline", onOffline);
@@ -406,7 +411,7 @@ export function App() {
           .find((evt) => evt.session_id)?.session_id;
         if (latestSession) {
           setAgentSessions((prev) => ({ ...prev, [id]: latestSession }));
-          if (activeAgent === id && !activeSessionId) {
+          if (activeAgentRef.current === id && !activeSessionIdRef.current) {
             setActiveSessionId(latestSession);
           }
           setEventMeta((prev) => ({
@@ -423,7 +428,10 @@ export function App() {
       }
       const ordered = [...events].sort((a, b) => compareEventOrder(a, b));
       const nextSlice = updateOutputCacheEntry(key, ordered);
-      updateAcpOutputCacheEntry(key, ordered);
+      const acpOrdered = ordered.filter((evt) => evt.stream === "acp");
+      if (acpOrdered.length > 0) {
+        updateAcpOutputCacheEntry(key, acpOrdered);
+      }
       const oldestEvent = nextSlice.length ? nextSlice[0] : null;
       const oldestId =
         typeof oldestEvent?.event_id === "number" ? oldestEvent.event_id : null;
@@ -465,8 +473,6 @@ export function App() {
     }
   }, [
     token,
-    activeAgent,
-    activeSessionId,
     eventLimit,
     updateOutputCacheEntry,
     updateAcpOutputCacheEntry,
@@ -502,7 +508,9 @@ export function App() {
       setOutputs((prev) => mergeOutputs(prev, ordered));
       setAcpOutputs((prev) => mergeOutputs(prev, acpOrdered));
       updateOutputCacheEntry(key, ordered);
-      updateAcpOutputCacheEntry(key, ordered);
+      if (acpOrdered.length > 0) {
+        updateAcpOutputCacheEntry(key, acpOrdered);
+      }
       setEventMeta((prev) => ({
         ...prev,
         [key]: {
@@ -826,12 +834,12 @@ export function App() {
                     agent.id === payload.agent_id
                       ? { ...agent, status: statusToAgentStatus(status) }
                       : agent
-                  )
+                    )
                 );
               }
+              updateAcpOutputCacheEntry(key, [line]);
             }
             updateOutputCacheEntry(key, [line]);
-            updateAcpOutputCacheEntry(key, [line]);
             const currentActive = activeAgentRef.current;
             if (payload.agent_id !== currentActive) {
               return;
@@ -847,14 +855,14 @@ export function App() {
           }
         } catch {
           if (typeof event.data === "string") {
+            if (isInvalidTokenMessage(event.data)) {
+              clearAuthAndRedirect();
+              return;
+            }
             const normalizedStreamError = sanitizeErrorBannerMessage(
               event.data,
               getNavigatorOnline()
             );
-            if (isInvalidTokenMessage(normalizedStreamError)) {
-              clearAuthAndRedirect();
-              return;
-            }
             if (
               shouldIgnoreAgentWsError(
                 normalizedStreamError,
@@ -877,8 +885,8 @@ export function App() {
         setSseState("reconnecting");
         setError(
           online
-            ? "Connection unavailable (gateway response). Reconnecting..."
-            : "Offline. Unable to connect to server."
+            ? UPSTREAM_HTML_MESSAGE
+            : OFFLINE_MESSAGE
         );
         source.close();
         sseRef.current = null;
@@ -1558,6 +1566,8 @@ export function App() {
             <span
               className={`session-connection ${connectionBadge.tone}`}
               title={connectionBadge.title}
+              role="status"
+              aria-live="polite"
             >
               <span className="session-connection-dot" aria-hidden="true" />
               <span>{connectionBadge.label}</span>

--- a/web/src/connection_status.test.ts
+++ b/web/src/connection_status.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveConnectionBadge,
+  OFFLINE_MESSAGE,
   sanitizeErrorBannerMessage,
+  UPSTREAM_HTML_MESSAGE,
 } from "./connection_status";
 
 describe("connection badge derivation", () => {
@@ -28,12 +30,18 @@ describe("connection badge derivation", () => {
     expect(badge.label).toBe("Online · SSE reconnecting");
     expect(badge.tone).toBe("warn");
   });
+
+  it("returns connecting badge while stream opens", () => {
+    const badge = deriveConnectionBadge(true, true, "connecting");
+    expect(badge.label).toBe("Online · SSE connecting");
+    expect(badge.tone).toBe("warn");
+  });
 });
 
 describe("error banner sanitization", () => {
   it("maps offline connectivity errors to a stable message", () => {
     const message = sanitizeErrorBannerMessage("failed to fetch", false);
-    expect(message).toBe("Offline. Unable to connect to server.");
+    expect(message).toBe(OFFLINE_MESSAGE);
   });
 
   it("keeps non-connectivity validation errors while offline", () => {
@@ -44,9 +52,33 @@ describe("error banner sanitization", () => {
   it("maps html gateway responses to a compact reconnect message", () => {
     const html = "<!doctype html><html><head><title>Cloudflare</title></head><body>error</body></html>";
     const message = sanitizeErrorBannerMessage(html, true);
-    expect(message).toBe(
-      "Connection unavailable (gateway response). Reconnecting..."
+    expect(message).toBe(UPSTREAM_HTML_MESSAGE);
+  });
+
+  it("does not treat non-tag substrings as html documents", () => {
+    const message = sanitizeErrorBannerMessage(
+      "error<bodyguard> is not an html page",
+      true
     );
+    expect(message).toBe("error<bodyguard> is not an html page");
+  });
+
+  it("keeps non-network business errors that mention connection", () => {
+    const message = sanitizeErrorBannerMessage(
+      "database connection pool exhausted",
+      false
+    );
+    expect(message).toBe("database connection pool exhausted");
+  });
+
+  it("returns generic request failure for empty online errors", () => {
+    const message = sanitizeErrorBannerMessage("", true);
+    expect(message).toBe("Request failed.");
+  });
+
+  it("returns offline message for whitespace-only offline errors", () => {
+    const message = sanitizeErrorBannerMessage("   \n\t  ", false);
+    expect(message).toBe(OFFLINE_MESSAGE);
   });
 
   it("truncates long plain text errors", () => {

--- a/web/src/connection_status.test.ts
+++ b/web/src/connection_status.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveConnectionBadge,
+  sanitizeErrorBannerMessage,
+} from "./connection_status";
+
+describe("connection badge derivation", () => {
+  it("returns offline badge when network is down", () => {
+    const badge = deriveConnectionBadge(false, true, "connected");
+    expect(badge.label).toBe("Offline · SSE disconnected");
+    expect(badge.tone).toBe("bad");
+  });
+
+  it("returns idle badge when no stream target exists", () => {
+    const badge = deriveConnectionBadge(true, false, "connected");
+    expect(badge.label).toBe("Online · SSE idle");
+    expect(badge.tone).toBe("muted");
+  });
+
+  it("returns connected badge when stream is connected", () => {
+    const badge = deriveConnectionBadge(true, true, "connected");
+    expect(badge.label).toBe("Online · SSE connected");
+    expect(badge.tone).toBe("ok");
+  });
+
+  it("returns reconnecting badge while stream retries", () => {
+    const badge = deriveConnectionBadge(true, true, "reconnecting");
+    expect(badge.label).toBe("Online · SSE reconnecting");
+    expect(badge.tone).toBe("warn");
+  });
+});
+
+describe("error banner sanitization", () => {
+  it("maps offline connectivity errors to a stable message", () => {
+    const message = sanitizeErrorBannerMessage("failed to fetch", false);
+    expect(message).toBe("Offline. Unable to connect to server.");
+  });
+
+  it("keeps non-connectivity validation errors while offline", () => {
+    const message = sanitizeErrorBannerMessage("workdir is required", false);
+    expect(message).toBe("workdir is required");
+  });
+
+  it("maps html gateway responses to a compact reconnect message", () => {
+    const html = "<!doctype html><html><head><title>Cloudflare</title></head><body>error</body></html>";
+    const message = sanitizeErrorBannerMessage(html, true);
+    expect(message).toBe(
+      "Connection unavailable (gateway response). Reconnecting..."
+    );
+  });
+
+  it("truncates long plain text errors", () => {
+    const message = sanitizeErrorBannerMessage("x".repeat(300), true);
+    expect(message.endsWith("...")).toBe(true);
+    expect(message.length).toBeLessThanOrEqual(243);
+  });
+});

--- a/web/src/connection_status.ts
+++ b/web/src/connection_status.ts
@@ -10,8 +10,8 @@ export type ConnectionBadge = {
   tone: "ok" | "warn" | "bad" | "muted";
 };
 
-const OFFLINE_MESSAGE = "Offline. Unable to connect to server.";
-const UPSTREAM_HTML_MESSAGE =
+export const OFFLINE_MESSAGE = "Offline. Unable to connect to server.";
+export const UPSTREAM_HTML_MESSAGE =
   "Connection unavailable (gateway response). Reconnecting...";
 const GENERIC_REQUEST_MESSAGE = "Request failed.";
 const MAX_ERROR_TEXT_LENGTH = 240;
@@ -90,10 +90,6 @@ function normalizeErrorText(rawMessage: string): string {
 function isLikelyHtmlErrorDocument(message: string): boolean {
   const lower = message.toLowerCase();
   if (lower.startsWith("<!doctype html")) return true;
-  if (lower.startsWith("<html")) return true;
-  if (lower.includes("<body")) return true;
-  if (lower.includes("<head")) return true;
-  if (lower.includes("<title")) return true;
   if (lower.includes("</html>")) return true;
   return /<(?:html|body|head|title|script|style|meta|link)\b/i.test(message);
 }
@@ -105,7 +101,13 @@ function isLikelyConnectivityError(message: string): boolean {
     lower.includes("fetch failed") ||
     lower.includes("networkerror") ||
     lower.includes("network error") ||
-    lower.includes("connection") ||
+    lower.includes("failed to connect") ||
+    lower.includes("could not connect") ||
+    lower.includes("cannot connect") ||
+    lower.includes("connection refused") ||
+    lower.includes("connection reset") ||
+    lower.includes("connection timed out") ||
+    lower.includes("connection timeout") ||
     lower.includes("timeout") ||
     lower.includes("gateway") ||
     lower.includes("cloudflare") ||

--- a/web/src/connection_status.ts
+++ b/web/src/connection_status.ts
@@ -1,0 +1,116 @@
+export type SseConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting";
+
+export type ConnectionBadge = {
+  label: string;
+  title: string;
+  tone: "ok" | "warn" | "bad" | "muted";
+};
+
+const OFFLINE_MESSAGE = "Offline. Unable to connect to server.";
+const UPSTREAM_HTML_MESSAGE =
+  "Connection unavailable (gateway response). Reconnecting...";
+const GENERIC_REQUEST_MESSAGE = "Request failed.";
+const MAX_ERROR_TEXT_LENGTH = 240;
+
+export function deriveConnectionBadge(
+  networkOnline: boolean,
+  hasStreamTarget: boolean,
+  sseState: SseConnectionState
+): ConnectionBadge {
+  if (!networkOnline) {
+    return {
+      label: "Offline · SSE disconnected",
+      title: "Network offline. SSE is disconnected.",
+      tone: "bad",
+    };
+  }
+  if (!hasStreamTarget) {
+    return {
+      label: "Online · SSE idle",
+      title: "Network online. No active SSE stream target.",
+      tone: "muted",
+    };
+  }
+  switch (sseState) {
+    case "connected":
+      return {
+        label: "Online · SSE connected",
+        title: "Network online. SSE is connected.",
+        tone: "ok",
+      };
+    case "connecting":
+      return {
+        label: "Online · SSE connecting",
+        title: "Network online. SSE is connecting.",
+        tone: "warn",
+      };
+    case "reconnecting":
+      return {
+        label: "Online · SSE reconnecting",
+        title: "Network online. SSE is reconnecting.",
+        tone: "warn",
+      };
+    case "idle":
+    default:
+      return {
+        label: "Online · SSE idle",
+        title: "Network online. SSE is idle.",
+        tone: "muted",
+      };
+  }
+}
+
+export function sanitizeErrorBannerMessage(
+  rawMessage: string,
+  networkOnline: boolean
+): string {
+  const compact = normalizeErrorText(rawMessage);
+  if (!compact) {
+    return networkOnline ? GENERIC_REQUEST_MESSAGE : OFFLINE_MESSAGE;
+  }
+  if (isLikelyHtmlErrorDocument(compact)) {
+    return networkOnline ? UPSTREAM_HTML_MESSAGE : OFFLINE_MESSAGE;
+  }
+  if (!networkOnline && isLikelyConnectivityError(compact)) {
+    return OFFLINE_MESSAGE;
+  }
+  return compact.length > MAX_ERROR_TEXT_LENGTH
+    ? `${compact.slice(0, MAX_ERROR_TEXT_LENGTH)}...`
+    : compact;
+}
+
+function normalizeErrorText(rawMessage: string): string {
+  return rawMessage.replace(/\s+/g, " ").trim();
+}
+
+function isLikelyHtmlErrorDocument(message: string): boolean {
+  const lower = message.toLowerCase();
+  if (lower.startsWith("<!doctype html")) return true;
+  if (lower.startsWith("<html")) return true;
+  if (lower.includes("<body")) return true;
+  if (lower.includes("<head")) return true;
+  if (lower.includes("<title")) return true;
+  if (lower.includes("</html>")) return true;
+  return /<(?:html|body|head|title|script|style|meta|link)\b/i.test(message);
+}
+
+function isLikelyConnectivityError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("failed to fetch") ||
+    lower.includes("fetch failed") ||
+    lower.includes("networkerror") ||
+    lower.includes("network error") ||
+    lower.includes("connection") ||
+    lower.includes("timeout") ||
+    lower.includes("gateway") ||
+    lower.includes("cloudflare") ||
+    lower.includes("service unavailable") ||
+    lower.includes("bad gateway") ||
+    lower.includes("sse")
+  );
+}

--- a/web/src/sse_targets.test.ts
+++ b/web/src/sse_targets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { AgentRecord } from "./api";
+import { buildSseTargetAgentIds, encodeSseTargetAgentIds } from "./sse_targets";
+
+function buildAgent(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    id: "agent-1",
+    name: "Agent",
+    workdir: "/tmp",
+    command: "codex",
+    args: [],
+    worktree_mode: "use_existing",
+    code_mode: true,
+    status: "running",
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+describe("sse target agent ids", () => {
+  it("selects active agents and dedupes ids", () => {
+    const ids = buildSseTargetAgentIds([
+      buildAgent({ id: "agent-a", status: "running" }),
+      buildAgent({ id: "agent-b", status: "idle" }),
+      buildAgent({ id: "agent-a", status: "running" }),
+      buildAgent({ id: "agent-c", status: "failed" }),
+    ]);
+    expect(ids).toEqual(["agent-a", "agent-b"]);
+  });
+
+  it("encodes comma-separated query ids", () => {
+    const query = encodeSseTargetAgentIds([" agent-a ", "", "agent-b"]);
+    expect(query).toBe("agent-a,agent-b");
+  });
+});

--- a/web/src/sse_targets.ts
+++ b/web/src/sse_targets.ts
@@ -1,0 +1,22 @@
+import { AgentRecord } from "./api";
+import { shouldOpenAgentSocket } from "./agent_ws";
+
+export function buildSseTargetAgentIds(agents: AgentRecord[]): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const agent of agents) {
+    if (!shouldOpenAgentSocket(agent.status)) continue;
+    const id = agent.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+export function encodeSseTargetAgentIds(ids: string[]): string {
+  return ids
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .join(",");
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -91,6 +91,62 @@ h1 {
   white-space: nowrap;
 }
 
+.session-connection {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid #d4dde6;
+  background: #f6f8fb;
+  color: #344350;
+  font-size: 12px;
+  line-height: 1.2;
+  padding: 4px 8px;
+  max-width: min(42vw, 260px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-connection-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.9;
+  flex: 0 0 auto;
+}
+
+.session-connection > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-connection.ok {
+  border-color: #b9e3c7;
+  background: #ecf9f0;
+  color: #1c6b3e;
+}
+
+.session-connection.warn {
+  border-color: #e8dcb4;
+  background: #fff8e7;
+  color: #9a6a08;
+}
+
+.session-connection.bad {
+  border-color: #e8c4c4;
+  background: #fff1f1;
+  color: #9a2b2b;
+}
+
+.session-connection.muted {
+  border-color: #d4dde6;
+  background: #f6f8fb;
+  color: #5a6772;
+}
+
 .icon-button {
   display: inline-flex;
   align-items: center;
@@ -2098,6 +2154,17 @@ select:not([class*="mantine-"]):focus-visible {
     gap: 8px;
   }
 
+  .session-connection {
+    font-size: 11px;
+    padding: 3px 7px;
+    gap: 5px;
+  }
+
+  .session-connection-dot {
+    width: 7px;
+    height: 7px;
+  }
+
   .output-meta {
     grid-column: 1 / -1;
     grid-row: 2;
@@ -2471,6 +2538,12 @@ select:not([class*="mantine-"]):focus-visible {
 
   .session {
     gap: 6px;
+  }
+
+  .session-connection {
+    font-size: 10px;
+    padding: 2px 6px;
+    gap: 4px;
   }
 
   .output-meta {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2546,6 +2546,11 @@ select:not([class*="mantine-"]):focus-visible {
     gap: 4px;
   }
 
+  .session-connection-dot {
+    width: 7px;
+    height: 7px;
+  }
+
   .output-meta {
     grid-column: 1 / -1;
     grid-row: 2;


### PR DESCRIPTION
## Summary
- add backend multi-agent SSE endpoint: `/sse/agents?ids=...` while keeping `/sse/agents/:id` compatible
- fan-in multiple agent output subscriptions into one SSE stream with heartbeat
- switch web client to a single EventSource bound to stream-eligible agents instead of selected agent only
- keep active conversation filtered by current agent/session while still updating background caches/status
- add unit tests for SSE target selection and backend id parsing
- add docs feature note and TODO verification item

## Why
Switching selected agent previously recreated SSE each time and caused connection state flapping in the header. Multi-agent subscription keeps connection state stable for multi-agent workflows.

## Validation
- `cargo test sse::tests`
- `npm --prefix web run test -- sse_targets.test.ts connection_status.test.ts`
- `npm --prefix web run build`

## Follow-up
- add E2E assertion for two active agents to verify no reconnect on active-agent switch
