### PR TITLE
fix: bound ACP command enqueue with timeout

### DIFF
--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -423,6 +423,27 @@ pub struct AcpHandle {
     tx: mpsc::Sender<AcpCommand>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcpSendError {
+    ChannelClosed,
+    Timeout(Duration),
+}
+
+impl std::fmt::Display for AcpSendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcpSendError::ChannelClosed => write!(f, "acp command channel closed"),
+            AcpSendError::Timeout(duration) => write!(
+                f,
+                "acp command queue is backpressured; timed out after {}ms",
+                duration.as_millis()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AcpSendError {}
+
 impl AcpHandle {
     pub async fn prompt(&self, input: String) -> anyhow::Result<()> {
         self.send(AcpCommand::Prompt(input)).await
@@ -451,17 +472,14 @@ impl AcpHandle {
     async fn send_with_timeout(&self, cmd: AcpCommand, timeout: Duration) -> anyhow::Result<()> {
         match tokio::time::timeout(timeout, self.tx.send(cmd)).await {
             Ok(Ok(())) => Ok(()),
-            Ok(Err(_)) => Err(anyhow::anyhow!("acp command channel closed")),
+            Ok(Err(_)) => Err(anyhow::Error::new(AcpSendError::ChannelClosed)),
             Err(_) => {
                 tracing::warn!(
                     session_id = %self.session_id,
                     timeout_ms = timeout.as_millis(),
                     "acp command send timed out due to backpressure"
                 );
-                Err(anyhow::anyhow!(
-                    "acp command queue is backpressured; timed out after {}ms",
-                    timeout.as_millis()
-                ))
+                Err(anyhow::Error::new(AcpSendError::Timeout(timeout)))
             }
         }
     }
@@ -1017,7 +1035,7 @@ impl AcpPermissionService {
 
 #[cfg(test)]
 mod tests {
-    use super::{AcpCommand, AcpHandle};
+    use super::{AcpCommand, AcpHandle, AcpSendError};
     use std::time::Duration;
     use tokio::sync::mpsc;
 
@@ -1034,6 +1052,10 @@ mod tests {
             .send_with_timeout(AcpCommand::Cancel, Duration::from_millis(25))
             .await
             .expect_err("send should timeout when queue is full");
+        let typed = err
+            .downcast_ref::<AcpSendError>()
+            .expect("error should be AcpSendError");
+        assert_eq!(*typed, AcpSendError::Timeout(Duration::from_millis(25)));
         assert!(
             err.to_string().contains("backpressured"),
             "unexpected error: {err}"
@@ -1053,6 +1075,10 @@ mod tests {
             .send_with_timeout(AcpCommand::Cancel, Duration::from_millis(25))
             .await
             .expect_err("send should fail when channel receiver is dropped");
+        let typed = err
+            .downcast_ref::<AcpSendError>()
+            .expect("error should be AcpSendError");
+        assert_eq!(*typed, AcpSendError::ChannelClosed);
         assert!(
             err.to_string().contains("channel closed"),
             "unexpected error: {err}"

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use agent_client_protocol::{
     Agent, CancelNotification, Client, ClientCapabilities, ClientSideConnection, ContentBlock,
@@ -31,6 +32,8 @@ use agenthub_acp_core::{
 
 const MCP_CONFIG_FILE: &str = ".agenthub/mcp.json";
 const SKILLS_CONFIG_FILE: &str = ".agenthub/skills.json";
+const ACP_COMMAND_CHANNEL_CAPACITY: usize = 64;
+const ACP_COMMAND_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct AcpActorSkillContext {
@@ -442,10 +445,25 @@ impl AcpHandle {
     }
 
     async fn send(&self, cmd: AcpCommand) -> anyhow::Result<()> {
-        self.tx
-            .send(cmd)
-            .await
-            .map_err(|_| anyhow::anyhow!("acp command channel closed"))
+        self.send_with_timeout(cmd, ACP_COMMAND_SEND_TIMEOUT).await
+    }
+
+    async fn send_with_timeout(&self, cmd: AcpCommand, timeout: Duration) -> anyhow::Result<()> {
+        match tokio::time::timeout(timeout, self.tx.send(cmd)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => Err(anyhow::anyhow!("acp command channel closed")),
+            Err(_) => {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    timeout_ms = timeout.as_millis(),
+                    "acp command send timed out due to backpressure"
+                );
+                Err(anyhow::anyhow!(
+                    "acp command queue is backpressured; timed out after {}ms",
+                    timeout.as_millis()
+                ))
+            }
+        }
     }
 }
 
@@ -462,7 +480,7 @@ pub async fn spawn_acp_session(
     safe_paths: Vec<String>,
     actor_context: Option<AcpActorSkillContext>,
 ) -> anyhow::Result<AcpHandle> {
-    let (cmd_tx, mut cmd_rx) = mpsc::channel::<AcpCommand>(64);
+    let (cmd_tx, mut cmd_rx) = mpsc::channel::<AcpCommand>(ACP_COMMAND_CHANNEL_CAPACITY);
     let (ready_tx, ready_rx) = oneshot::channel::<Result<String, String>>();
 
     std::thread::spawn(move || {
@@ -994,5 +1012,50 @@ impl AcpPermissionService {
             });
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AcpCommand, AcpHandle};
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn acp_handle_send_times_out_when_channel_is_backpressured() {
+        let (tx, _rx) = mpsc::channel::<AcpCommand>(1);
+        tx.try_send(AcpCommand::Cancel).expect("fill queue");
+        let handle = AcpHandle {
+            session_id: "session-backpressure".to_string(),
+            tx,
+        };
+
+        let err = handle
+            .send_with_timeout(AcpCommand::Cancel, Duration::from_millis(25))
+            .await
+            .expect_err("send should timeout when queue is full");
+        assert!(
+            err.to_string().contains("backpressured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acp_handle_send_returns_closed_when_receiver_dropped() {
+        let (tx, rx) = mpsc::channel::<AcpCommand>(1);
+        drop(rx);
+        let handle = AcpHandle {
+            session_id: "session-closed".to_string(),
+            tx,
+        };
+
+        let err = handle
+            .send_with_timeout(AcpCommand::Cancel, Duration::from_millis(25))
+            .await
+            .expect_err("send should fail when channel receiver is dropped");
+        assert!(
+            err.to_string().contains("channel closed"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/docs/features/2026-02-16-acp-command-backpressure-timeout.md
+++ b/docs/features/2026-02-16-acp-command-backpressure-timeout.md
@@ -1,0 +1,37 @@
+# ACP Command Backpressure Timeout
+
+## Background
+
+ACP commands (`prompt`, `set_mode`, `set_model`, `set_config`, `cancel`) are
+forwarded through a bounded `mpsc` queue into the ACP worker loop. Without a
+send timeout, callers can wait indefinitely if the queue remains full due to
+worker-side stalls or long-running command processing.
+
+## Scope
+
+- Keep the ACP command queue bounded.
+- Add a timeout guard on command enqueue (`AcpHandle::send`).
+- Return explicit errors on timeout vs. channel-closed conditions.
+- Add unit tests for timeout and closed-channel branches.
+
+## Key Decisions
+
+- Keep queue capacity at `64` (`ACP_COMMAND_CHANNEL_CAPACITY`).
+- Add `ACP_COMMAND_SEND_TIMEOUT = 5s`.
+- Use `tokio::time::timeout(...)` around `mpsc::Sender::send(...)`.
+- Emit a warning log when timeout occurs and include session ID + timeout ms.
+- Preserve existing behavior for closed channel with an explicit
+  `acp command channel closed` error.
+
+## Validation
+
+```bash
+cargo test -p agenthub-acp
+cargo test --all
+```
+
+Expected outcomes:
+
+- command enqueue no longer waits forever under sustained backpressure;
+- timeout path returns a clear error and logs a warning;
+- closed receiver path still returns deterministic channel-closed error.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -127,6 +127,7 @@
 - [ ] Verify ACP debug layout, interrupt gating, permission debug events, and tool output logging (see `docs/features/2026-02-09-acp-debug-layout-fixes.md`).
 - [ ] Verify ACP debug raw events auto-scrolls in the Raw tab (see `docs/features/2026-02-10-acp-raw-scroll.md`).
 - [ ] Verify single-instance agent start, ACP timeout cleanup, and SQLite WAL settings (see `docs/features/2026-02-08-backend-stability-hardening.md`).
+- [ ] Verify ACP command send timeout reports backpressure quickly (without indefinite hangs) when the ACP command queue is saturated or worker-side processing stalls (see `docs/features/2026-02-16-acp-command-backpressure-timeout.md`).
 - [ ] Verify ACP output cache isolation and UI stability (see `docs/features/2026-02-07-acp-output-cache-and-polling.md`).
 - [ ] Verify admin/join flows and focus ring styling after frontend refactor (see `docs/features/2026-02-08-frontend-quality-refactor.md`).
 - [ ] Verify agent list actions, input dock behavior, and permission modal rendering after component extraction (see `docs/features/2026-02-08-frontend-quality-refactor.md`).


### PR DESCRIPTION
## Summary
- Add timeout-guarded ACP command enqueue to avoid indefinite waits when the ACP command queue is saturated.
- Keep ACP command queue bounded and make capacity explicit via constants.
- Add unit tests for backpressure-timeout and closed-channel send behavior.
- Add feature note and TODO entry for runtime verification follow-up.

## Motivation
- `AcpHandle` command dispatch could appear "stuck" when queue pressure persisted.
- We want deterministic failure semantics under sustained backpressure instead of unbounded waiting.

## Changes
- `crates/agenthub-acp/src/lib.rs`
  - Introduce `ACP_COMMAND_CHANNEL_CAPACITY` and `ACP_COMMAND_SEND_TIMEOUT`.
  - Route `AcpHandle::send` through timeout-wrapped enqueue (`send_with_timeout`).
  - Emit warning logs with session id when enqueue times out.
  - Keep explicit error for closed channel.
  - Add tests:
    - `acp_handle_send_times_out_when_channel_is_backpressured`
    - `acp_handle_send_returns_closed_when_receiver_dropped`
- `docs/features/2026-02-16-acp-command-backpressure-timeout.md`
  - Document background, decisions, and validation.
- `docs/todo.md`
  - Add follow-up verification item for runtime backpressure timeout behavior.

## Validation
- `cargo test -p agenthub-acp`
- `cargo test --all`
