### PR TITLE
perf(web): isolate render hot paths and hide reconnect banner noise

### DIFF
--- a/docs/features/2026-02-16-connection-unavailable-banner-filter.md
+++ b/docs/features/2026-02-16-connection-unavailable-banner-filter.md
@@ -1,0 +1,49 @@
+# Connection Unavailable Banner Filter
+
+## Summary
+
+Hide the connection-recovery message from the global error banner and keep
+connection state feedback in the header connection badge only.
+
+## Background
+
+The app already exposes network/SSE state via the connection badge (`Online ·
+SSE ...` / `Offline · SSE ...`). Showing
+`Connection unavailable (gateway response). Reconnecting...` again in
+`ErrorBanner` duplicates status information and creates unnecessary visual
+noise during reconnect loops.
+
+## Scope
+
+- `web/src/app.tsx`
+- `web/src/connection_status.ts`
+- `web/src/connection_status.test.ts`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Keep sanitization behavior unchanged (`sanitizeErrorBannerMessage`) so error
+   normalization remains centralized and predictable.
+2. Add `shouldHideErrorBannerMessage` in `connection_status.ts` and treat
+   `UPSTREAM_HTML_MESSAGE` as connection-status-only text.
+3. In `App`, filter banner output after sanitization:
+   - if message should be hidden, return `null` for `normalizedError`;
+   - otherwise keep existing banner behavior.
+4. Do not suppress other business/validation errors.
+
+## Validation
+
+Recommended command:
+
+```bash
+npm --prefix web run test -- src/connection_status.test.ts
+```
+
+Manual checks:
+
+1. Simulate gateway/SSE interruption.
+2. Confirm header badge shows reconnecting state.
+3. Confirm `ErrorBanner` does not show
+   `Connection unavailable (gateway response). Reconnecting...`.
+4. Trigger a normal business error (for example invalid workdir) and confirm
+   it still appears in `ErrorBanner`.

--- a/docs/features/2026-02-16-web-render-isolation-memoization.md
+++ b/docs/features/2026-02-16-web-render-isolation-memoization.md
@@ -52,6 +52,11 @@ change.
    - no ACP flow changes
 5. Keep `acp_panel` callback test intact by exporting an internal render
    function (`AcpPanelView`) for direct event callback assertions.
+6. Keep hook initialization order safe:
+   - callbacks referenced by memoized prop objects must be initialized before
+     those `useMemo` blocks run;
+   - avoid TDZ (`Cannot access 'onAcpSetMode' before initialization`) causing a
+     blank initial app shell.
 
 ## Validation
 
@@ -59,6 +64,7 @@ Recommended commands:
 
 ```bash
 npm --prefix web run test -- src/output_body.test.tsx src/acp_panel.test.tsx src/output_header.test.tsx
+npm --prefix web run e2e -- tests/e2e/app.e2e.ts
 ```
 
 Manual checks:

--- a/docs/features/2026-02-16-web-render-isolation-memoization.md
+++ b/docs/features/2026-02-16-web-render-isolation-memoization.md
@@ -1,0 +1,70 @@
+# Web Render Isolation Memoization
+
+## Summary
+
+Reduce unnecessary frontend re-renders by isolating heavy workspace panels from
+high-frequency input state updates.
+
+## Background
+
+`web/src/app.tsx` manages both:
+
+- high-frequency state updates (input typing, composition state), and
+- large UI trees (agents list, output header, ACP conversation/debug panels).
+
+Before this change, several heavy subtrees received inline object/callback props
+from `App`, causing avoidable re-renders even when their effective data did not
+change.
+
+## Scope
+
+- `web/src/app.tsx`
+- `web/src/components/output_body.tsx`
+- `web/src/components/acp_panel.tsx`
+- `web/src/components/agents_panel.tsx`
+- `web/src/components/output_header.tsx`
+- `web/src/acp_panel.test.tsx`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Add `React.memo` to panel-level components:
+   - `OutputBody`
+   - `AcpPanel`
+   - `AgentsPanel`
+   - `OutputHeader`
+2. Stabilize expensive props in `App` using `useMemo`:
+   - `acpRuntimeMetrics`
+   - `acpConversationProps`
+   - `acpDebugProps`
+   - `acpPanelProps`
+3. Stabilize panel callbacks using `useCallback`:
+   - ACP actions (`onAcpSetMode`, `onAcpSetModel`, `onAcpSetConfig`,
+     `onAcpCancel`, `onAcpClearSession`)
+   - Agent row actions (`onStartAgent`, `onStopAgent`, `onDeleteAgent`,
+     `onSetCodeMode`)
+   - Workspace selection/toggle handlers (`handleSelectAgent`,
+     `handleCollapseAgents`, `handleExpandAgents`, `handleToggleAgents`,
+     `handleAcpTabSelect`)
+4. Keep behavior unchanged:
+   - no API contract changes
+   - no output ordering changes
+   - no ACP flow changes
+5. Keep `acp_panel` callback test intact by exporting an internal render
+   function (`AcpPanelView`) for direct event callback assertions.
+
+## Validation
+
+Recommended commands:
+
+```bash
+npm --prefix web run test -- src/output_body.test.tsx src/acp_panel.test.tsx src/output_header.test.tsx
+```
+
+Manual checks:
+
+1. Open an active ACP session and type continuously in the input dock.
+2. Confirm conversation/debug panes do not flicker and interaction remains
+   smooth.
+3. Switch tabs (`Conversation`/`Debug`) and verify behavior is unchanged.
+4. Select/collapse/expand agents and verify panel behavior is unchanged.

--- a/docs/features/2026-02-16-web-render-isolation-memoization.md
+++ b/docs/features/2026-02-16-web-render-isolation-memoization.md
@@ -61,6 +61,11 @@ change.
    - include `acpConversation.conversationRenderItems` in
      `acpRuntimeMetrics` dependencies so cache hit/miss counters are refreshed
      when rendered conversation slices change.
+8. Remove redundant memo dependencies:
+   - drop `acpConversation.conversationRenderedItems` from
+     `acpRuntimeMetrics` dependencies because it is derived from
+     `conversationRenderItems.length` and already covered by
+     `conversationRenderItems` reference changes.
 
 ## Validation
 

--- a/docs/features/2026-02-16-web-render-isolation-memoization.md
+++ b/docs/features/2026-02-16-web-render-isolation-memoization.md
@@ -57,6 +57,10 @@ change.
      those `useMemo` blocks run;
    - avoid TDZ (`Cannot access 'onAcpSetMode' before initialization`) causing a
      blank initial app shell.
+7. Keep ACP debug runtime metrics fresh while preserving memoization:
+   - include `acpConversation.conversationRenderItems` in
+     `acpRuntimeMetrics` dependencies so cache hit/miss counters are refreshed
+     when rendered conversation slices change.
 
 ## Validation
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,7 @@
 
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
 - [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
+- [ ] Verify login shell E2E remains stable after render-isolation hook ordering fix (no blank page / no TDZ during initial App render) (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify `Connection unavailable (gateway response). Reconnecting...` is hidden from `ErrorBanner` and only reflected by connection badge state transitions (`connecting`/`reconnecting`) (see `docs/features/2026-02-16-connection-unavailable-banner-filter.md`).
 - [ ] Verify `scripts/check_team_proto_codegen.sh` fails fast when `team.proto` generated symbols drift and when generated protobuf Rust files are accidentally tracked (see `docs/features/2026-02-15-team-proto-codegen-check.md`).
 - [ ] Verify new `userdocs` information architecture and cross-page navigation links after content expansion (see `docs/features/2026-02-15-userdocs-content-expansion.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,7 @@
 # TODO
 
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
+- [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify `scripts/check_team_proto_codegen.sh` fails fast when `team.proto` generated symbols drift and when generated protobuf Rust files are accidentally tracked (see `docs/features/2026-02-15-team-proto-codegen-check.md`).
 - [ ] Verify new `userdocs` information architecture and cross-page navigation links after content expansion (see `docs/features/2026-02-15-userdocs-content-expansion.md`).
 - [ ] Verify newly added `userdocs` practical pages (`configuration`, `review`, `security`, `daily checklist`) align with current UI labels and runtime behavior (see `docs/features/2026-02-15-userdocs-content-expansion.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,7 @@
 
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
 - [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
+- [ ] Verify ACP debug runtime metrics refresh cache hit/miss counters when conversation rendered window changes (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify login shell E2E remains stable after render-isolation hook ordering fix (no blank page / no TDZ during initial App render) (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify `Connection unavailable (gateway response). Reconnecting...` is hidden from `ErrorBanner` and only reflected by connection badge state transitions (`connecting`/`reconnecting`) (see `docs/features/2026-02-16-connection-unavailable-banner-filter.md`).
 - [ ] Verify `scripts/check_team_proto_codegen.sh` fails fast when `team.proto` generated symbols drift and when generated protobuf Rust files are accidentally tracked (see `docs/features/2026-02-15-team-proto-codegen-check.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,7 @@
 
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
 - [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
+- [ ] Verify `Connection unavailable (gateway response). Reconnecting...` is hidden from `ErrorBanner` and only reflected by connection badge state transitions (`connecting`/`reconnecting`) (see `docs/features/2026-02-16-connection-unavailable-banner-filter.md`).
 - [ ] Verify `scripts/check_team_proto_codegen.sh` fails fast when `team.proto` generated symbols drift and when generated protobuf Rust files are accidentally tracked (see `docs/features/2026-02-15-team-proto-codegen-check.md`).
 - [ ] Verify new `userdocs` information architecture and cross-page navigation links after content expansion (see `docs/features/2026-02-15-userdocs-content-expansion.md`).
 - [ ] Verify newly added `userdocs` practical pages (`configuration`, `review`, `security`, `daily checklist`) align with current UI labels and runtime behavior (see `docs/features/2026-02-15-userdocs-content-expansion.md`).

--- a/web/src/acp_panel.test.tsx
+++ b/web/src/acp_panel.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { AcpPanel, AcpPanelProps } from "./components/acp_panel";
+import { AcpPanel, AcpPanelProps, AcpPanelView } from "./components/acp_panel";
 import { AcpView } from "./acp";
 
 const baseView: AcpView = {
@@ -117,7 +117,7 @@ describe("AcpPanel layout", () => {
 
   it("invokes tab selection callbacks for both tabs", () => {
     const onSelectTab = vi.fn();
-    const tree = AcpPanel({
+    const tree = AcpPanelView({
       ...baseProps,
       onSelectTab,
       showConversationBadge: true,

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1571,6 +1571,7 @@ export function App() {
     acpConversation.conversationTotalItems,
     acpConversation.conversationSourceItems,
     acpConversation.conversationRenderedItems,
+    acpConversation.conversationRenderItems,
     acpConversation.conversationPendingCount,
     acpConversation.conversationVirtualized,
     acpConversation.conversationStickToBottom,

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1570,7 +1570,6 @@ export function App() {
   }, [
     acpConversation.conversationTotalItems,
     acpConversation.conversationSourceItems,
-    acpConversation.conversationRenderedItems,
     acpConversation.conversationRenderItems,
     acpConversation.conversationPendingCount,
     acpConversation.conversationVirtualized,

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -196,6 +196,9 @@ export function App() {
   const [acpTab, setAcpTab] = useState<"conversation" | "debug">(
     "conversation"
   );
+  const handleAcpTabSelect = useCallback((next: "conversation" | "debug") => {
+    setAcpTab(next);
+  }, []);
   const [createAgentBusy, setCreateAgentBusy] = useState(false);
   const [acpPermissionHistory, setAcpPermissionHistory] = useState<
     AcpPermissionRecord[]
@@ -558,25 +561,131 @@ export function App() {
     isAgentActive,
     onLoadOlder: loadOlderEvents,
   });
-  const cacheStats = getAcpConversationCacheStats();
-  const acpRuntimeMetrics = {
-    totalConversationItems: acpConversation.conversationTotalItems,
-    sourceConversationItems: acpConversation.conversationSourceItems,
-    renderedConversationItems: acpConversation.conversationRenderedItems,
-    pendingConversationItems: acpConversation.conversationPendingCount,
-    virtualizedConversation: acpConversation.conversationVirtualized,
-    stickToBottom: acpConversation.conversationStickToBottom,
-    averageConversationHeight: Math.round(acpConversation.conversationAvgHeight),
-    rawEventCount: acpView.rawEvents.length,
-    toolCallCount: acpView.toolCalls.length,
-    messageCount: acpView.messages.length,
-    markdownCacheHits: cacheStats.markdownHits,
-    markdownCacheMisses: cacheStats.markdownMisses,
-    ansiCacheHits: cacheStats.ansiHits,
-    ansiCacheMisses: cacheStats.ansiMisses,
-    payloadParses: cacheStats.payloadParses,
-    payloadParseFailures: cacheStats.payloadParseFailures,
-  };
+  const acpRuntimeMetrics = useMemo(() => {
+    const cacheStats = getAcpConversationCacheStats();
+    return {
+      totalConversationItems: acpConversation.conversationTotalItems,
+      sourceConversationItems: acpConversation.conversationSourceItems,
+      renderedConversationItems: acpConversation.conversationRenderedItems,
+      pendingConversationItems: acpConversation.conversationPendingCount,
+      virtualizedConversation: acpConversation.conversationVirtualized,
+      stickToBottom: acpConversation.conversationStickToBottom,
+      averageConversationHeight: Math.round(acpConversation.conversationAvgHeight),
+      rawEventCount: acpView.rawEvents.length,
+      toolCallCount: acpView.toolCalls.length,
+      messageCount: acpView.messages.length,
+      markdownCacheHits: cacheStats.markdownHits,
+      markdownCacheMisses: cacheStats.markdownMisses,
+      ansiCacheHits: cacheStats.ansiHits,
+      ansiCacheMisses: cacheStats.ansiMisses,
+      payloadParses: cacheStats.payloadParses,
+      payloadParseFailures: cacheStats.payloadParseFailures,
+    };
+  }, [
+    acpConversation.conversationTotalItems,
+    acpConversation.conversationSourceItems,
+    acpConversation.conversationRenderedItems,
+    acpConversation.conversationPendingCount,
+    acpConversation.conversationVirtualized,
+    acpConversation.conversationStickToBottom,
+    acpConversation.conversationAvgHeight,
+    acpView.rawEvents.length,
+    acpView.toolCalls.length,
+    acpView.messages.length,
+  ]);
+  const acpConversationProps = useMemo(
+    () => ({
+      items: acpConversation.conversationRenderItems,
+      windowOffset: acpConversation.conversationWindowOffset,
+      isFrozenView: acpConversation.isFrozenView,
+      shouldAutoCollapse: acpConversation.shouldAutoCollapse,
+      collapseCutoff: acpConversation.collapseCutoff,
+      runStatus: acpView.runStatus?.status ?? null,
+      virtualTopSpacer: acpConversation.conversationVirtualTopSpacer,
+      virtualBottomSpacer: acpConversation.conversationVirtualBottomSpacer,
+      stickToBottom: acpConversation.conversationStickToBottom,
+      pendingCount: acpConversation.conversationPendingCount,
+      avgHeight: acpConversation.conversationAvgHeight,
+      onScroll: acpConversation.handleConversationScroll,
+      containerRef: acpConversation.acpConversationRef,
+      ansi,
+    }),
+    [
+      acpConversation.conversationRenderItems,
+      acpConversation.conversationWindowOffset,
+      acpConversation.isFrozenView,
+      acpConversation.shouldAutoCollapse,
+      acpConversation.collapseCutoff,
+      acpConversation.conversationVirtualTopSpacer,
+      acpConversation.conversationVirtualBottomSpacer,
+      acpConversation.conversationStickToBottom,
+      acpConversation.conversationPendingCount,
+      acpConversation.conversationAvgHeight,
+      acpConversation.handleConversationScroll,
+      acpConversation.acpConversationRef,
+      acpView.runStatus?.status,
+      ansi,
+    ]
+  );
+  const acpDebugProps = useMemo(
+    () => ({
+      currentMode: acpView.currentMode,
+      rawEvents: acpView.rawEvents,
+      acpPermissionHistory,
+      acpModeId,
+      acpModelId,
+      acpConfigId,
+      acpConfigValue,
+      onAcpModeIdChange: setAcpModeId,
+      onAcpModelIdChange: setAcpModelId,
+      onAcpConfigIdChange: setAcpConfigId,
+      onAcpConfigValueChange: setAcpConfigValue,
+      canControlAcp,
+      onAcpSetMode,
+      onAcpSetModel,
+      onAcpSetConfig,
+      onAcpCancel,
+      onAcpClearSession,
+      runtimeMetrics: acpRuntimeMetrics,
+    }),
+    [
+      acpView.currentMode,
+      acpView.rawEvents,
+      acpPermissionHistory,
+      acpModeId,
+      acpModelId,
+      acpConfigId,
+      acpConfigValue,
+      canControlAcp,
+      onAcpSetMode,
+      onAcpSetModel,
+      onAcpSetConfig,
+      onAcpCancel,
+      onAcpClearSession,
+      acpRuntimeMetrics,
+    ]
+  );
+  const acpPanelProps = useMemo(
+    () => ({
+      acpView,
+      subtitle: activeAgentRecord?.workdir ?? null,
+      acpTab,
+      onSelectTab: handleAcpTabSelect,
+      showConversationBadge: acpConversation.showConversationBadge,
+      conversation: acpConversationProps,
+      debug: acpDebugProps,
+    }),
+    [
+      acpView,
+      activeAgentRecord?.workdir,
+      acpTab,
+      handleAcpTabSelect,
+      acpConversation.showConversationBadge,
+      acpConversationProps,
+      acpDebugProps,
+    ]
+  );
+  const showInputDock = !(acpTab === "debug" && acpView.hasAcp);
   useEffect(() => {
     if (outputPersistTimerRef.current) {
       window.clearTimeout(outputPersistTimerRef.current);
@@ -1192,7 +1301,7 @@ export function App() {
     }
   };
 
-  const onStartAgent = async (id: string) => {
+  const onStartAgent = useCallback(async (id: string) => {
     if (!token) return;
     setError(null);
     setWorktreeError(null);
@@ -1211,9 +1320,9 @@ export function App() {
       const hint = formatWorktreeError(err);
       setError(hint ?? message);
     }
-  };
+  }, [token, refreshAgents]);
 
-  const onStopAgent = async (id: string) => {
+  const onStopAgent = useCallback(async (id: string) => {
     if (!token) return;
     setError(null);
     setWorktreeError(null);
@@ -1224,9 +1333,9 @@ export function App() {
     } catch (err) {
       setError(String(err));
     }
-  };
+  }, [token, refreshAgents]);
 
-  const onDeleteAgent = async (id: string) => {
+  const onDeleteAgent = useCallback(async (id: string) => {
     if (!token) return;
     setError(null);
     try {
@@ -1246,9 +1355,9 @@ export function App() {
     } catch (err) {
       setError(String(err));
     }
-  };
+  }, [token, activeAgent]);
 
-  const onSetCodeMode = async (id: string, next: boolean) => {
+  const onSetCodeMode = useCallback(async (id: string, next: boolean) => {
     if (!token) return;
     setError(null);
     try {
@@ -1261,9 +1370,9 @@ export function App() {
     } catch (err) {
       setError(String(err));
     }
-  };
+  }, [token]);
 
-  const onAcpSetMode = async () => {
+  const onAcpSetMode = useCallback(async () => {
     if (!token || !activeAgent) return;
     const modeId = acpModeId.trim();
     if (!modeId) {
@@ -1276,9 +1385,9 @@ export function App() {
     } catch (err) {
       setError(parseApiErrorMessage(err) ?? String(err));
     }
-  };
+  }, [token, activeAgent, acpModeId]);
 
-  const onAcpSetModel = async () => {
+  const onAcpSetModel = useCallback(async () => {
     if (!token || !activeAgent) return;
     const modelId = acpModelId.trim();
     if (!modelId) {
@@ -1291,9 +1400,9 @@ export function App() {
     } catch (err) {
       setError(parseApiErrorMessage(err) ?? String(err));
     }
-  };
+  }, [token, activeAgent, acpModelId]);
 
-  const onAcpSetConfig = async () => {
+  const onAcpSetConfig = useCallback(async () => {
     if (!token || !activeAgent) return;
     const configId = acpConfigId.trim();
     const configValue = acpConfigValue.trim();
@@ -1307,9 +1416,9 @@ export function App() {
     } catch (err) {
       setError(parseApiErrorMessage(err) ?? String(err));
     }
-  };
+  }, [token, activeAgent, acpConfigId, acpConfigValue]);
 
-  const onAcpCancel = async () => {
+  const onAcpCancel = useCallback(async () => {
     if (!token || !activeAgent) return;
     setError(null);
     try {
@@ -1317,9 +1426,9 @@ export function App() {
     } catch (err) {
       setError(parseApiErrorMessage(err) ?? String(err));
     }
-  };
+  }, [token, activeAgent]);
 
-  const onAcpClearSession = async () => {
+  const onAcpClearSession = useCallback(async () => {
     if (!token || !activeAgent) return;
     setError(null);
     try {
@@ -1327,9 +1436,9 @@ export function App() {
     } catch (err) {
       setError(parseApiErrorMessage(err) ?? String(err));
     }
-  };
+  }, [token, activeAgent]);
 
-  const onSendInput = async () => {
+  const onSendInput = useCallback(async () => {
     if (!input.trim()) return;
     if (!token || !activeAgent) return;
     eventPollRef.current.boostUntil = Date.now() + 10_000;
@@ -1356,7 +1465,14 @@ export function App() {
         await refreshAgents();
       }
     }
-  };
+  }, [
+    input,
+    token,
+    activeAgent,
+    activeSessionId,
+    acpConversation.jumpToConversationBottom,
+    refreshAgents,
+  ]);
 
   const onInputChange = useCallback(
     (value: string) => {
@@ -1406,6 +1522,24 @@ export function App() {
     },
     [inputHistory]
   );
+
+  const handleCollapseAgents = useCallback(() => {
+    setAgentsCollapsed(true);
+  }, []);
+
+  const handleExpandAgents = useCallback(() => {
+    setAgentsCollapsed(false);
+  }, []);
+
+  const handleToggleAgents = useCallback(() => {
+    setAgentsCollapsed((prev) => !prev);
+  }, []);
+
+  const handleSelectAgent = useCallback((id: string) => {
+    setActiveAgent(id);
+    setActiveSessionId(agentSessions[id] ?? null);
+    setAgentsCollapsed(true);
+  }, [agentSessions]);
 
   const onRespondPermission = async (
     agentId: string,
@@ -1644,14 +1778,10 @@ export function App() {
             agents={agents}
             activeAgent={activeAgent}
             agentsCollapsed={agentsCollapsed}
-            onCollapse={() => setAgentsCollapsed(true)}
-            onExpand={() => setAgentsCollapsed(false)}
+            onCollapse={handleCollapseAgents}
+            onExpand={handleExpandAgents}
             onCreateAgent={openCreateAgentModal}
-            onSelectAgent={(id) => {
-              setActiveAgent(id);
-              setActiveSessionId(agentSessions[id] ?? null);
-              setAgentsCollapsed(true);
-            }}
+            onSelectAgent={handleSelectAgent}
             onToggleCodeMode={onSetCodeMode}
             onStartAgent={onStartAgent}
             onStopAgent={onStopAgent}
@@ -1665,7 +1795,7 @@ export function App() {
               hasAcp={acpView.hasAcp}
               thinkingStartTs={thinkingStartTs}
               modelLabel={activeAgentModelLabel}
-              onToggleAgents={() => setAgentsCollapsed((prev) => !prev)}
+              onToggleAgents={handleToggleAgents}
             />
             {activeAgent ? (
               <OutputErrorBoundary>
@@ -1675,53 +1805,11 @@ export function App() {
                   isOutputLoading={isOutputLoading}
                   outputs={outputs}
                   ansi={ansi}
-                  acpPanelProps={{
-                    acpView,
-                    subtitle: activeAgentRecord?.workdir ?? null,
-                    acpTab,
-                    onSelectTab: (next) => setAcpTab(next),
-                    showConversationBadge: acpConversation.showConversationBadge,
-                    conversation: {
-                      items: acpConversation.conversationRenderItems,
-                      windowOffset: acpConversation.conversationWindowOffset,
-                      isFrozenView: acpConversation.isFrozenView,
-                      shouldAutoCollapse: acpConversation.shouldAutoCollapse,
-                      collapseCutoff: acpConversation.collapseCutoff,
-                      runStatus: acpView.runStatus?.status ?? null,
-                      virtualTopSpacer: acpConversation.conversationVirtualTopSpacer,
-                      virtualBottomSpacer: acpConversation.conversationVirtualBottomSpacer,
-                      stickToBottom: acpConversation.conversationStickToBottom,
-                      pendingCount: acpConversation.conversationPendingCount,
-                      avgHeight: acpConversation.conversationAvgHeight,
-                      onScroll: acpConversation.handleConversationScroll,
-                      containerRef: acpConversation.acpConversationRef,
-                      ansi,
-                    },
-                    debug: {
-                      currentMode: acpView.currentMode,
-                      rawEvents: acpView.rawEvents,
-                      acpPermissionHistory,
-                      acpModeId,
-                      acpModelId,
-                      acpConfigId,
-                      acpConfigValue,
-                      onAcpModeIdChange: setAcpModeId,
-                      onAcpModelIdChange: setAcpModelId,
-                      onAcpConfigIdChange: setAcpConfigId,
-                      onAcpConfigValueChange: setAcpConfigValue,
-                      canControlAcp,
-                      onAcpSetMode,
-                      onAcpSetModel,
-                      onAcpSetConfig,
-                      onAcpCancel,
-                      onAcpClearSession,
-                      runtimeMetrics: acpRuntimeMetrics,
-                    },
-                  }}
+                  acpPanelProps={acpPanelProps}
                 />
               </OutputErrorBoundary>
             ) : null}
-            {!(acpTab === "debug" && acpView.hasAcp) && (
+            {showInputDock && (
               <InputDock
                 input={input}
                 historyCommands={inputHistory}

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -566,131 +566,6 @@ export function App() {
     isAgentActive,
     onLoadOlder: loadOlderEvents,
   });
-  const acpRuntimeMetrics = useMemo(() => {
-    const cacheStats = getAcpConversationCacheStats();
-    return {
-      totalConversationItems: acpConversation.conversationTotalItems,
-      sourceConversationItems: acpConversation.conversationSourceItems,
-      renderedConversationItems: acpConversation.conversationRenderedItems,
-      pendingConversationItems: acpConversation.conversationPendingCount,
-      virtualizedConversation: acpConversation.conversationVirtualized,
-      stickToBottom: acpConversation.conversationStickToBottom,
-      averageConversationHeight: Math.round(acpConversation.conversationAvgHeight),
-      rawEventCount: acpView.rawEvents.length,
-      toolCallCount: acpView.toolCalls.length,
-      messageCount: acpView.messages.length,
-      markdownCacheHits: cacheStats.markdownHits,
-      markdownCacheMisses: cacheStats.markdownMisses,
-      ansiCacheHits: cacheStats.ansiHits,
-      ansiCacheMisses: cacheStats.ansiMisses,
-      payloadParses: cacheStats.payloadParses,
-      payloadParseFailures: cacheStats.payloadParseFailures,
-    };
-  }, [
-    acpConversation.conversationTotalItems,
-    acpConversation.conversationSourceItems,
-    acpConversation.conversationRenderedItems,
-    acpConversation.conversationPendingCount,
-    acpConversation.conversationVirtualized,
-    acpConversation.conversationStickToBottom,
-    acpConversation.conversationAvgHeight,
-    acpView.rawEvents.length,
-    acpView.toolCalls.length,
-    acpView.messages.length,
-  ]);
-  const acpConversationProps = useMemo(
-    () => ({
-      items: acpConversation.conversationRenderItems,
-      windowOffset: acpConversation.conversationWindowOffset,
-      isFrozenView: acpConversation.isFrozenView,
-      shouldAutoCollapse: acpConversation.shouldAutoCollapse,
-      collapseCutoff: acpConversation.collapseCutoff,
-      runStatus: acpView.runStatus?.status ?? null,
-      virtualTopSpacer: acpConversation.conversationVirtualTopSpacer,
-      virtualBottomSpacer: acpConversation.conversationVirtualBottomSpacer,
-      stickToBottom: acpConversation.conversationStickToBottom,
-      pendingCount: acpConversation.conversationPendingCount,
-      avgHeight: acpConversation.conversationAvgHeight,
-      onScroll: acpConversation.handleConversationScroll,
-      containerRef: acpConversation.acpConversationRef,
-      ansi,
-    }),
-    [
-      acpConversation.conversationRenderItems,
-      acpConversation.conversationWindowOffset,
-      acpConversation.isFrozenView,
-      acpConversation.shouldAutoCollapse,
-      acpConversation.collapseCutoff,
-      acpConversation.conversationVirtualTopSpacer,
-      acpConversation.conversationVirtualBottomSpacer,
-      acpConversation.conversationStickToBottom,
-      acpConversation.conversationPendingCount,
-      acpConversation.conversationAvgHeight,
-      acpConversation.handleConversationScroll,
-      acpConversation.acpConversationRef,
-      acpView.runStatus?.status,
-      ansi,
-    ]
-  );
-  const acpDebugProps = useMemo(
-    () => ({
-      currentMode: acpView.currentMode,
-      rawEvents: acpView.rawEvents,
-      acpPermissionHistory,
-      acpModeId,
-      acpModelId,
-      acpConfigId,
-      acpConfigValue,
-      onAcpModeIdChange: setAcpModeId,
-      onAcpModelIdChange: setAcpModelId,
-      onAcpConfigIdChange: setAcpConfigId,
-      onAcpConfigValueChange: setAcpConfigValue,
-      canControlAcp,
-      onAcpSetMode,
-      onAcpSetModel,
-      onAcpSetConfig,
-      onAcpCancel,
-      onAcpClearSession,
-      runtimeMetrics: acpRuntimeMetrics,
-    }),
-    [
-      acpView.currentMode,
-      acpView.rawEvents,
-      acpPermissionHistory,
-      acpModeId,
-      acpModelId,
-      acpConfigId,
-      acpConfigValue,
-      canControlAcp,
-      onAcpSetMode,
-      onAcpSetModel,
-      onAcpSetConfig,
-      onAcpCancel,
-      onAcpClearSession,
-      acpRuntimeMetrics,
-    ]
-  );
-  const acpPanelProps = useMemo(
-    () => ({
-      acpView,
-      subtitle: activeAgentRecord?.workdir ?? null,
-      acpTab,
-      onSelectTab: handleAcpTabSelect,
-      showConversationBadge: acpConversation.showConversationBadge,
-      conversation: acpConversationProps,
-      debug: acpDebugProps,
-    }),
-    [
-      acpView,
-      activeAgentRecord?.workdir,
-      acpTab,
-      handleAcpTabSelect,
-      acpConversation.showConversationBadge,
-      acpConversationProps,
-      acpDebugProps,
-    ]
-  );
-  const showInputDock = !(acpTab === "debug" && acpView.hasAcp);
   useEffect(() => {
     if (outputPersistTimerRef.current) {
       window.clearTimeout(outputPersistTimerRef.current);
@@ -1671,6 +1546,132 @@ export function App() {
       setError(String(err));
     }
   };
+
+  const acpRuntimeMetrics = useMemo(() => {
+    const cacheStats = getAcpConversationCacheStats();
+    return {
+      totalConversationItems: acpConversation.conversationTotalItems,
+      sourceConversationItems: acpConversation.conversationSourceItems,
+      renderedConversationItems: acpConversation.conversationRenderedItems,
+      pendingConversationItems: acpConversation.conversationPendingCount,
+      virtualizedConversation: acpConversation.conversationVirtualized,
+      stickToBottom: acpConversation.conversationStickToBottom,
+      averageConversationHeight: Math.round(acpConversation.conversationAvgHeight),
+      rawEventCount: acpView.rawEvents.length,
+      toolCallCount: acpView.toolCalls.length,
+      messageCount: acpView.messages.length,
+      markdownCacheHits: cacheStats.markdownHits,
+      markdownCacheMisses: cacheStats.markdownMisses,
+      ansiCacheHits: cacheStats.ansiHits,
+      ansiCacheMisses: cacheStats.ansiMisses,
+      payloadParses: cacheStats.payloadParses,
+      payloadParseFailures: cacheStats.payloadParseFailures,
+    };
+  }, [
+    acpConversation.conversationTotalItems,
+    acpConversation.conversationSourceItems,
+    acpConversation.conversationRenderedItems,
+    acpConversation.conversationPendingCount,
+    acpConversation.conversationVirtualized,
+    acpConversation.conversationStickToBottom,
+    acpConversation.conversationAvgHeight,
+    acpView.rawEvents.length,
+    acpView.toolCalls.length,
+    acpView.messages.length,
+  ]);
+  const acpConversationProps = useMemo(
+    () => ({
+      items: acpConversation.conversationRenderItems,
+      windowOffset: acpConversation.conversationWindowOffset,
+      isFrozenView: acpConversation.isFrozenView,
+      shouldAutoCollapse: acpConversation.shouldAutoCollapse,
+      collapseCutoff: acpConversation.collapseCutoff,
+      runStatus: acpView.runStatus?.status ?? null,
+      virtualTopSpacer: acpConversation.conversationVirtualTopSpacer,
+      virtualBottomSpacer: acpConversation.conversationVirtualBottomSpacer,
+      stickToBottom: acpConversation.conversationStickToBottom,
+      pendingCount: acpConversation.conversationPendingCount,
+      avgHeight: acpConversation.conversationAvgHeight,
+      onScroll: acpConversation.handleConversationScroll,
+      containerRef: acpConversation.acpConversationRef,
+      ansi,
+    }),
+    [
+      acpConversation.conversationRenderItems,
+      acpConversation.conversationWindowOffset,
+      acpConversation.isFrozenView,
+      acpConversation.shouldAutoCollapse,
+      acpConversation.collapseCutoff,
+      acpConversation.conversationVirtualTopSpacer,
+      acpConversation.conversationVirtualBottomSpacer,
+      acpConversation.conversationStickToBottom,
+      acpConversation.conversationPendingCount,
+      acpConversation.conversationAvgHeight,
+      acpConversation.handleConversationScroll,
+      acpConversation.acpConversationRef,
+      acpView.runStatus?.status,
+      ansi,
+    ]
+  );
+  const acpDebugProps = useMemo(
+    () => ({
+      currentMode: acpView.currentMode,
+      rawEvents: acpView.rawEvents,
+      acpPermissionHistory,
+      acpModeId,
+      acpModelId,
+      acpConfigId,
+      acpConfigValue,
+      onAcpModeIdChange: setAcpModeId,
+      onAcpModelIdChange: setAcpModelId,
+      onAcpConfigIdChange: setAcpConfigId,
+      onAcpConfigValueChange: setAcpConfigValue,
+      canControlAcp,
+      onAcpSetMode,
+      onAcpSetModel,
+      onAcpSetConfig,
+      onAcpCancel,
+      onAcpClearSession,
+      runtimeMetrics: acpRuntimeMetrics,
+    }),
+    [
+      acpView.currentMode,
+      acpView.rawEvents,
+      acpPermissionHistory,
+      acpModeId,
+      acpModelId,
+      acpConfigId,
+      acpConfigValue,
+      canControlAcp,
+      onAcpSetMode,
+      onAcpSetModel,
+      onAcpSetConfig,
+      onAcpCancel,
+      onAcpClearSession,
+      acpRuntimeMetrics,
+    ]
+  );
+  const acpPanelProps = useMemo(
+    () => ({
+      acpView,
+      subtitle: activeAgentRecord?.workdir ?? null,
+      acpTab,
+      onSelectTab: handleAcpTabSelect,
+      showConversationBadge: acpConversation.showConversationBadge,
+      conversation: acpConversationProps,
+      debug: acpDebugProps,
+    }),
+    [
+      acpView,
+      activeAgentRecord?.workdir,
+      acpTab,
+      handleAcpTabSelect,
+      acpConversation.showConversationBadge,
+      acpConversationProps,
+      acpDebugProps,
+    ]
+  );
+  const showInputDock = !(acpTab === "debug" && acpView.hasAcp);
 
   if (location.pathname.startsWith("/join")) {
     return <JoinPage onComplete={(next) => setAuth(next)} />;

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -21,6 +21,7 @@ import {
   deriveConnectionBadge,
   OFFLINE_MESSAGE,
   sanitizeErrorBannerMessage,
+  shouldHideErrorBannerMessage,
   type SseConnectionState,
   UPSTREAM_HTML_MESSAGE,
 } from "./connection_status";
@@ -330,7 +331,11 @@ export function App() {
     [networkOnline, hasSseTarget, sseState]
   );
   const normalizedError = useMemo(
-    () => (error ? sanitizeErrorBannerMessage(error, networkOnline) : null),
+    () => {
+      if (!error) return null;
+      const message = sanitizeErrorBannerMessage(error, networkOnline);
+      return shouldHideErrorBannerMessage(message) ? null : message;
+    },
     [error, networkOnline]
   );
   const thinkingStartTs =

--- a/web/src/components/acp_panel.tsx
+++ b/web/src/components/acp_panel.tsx
@@ -13,7 +13,7 @@ type AcpPanelProps = {
   debug: AcpDebugProps;
 };
 
-export function AcpPanel({
+function AcpPanelView({
   subtitle,
   acpTab,
   onSelectTab,
@@ -53,4 +53,7 @@ export function AcpPanel({
   );
 }
 
+export const AcpPanel = React.memo(AcpPanelView);
+
 export type { AcpPanelProps };
+export { AcpPanelView };

--- a/web/src/components/agents_panel.tsx
+++ b/web/src/components/agents_panel.tsx
@@ -17,7 +17,7 @@ type AgentsPanelProps = {
   onDeleteAgent: (id: string) => void;
 };
 
-export function AgentsPanel({
+export const AgentsPanel = React.memo(function AgentsPanel({
   agents,
   activeAgent,
   agentsCollapsed,
@@ -198,4 +198,4 @@ export function AgentsPanel({
       </div>
     </>
   );
-}
+});

--- a/web/src/components/output_body.tsx
+++ b/web/src/components/output_body.tsx
@@ -12,7 +12,7 @@ type OutputBodyProps = {
   acpPanelProps: AcpPanelProps;
 };
 
-export function OutputBody({
+export const OutputBody = React.memo(function OutputBody({
   terminalRef,
   onTerminalScroll,
   isOutputLoading,
@@ -44,4 +44,4 @@ export function OutputBody({
       )}
     </div>
   );
-}
+});

--- a/web/src/components/output_header.tsx
+++ b/web/src/components/output_header.tsx
@@ -11,7 +11,7 @@ type OutputHeaderProps = {
   onToggleAgents: () => void;
 };
 
-export function OutputHeader({
+export const OutputHeader = React.memo(function OutputHeader({
   activeAgent,
   activeSessionId,
   agentsCollapsed,
@@ -83,4 +83,4 @@ export function OutputHeader({
       ) : null}
     </div>
   );
-}
+});

--- a/web/src/connection_status.test.ts
+++ b/web/src/connection_status.test.ts
@@ -3,6 +3,7 @@ import {
   deriveConnectionBadge,
   OFFLINE_MESSAGE,
   sanitizeErrorBannerMessage,
+  shouldHideErrorBannerMessage,
   UPSTREAM_HTML_MESSAGE,
 } from "./connection_status";
 
@@ -85,5 +86,10 @@ describe("error banner sanitization", () => {
     const message = sanitizeErrorBannerMessage("x".repeat(300), true);
     expect(message.endsWith("...")).toBe(true);
     expect(message.length).toBeLessThanOrEqual(243);
+  });
+
+  it("marks connection unavailable message as banner-hidden", () => {
+    expect(shouldHideErrorBannerMessage(UPSTREAM_HTML_MESSAGE)).toBe(true);
+    expect(shouldHideErrorBannerMessage("workdir is required")).toBe(false);
   });
 });

--- a/web/src/connection_status.ts
+++ b/web/src/connection_status.ts
@@ -83,6 +83,10 @@ export function sanitizeErrorBannerMessage(
     : compact;
 }
 
+export function shouldHideErrorBannerMessage(message: string): boolean {
+  return normalizeErrorText(message) === UPSTREAM_HTML_MESSAGE;
+}
+
 function normalizeErrorText(rawMessage: string): string {
   return rawMessage.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary

Optimize frontend rendering performance by isolating heavy workspace panels from high-frequency input updates, and hide reconnect-only connection text from the global error banner.

## Changes

- add `React.memo` to panel-level components:
  - `AgentsPanel`
  - `OutputHeader`
  - `OutputBody`
  - `AcpPanel`
- stabilize callback/object props in `App` using `useCallback`/`useMemo` for ACP and workspace panel props
- keep `Connection unavailable (gateway response). Reconnecting...` in connection badge semantics only (filtered from `ErrorBanner`)
- add/update tests:
  - `web/src/acp_panel.test.tsx`
  - `web/src/connection_status.test.ts`
- add docs:
  - `docs/features/2026-02-16-web-render-isolation-memoization.md`
  - `docs/features/2026-02-16-connection-unavailable-banner-filter.md`
  - `docs/todo.md`

## Validation

- CI should validate:
  - Rust workflow
  - Web workflow
  - Web E2E workflow
- Local test command attempted in this environment but `vitest` was not installed:
  - `npm --prefix web run test -- src/output_body.test.tsx src/acp_panel.test.tsx src/output_header.test.tsx`
  - `npm --prefix web run test -- src/connection_status.test.ts`

## Related

- branch: `perf/frontend-performance-pass1`
