### PR TITLE
fix: restart create_worktree agents without false non-empty errors

### DIFF
--- a/docs/features/2026-02-15-create-worktree-restart-reuse.md
+++ b/docs/features/2026-02-15-create-worktree-restart-reuse.md
@@ -28,12 +28,20 @@ their already-created worktree paths, so the next start failed with
    a valid reuse path and continue start flow.
 4. Add a router-level regression test to cover repeated
    `start -> stop -> start` for a `create_worktree` agent.
+5. Harden reuse safety: reject reuse when the same workdir is already bound to
+   another agent record.
+6. Validate existing worktree ref against configured `worktree_ref` (except
+   `HEAD` which intentionally allows current head semantics).
+7. Serialize reuse audit details as JSON text to avoid log field injection from
+   untrusted path strings.
 
 ## Validation
 
 ```bash
 cargo test create_worktree_agent_can_start_again_after_stop -- --nocapture
-cargo test worktree_list_contains_path_ -- --nocapture
+cargo test create_worktree_rejects_reuse_by_other_agent -- --nocapture
+cargo test parse_worktree_list_extracts_entries -- --nocapture
+cargo test worktree_ref_matches_ -- --nocapture
 cargo test start_route_with_actor_runtime_payload_injects_actor_envs -- --nocapture
 cargo test --all
 ```

--- a/docs/features/2026-02-15-create-worktree-restart-reuse.md
+++ b/docs/features/2026-02-15-create-worktree-restart-reuse.md
@@ -1,0 +1,39 @@
+# Create Worktree Restart Reuse
+
+## Summary
+
+Fix `create_worktree` start behavior so an existing non-empty workdir is
+reused when it is already a valid git worktree of the configured repository.
+
+## Background
+
+`prepare_worktree_with_paths` previously rejected any non-empty target workdir
+for `create_worktree`. After process restart, existing agents still point to
+their already-created worktree paths, so the next start failed with
+`workdir is not empty`.
+
+## Scope
+
+- `src/agent/manager/runtime.rs`
+- `src/api/agents.rs`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Keep strict rejection for unknown non-empty directories in
+   `create_worktree` mode to avoid writing into arbitrary paths.
+2. Before rejecting non-empty workdir, query
+   `git worktree list --porcelain` on the configured repo.
+3. If the target workdir is already present in that worktree list, treat it as
+   a valid reuse path and continue start flow.
+4. Add a router-level regression test to cover repeated
+   `start -> stop -> start` for a `create_worktree` agent.
+
+## Validation
+
+```bash
+cargo test create_worktree_agent_can_start_again_after_stop -- --nocapture
+cargo test worktree_list_contains_path_ -- --nocapture
+cargo test start_route_with_actor_runtime_payload_injects_actor_envs -- --nocapture
+cargo test --all
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -105,6 +105,7 @@
 - [x] Verify worktree-default helper logic (`runtime defaults` + `create modal prefill`) with dedicated web unit tests to keep coverage stable (see `docs/features/2026-02-15-worktree-default-root.md`).
 - [x] Verify `create_worktree` modal defaults to non-editable workdir display and exposes override only via `Customize path` (see `docs/features/2026-02-15-worktree-default-root.md`).
 - [x] Verify `use_existing` mode no longer auto-fills workdir with default root on modal open or mode switch (see `docs/features/2026-02-15-worktree-default-root.md`).
+- [ ] Verify `create_worktree` agents can restart after process reboot without failing `workdir is not empty` when the target path is already a valid git worktree for the configured repo (see `docs/features/2026-02-15-create-worktree-restart-reuse.md`).
 - [x] Verify runtime default safe paths always include `~/.agenthub/worktrees` and keep configured safe path entries deduplicated (see `docs/features/2026-02-15-safe-path-default-worktrees.md`).
 - [x] Fix Rust CI test compile failure after `AppState` default root field expansion by updating `api/agents` test state builder (see `docs/features/2026-02-15-rust-ci-appstate-default-worktree-root.md`).
 - [ ] Verify agent model tag shows model flag or provider fallback (see `docs/features/2026-02-10-agent-model-tag.md`).

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -14,7 +14,17 @@ use super::{AgentHandle, AgentManager, normalize_path};
 use crate::agent::{AgentOutput, AgentRecord, OutputStream, WorktreeMode};
 use crate::push::PushService;
 
-async fn repo_contains_worktree_path(repo: &str, workdir: &str) -> anyhow::Result<bool> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitWorktreeEntry {
+    path: String,
+    head: Option<String>,
+    branch: Option<String>,
+}
+
+async fn repo_find_worktree_entry(
+    repo: &str,
+    workdir: &str,
+) -> anyhow::Result<Option<GitWorktreeEntry>> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
@@ -32,22 +42,95 @@ async fn repo_contains_worktree_path(repo: &str, workdir: &str) -> anyhow::Resul
         anyhow::bail!("git worktree list failed: {reason}");
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(worktree_list_contains_path(&stdout, workdir))
+    let target = normalize_worktree_path(workdir);
+    Ok(parse_worktree_list(&stdout)
+        .into_iter()
+        .find(|entry| normalize_worktree_path(&entry.path) == target))
 }
 
-fn worktree_list_contains_path(stdout: &str, workdir: &str) -> bool {
-    let target = normalize_worktree_path(workdir);
-    stdout
-        .lines()
-        .filter_map(|line| line.strip_prefix("worktree "))
-        .map(normalize_worktree_path)
-        .any(|candidate| candidate == target)
+fn parse_worktree_list(stdout: &str) -> Vec<GitWorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut current: Option<GitWorktreeEntry> = None;
+    for line in stdout.lines() {
+        if line.is_empty() {
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+            current = Some(GitWorktreeEntry {
+                path: path.to_string(),
+                head: None,
+                branch: None,
+            });
+            continue;
+        }
+        if let Some(head) = line.strip_prefix("HEAD ") {
+            if let Some(entry) = current.as_mut() {
+                entry.head = Some(head.to_string());
+            }
+            continue;
+        }
+        if let Some(branch) = line.strip_prefix("branch ") {
+            if let Some(entry) = current.as_mut() {
+                entry.branch = Some(branch.to_string());
+            }
+        }
+    }
+    if let Some(entry) = current.take() {
+        entries.push(entry);
+    }
+    entries
+}
+
+fn trim_ref_prefix(value: &str) -> &str {
+    value.strip_prefix("refs/heads/").unwrap_or(value)
+}
+
+fn is_hex_sha(value: &str) -> bool {
+    let len = value.len();
+    len >= 7 && len <= 40 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn worktree_ref_matches(entry: &GitWorktreeEntry, expected_ref: &str) -> bool {
+    let expected = expected_ref.trim();
+    if expected.eq_ignore_ascii_case("HEAD") {
+        return true;
+    }
+
+    let expected_branch = trim_ref_prefix(expected);
+    if !expected_branch.is_empty() {
+        if let Some(branch) = entry.branch.as_deref() {
+            if trim_ref_prefix(branch) == expected_branch {
+                return true;
+            }
+        }
+    }
+
+    if is_hex_sha(expected) {
+        if let Some(head) = entry.head.as_deref() {
+            return head.starts_with(expected);
+        }
+    }
+
+    false
 }
 
 fn normalize_worktree_path(path: &str) -> String {
     let canonical = std::fs::canonicalize(path)
         .map(|value| value.to_string_lossy().to_string())
-        .unwrap_or_else(|_| path.to_string());
+        .unwrap_or_else(|err| {
+            tracing::warn!(
+                path = %path,
+                error = %err,
+                "failed to canonicalize worktree path"
+            );
+            path.to_string()
+        });
     normalize_path(&canonical)
 }
 
@@ -330,6 +413,7 @@ impl AgentManager {
             WorktreeMode::CreateWorktree => {
                 let repo =
                     worktree_repo.ok_or_else(|| anyhow::anyhow!("worktree_repo required"))?;
+                let ref_name = agent.worktree_ref.as_deref().unwrap_or("HEAD");
                 if let Err(err) = self.ensure_safe_path(repo).await {
                     let detail = format!(
                         "agent_id={}, mode=create_worktree, repo={}, workdir={}, error={}",
@@ -350,11 +434,68 @@ impl AgentManager {
                 }
                 let workdir_path = Path::new(workdir);
                 if workdir_path.exists() && !is_dir_empty(workdir_path)? {
-                    if repo_contains_worktree_path(repo, workdir).await? {
-                        let detail = format!(
-                            "agent_id={}, mode=create_worktree, repo={}, workdir={}, source=existing_worktree",
-                            agent.id, repo, workdir
-                        );
+                    if let Some(existing_worktree) = repo_find_worktree_entry(repo, workdir).await?
+                    {
+                        if self
+                            .is_workdir_bound_to_other_agent(&agent.id, workdir)
+                            .await?
+                        {
+                            let detail = serde_json::json!({
+                                "agent_id": agent.id,
+                                "mode": "create_worktree",
+                                "repo": repo,
+                                "workdir": workdir,
+                                "error": "workdir belongs to another agent",
+                            })
+                            .to_string();
+                            let _ = self
+                                .auth
+                                .record_audit(
+                                    None,
+                                    None,
+                                    "worktree_create_failed",
+                                    Some(&detail),
+                                    None,
+                                    None,
+                                )
+                                .await;
+                            anyhow::bail!("existing worktree belongs to another agent");
+                        }
+
+                        if !worktree_ref_matches(&existing_worktree, ref_name) {
+                            let detail = serde_json::json!({
+                                "agent_id": agent.id,
+                                "mode": "create_worktree",
+                                "repo": repo,
+                                "workdir": workdir,
+                                "configured_ref": ref_name,
+                                "existing_branch": existing_worktree.branch,
+                                "existing_head": existing_worktree.head,
+                                "error": "worktree ref mismatch",
+                            })
+                            .to_string();
+                            let _ = self
+                                .auth
+                                .record_audit(
+                                    None,
+                                    None,
+                                    "worktree_create_failed",
+                                    Some(&detail),
+                                    None,
+                                    None,
+                                )
+                                .await;
+                            anyhow::bail!("existing worktree ref mismatch");
+                        }
+
+                        let detail = serde_json::json!({
+                            "agent_id": agent.id,
+                            "mode": "create_worktree",
+                            "repo": repo,
+                            "workdir": workdir,
+                            "source": "existing_worktree",
+                        })
+                        .to_string();
                         let _ = self
                             .auth
                             .record_audit(None, None, "worktree_reuse", Some(&detail), None, None)
@@ -378,7 +519,6 @@ impl AgentManager {
                         .await;
                     anyhow::bail!("workdir is not empty");
                 }
-                let ref_name = agent.worktree_ref.as_deref().unwrap_or("HEAD");
                 let output = Command::new("git")
                     .arg("-C")
                     .arg(repo)
@@ -422,6 +562,26 @@ impl AgentManager {
                 Ok(())
             }
         }
+    }
+
+    async fn is_workdir_bound_to_other_agent(
+        &self,
+        agent_id: &str,
+        workdir: &str,
+    ) -> anyhow::Result<bool> {
+        let row = sqlx::query(
+            r#"
+            SELECT id
+            FROM agents
+            WHERE workdir = ?1 AND id != ?2
+            LIMIT 1
+            "#,
+        )
+        .bind(workdir)
+        .bind(agent_id)
+        .fetch_optional(&self.db)
+        .await?;
+        Ok(row.is_some())
     }
 
     pub async fn set_code_mode(&self, agent_id: &str, code_mode: bool) -> anyhow::Result<()> {
@@ -500,10 +660,10 @@ impl AgentManager {
 
 #[cfg(test)]
 mod tests {
-    use super::worktree_list_contains_path;
+    use super::{GitWorktreeEntry, parse_worktree_list, worktree_ref_matches};
 
     #[test]
-    fn worktree_list_contains_path_matches_normalized_paths() {
+    fn parse_worktree_list_extracts_entries() {
         let stdout = r#"
 worktree /tmp/repo
 HEAD 0000000000000000000000000000000000000000
@@ -513,22 +673,42 @@ worktree /tmp/repo/worktrees/agent-a
 HEAD 1111111111111111111111111111111111111111
 branch refs/heads/agent-a
 "#;
-        assert!(worktree_list_contains_path(
-            stdout,
-            "/tmp/repo/worktrees/agent-a/",
-        ));
+        let entries = parse_worktree_list(stdout);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].path, "/tmp/repo/worktrees/agent-a");
+        assert_eq!(entries[1].branch.as_deref(), Some("refs/heads/agent-a"));
     }
 
     #[test]
-    fn worktree_list_contains_path_rejects_unknown_paths() {
-        let stdout = r#"
-worktree /tmp/repo
-HEAD 0000000000000000000000000000000000000000
-branch refs/heads/main
-"#;
-        assert!(!worktree_list_contains_path(
-            stdout,
-            "/tmp/repo/worktrees/missing",
-        ));
+    fn worktree_ref_matches_accepts_head() {
+        let entry = GitWorktreeEntry {
+            path: "/tmp/repo/worktrees/agent-a".to_string(),
+            head: Some("1111111111111111111111111111111111111111".to_string()),
+            branch: Some("refs/heads/agent-a".to_string()),
+        };
+        assert!(worktree_ref_matches(&entry, "HEAD"));
+    }
+
+    #[test]
+    fn worktree_ref_matches_accepts_matching_branch() {
+        let entry = GitWorktreeEntry {
+            path: "/tmp/repo/worktrees/agent-a".to_string(),
+            head: Some("1111111111111111111111111111111111111111".to_string()),
+            branch: Some("refs/heads/agent-a".to_string()),
+        };
+        assert!(worktree_ref_matches(&entry, "refs/heads/agent-a"));
+        assert!(worktree_ref_matches(&entry, "agent-a"));
+        assert!(!worktree_ref_matches(&entry, "agent-b"));
+    }
+
+    #[test]
+    fn worktree_ref_matches_accepts_matching_commit_prefix() {
+        let entry = GitWorktreeEntry {
+            path: "/tmp/repo/worktrees/agent-a".to_string(),
+            head: Some("1111111111111111111111111111111111111111".to_string()),
+            branch: None,
+        };
+        assert!(worktree_ref_matches(&entry, "1111111"));
+        assert!(!worktree_ref_matches(&entry, "2222222"));
     }
 }

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -93,7 +93,7 @@ fn trim_ref_prefix(value: &str) -> &str {
 
 fn is_hex_sha(value: &str) -> bool {
     let len = value.len();
-    len >= 7 && len <= 40 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+    len >= 7 && len <= 64 && value.chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
 fn worktree_ref_matches(entry: &GitWorktreeEntry, expected_ref: &str) -> bool {
@@ -121,16 +121,20 @@ fn worktree_ref_matches(entry: &GitWorktreeEntry, expected_ref: &str) -> bool {
 }
 
 fn normalize_worktree_path(path: &str) -> String {
-    let canonical = std::fs::canonicalize(path)
+    let canonical = std::fs::canonicalize(path).or_else(|err| {
+        tracing::warn!(
+            path = %path,
+            error = %err,
+            "failed to canonicalize worktree path"
+        );
+        if Path::new(path).is_absolute() {
+            return Ok(Path::new(path).to_path_buf());
+        }
+        std::env::current_dir().map(|cwd| cwd.join(path))
+    });
+    let canonical = canonical
         .map(|value| value.to_string_lossy().to_string())
-        .unwrap_or_else(|err| {
-            tracing::warn!(
-                path = %path,
-                error = %err,
-                "failed to canonicalize worktree path"
-            );
-            path.to_string()
-        });
+        .unwrap_or_else(|_| path.to_string());
     normalize_path(&canonical)
 }
 
@@ -383,10 +387,13 @@ impl AgentManager {
             WorktreeMode::UseExisting => Ok(()),
             WorktreeMode::ReuseWorktree => {
                 if !Path::new(workdir).exists() {
-                    let detail = format!(
-                        "agent_id={}, mode=reuse_worktree, workdir={}, error=worktree missing",
-                        agent.id, workdir
-                    );
+                    let detail = serde_json::json!({
+                        "agent_id": agent.id,
+                        "mode": "reuse_worktree",
+                        "workdir": workdir,
+                        "error": "worktree missing",
+                    })
+                    .to_string();
                     let _ = self
                         .auth
                         .record_audit(
@@ -400,10 +407,12 @@ impl AgentManager {
                         .await;
                     anyhow::bail!("worktree does not exist");
                 }
-                let detail = format!(
-                    "agent_id={}, mode=reuse_worktree, workdir={}",
-                    agent.id, workdir
-                );
+                let detail = serde_json::json!({
+                    "agent_id": agent.id,
+                    "mode": "reuse_worktree",
+                    "workdir": workdir,
+                })
+                .to_string();
                 let _ = self
                     .auth
                     .record_audit(None, None, "worktree_reuse", Some(&detail), None, None)
@@ -415,10 +424,14 @@ impl AgentManager {
                     worktree_repo.ok_or_else(|| anyhow::anyhow!("worktree_repo required"))?;
                 let ref_name = agent.worktree_ref.as_deref().unwrap_or("HEAD");
                 if let Err(err) = self.ensure_safe_path(repo).await {
-                    let detail = format!(
-                        "agent_id={}, mode=create_worktree, repo={}, workdir={}, error={}",
-                        agent.id, repo, workdir, err
-                    );
+                    let detail = serde_json::json!({
+                        "agent_id": agent.id,
+                        "mode": "create_worktree",
+                        "repo": repo,
+                        "workdir": workdir,
+                        "error": err.to_string(),
+                    })
+                    .to_string();
                     let _ = self
                         .auth
                         .record_audit(
@@ -526,10 +539,14 @@ impl AgentManager {
                             .await;
                         return Ok(());
                     }
-                    let detail = format!(
-                        "agent_id={}, mode=create_worktree, repo={}, workdir={}, error=workdir not empty",
-                        agent.id, repo, workdir
-                    );
+                    let detail = serde_json::json!({
+                        "agent_id": agent.id,
+                        "mode": "create_worktree",
+                        "repo": repo,
+                        "workdir": workdir,
+                        "error": "workdir not empty",
+                    })
+                    .to_string();
                     let _ = self
                         .auth
                         .record_audit(
@@ -554,14 +571,15 @@ impl AgentManager {
                     .await?;
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                    let detail = format!(
-                        "agent_id={}, mode=create_worktree, repo={}, workdir={}, ref={}, error={}",
-                        agent.id,
-                        repo,
-                        workdir,
-                        ref_name,
-                        stderr.trim()
-                    );
+                    let detail = serde_json::json!({
+                        "agent_id": agent.id,
+                        "mode": "create_worktree",
+                        "repo": repo,
+                        "workdir": workdir,
+                        "ref": ref_name,
+                        "error": stderr.trim(),
+                    })
+                    .to_string();
                     let _ = self
                         .auth
                         .record_audit(
@@ -575,10 +593,14 @@ impl AgentManager {
                         .await;
                     anyhow::bail!("git worktree add failed: {}", stderr.trim());
                 }
-                let detail = format!(
-                    "agent_id={}, mode=create_worktree, repo={}, workdir={}, ref={}",
-                    agent.id, repo, workdir, ref_name
-                );
+                let detail = serde_json::json!({
+                    "agent_id": agent.id,
+                    "mode": "create_worktree",
+                    "repo": repo,
+                    "workdir": workdir,
+                    "ref": ref_name,
+                })
+                .to_string();
                 let _ = self
                     .auth
                     .record_audit(None, None, "worktree_created", Some(&detail), None, None)
@@ -684,7 +706,7 @@ impl AgentManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{GitWorktreeEntry, parse_worktree_list, worktree_ref_matches};
+    use super::{GitWorktreeEntry, is_hex_sha, parse_worktree_list, worktree_ref_matches};
 
     #[test]
     fn parse_worktree_list_extracts_entries() {
@@ -734,5 +756,12 @@ branch refs/heads/agent-a
         };
         assert!(worktree_ref_matches(&entry, "1111111"));
         assert!(!worktree_ref_matches(&entry, "2222222"));
+    }
+
+    #[test]
+    fn is_hex_sha_accepts_sha256_length() {
+        assert!(is_hex_sha(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
     }
 }

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -434,8 +434,32 @@ impl AgentManager {
                 }
                 let workdir_path = Path::new(workdir);
                 if workdir_path.exists() && !is_dir_empty(workdir_path)? {
-                    if let Some(existing_worktree) = repo_find_worktree_entry(repo, workdir).await?
-                    {
+                    let existing_worktree = match repo_find_worktree_entry(repo, workdir).await {
+                        Ok(entry) => entry,
+                        Err(err) => {
+                            let detail = serde_json::json!({
+                                "agent_id": agent.id,
+                                "mode": "create_worktree",
+                                "repo": repo,
+                                "workdir": workdir,
+                                "error": format!("worktree list failed: {err}"),
+                            })
+                            .to_string();
+                            let _ = self
+                                .auth
+                                .record_audit(
+                                    None,
+                                    None,
+                                    "worktree_create_failed",
+                                    Some(&detail),
+                                    None,
+                                    None,
+                                )
+                                .await;
+                            return Err(err);
+                        }
+                    };
+                    if let Some(existing_worktree) = existing_worktree {
                         if self
                             .is_workdir_bound_to_other_agent(&agent.id, workdir)
                             .await?

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -10,9 +10,46 @@ use tokio::sync::{RwLock, broadcast};
 use uuid::Uuid;
 
 use super::codec::{is_acp_message, is_dir_empty, stream_to_str};
-use super::{AgentHandle, AgentManager};
+use super::{AgentHandle, AgentManager, normalize_path};
 use crate::agent::{AgentOutput, AgentRecord, OutputStream, WorktreeMode};
 use crate::push::PushService;
+
+async fn repo_contains_worktree_path(repo: &str, workdir: &str) -> anyhow::Result<bool> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("worktree")
+        .arg("list")
+        .arg("--porcelain")
+        .output()
+        .await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let reason = stderr.trim();
+        if reason.is_empty() {
+            anyhow::bail!("git worktree list failed");
+        }
+        anyhow::bail!("git worktree list failed: {reason}");
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(worktree_list_contains_path(&stdout, workdir))
+}
+
+fn worktree_list_contains_path(stdout: &str, workdir: &str) -> bool {
+    let target = normalize_worktree_path(workdir);
+    stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(normalize_worktree_path)
+        .any(|candidate| candidate == target)
+}
+
+fn normalize_worktree_path(path: &str) -> String {
+    let canonical = std::fs::canonicalize(path)
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string());
+    normalize_path(&canonical)
+}
 
 impl AgentManager {
     pub(super) async fn emit_run_status(
@@ -313,6 +350,17 @@ impl AgentManager {
                 }
                 let workdir_path = Path::new(workdir);
                 if workdir_path.exists() && !is_dir_empty(workdir_path)? {
+                    if repo_contains_worktree_path(repo, workdir).await? {
+                        let detail = format!(
+                            "agent_id={}, mode=create_worktree, repo={}, workdir={}, source=existing_worktree",
+                            agent.id, repo, workdir
+                        );
+                        let _ = self
+                            .auth
+                            .record_audit(None, None, "worktree_reuse", Some(&detail), None, None)
+                            .await;
+                        return Ok(());
+                    }
                     let detail = format!(
                         "agent_id={}, mode=create_worktree, repo={}, workdir={}, error=workdir not empty",
                         agent.id, repo, workdir
@@ -447,5 +495,40 @@ impl AgentManager {
             .await?;
         tx.commit().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::worktree_list_contains_path;
+
+    #[test]
+    fn worktree_list_contains_path_matches_normalized_paths() {
+        let stdout = r#"
+worktree /tmp/repo
+HEAD 0000000000000000000000000000000000000000
+branch refs/heads/main
+
+worktree /tmp/repo/worktrees/agent-a
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/agent-a
+"#;
+        assert!(worktree_list_contains_path(
+            stdout,
+            "/tmp/repo/worktrees/agent-a/",
+        ));
+    }
+
+    #[test]
+    fn worktree_list_contains_path_rejects_unknown_paths() {
+        let stdout = r#"
+worktree /tmp/repo
+HEAD 0000000000000000000000000000000000000000
+branch refs/heads/main
+"#;
+        assert!(!worktree_list_contains_path(
+            stdout,
+            "/tmp/repo/worktrees/missing",
+        ));
     }
 }

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -886,6 +886,13 @@ mod tests {
         serde_json::from_slice(&bytes).expect("decode response json")
     }
 
+    async fn decode_text_body(response: axum::response::Response) -> String {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        String::from_utf8(bytes.to_vec()).expect("decode response text")
+    }
+
     fn run_git(repo_dir: &std::path::Path, args: &[&str]) {
         let status = StdCommand::new("git")
             .arg("-C")
@@ -1001,6 +1008,132 @@ mod tests {
             .await
             .expect("stop create_worktree agent (second)");
         assert_eq!(stop_second.status(), StatusCode::OK);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn create_worktree_rejects_reuse_by_other_agent() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = router(state.clone());
+
+        let base =
+            std::env::temp_dir().join(format!("agenthub-create-worktree-{}", Uuid::new_v4()));
+        let repo_dir = base.join("repo");
+        let workdir = base.join("worktree-agent");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        run_git(&repo_dir, &["init"]);
+        run_git(
+            &repo_dir,
+            &["config", "user.email", "agenthub-test@example.com"],
+        );
+        run_git(&repo_dir, &["config", "user.name", "AgentHub Test"]);
+        std::fs::write(repo_dir.join("README.md"), "seed\n").expect("write seed file");
+        run_git(&repo_dir, &["add", "README.md"]);
+        run_git(&repo_dir, &["commit", "-m", "init"]);
+
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(repo_dir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert repo safe path");
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(workdir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert workdir safe path");
+
+        let first_create = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "create-worktree-owner",
+                    "workdir": workdir.to_string_lossy().to_string(),
+                    "command": "/bin/sh",
+                    "args": ["-lc", "sleep 30"],
+                    "worktree_mode": "create_worktree",
+                    "worktree_repo": repo_dir.to_string_lossy().to_string(),
+                    "worktree_ref": "HEAD",
+                    "code_mode": true
+                })),
+            ))
+            .await
+            .expect("create owner agent");
+        assert_eq!(first_create.status(), StatusCode::OK);
+        let first_agent = decode_json_body(first_create).await;
+        let first_id = first_agent["id"].as_str().expect("first agent id");
+
+        let first_start = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{first_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start owner agent");
+        assert_eq!(first_start.status(), StatusCode::OK);
+
+        let first_stop = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{first_id}/stop"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("stop owner agent");
+        assert_eq!(first_stop.status(), StatusCode::OK);
+
+        let second_create = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "create-worktree-attacker",
+                    "workdir": workdir.to_string_lossy().to_string(),
+                    "command": "/bin/sh",
+                    "args": ["-lc", "sleep 30"],
+                    "worktree_mode": "create_worktree",
+                    "worktree_repo": repo_dir.to_string_lossy().to_string(),
+                    "worktree_ref": "HEAD",
+                    "code_mode": true
+                })),
+            ))
+            .await
+            .expect("create second agent");
+        assert_eq!(second_create.status(), StatusCode::OK);
+        let second_agent = decode_json_body(second_create).await;
+        let second_id = second_agent["id"].as_str().expect("second agent id");
+
+        let second_start = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{second_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start second agent");
+        assert_eq!(second_start.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = decode_text_body(second_start).await;
+        assert!(
+            body.contains("existing worktree belongs to another agent"),
+            "unexpected error body: {body}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -809,7 +809,7 @@ mod tests {
             ..Default::default()
         };
         let push = Arc::new(PushService::new(db.clone(), &config).expect("create push service"));
-        let _ = std::fs::remove_dir_all(&keys_dir);
+        remove_dir_best_effort(&keys_dir);
         let auth = Arc::new(
             AuthService::new(db.clone(), &config)
                 .await
@@ -834,6 +834,15 @@ mod tests {
             auth,
             acp_permissions: permissions,
             default_worktree_root: config.default_worktree_root(),
+        }
+    }
+
+    fn remove_dir_best_effort(path: &std::path::Path) {
+        if let Err(err) = std::fs::remove_dir_all(path) {
+            eprintln!(
+                "warning: failed to remove temp directory {}: {err}",
+                path.display()
+            );
         }
     }
 
@@ -899,7 +908,9 @@ mod tests {
             .arg(repo_dir)
             .args(args)
             .status()
-            .expect("failed to execute `git` command; ensure `git` is installed and available on PATH");
+            .expect(
+                "failed to execute `git` command; ensure `git` is installed and available on PATH",
+            );
         assert!(status.success(), "git command failed: {:?}", args);
     }
 
@@ -1024,7 +1035,7 @@ mod tests {
             .expect("stop create_worktree agent (second)");
         assert_eq!(stop_second.status(), StatusCode::OK);
 
-        let _ = std::fs::remove_dir_all(&base);
+        remove_dir_best_effort(&base);
     }
 
     #[tokio::test]
@@ -1156,7 +1167,7 @@ mod tests {
             "unexpected error body: {body}"
         );
 
-        let _ = std::fs::remove_dir_all(&base);
+        remove_dir_best_effort(&base);
     }
 
     #[tokio::test]
@@ -1261,6 +1272,6 @@ mod tests {
             .expect("stop agent");
         assert_eq!(stop_resp.status(), StatusCode::OK);
 
-        let _ = std::fs::remove_dir_all(&workdir);
+        remove_dir_best_effort(&workdir);
     }
 }

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -899,12 +899,27 @@ mod tests {
             .arg(repo_dir)
             .args(args)
             .status()
-            .expect("run git command");
+            .expect("failed to execute `git` command; ensure `git` is installed and available on PATH");
         assert!(status.success(), "git command failed: {:?}", args);
+    }
+
+    fn is_git_available() -> bool {
+        let status = StdCommand::new("git")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        matches!(status, Ok(status) if status.success())
     }
 
     #[tokio::test]
     async fn create_worktree_agent_can_start_again_after_stop() {
+        if !is_git_available() {
+            eprintln!(
+                "skipping create_worktree_agent_can_start_again_after_stop: `git` is not available on PATH"
+            );
+            return;
+        }
         let state = build_test_state().await;
         let token = create_auth_token(&state).await;
         let app = router(state.clone());
@@ -1014,6 +1029,12 @@ mod tests {
 
     #[tokio::test]
     async fn create_worktree_rejects_reuse_by_other_agent() {
+        if !is_git_available() {
+            eprintln!(
+                "skipping create_worktree_rejects_reuse_by_other_agent: `git` is not available on PATH"
+            );
+            return;
+        }
         let state = build_test_state().await;
         let token = create_auth_token(&state).await;
         let app = router(state.clone());

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -493,6 +493,7 @@ fn parse_start_actor_runtime_context(
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command as StdCommand;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -883,6 +884,125 @@ mod tests {
             .await
             .expect("read response body");
         serde_json::from_slice(&bytes).expect("decode response json")
+    }
+
+    fn run_git(repo_dir: &std::path::Path, args: &[&str]) {
+        let status = StdCommand::new("git")
+            .arg("-C")
+            .arg(repo_dir)
+            .args(args)
+            .status()
+            .expect("run git command");
+        assert!(status.success(), "git command failed: {:?}", args);
+    }
+
+    #[tokio::test]
+    async fn create_worktree_agent_can_start_again_after_stop() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = router(state.clone());
+
+        let base =
+            std::env::temp_dir().join(format!("agenthub-create-worktree-{}", Uuid::new_v4()));
+        let repo_dir = base.join("repo");
+        let workdir = base.join("worktree-agent");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        run_git(&repo_dir, &["init"]);
+        run_git(
+            &repo_dir,
+            &["config", "user.email", "agenthub-test@example.com"],
+        );
+        run_git(&repo_dir, &["config", "user.name", "AgentHub Test"]);
+        std::fs::write(repo_dir.join("README.md"), "seed\n").expect("write seed file");
+        run_git(&repo_dir, &["add", "README.md"]);
+        run_git(&repo_dir, &["commit", "-m", "init"]);
+
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(repo_dir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert repo safe path");
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(workdir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert workdir safe path");
+
+        let create_resp = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "create-worktree-restart",
+                    "workdir": workdir.to_string_lossy().to_string(),
+                    "command": "/bin/sh",
+                    "args": ["-lc", "sleep 30"],
+                    "worktree_mode": "create_worktree",
+                    "worktree_repo": repo_dir.to_string_lossy().to_string(),
+                    "worktree_ref": "HEAD",
+                    "code_mode": true
+                })),
+            ))
+            .await
+            .expect("create create_worktree agent");
+        assert_eq!(create_resp.status(), StatusCode::OK);
+        let created = decode_json_body(create_resp).await;
+        let agent_id = created["id"].as_str().expect("agent id");
+
+        let start_first = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start create_worktree agent (first)");
+        assert_eq!(start_first.status(), StatusCode::OK);
+
+        let stop_first = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/stop"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("stop create_worktree agent (first)");
+        assert_eq!(stop_first.status(), StatusCode::OK);
+
+        let start_second = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start create_worktree agent (second)");
+        assert_eq!(start_second.status(), StatusCode::OK);
+
+        let stop_second = app
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/stop"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("stop create_worktree agent (second)");
+        assert_eq!(stop_second.status(), StatusCode::OK);
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

This PR fixes a restart regression for agents created with `worktree_mode=create_worktree`.

Before this change, restarting an existing agent after process reboot could fail with:

- `start failed: workdir is not empty`

because the runtime rejected any non-empty workdir in create-worktree mode.

## What Changed

- `src/agent/manager/runtime.rs`
  - For `CreateWorktree` mode, when `workdir` is non-empty:
    - Query `git worktree list --porcelain` on `worktree_repo`
    - If `workdir` already belongs to that repo's worktree list, reuse it instead of failing
    - Otherwise keep the original safety behavior and fail (`workdir is not empty`)
  - Normalize/canonicalize paths before matching to avoid `/var` vs `/private/var` mismatches.
  - Added unit tests for worktree list path matching.

- `src/api/agents.rs`
  - Added router-level regression test:
    - create a `create_worktree` agent
    - `start -> stop -> start`
    - verify second start succeeds

- Docs
  - Added feature note: `docs/features/2026-02-15-create-worktree-restart-reuse.md`
  - Added TODO verification item in `docs/todo.md`

## Why

This keeps `create_worktree` mode idempotent across restarts while preserving safety for unknown non-empty directories.

## Validation

- `cargo test create_worktree_agent_can_start_again_after_stop -- --nocapture`
- `cargo test worktree_list_contains_path_ -- --nocapture`
- `cargo test start_route_with_actor_runtime_payload_injects_actor_envs -- --nocapture`
- `cargo test --all`
