### PR TITLE
feat: add Team Workbench UI, runs list API, and OpenAPI discovery

### DIFF
--- a/docs/features/2026-02-16-openapi-discovery-endpoints.md
+++ b/docs/features/2026-02-16-openapi-discovery-endpoints.md
@@ -1,0 +1,40 @@
+# OpenAPI Discovery Endpoints
+
+## Background
+
+Team APIs have grown quickly, but there was no built-in endpoint to inspect a machine-readable
+contract in one place. This made frontend and integration debugging slower.
+
+## Scope
+
+- Add `GET /api/openapi.json` for authenticated OpenAPI discovery.
+- Add `GET /api/openapi/docs` for a lightweight browser page that fetches and renders
+  `/api/openapi.json`.
+- Cover current Team Workbench related contracts in the generated OpenAPI document, including
+  team runs listing (`GET /api/teams/{id}/runs`).
+- Add tests for:
+  - unauthorized access to `/openapi.json`
+  - spec presence for key team paths
+
+## Key Decisions
+
+- Keep `/api/openapi.json` authenticated to match existing API access control semantics.
+- Keep `/api/openapi/docs` public as a static viewer page, while the actual spec fetch still uses
+  Bearer auth from `localStorage.agenthub_auth`.
+- Start with Team-focused path coverage and extend incrementally as new API domains stabilize.
+
+## Validation
+
+Suggested checks:
+
+```bash
+cargo test openapi_json_requires_authorization -- --nocapture
+cargo test openapi_json_contains_team_runs_list_path -- --nocapture
+cargo test teams_router_http_contract -- --nocapture
+```
+
+Manual checks:
+
+1. Open `/api/openapi/docs` in a logged-in browser session.
+2. Verify the page can load `/api/openapi.json` and render formatted JSON.
+3. Verify clearing `agenthub_auth` causes `/api/openapi.json` fetch to return `401`.

--- a/docs/features/2026-02-16-team-runs-list-api.md
+++ b/docs/features/2026-02-16-team-runs-list-api.md
@@ -1,0 +1,38 @@
+# Team Runs List API
+
+## Background
+
+Team APIs already supported team create/run create/run details, but there was no endpoint to list runs
+for a specific team. This made UI reconstruction after refresh/reconnect difficult and forced
+client-side run state caching.
+
+## Scope
+
+- Add `GET /api/teams/:id/runs`.
+- Add query options:
+  - `limit` (default 100, clamp `1..500`)
+  - `status` (one of `submitted|working|input_required|completed|failed|canceled`)
+  - `before_created_at` (cursor for older pages)
+- Add manager-layer method to query team runs with ordering and optional filters.
+- Add API tests (core + router) for:
+  - happy path listing
+  - status filter
+  - cursor paging by `before_created_at`
+  - invalid status validation
+  - missing team behavior (`404`)
+
+## Key Decisions
+
+- Keep cursor semantics simple and stable with `before_created_at` for now.
+- Order by `created_at DESC, id DESC` to provide deterministic paging order for identical timestamps.
+- Reuse existing auth and not-found mapping semantics (`require_user`, `map_not_found_error`).
+
+## Validation
+
+Suggested checks:
+
+```bash
+cargo test team_runs_api_lists_team_runs_with_status_filter_and_cursor -- --nocapture
+cargo test teams_router_http_contract -- --nocapture
+cargo test -p agenthub-web
+```

--- a/docs/features/2026-02-16-team-workbench-ui.md
+++ b/docs/features/2026-02-16-team-workbench-ui.md
@@ -1,0 +1,46 @@
+# Team Workbench UI
+
+## Background
+
+Team backend APIs (`/api/teams`, run lifecycle, step lifecycle, actor mailbox) are already available,
+but there is no first-class UI to operate these flows from the web app.
+
+## Scope
+
+- Add a dedicated Team Workbench page at `/teams`.
+- Add Team API types and request wrappers in `web/src/api.ts`.
+- Add Team entry in the main authenticated header.
+- Implement interactive flows:
+  - Team create and team list selection
+  - Run create, run lookup by `run_id`, run status refresh, run cancel
+  - Run event timeline refresh and older-page replay (`before_id` pagination)
+  - Step submit + lifecycle transitions (`start`, `complete`, `fail`, `input_required`, `resume`)
+  - Actor mailbox send/inbox/ack operations
+
+## Key Decisions
+
+- Keep Team interactions in a standalone page (`web/src/pages/team_page.tsx`) to avoid coupling
+  with the existing Agent workspace state machine.
+- Because there is no `list runs by team` HTTP API yet, the UI supports:
+  - creating runs,
+  - loading existing runs by `run_id`,
+  - keeping a browser-session run list for quick switching.
+- Keep JSON-first input UX for spec/input/payload/route to match backend contracts exactly
+  and unblock debugging.
+
+## Validation
+
+Suggested checks:
+
+```bash
+npm --prefix web run lint
+npm --prefix web run test
+```
+
+Manual checks:
+
+1. Create a team with valid JSON spec.
+2. Create a run and verify status/event updates.
+3. Submit a step and drive it through lifecycle transitions.
+4. Send actor message, fetch inbox, and ack it.
+5. Verify `/teams` can load an existing run by `run_id` after page refresh.

--- a/docs/features/2026-02-16-team-workbench-ui.md
+++ b/docs/features/2026-02-16-team-workbench-ui.md
@@ -16,15 +16,14 @@ but there is no first-class UI to operate these flows from the web app.
   - Run event timeline refresh and older-page replay (`before_id` pagination)
   - Step submit + lifecycle transitions (`start`, `complete`, `fail`, `input_required`, `resume`)
   - Actor mailbox send/inbox/ack operations
+  - Team run list loading through `GET /api/teams/:id/runs`
 
 ## Key Decisions
 
 - Keep Team interactions in a standalone page (`web/src/pages/team_page.tsx`) to avoid coupling
   with the existing Agent workspace state machine.
-- Because there is no `list runs by team` HTTP API yet, the UI supports:
-  - creating runs,
-  - loading existing runs by `run_id`,
-  - keeping a browser-session run list for quick switching.
+- Use backend `list runs by team` API as the source of truth for run list rendering; `load by run_id`
+  remains available for fast jump-to-run workflows.
 - Keep JSON-first input UX for spec/input/payload/route to match backend contracts exactly
   and unblock debugging.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -52,6 +52,7 @@
 - [x] Verify Codecov uploads Rust and web coverage artifacts (see `docs/features/2026-02-12-codecov-ci.md`).
 - [x] Restore `npm ci` in workflows after updating `web/package-lock.json` (see `docs/features/2026-02-12-codecov-ci.md`).
 - [x] Verify A2A Agent Team phase-1 APIs and event ordering (see `docs/features/2026-02-12-a2a-agent-team-phase1.md`).
+- [ ] Verify Team Workbench UI (`/teams`) create/run/step/message interaction flow end-to-end in a real browser (see `docs/features/2026-02-16-team-workbench-ui.md`).
 - [x] Add router-level HTTP tests for Team APIs to validate wire payload/status through Axum stack (see `docs/features/2026-02-13-a2a-team-phase1-api-hardening.md`).
 - [x] Add Team spec schema validation and API tests for invalid spec payloads before orchestrator wiring.
 - [x] Define cross-field Team spec constraints (entrypoint/member/step graph) for scheduler phase.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -54,6 +54,7 @@
 - [x] Verify A2A Agent Team phase-1 APIs and event ordering (see `docs/features/2026-02-12-a2a-agent-team-phase1.md`).
 - [ ] Verify Team Workbench UI (`/teams`) create/run/step/message interaction flow end-to-end in a real browser (see `docs/features/2026-02-16-team-workbench-ui.md`).
 - [ ] Verify Team run list API (`GET /api/teams/:id/runs`) pagination/filter behavior in staging with real run volumes (see `docs/features/2026-02-16-team-runs-list-api.md`).
+- [ ] Verify OpenAPI discovery endpoints (`/api/openapi.json`, `/api/openapi/docs`) auth behavior and docs-page token fetch flow in a real browser (see `docs/features/2026-02-16-openapi-discovery-endpoints.md`).
 - [x] Add router-level HTTP tests for Team APIs to validate wire payload/status through Axum stack (see `docs/features/2026-02-13-a2a-team-phase1-api-hardening.md`).
 - [x] Add Team spec schema validation and API tests for invalid spec payloads before orchestrator wiring.
 - [x] Define cross-field Team spec constraints (entrypoint/member/step graph) for scheduler phase.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -55,6 +55,8 @@
 - [ ] Verify Team Workbench UI (`/teams`) create/run/step/message interaction flow end-to-end in a real browser (see `docs/features/2026-02-16-team-workbench-ui.md`).
 - [ ] Verify Team run list API (`GET /api/teams/:id/runs`) pagination/filter behavior in staging with real run volumes (see `docs/features/2026-02-16-team-runs-list-api.md`).
 - [ ] Verify OpenAPI discovery endpoints (`/api/openapi.json`, `/api/openapi/docs`) auth behavior and docs-page token fetch flow in a real browser (see `docs/features/2026-02-16-openapi-discovery-endpoints.md`).
+- [ ] Refactor `web/src/pages/team_page.tsx` into smaller feature-focused components (`TeamSidebar`, `RunPanel`, tab subviews) and a reducer-based state model for maintainability (see `docs/features/2026-02-16-team-workbench-ui.md`).
+- [ ] Refactor `src/api/openapi.rs` OpenAPI spec assembly into smaller helpers (`components`, `paths`) or a typed generator approach to reduce single-function complexity (see `docs/features/2026-02-16-openapi-discovery-endpoints.md`).
 - [x] Add router-level HTTP tests for Team APIs to validate wire payload/status through Axum stack (see `docs/features/2026-02-13-a2a-team-phase1-api-hardening.md`).
 - [x] Add Team spec schema validation and API tests for invalid spec payloads before orchestrator wiring.
 - [x] Define cross-field Team spec constraints (entrypoint/member/step graph) for scheduler phase.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -53,6 +53,7 @@
 - [x] Restore `npm ci` in workflows after updating `web/package-lock.json` (see `docs/features/2026-02-12-codecov-ci.md`).
 - [x] Verify A2A Agent Team phase-1 APIs and event ordering (see `docs/features/2026-02-12-a2a-agent-team-phase1.md`).
 - [ ] Verify Team Workbench UI (`/teams`) create/run/step/message interaction flow end-to-end in a real browser (see `docs/features/2026-02-16-team-workbench-ui.md`).
+- [ ] Verify Team run list API (`GET /api/teams/:id/runs`) pagination/filter behavior in staging with real run volumes (see `docs/features/2026-02-16-team-runs-list-api.md`).
 - [x] Add router-level HTTP tests for Team APIs to validate wire payload/status through Axum stack (see `docs/features/2026-02-13-a2a-team-phase1-api-hardening.md`).
 - [x] Add Team spec schema validation and API tests for invalid spec payloads before orchestrator wiring.
 - [x] Define cross-field Team spec constraints (entrypoint/member/step graph) for scheduler phase.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ mod auth;
 mod authz;
 mod error;
 mod join;
+mod openapi;
 mod push;
 mod settings;
 mod teams;
@@ -20,6 +21,7 @@ pub fn router(state: AppState) -> Router {
         .nest("/auth", auth::router(state.clone()))
         .nest("/join", join::router(state.clone()))
         .nest("/settings", settings::router(state.clone()))
+        .merge(openapi::router(state.clone()))
         .nest("/push", push::router(state))
 }
 

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -10,6 +10,7 @@ use serde_json::{Value, json};
 use crate::api::authz::require_user;
 use crate::api::error::ApiError;
 use crate::state::AppState;
+use crate::team::{TEAM_RUN_STATUS_VALUES, TEAM_STEP_STATUS_VALUES};
 
 pub fn router(state: AppState) -> Router {
     Router::new()
@@ -82,7 +83,7 @@ fn openapi_spec() -> Value {
               "context_id": { "type": "string" },
               "status": {
                 "type": "string",
-                "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+                "enum": TEAM_RUN_STATUS_VALUES
               },
               "input": { "type": "object", "additionalProperties": true },
               "created_at": { "type": "integer", "format": "int64" },
@@ -115,7 +116,7 @@ fn openapi_spec() -> Value {
               "remote_task_id": { "type": ["string", "null"] },
               "status": {
                 "type": "string",
-                "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+                "enum": TEAM_STEP_STATUS_VALUES
               },
               "attempt": { "type": "integer", "format": "int64" },
               "depends_on": { "type": "array", "items": { "type": "string" } },
@@ -308,7 +309,7 @@ fn openapi_spec() -> Value {
                 "in": "query",
                 "schema": {
                   "type": "string",
-                  "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+                  "enum": TEAM_RUN_STATUS_VALUES
                 }
               },
               { "name": "before_created_at", "in": "query", "schema": { "type": "integer", "format": "int64" } }
@@ -734,7 +735,7 @@ const OPENAPI_DOCS_HTML: &str = r#"<!doctype html>
           const resp = await fetch("/api/openapi.json", { headers });
           if (!resp.ok) {
             const text = await resp.text();
-            output.innerHTML = `<span class="error">HTTP ${resp.status}</span>\n${text}`;
+            output.textContent = `HTTP ${resp.status}\n${text}`;
             currentJson = "";
             return;
           }
@@ -742,7 +743,7 @@ const OPENAPI_DOCS_HTML: &str = r#"<!doctype html>
           currentJson = JSON.stringify(body, null, 2);
           output.textContent = currentJson;
         } catch (err) {
-          output.innerHTML = `<span class="error">${String(err)}</span>`;
+          output.textContent = String(err);
           currentJson = "";
         }
       }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,0 +1,819 @@
+use axum::{
+    Json, Router,
+    extract::State,
+    http::HeaderMap,
+    response::{Html, IntoResponse},
+    routing::get,
+};
+use serde_json::{Value, json};
+
+use crate::api::authz::require_user;
+use crate::api::error::ApiError;
+use crate::state::AppState;
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/openapi.json", get(get_openapi_json))
+        .route("/openapi/docs", get(get_openapi_docs))
+        .with_state(state)
+}
+
+async fn get_openapi_json(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, ApiError> {
+    let _user = require_user(&headers, &state).await?;
+    Ok(Json(openapi_spec()))
+}
+
+async fn get_openapi_docs() -> impl IntoResponse {
+    Html(OPENAPI_DOCS_HTML)
+}
+
+fn openapi_spec() -> Value {
+    json!({
+      "openapi": "3.0.3",
+      "info": {
+        "title": "AgentHub HTTP API",
+        "version": "0.1.0",
+        "description": "AgentHub API contract. Current OpenAPI focus covers Team workbench endpoints and can be incrementally extended."
+      },
+      "servers": [
+        { "url": "/" }
+      ],
+      "tags": [
+        { "name": "openapi", "description": "OpenAPI discovery endpoints" },
+        { "name": "teams", "description": "Team definitions, runs, steps, and actor mailbox" }
+      ],
+      "components": {
+        "securitySchemes": {
+          "bearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT"
+          }
+        },
+        "schemas": {
+          "ApiError": {
+            "type": "object",
+            "required": ["error"],
+            "properties": {
+              "error": { "type": "string" }
+            }
+          },
+          "TeamDefinitionRecord": {
+            "type": "object",
+            "required": ["id", "name", "spec", "created_at", "updated_at"],
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "description": { "type": ["string", "null"] },
+              "spec": { "type": "object", "additionalProperties": true },
+              "created_at": { "type": "integer", "format": "int64" },
+              "updated_at": { "type": "integer", "format": "int64" }
+            }
+          },
+          "TeamRunRecord": {
+            "type": "object",
+            "required": ["id", "team_id", "context_id", "status", "input", "created_at"],
+            "properties": {
+              "id": { "type": "string" },
+              "team_id": { "type": "string" },
+              "context_id": { "type": "string" },
+              "status": {
+                "type": "string",
+                "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+              },
+              "input": { "type": "object", "additionalProperties": true },
+              "created_at": { "type": "integer", "format": "int64" },
+              "started_at": { "type": ["integer", "null"], "format": "int64" },
+              "ended_at": { "type": ["integer", "null"], "format": "int64" }
+            }
+          },
+          "TeamRunEventRecord": {
+            "type": "object",
+            "required": ["event_id", "run_id", "event_type", "ts", "payload"],
+            "properties": {
+              "event_id": { "type": "integer", "format": "int64" },
+              "run_id": { "type": "string" },
+              "step_id": { "type": ["string", "null"] },
+              "event_type": { "type": "string" },
+              "ts": { "type": "integer", "format": "int64" },
+              "payload": { "type": "object", "additionalProperties": true }
+            }
+          },
+          "TeamStepRecord": {
+            "type": "object",
+            "required": [
+              "id", "run_id", "step_key", "member_id", "status", "attempt", "depends_on"
+            ],
+            "properties": {
+              "id": { "type": "string" },
+              "run_id": { "type": "string" },
+              "step_key": { "type": "string" },
+              "member_id": { "type": "string" },
+              "remote_task_id": { "type": ["string", "null"] },
+              "status": {
+                "type": "string",
+                "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+              },
+              "attempt": { "type": "integer", "format": "int64" },
+              "depends_on": { "type": "array", "items": { "type": "string" } },
+              "input": { "type": ["object", "null"], "additionalProperties": true },
+              "output": { "type": ["object", "null"], "additionalProperties": true },
+              "error_text": { "type": ["string", "null"] },
+              "started_at": { "type": ["integer", "null"], "format": "int64" },
+              "ended_at": { "type": ["integer", "null"], "format": "int64" }
+            }
+          },
+          "TeamActorMessageRecord": {
+            "type": "object",
+            "required": [
+              "message_id", "run_id", "from_actor_id", "to_actor_id", "channel", "transport", "payload", "status", "created_at"
+            ],
+            "properties": {
+              "message_id": { "type": "integer", "format": "int64" },
+              "run_id": { "type": "string" },
+              "from_actor_id": { "type": "string" },
+              "to_actor_id": { "type": "string" },
+              "channel": { "type": "string" },
+              "transport": { "type": "string", "enum": ["local", "remote"] },
+              "route": { "type": ["object", "null"], "additionalProperties": true },
+              "payload": { "type": "object", "additionalProperties": true },
+              "status": { "type": "string", "enum": ["pending", "delivered", "dead_letter"] },
+              "created_at": { "type": "integer", "format": "int64" },
+              "delivered_at": { "type": ["integer", "null"], "format": "int64" }
+            }
+          },
+          "CreateTeamRequest": {
+            "type": "object",
+            "required": ["name", "spec"],
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": ["string", "null"] },
+              "spec": { "type": "object", "additionalProperties": true }
+            }
+          },
+          "CreateTeamRunRequest": {
+            "type": "object",
+            "properties": {
+              "context_id": { "type": ["string", "null"] },
+              "input": { "type": ["object", "null"], "additionalProperties": true }
+            }
+          },
+          "SubmitTeamRunStepRequest": {
+            "type": "object",
+            "required": ["step_key", "member_id"],
+            "properties": {
+              "step_key": { "type": "string" },
+              "member_id": { "type": "string" },
+              "depends_on": { "type": "array", "items": { "type": "string" } },
+              "input": { "type": ["object", "null"], "additionalProperties": true }
+            }
+          },
+          "SendTeamRunMessageRequest": {
+            "type": "object",
+            "required": ["from_actor_id", "to_actor_id", "payload"],
+            "properties": {
+              "from_actor_id": { "type": "string" },
+              "to_actor_id": { "type": "string" },
+              "channel": { "type": ["string", "null"] },
+              "transport": { "type": ["string", "null"], "enum": ["local", "remote", null] },
+              "route": { "type": ["object", "null"], "additionalProperties": true },
+              "payload": { "type": "object", "additionalProperties": true },
+              "idempotency_key": { "type": ["string", "null"] }
+            }
+          }
+        }
+      },
+      "security": [
+        { "bearerAuth": [] }
+      ],
+      "paths": {
+        "/api/openapi.json": {
+          "get": {
+            "tags": ["openapi"],
+            "summary": "Get OpenAPI JSON",
+            "responses": {
+              "200": {
+                "description": "OpenAPI document",
+                "content": {
+                  "application/json": {
+                    "schema": { "type": "object", "additionalProperties": true }
+                  }
+                }
+              },
+              "401": {
+                "description": "Unauthorized",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ApiError" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/openapi/docs": {
+          "get": {
+            "tags": ["openapi"],
+            "summary": "Get OpenAPI docs page",
+            "security": [],
+            "responses": {
+              "200": {
+                "description": "HTML docs page",
+                "content": {
+                  "text/html": {
+                    "schema": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "List teams",
+            "responses": {
+              "200": {
+                "description": "Team definitions",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamDefinitionRecord" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "post": {
+            "tags": ["teams"],
+            "summary": "Create team",
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/CreateTeamRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Created team",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamDefinitionRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "Get team",
+            "parameters": [
+              {
+                "name": "id",
+                "in": "path",
+                "required": true,
+                "schema": { "type": "string" }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Team definition",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamDefinitionRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}/runs": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "List runs for a team",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } },
+              {
+                "name": "status",
+                "in": "query",
+                "schema": {
+                  "type": "string",
+                  "enum": ["submitted", "working", "input_required", "completed", "failed", "canceled"]
+                }
+              },
+              { "name": "before_created_at", "in": "query", "schema": { "type": "integer", "format": "int64" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Team runs",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamRunRecord" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "post": {
+            "tags": ["teams"],
+            "summary": "Create run for a team",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/CreateTeamRunRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Created run",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamRunRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "Get run",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Run record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamRunRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/cancel": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Cancel run",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Canceled run",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamRunRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/events": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "List run events",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 1000 } },
+              { "name": "before_id", "in": "query", "schema": { "type": "integer", "format": "int64" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Run events",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamRunEventRecord" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "List run steps",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Run steps",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamStepRecord" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "post": {
+            "tags": ["teams"],
+            "summary": "Submit run step",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/SubmitTeamRunStepRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps/{step_id}/start": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Start run step",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "step_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps/{step_id}/complete": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Complete run step",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "step_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps/{step_id}/fail": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Fail run step",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "step_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps/{step_id}/input_required": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Set run step input required",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "step_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/steps/{step_id}/resume": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Resume run step",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "step_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Step record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamStepRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/messages/send": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Send actor message",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/SendTeamRunMessageRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Actor message record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/messages/inbox": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "List actor inbox",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "actor_id", "in": "query", "required": true, "schema": { "type": "string" } },
+              { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 1000 } },
+              { "name": "after_id", "in": "query", "schema": { "type": "integer", "format": "int64" } },
+              { "name": "include_delivered", "in": "query", "schema": { "type": "boolean" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Actor inbox",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/messages/{message_id}/ack": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Acknowledge actor message",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "message_id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Actor message record",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+}
+
+const OPENAPI_DOCS_HTML: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AgentHub OpenAPI</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+        background: #0f1115;
+        color: #e6ebf2;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 12px 16px;
+        border-bottom: 1px solid #2a3140;
+        background: #141925;
+      }
+      h1 {
+        margin: 0;
+        font-size: 16px;
+      }
+      .actions {
+        display: flex;
+        gap: 8px;
+      }
+      button {
+        background: #2d3a52;
+        color: #fff;
+        border: 1px solid #42557a;
+        border-radius: 8px;
+        padding: 6px 10px;
+        cursor: pointer;
+      }
+      .hint {
+        padding: 10px 16px;
+        border-bottom: 1px solid #2a3140;
+        color: #c4cfdf;
+        font-size: 13px;
+      }
+      pre {
+        margin: 0;
+        padding: 16px;
+        overflow: auto;
+        font-size: 12px;
+        line-height: 1.5;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      .error {
+        color: #ff8b8b;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>AgentHub OpenAPI</h1>
+      <div class="actions">
+        <button id="reload">Reload</button>
+        <button id="copy">Copy JSON</button>
+      </div>
+    </header>
+    <div class="hint">
+      Reads token from <code>localStorage.agenthub_auth</code> and requests <code>/api/openapi.json</code>.
+    </div>
+    <pre id="output">Loading...</pre>
+    <script>
+      let currentJson = "";
+
+      function getToken() {
+        try {
+          const raw = localStorage.getItem("agenthub_auth");
+          if (!raw) return null;
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed.token === "string" && parsed.token) {
+            return parsed.token;
+          }
+        } catch (_) {}
+        return null;
+      }
+
+      async function loadSpec() {
+        const output = document.getElementById("output");
+        output.textContent = "Loading...";
+        const token = getToken();
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        try {
+          const resp = await fetch("/api/openapi.json", { headers });
+          if (!resp.ok) {
+            const text = await resp.text();
+            output.innerHTML = `<span class="error">HTTP ${resp.status}</span>\n${text}`;
+            currentJson = "";
+            return;
+          }
+          const body = await resp.json();
+          currentJson = JSON.stringify(body, null, 2);
+          output.textContent = currentJson;
+        } catch (err) {
+          output.innerHTML = `<span class="error">${String(err)}</span>`;
+          currentJson = "";
+        }
+      }
+
+      document.getElementById("reload").addEventListener("click", loadSpec);
+      document.getElementById("copy").addEventListener("click", async () => {
+        if (!currentJson) return;
+        try {
+          await navigator.clipboard.writeText(currentJson);
+        } catch (_) {}
+      });
+
+      loadSpec();
+    </script>
+  </body>
+</html>
+"#;
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode, header},
+    };
+    use serde_json::Value;
+    use tower::util::ServiceExt;
+
+    use crate::api::teams::tests::build_test_state;
+
+    #[tokio::test]
+    async fn openapi_json_requires_authorization() {
+        let state = build_test_state().await;
+        let app = super::router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/openapi.json")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("request openapi without auth");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn openapi_json_contains_team_runs_list_path() {
+        let state = build_test_state().await;
+        let token = crate::api::teams::tests::create_auth_token(&state).await;
+        let app = super::router(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/openapi.json")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("build authorized request"),
+            )
+            .await
+            .expect("request openapi with auth");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let value: Value = serde_json::from_slice(&bytes).expect("decode openapi json");
+        assert_eq!(value["openapi"], Value::from("3.0.3"));
+        assert!(value["paths"]["/api/teams/{id}/runs"].is_object());
+    }
+}

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -15,8 +15,9 @@ use crate::api::authz::require_user;
 use crate::api::error::ApiError;
 use crate::state::AppState;
 use crate::team::{
-    TeamActorMessageRecord, TeamActorMessageTransport, TeamDefinitionConfig, TeamDefinitionRecord,
-    TeamManager, TeamRunEventRecord, TeamRunRecord, TeamStepRecord,
+    TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport,
+    TeamDefinitionConfig, TeamDefinitionRecord, TeamManager, TeamRunEventRecord, TeamRunRecord,
+    TeamStepRecord,
 };
 
 const TEAM_SPEC_VERSION_V1: i64 = 1;
@@ -673,14 +674,13 @@ fn normalize_optional_run_status_filter(value: Option<&str>) -> Result<Option<St
     if trimmed.is_empty() {
         return Ok(None);
     }
-    match trimmed {
-        "submitted" | "working" | "input_required" | "completed" | "failed" | "canceled" => {
-            Ok(Some(trimmed.to_string()))
-        }
-        _ => Err(ApiError::bad_request(
-            "status must be one of: submitted, working, input_required, completed, failed, canceled",
-        )),
+    if TEAM_RUN_STATUS_VALUES.contains(&trimmed) {
+        return Ok(Some(trimmed.to_string()));
     }
+    Err(ApiError::bad_request(&format!(
+        "status must be one of: {}",
+        TEAM_RUN_STATUS_VALUES.join(", ")
+    )))
 }
 
 async fn load_run_and_member_ids(

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -37,6 +37,13 @@ pub struct CreateTeamRunRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct ListTeamRunsQuery {
+    pub limit: Option<i64>,
+    pub status: Option<String>,
+    pub before_created_at: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ListTeamRunEventsQuery {
     pub limit: Option<i64>,
     pub before_id: Option<i64>,
@@ -104,7 +111,7 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/", post(create_team).get(list_teams))
         .route("/:id", get(get_team))
-        .route("/:id/runs", post(create_team_run))
+        .route("/:id/runs", post(create_team_run).get(list_team_runs))
         .route("/runs/:run_id", get(get_team_run))
         .route("/runs/:run_id/cancel", post(cancel_team_run))
         .route("/runs/:run_id/events", get(list_team_run_events))
@@ -212,6 +219,28 @@ async fn create_team_run(
         .await
         .map_err(map_team_internal_error)?;
     Ok(Json(run))
+}
+
+async fn list_team_runs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(team_id): Path<String>,
+    Query(query): Query<ListTeamRunsQuery>,
+) -> Result<Json<Vec<TeamRunRecord>>, ApiError> {
+    let _user = require_user(&headers, &state).await?;
+    state
+        .teams
+        .get_team(&team_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    let limit = query.limit.unwrap_or(100).clamp(1, 500);
+    let status = normalize_optional_run_status_filter(query.status.as_deref())?;
+    let runs = state
+        .teams
+        .list_runs(&team_id, limit, status.as_deref(), query.before_created_at)
+        .await
+        .map_err(map_team_internal_error)?;
+    Ok(Json(runs))
 }
 
 async fn get_team_run(
@@ -634,6 +663,24 @@ fn normalize_optional_idempotency_key(value: Option<&str>) -> Result<Option<Stri
         ));
     }
     Ok(Some(trimmed.to_string()))
+}
+
+fn normalize_optional_run_status_filter(value: Option<&str>) -> Result<Option<String>, ApiError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    match trimmed {
+        "submitted" | "working" | "input_required" | "completed" | "failed" | "canceled" => {
+            Ok(Some(trimmed.to_string()))
+        }
+        _ => Err(ApiError::bad_request(
+            "status must be one of: submitted, working, input_required, completed, failed, canceled",
+        )),
+    }
 }
 
 async fn load_run_and_member_ids(

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -26,12 +26,12 @@ use crate::team::TeamManager;
 
 use super::{
     AckTeamRunMessageRequest, CompleteTeamRunStepRequest, CreateTeamRequest, CreateTeamRunRequest,
-    FailTeamRunStepRequest, ListTeamRunEventsQuery, ListTeamRunInboxQuery,
+    FailTeamRunStepRequest, ListTeamRunEventsQuery, ListTeamRunInboxQuery, ListTeamRunsQuery,
     ResumeTeamRunStepRequest, SendTeamRunMessageRequest, SetTeamRunStepInputRequiredRequest,
     StartTeamRunStepRequest, SubmitTeamRunStepRequest, ack_team_run_message, cancel_team_run,
     complete_team_run_step, create_team, create_team_run, fail_team_run_step, get_team,
-    get_team_run, list_team_run_events, list_team_run_inbox, list_team_run_steps, list_teams,
-    resume_team_run_step, send_team_run_message, set_team_run_step_input_required,
+    get_team_run, list_team_run_events, list_team_run_inbox, list_team_run_steps, list_team_runs,
+    list_teams, resume_team_run_step, send_team_run_message, set_team_run_step_input_required,
     start_team_run_step, submit_team_run_step,
 };
 

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -335,6 +335,172 @@ async fn team_runs_api_supports_lifecycle_and_event_pagination() {
 }
 
 #[tokio::test]
+async fn team_runs_api_lists_team_runs_with_status_filter_and_cursor() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "runs-list-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    let Json(other_team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "runs-list-other-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        }),
+    )
+    .await
+    .expect("create other team");
+
+    let Json(first_run) = create_team_run(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-runs-list-1".to_string()),
+            input: Some(json!({"seq":1})),
+        }),
+    )
+    .await
+    .expect("create first run");
+
+    let Json(second_run) = create_team_run(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-runs-list-2".to_string()),
+            input: Some(json!({"seq":2})),
+        }),
+    )
+    .await
+    .expect("create second run");
+
+    let Json(other_team_run) = create_team_run(
+        State(state.clone()),
+        headers.clone(),
+        Path(other_team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-runs-list-other".to_string()),
+            input: Some(json!({"seq":3})),
+        }),
+    )
+    .await
+    .expect("create other team run");
+
+    sqlx::query("UPDATE team_runs SET created_at = ?1 WHERE id = ?2")
+        .bind(100_i64)
+        .bind(&first_run.id)
+        .execute(&state.db)
+        .await
+        .expect("set first run created_at");
+    sqlx::query("UPDATE team_runs SET created_at = ?1 WHERE id = ?2")
+        .bind(200_i64)
+        .bind(&second_run.id)
+        .execute(&state.db)
+        .await
+        .expect("set second run created_at");
+    sqlx::query("UPDATE team_runs SET created_at = ?1 WHERE id = ?2")
+        .bind(300_i64)
+        .bind(&other_team_run.id)
+        .execute(&state.db)
+        .await
+        .expect("set other team run created_at");
+
+    let Json(runs) = list_team_runs(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamRunsQuery {
+            limit: Some(100),
+            status: None,
+            before_created_at: None,
+        }),
+    )
+    .await
+    .expect("list team runs");
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0].id, second_run.id);
+    assert_eq!(runs[1].id, first_run.id);
+
+    let _ = cancel_team_run(State(state.clone()), headers.clone(), Path(first_run.id.clone()))
+        .await
+        .expect("cancel first run");
+
+    let Json(canceled_runs) = list_team_runs(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamRunsQuery {
+            limit: Some(100),
+            status: Some("canceled".to_string()),
+            before_created_at: None,
+        }),
+    )
+    .await
+    .expect("list canceled team runs");
+    assert_eq!(canceled_runs.len(), 1);
+    assert_eq!(canceled_runs[0].id, first_run.id);
+
+    let Json(cursor_page) = list_team_runs(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamRunsQuery {
+            limit: Some(100),
+            status: None,
+            before_created_at: Some(200),
+        }),
+    )
+    .await
+    .expect("list team runs with cursor");
+    assert_eq!(cursor_page.len(), 1);
+    assert_eq!(cursor_page[0].id, first_run.id);
+
+    let invalid_status_err = list_team_runs(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamRunsQuery {
+            limit: Some(100),
+            status: Some("invalid".to_string()),
+            before_created_at: None,
+        }),
+    )
+    .await
+    .expect_err("invalid status should fail");
+    assert_eq!(
+        invalid_status_err.into_response().status(),
+        StatusCode::BAD_REQUEST
+    );
+
+    let missing_team_err = list_team_runs(
+        State(state),
+        headers,
+        Path("missing-team".to_string()),
+        Query(ListTeamRunsQuery {
+            limit: Some(100),
+            status: None,
+            before_created_at: None,
+        }),
+    )
+    .await
+    .expect_err("missing team should fail");
+    assert_eq!(missing_team_err.into_response().status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn team_run_steps_api_supports_scheduler_lifecycle_bridge() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -103,6 +103,34 @@ async fn teams_router_http_contract() {
     let run_id = run["id"].as_str().expect("run id").to_string();
     assert_eq!(run["status"], "submitted");
 
+    let list_runs_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/{team_id}/runs?limit=100"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("list runs via router");
+    assert_eq!(list_runs_resp.status(), StatusCode::OK);
+    let listed_runs = decode_json_body(list_runs_resp).await;
+    let listed_runs = listed_runs.as_array().expect("runs array");
+    assert_eq!(listed_runs.len(), 1);
+    assert_eq!(listed_runs[0]["id"], run_id);
+
+    let invalid_status_runs_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/{team_id}/runs?status=invalid"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("invalid runs status request");
+    assert_eq!(invalid_status_runs_resp.status(), StatusCode::BAD_REQUEST);
+
     let cancel_run_resp = app
         .clone()
         .oneshot(build_json_request(
@@ -618,6 +646,18 @@ async fn teams_router_http_contract() {
         .await
         .expect("missing team request");
     assert_eq!(missing_team_resp.status(), StatusCode::NOT_FOUND);
+
+    let missing_team_list_runs_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            "/missing-team/runs",
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("missing team list runs request");
+    assert_eq!(missing_team_list_runs_resp.status(), StatusCode::NOT_FOUND);
 
     let missing_run_resp = app
         .clone()

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -297,6 +297,54 @@ impl TeamManager {
         Ok(runs)
     }
 
+    pub async fn list_runs(
+        &self,
+        team_id: &str,
+        limit: i64,
+        status: Option<&str>,
+        before_created_at: Option<i64>,
+    ) -> anyhow::Result<Vec<TeamRunRecord>> {
+        let limit = limit.max(1);
+        let rows = if let Some(before_created_at) = before_created_at {
+            sqlx::query(
+                r#"
+                SELECT id, team_id, context_id, status, input_json, created_at, started_at, ended_at
+                FROM team_runs
+                WHERE team_id = ?1 AND (?2 IS NULL OR status = ?2) AND created_at < ?3
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?4
+                "#,
+            )
+            .bind(team_id)
+            .bind(status)
+            .bind(before_created_at)
+            .bind(limit)
+            .fetch_all(&self.db)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                SELECT id, team_id, context_id, status, input_json, created_at, started_at, ended_at
+                FROM team_runs
+                WHERE team_id = ?1 AND (?2 IS NULL OR status = ?2)
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?3
+                "#,
+            )
+            .bind(team_id)
+            .bind(status)
+            .bind(limit)
+            .fetch_all(&self.db)
+            .await?
+        };
+
+        let mut runs = Vec::with_capacity(rows.len());
+        for row in rows {
+            runs.push(parse_team_run_row(&row)?);
+        }
+        Ok(runs)
+    }
+
     pub async fn get_agent_session_status(
         &self,
         session_id: &str,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use chrono::Utc;
 use serde_json::Value;
-use sqlx::{Row, SqlitePool};
+use sqlx::{QueryBuilder, Row, SqlitePool};
 use uuid::Uuid;
 
 pub use mailbox::TeamRemoteRelayWorkerSettings;
@@ -305,38 +305,25 @@ impl TeamManager {
         before_created_at: Option<i64>,
     ) -> anyhow::Result<Vec<TeamRunRecord>> {
         let limit = limit.max(1);
-        let rows = if let Some(before_created_at) = before_created_at {
-            sqlx::query(
-                r#"
-                SELECT id, team_id, context_id, status, input_json, created_at, started_at, ended_at
-                FROM team_runs
-                WHERE team_id = ?1 AND (?2 IS NULL OR status = ?2) AND created_at < ?3
-                ORDER BY created_at DESC, id DESC
-                LIMIT ?4
-                "#,
-            )
-            .bind(team_id)
-            .bind(status)
-            .bind(before_created_at)
-            .bind(limit)
-            .fetch_all(&self.db)
-            .await?
-        } else {
-            sqlx::query(
-                r#"
-                SELECT id, team_id, context_id, status, input_json, created_at, started_at, ended_at
-                FROM team_runs
-                WHERE team_id = ?1 AND (?2 IS NULL OR status = ?2)
-                ORDER BY created_at DESC, id DESC
-                LIMIT ?3
-                "#,
-            )
-            .bind(team_id)
-            .bind(status)
-            .bind(limit)
-            .fetch_all(&self.db)
-            .await?
-        };
+        let mut builder = QueryBuilder::<sqlx::Sqlite>::new(
+            r#"
+            SELECT id, team_id, context_id, status, input_json, created_at, started_at, ended_at
+            FROM team_runs
+            WHERE team_id = "#,
+        );
+        builder.push_bind(team_id);
+        if let Some(status) = status {
+            builder.push(" AND status = ");
+            builder.push_bind(status);
+        }
+        if let Some(before_created_at) = before_created_at {
+            builder.push(" AND created_at < ");
+            builder.push_bind(before_created_at);
+        }
+        builder.push(" ORDER BY created_at DESC, id DESC LIMIT ");
+        builder.push_bind(limit);
+
+        let rows = builder.build().fetch_all(&self.db).await?;
 
         let mut runs = Vec::with_capacity(rows.len());
         for row in rows {

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1393,3 +1393,66 @@ async fn list_active_runs_returns_non_terminal_runs_only() {
     assert!(active_ids.contains(&working_run.id.as_str()));
     assert!(!active_ids.contains(&canceled_run.id.as_str()));
 }
+
+#[tokio::test]
+async fn list_runs_supports_status_filter_and_cursor() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "list-runs-team".to_string(),
+            description: Some("team to verify run listing".to_string()),
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        })
+        .await
+        .expect("create team");
+
+    let first_run = manager
+        .create_run(&team.id, Some("ctx-list-runs-1"), json!({"seq": 1}))
+        .await
+        .expect("create first run");
+    let second_run = manager
+        .create_run(&team.id, Some("ctx-list-runs-2"), json!({"seq": 2}))
+        .await
+        .expect("create second run");
+    let _ = manager
+        .cancel_run(&first_run.id)
+        .await
+        .expect("cancel first run");
+
+    sqlx::query("UPDATE team_runs SET created_at = ?1 WHERE id = ?2")
+        .bind(100_i64)
+        .bind(&first_run.id)
+        .execute(&db)
+        .await
+        .expect("set first run created_at");
+    sqlx::query("UPDATE team_runs SET created_at = ?1 WHERE id = ?2")
+        .bind(200_i64)
+        .bind(&second_run.id)
+        .execute(&db)
+        .await
+        .expect("set second run created_at");
+
+    let all_runs = manager
+        .list_runs(&team.id, 100, None, None)
+        .await
+        .expect("list all runs");
+    assert_eq!(all_runs.len(), 2);
+    assert_eq!(all_runs[0].id, second_run.id);
+    assert_eq!(all_runs[1].id, first_run.id);
+
+    let canceled_runs = manager
+        .list_runs(&team.id, 100, Some("canceled"), None)
+        .await
+        .expect("list canceled runs");
+    assert_eq!(canceled_runs.len(), 1);
+    assert_eq!(canceled_runs[0].id, first_run.id);
+
+    let cursor_runs = manager
+        .list_runs(&team.id, 100, None, Some(200))
+        .await
+        .expect("list runs with cursor");
+    assert_eq!(cursor_runs.len(), 1);
+    assert_eq!(cursor_runs[0].id, first_run.id);
+}

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -11,6 +11,24 @@ pub use agenthub_team_actor::{
 pub use manager::{TeamManager, TeamRemoteRelayWorkerSettings};
 pub use orchestrator::{TeamOrchestratorWorker, TeamOrchestratorWorkerSettings};
 
+pub const TEAM_RUN_STATUS_VALUES: [&str; 6] = [
+    "submitted",
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "canceled",
+];
+
+pub const TEAM_STEP_STATUS_VALUES: [&str; 6] = [
+    "submitted",
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "canceled",
+];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TeamDefinitionConfig {
     pub name: String,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -124,6 +124,85 @@ export type RuntimeDefaults = {
   default_worktree_root: string;
 };
 
+export type TeamRunStatus =
+  | "submitted"
+  | "working"
+  | "input_required"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export type TeamStepStatus =
+  | "submitted"
+  | "working"
+  | "input_required"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export type TeamActorMessageTransport = "local" | "remote";
+
+export type TeamActorMessageStatus = "pending" | "delivered" | "dead_letter";
+
+export type TeamDefinitionRecord = {
+  id: string;
+  name: string;
+  description?: string | null;
+  spec: unknown;
+  created_at: number;
+  updated_at: number;
+};
+
+export type TeamRunRecord = {
+  id: string;
+  team_id: string;
+  context_id: string;
+  status: TeamRunStatus;
+  input: unknown;
+  created_at: number;
+  started_at?: number | null;
+  ended_at?: number | null;
+};
+
+export type TeamRunEventRecord = {
+  event_id: number;
+  run_id: string;
+  step_id?: string | null;
+  event_type: string;
+  ts: number;
+  payload: unknown;
+};
+
+export type TeamStepRecord = {
+  id: string;
+  run_id: string;
+  step_key: string;
+  member_id: string;
+  remote_task_id?: string | null;
+  status: TeamStepStatus;
+  attempt: number;
+  depends_on: string[];
+  input?: unknown;
+  output?: unknown;
+  error_text?: string | null;
+  started_at?: number | null;
+  ended_at?: number | null;
+};
+
+export type TeamActorMessageRecord = {
+  message_id: number;
+  run_id: string;
+  from_actor_id: string;
+  to_actor_id: string;
+  channel: string;
+  transport: TeamActorMessageTransport;
+  route?: unknown;
+  payload: unknown;
+  status: TeamActorMessageStatus;
+  created_at: number;
+  delivered_at?: number | null;
+};
+
 function parseApiErrorText(raw: string): string | null {
   if (!raw) return null;
   if (!raw.trim().startsWith("{")) return raw;
@@ -238,6 +317,170 @@ export const api = {
       "/api/admin/join/start",
       token,
       { method: "POST" }
+    ),
+  createTeam: (
+    token: string,
+    payload: { name: string; description?: string; spec: unknown }
+  ) =>
+    apiFetch<TeamDefinitionRecord>("/api/teams", token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  listTeams: (token: string) =>
+    apiFetch<TeamDefinitionRecord[]>("/api/teams", token),
+  getTeam: (token: string, id: string) =>
+    apiFetch<TeamDefinitionRecord>(`/api/teams/${id}`, token),
+  createTeamRun: (
+    token: string,
+    teamId: string,
+    payload: { context_id?: string; input?: unknown }
+  ) =>
+    apiFetch<TeamRunRecord>(`/api/teams/${teamId}/runs`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  getTeamRun: (token: string, runId: string) =>
+    apiFetch<TeamRunRecord>(`/api/teams/runs/${runId}`, token),
+  cancelTeamRun: (token: string, runId: string) =>
+    apiFetch<TeamRunRecord>(`/api/teams/runs/${runId}/cancel`, token, {
+      method: "POST",
+    }),
+  listTeamRunEvents: (
+    token: string,
+    runId: string,
+    limit = 200,
+    beforeId?: number
+  ) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (beforeId != null) params.set("before_id", String(beforeId));
+    return apiFetch<TeamRunEventRecord[]>(
+      `/api/teams/runs/${runId}/events?${params.toString()}`,
+      token
+    );
+  },
+  listTeamRunSteps: (token: string, runId: string) =>
+    apiFetch<TeamStepRecord[]>(`/api/teams/runs/${runId}/steps`, token),
+  submitTeamRunStep: (
+    token: string,
+    runId: string,
+    payload: {
+      step_key: string;
+      member_id: string;
+      depends_on?: string[];
+      input?: unknown;
+    }
+  ) =>
+    apiFetch<TeamStepRecord>(`/api/teams/runs/${runId}/steps`, token, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  startTeamRunStep: (
+    token: string,
+    runId: string,
+    stepId: string,
+    payload: { remote_task_id?: string }
+  ) =>
+    apiFetch<TeamStepRecord>(
+      `/api/teams/runs/${runId}/steps/${stepId}/start`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  completeTeamRunStep: (
+    token: string,
+    runId: string,
+    stepId: string,
+    payload: { output?: unknown }
+  ) =>
+    apiFetch<TeamStepRecord>(
+      `/api/teams/runs/${runId}/steps/${stepId}/complete`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  failTeamRunStep: (
+    token: string,
+    runId: string,
+    stepId: string,
+    payload: { error_text: string }
+  ) =>
+    apiFetch<TeamStepRecord>(
+      `/api/teams/runs/${runId}/steps/${stepId}/fail`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  setTeamRunStepInputRequired: (
+    token: string,
+    runId: string,
+    stepId: string,
+    payload: { reason?: string; input?: unknown }
+  ) =>
+    apiFetch<TeamStepRecord>(
+      `/api/teams/runs/${runId}/steps/${stepId}/input_required`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  resumeTeamRunStep: (
+    token: string,
+    runId: string,
+    stepId: string,
+    payload: { input?: unknown }
+  ) =>
+    apiFetch<TeamStepRecord>(
+      `/api/teams/runs/${runId}/steps/${stepId}/resume`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  sendTeamRunMessage: (
+    token: string,
+    runId: string,
+    payload: {
+      from_actor_id: string;
+      to_actor_id: string;
+      channel?: string;
+      transport?: TeamActorMessageTransport;
+      route?: unknown;
+      payload: unknown;
+      idempotency_key?: string;
+    }
+  ) =>
+    apiFetch<TeamActorMessageRecord>(
+      `/api/teams/runs/${runId}/messages/send`,
+      token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
+  listTeamRunInbox: (
+    token: string,
+    runId: string,
+    payload: {
+      actor_id: string;
+      limit?: number;
+      after_id?: number;
+      include_delivered?: boolean;
+    }
+  ) => {
+    const params = new URLSearchParams({ actor_id: payload.actor_id });
+    if (payload.limit != null) params.set("limit", String(payload.limit));
+    if (payload.after_id != null) params.set("after_id", String(payload.after_id));
+    if (payload.include_delivered != null) {
+      params.set(
+        "include_delivered",
+        payload.include_delivered ? "true" : "false"
+      );
+    }
+    return apiFetch<TeamActorMessageRecord[]>(
+      `/api/teams/runs/${runId}/messages/inbox?${params.toString()}`,
+      token
+    );
+  },
+  ackTeamRunMessage: (
+    token: string,
+    runId: string,
+    messageId: number,
+    actorId: string
+  ) =>
+    apiFetch<TeamActorMessageRecord>(
+      `/api/teams/runs/${runId}/messages/${messageId}/ack`,
+      token,
+      { method: "POST", body: JSON.stringify({ actor_id: actorId }) }
     ),
   listAgents: (token: string) => apiFetch<AgentRecord[]>("/api/agents", token),
   sendInput: (token: string, id: string, input: string, message_id?: string) =>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -330,6 +330,24 @@ export const api = {
     apiFetch<TeamDefinitionRecord[]>("/api/teams", token),
   getTeam: (token: string, id: string) =>
     apiFetch<TeamDefinitionRecord>(`/api/teams/${id}`, token),
+  listTeamRuns: (
+    token: string,
+    teamId: string,
+    payload?: {
+      limit?: number;
+      status?: TeamRunStatus;
+      before_created_at?: number;
+    }
+  ) => {
+    const params = new URLSearchParams();
+    if (payload?.limit != null) params.set("limit", String(payload.limit));
+    if (payload?.status) params.set("status", payload.status);
+    if (payload?.before_created_at != null) {
+      params.set("before_created_at", String(payload.before_created_at));
+    }
+    const suffix = params.size > 0 ? `?${params.toString()}` : "";
+    return apiFetch<TeamRunRecord[]>(`/api/teams/${teamId}/runs${suffix}`, token);
+  },
   createTeamRun: (
     token: string,
     teamId: string,

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -68,6 +68,7 @@ import {
 import { AdminPage } from "./pages/admin_page";
 import { AuthRequired, ForbiddenPage } from "./pages/auth_pages";
 import { JoinPage } from "./pages/join_page";
+import { TeamPage } from "./pages/team_page";
 import { ensurePushSubscription } from "./push";
 import {
   INPUT_HISTORY_STORAGE_KEY,
@@ -1571,6 +1572,13 @@ export function App() {
     );
   }
 
+  if (location.pathname.startsWith("/teams")) {
+    if (!auth || !token) {
+      return <AuthRequired />;
+    }
+    return <TeamPage auth={auth} token={token} onLogout={onLogout} />;
+  }
+
   return (
     <div className="app">
       <header>
@@ -1587,6 +1595,14 @@ export function App() {
               <span>{connectionBadge.label}</span>
             </span>
             <span>{auth.username}</span>
+            <a
+              className="icon-button"
+              href="/teams"
+              title="Teams"
+              aria-label="Teams"
+            >
+              <i className="bi bi-diagram-3" aria-hidden="true" />
+            </a>
             {auth.role === "root" && (
               <a
                 className="icon-button"

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -230,6 +230,18 @@ export function TeamPage(props: TeamPageProps) {
     [props.token]
   );
 
+  const refreshTeamRuns = useCallback(
+    async (teamId: string) => {
+      const list = await api.listTeamRuns(props.token, teamId, { limit: 200 });
+      setRuns((prev) => {
+        const otherTeamRuns = prev.filter((run) => run.team_id !== teamId);
+        return sortRuns([...otherTeamRuns, ...list]);
+      });
+      return list;
+    },
+    [props.token]
+  );
+
   const refreshSteps = useCallback(
     async (runId: string) => {
       const list = await api.listTeamRunSteps(props.token, runId);
@@ -302,13 +314,39 @@ export function TeamPage(props: TeamPageProps) {
       setInbox([]);
       return;
     }
+    let canceled = false;
+    const loadTeamRuns = async () => {
+      try {
+        setError(null);
+        const list = await refreshTeamRuns(selectedTeamId);
+        if (canceled) return;
+        setActiveRunId((prev) => {
+          if (prev && list.some((run) => run.id === prev)) {
+            return prev;
+          }
+          return list[0]?.id ?? null;
+        });
+      } catch (err) {
+        if (!canceled) {
+          setError(parseErrorMessage(err));
+        }
+      }
+    };
+    void loadTeamRuns();
+    return () => {
+      canceled = true;
+    };
+  }, [refreshTeamRuns, selectedTeamId]);
+
+  useEffect(() => {
+    if (!selectedTeamId) return;
     setActiveRunId((prev) => {
       if (prev && runs.some((run) => run.id === prev && run.team_id === selectedTeamId)) {
         return prev;
       }
       return runs.find((run) => run.team_id === selectedTeamId)?.id ?? null;
     });
-  }, [selectedTeamId, runs]);
+  }, [runs, selectedTeamId]);
 
   useEffect(() => {
     if (!activeRunId) {
@@ -683,7 +721,7 @@ export function TeamPage(props: TeamPageProps) {
                   </div>
                 </div>
                 <div className="teams-run-list">
-                  <h3>Runs In This Browser Session</h3>
+                  <h3>Runs</h3>
                   {visibleRuns.length === 0 && (
                     <p className="muted">No runs loaded yet. Create one or load by run_id.</p>
                   )}

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   api,
   TeamActorMessageRecord,
@@ -184,6 +184,7 @@ export function TeamPage(props: TeamPageProps) {
   const [inboxAfterId, setInboxAfterId] = useState("");
   const [inboxIncludeDelivered, setInboxIncludeDelivered] = useState(false);
   const [inbox, setInbox] = useState<TeamActorMessageRecord[]>([]);
+  const eventsRef = useRef<TeamRunEventRecord[]>([]);
 
   const selectedTeam = useMemo(
     () => teams.find((team) => team.id === selectedTeamId) ?? null,
@@ -261,7 +262,8 @@ export function TeamPage(props: TeamPageProps) {
     async (runId: string, mode: "replace" | "prepend" = "replace") => {
       setEventsLoading(true);
       try {
-        const beforeId = mode === "prepend" ? oldestEventId ?? undefined : undefined;
+        const beforeId =
+          mode === "prepend" ? eventsRef.current[0]?.event_id : undefined;
         const list = await api.listTeamRunEvents(
           props.token,
           runId,
@@ -274,8 +276,12 @@ export function TeamPage(props: TeamPageProps) {
         setEventsLoading(false);
       }
     },
-    [oldestEventId, props.token]
+    [props.token]
   );
+
+  useEffect(() => {
+    eventsRef.current = events;
+  }, [events]);
 
   const loadInbox = useCallback(async () => {
     if (!activeRunId) return;

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1,0 +1,1094 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  api,
+  TeamActorMessageRecord,
+  TeamDefinitionRecord,
+  TeamRunEventRecord,
+  TeamRunRecord,
+  TeamStepRecord,
+} from "../api";
+import { ErrorBanner } from "../error_banner";
+import { AuthState } from "../types";
+
+type TeamPageProps = {
+  auth: AuthState;
+  token: string;
+  onLogout: () => void;
+};
+
+type TeamTab = "events" | "steps" | "messages";
+type StepAction =
+  | "start"
+  | "complete"
+  | "fail"
+  | "input_required"
+  | "resume";
+
+const EVENT_PAGE_LIMIT = 100;
+const DEFAULT_TEAM_SPEC = `{
+  "spec_version": 1,
+  "entrypoint": "planner",
+  "members": [
+    {
+      "member_id": "planner"
+    }
+  ]
+}`;
+
+function sortRuns(runs: TeamRunRecord[]): TeamRunRecord[] {
+  return [...runs].sort((a, b) => b.created_at - a.created_at);
+}
+
+function upsertRun(list: TeamRunRecord[], nextRun: TeamRunRecord): TeamRunRecord[] {
+  const withoutCurrent = list.filter((run) => run.id !== nextRun.id);
+  return sortRuns([nextRun, ...withoutCurrent]);
+}
+
+function upsertEventList(
+  prev: TeamRunEventRecord[],
+  next: TeamRunEventRecord[],
+  mode: "replace" | "prepend"
+): TeamRunEventRecord[] {
+  const merged = mode === "replace" ? [...next] : [...next, ...prev];
+  const byId = new Map<number, TeamRunEventRecord>();
+  for (const event of merged) {
+    byId.set(event.event_id, event);
+  }
+  return [...byId.values()].sort((a, b) => a.event_id - b.event_id);
+}
+
+function parseErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    const msg = err.message ?? "request failed";
+    if (!msg.trim().startsWith("{")) {
+      return msg;
+    }
+    try {
+      const parsed = JSON.parse(msg) as { error?: string };
+      if (typeof parsed.error === "string" && parsed.error) {
+        return parsed.error;
+      }
+      return msg;
+    } catch {
+      return msg;
+    }
+  }
+  return String(err);
+}
+
+function parseRequiredJson(raw: string, field: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error(`${field} must be valid JSON`);
+  }
+}
+
+function parseOptionalJson(raw: string, field: string): unknown | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error(`${field} must be valid JSON`);
+  }
+}
+
+function parseOptionalInteger(raw: string, field: string): number | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parseCsvList(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function formatTs(ts?: number | null): string {
+  if (!ts) return "-";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+function toPrettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function TeamPage(props: TeamPageProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const [tab, setTab] = useState<TeamTab>("events");
+  const [teams, setTeams] = useState<TeamDefinitionRecord[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+
+  const [newTeamName, setNewTeamName] = useState("");
+  const [newTeamDescription, setNewTeamDescription] = useState("");
+  const [newTeamSpec, setNewTeamSpec] = useState(DEFAULT_TEAM_SPEC);
+
+  const [runContextId, setRunContextId] = useState("");
+  const [runInput, setRunInput] = useState("{}");
+  const [runLookupId, setRunLookupId] = useState("");
+
+  const [runs, setRuns] = useState<TeamRunRecord[]>([]);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+
+  const [events, setEvents] = useState<TeamRunEventRecord[]>([]);
+  const [eventsHasMore, setEventsHasMore] = useState(false);
+  const [eventsLoading, setEventsLoading] = useState(false);
+  const [eventsAutoRefresh, setEventsAutoRefresh] = useState(true);
+
+  const [steps, setSteps] = useState<TeamStepRecord[]>([]);
+  const [stepKey, setStepKey] = useState("");
+  const [stepMemberId, setStepMemberId] = useState("");
+  const [stepDependsOn, setStepDependsOn] = useState("");
+  const [stepInput, setStepInput] = useState("{}");
+
+  const [selectedStepId, setSelectedStepId] = useState<string>("");
+  const [stepAction, setStepAction] = useState<StepAction>("start");
+  const [stepRemoteTaskId, setStepRemoteTaskId] = useState("");
+  const [stepOutput, setStepOutput] = useState("{}");
+  const [stepFailText, setStepFailText] = useState("");
+  const [stepInputReason, setStepInputReason] = useState("");
+  const [stepInputRequiredPayload, setStepInputRequiredPayload] = useState("{}");
+  const [stepResumePayload, setStepResumePayload] = useState("{}");
+
+  const [msgFromActorId, setMsgFromActorId] = useState("");
+  const [msgToActorId, setMsgToActorId] = useState("");
+  const [msgChannel, setMsgChannel] = useState("default");
+  const [msgTransport, setMsgTransport] = useState<"local" | "remote">("local");
+  const [msgRoute, setMsgRoute] = useState("");
+  const [msgPayload, setMsgPayload] = useState("{}");
+  const [msgIdempotencyKey, setMsgIdempotencyKey] = useState("");
+
+  const [inboxActorId, setInboxActorId] = useState("");
+  const [inboxLimit, setInboxLimit] = useState("100");
+  const [inboxAfterId, setInboxAfterId] = useState("");
+  const [inboxIncludeDelivered, setInboxIncludeDelivered] = useState(false);
+  const [inbox, setInbox] = useState<TeamActorMessageRecord[]>([]);
+
+  const selectedTeam = useMemo(
+    () => teams.find((team) => team.id === selectedTeamId) ?? null,
+    [teams, selectedTeamId]
+  );
+
+  const activeRun = useMemo(
+    () => runs.find((run) => run.id === activeRunId) ?? null,
+    [runs, activeRunId]
+  );
+
+  const visibleRuns = useMemo(() => {
+    if (!selectedTeamId) return [];
+    return runs.filter((run) => run.team_id === selectedTeamId);
+  }, [runs, selectedTeamId]);
+
+  const oldestEventId = events.length > 0 ? events[0].event_id : null;
+
+  const refreshTeams = useCallback(async () => {
+    setBusy("refresh-teams");
+    setError(null);
+    try {
+      const list = await api.listTeams(props.token);
+      setTeams(list);
+      setSelectedTeamId((prev) => {
+        if (prev && list.some((team) => team.id === prev)) {
+          return prev;
+        }
+        return list[0]?.id ?? null;
+      });
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  }, [props.token]);
+
+  const refreshRun = useCallback(
+    async (runId: string) => {
+      const run = await api.getTeamRun(props.token, runId);
+      setRuns((prev) => upsertRun(prev, run));
+      return run;
+    },
+    [props.token]
+  );
+
+  const refreshSteps = useCallback(
+    async (runId: string) => {
+      const list = await api.listTeamRunSteps(props.token, runId);
+      setSteps(list);
+      setSelectedStepId((prev) => {
+        if (prev && list.some((step) => step.id === prev)) {
+          return prev;
+        }
+        return list[0]?.id ?? "";
+      });
+      return list;
+    },
+    [props.token]
+  );
+
+  const refreshEvents = useCallback(
+    async (runId: string, mode: "replace" | "prepend" = "replace") => {
+      setEventsLoading(true);
+      try {
+        const beforeId = mode === "prepend" ? oldestEventId ?? undefined : undefined;
+        const list = await api.listTeamRunEvents(
+          props.token,
+          runId,
+          EVENT_PAGE_LIMIT,
+          beforeId
+        );
+        setEvents((prev) => upsertEventList(prev, list, mode));
+        setEventsHasMore(list.length >= EVENT_PAGE_LIMIT);
+      } finally {
+        setEventsLoading(false);
+      }
+    },
+    [oldestEventId, props.token]
+  );
+
+  const loadInbox = useCallback(async () => {
+    if (!activeRunId) return;
+    const actorId = inboxActorId.trim();
+    if (!actorId) {
+      throw new Error("Inbox actor_id is required");
+    }
+    const limit = parseOptionalInteger(inboxLimit, "Inbox limit") ?? 100;
+    const afterId = parseOptionalInteger(inboxAfterId, "Inbox after_id");
+    const list = await api.listTeamRunInbox(props.token, activeRunId, {
+      actor_id: actorId,
+      limit,
+      after_id: afterId,
+      include_delivered: inboxIncludeDelivered,
+    });
+    setInbox(list);
+  }, [
+    activeRunId,
+    inboxActorId,
+    inboxAfterId,
+    inboxIncludeDelivered,
+    inboxLimit,
+    props.token,
+  ]);
+
+  useEffect(() => {
+    void refreshTeams();
+  }, [refreshTeams]);
+
+  useEffect(() => {
+    if (!selectedTeamId) {
+      setActiveRunId(null);
+      setRuns([]);
+      setEvents([]);
+      setSteps([]);
+      setInbox([]);
+      return;
+    }
+    setActiveRunId((prev) => {
+      if (prev && runs.some((run) => run.id === prev && run.team_id === selectedTeamId)) {
+        return prev;
+      }
+      return runs.find((run) => run.team_id === selectedTeamId)?.id ?? null;
+    });
+  }, [selectedTeamId, runs]);
+
+  useEffect(() => {
+    if (!activeRunId) {
+      setEvents([]);
+      setSteps([]);
+      setInbox([]);
+      return;
+    }
+    let canceled = false;
+    const loadAll = async () => {
+      try {
+        setError(null);
+        const run = await refreshRun(activeRunId);
+        if (canceled) return;
+        if (run.team_id !== selectedTeamId) {
+          setSelectedTeamId(run.team_id);
+        }
+        await Promise.all([refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+      } catch (err) {
+        if (!canceled) {
+          setError(parseErrorMessage(err));
+        }
+      }
+    };
+    void loadAll();
+    return () => {
+      canceled = true;
+    };
+  }, [activeRunId, refreshEvents, refreshRun, refreshSteps, selectedTeamId]);
+
+  useEffect(() => {
+    if (!activeRunId || !eventsAutoRefresh) return;
+    const timer = window.setInterval(() => {
+      void refreshRun(activeRunId).catch(() => undefined);
+      void refreshEvents(activeRunId).catch(() => undefined);
+    }, 4000);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [activeRunId, eventsAutoRefresh, refreshEvents, refreshRun]);
+
+  const onCreateTeam = async () => {
+    const name = newTeamName.trim();
+    if (!name) {
+      setError("Team name is required");
+      return;
+    }
+    setBusy("create-team");
+    setError(null);
+    try {
+      const created = await api.createTeam(props.token, {
+        name,
+        description: newTeamDescription.trim() || undefined,
+        spec: parseRequiredJson(newTeamSpec, "Team spec"),
+      });
+      setTeams((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+      setSelectedTeamId(created.id);
+      setNewTeamName("");
+      setNewTeamDescription("");
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onCreateRun = async () => {
+    if (!selectedTeamId) {
+      setError("Select a team first");
+      return;
+    }
+    setBusy("create-run");
+    setError(null);
+    try {
+      const created = await api.createTeamRun(props.token, selectedTeamId, {
+        context_id: runContextId.trim() || undefined,
+        input: parseOptionalJson(runInput, "Run input") ?? {},
+      });
+      setRuns((prev) => upsertRun(prev, created));
+      setActiveRunId(created.id);
+      setRunLookupId(created.id);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onLoadRunById = async () => {
+    const runId = runLookupId.trim();
+    if (!runId) {
+      setError("Run ID is required");
+      return;
+    }
+    setBusy("load-run");
+    setError(null);
+    try {
+      const run = await refreshRun(runId);
+      setSelectedTeamId(run.team_id);
+      setActiveRunId(run.id);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onCancelRun = async () => {
+    if (!activeRunId) return;
+    setBusy("cancel-run");
+    setError(null);
+    try {
+      const canceled = await api.cancelTeamRun(props.token, activeRunId);
+      setRuns((prev) => upsertRun(prev, canceled));
+      await refreshEvents(activeRunId);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onSubmitStep = async () => {
+    if (!activeRunId) {
+      setError("Select a run first");
+      return;
+    }
+    if (!stepKey.trim()) {
+      setError("step_key is required");
+      return;
+    }
+    if (!stepMemberId.trim()) {
+      setError("member_id is required");
+      return;
+    }
+    setBusy("submit-step");
+    setError(null);
+    try {
+      const created = await api.submitTeamRunStep(props.token, activeRunId, {
+        step_key: stepKey.trim(),
+        member_id: stepMemberId.trim(),
+        depends_on: parseCsvList(stepDependsOn),
+        input: parseOptionalJson(stepInput, "Step input"),
+      });
+      await Promise.all([refreshRun(activeRunId), refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+      setSelectedStepId(created.id);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onApplyStepAction = async () => {
+    if (!activeRunId) {
+      setError("Select a run first");
+      return;
+    }
+    if (!selectedStepId) {
+      setError("Select a step first");
+      return;
+    }
+    setBusy(`step-${stepAction}`);
+    setError(null);
+    try {
+      if (stepAction === "start") {
+        await api.startTeamRunStep(props.token, activeRunId, selectedStepId, {
+          remote_task_id: stepRemoteTaskId.trim() || undefined,
+        });
+      } else if (stepAction === "complete") {
+        await api.completeTeamRunStep(props.token, activeRunId, selectedStepId, {
+          output: parseOptionalJson(stepOutput, "Step output"),
+        });
+      } else if (stepAction === "fail") {
+        const errorText = stepFailText.trim();
+        if (!errorText) {
+          throw new Error("Fail reason is required");
+        }
+        await api.failTeamRunStep(props.token, activeRunId, selectedStepId, {
+          error_text: errorText,
+        });
+      } else if (stepAction === "input_required") {
+        await api.setTeamRunStepInputRequired(props.token, activeRunId, selectedStepId, {
+          reason: stepInputReason.trim() || undefined,
+          input: parseOptionalJson(stepInputRequiredPayload, "Input required payload"),
+        });
+      } else {
+        await api.resumeTeamRunStep(props.token, activeRunId, selectedStepId, {
+          input: parseOptionalJson(stepResumePayload, "Resume payload"),
+        });
+      }
+      await Promise.all([refreshRun(activeRunId), refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onSendMessage = async () => {
+    if (!activeRunId) {
+      setError("Select a run first");
+      return;
+    }
+    const fromActorId = msgFromActorId.trim();
+    const toActorId = msgToActorId.trim();
+    if (!fromActorId || !toActorId) {
+      setError("from_actor_id and to_actor_id are required");
+      return;
+    }
+    setBusy("send-message");
+    setError(null);
+    try {
+      await api.sendTeamRunMessage(props.token, activeRunId, {
+        from_actor_id: fromActorId,
+        to_actor_id: toActorId,
+        channel: msgChannel.trim() || undefined,
+        transport: msgTransport,
+        route: parseOptionalJson(msgRoute, "Message route"),
+        payload: parseRequiredJson(msgPayload, "Message payload"),
+        idempotency_key: msgIdempotencyKey.trim() || undefined,
+      });
+      await refreshEvents(activeRunId);
+      if (inboxActorId.trim()) {
+        await loadInbox();
+      }
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onRefreshInbox = async () => {
+    if (!activeRunId) {
+      setError("Select a run first");
+      return;
+    }
+    setBusy("refresh-inbox");
+    setError(null);
+    try {
+      await loadInbox();
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onAckMessage = async (message: TeamActorMessageRecord) => {
+    if (!activeRunId) return;
+    const actorId = inboxActorId.trim() || message.to_actor_id;
+    setBusy(`ack-${message.message_id}`);
+    setError(null);
+    try {
+      await api.ackTeamRunMessage(props.token, activeRunId, message.message_id, actorId);
+      await Promise.all([loadInbox(), refreshEvents(activeRunId)]);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="app">
+      <header>
+        <h1>AgentHub Teams</h1>
+        <div className="session">
+          <a className="icon-button" href="/" title="Back" aria-label="Back">
+            <i className="bi bi-arrow-left" aria-hidden="true" />
+          </a>
+          <span>{props.auth.username}</span>
+          <button onClick={props.onLogout}>Logout</button>
+        </div>
+      </header>
+
+      {error && <ErrorBanner message={error} onClose={() => setError(null)} />}
+
+      <section className="teams-layout">
+        <aside className="card teams-sidebar">
+          <div className="toolbar">
+            <h2>Teams</h2>
+            <button onClick={() => void refreshTeams()} disabled={busy === "refresh-teams"}>
+              Refresh
+            </button>
+          </div>
+
+          <div className="teams-form">
+            <h3>Create Team</h3>
+            <input
+              placeholder="team name"
+              value={newTeamName}
+              onChange={(event) => setNewTeamName(event.target.value)}
+            />
+            <input
+              placeholder="description (optional)"
+              value={newTeamDescription}
+              onChange={(event) => setNewTeamDescription(event.target.value)}
+            />
+            <textarea
+              className="mono"
+              rows={10}
+              value={newTeamSpec}
+              onChange={(event) => setNewTeamSpec(event.target.value)}
+            />
+            <button onClick={onCreateTeam} disabled={busy === "create-team"}>
+              Create Team
+            </button>
+          </div>
+
+          <div className="teams-list">
+            {teams.length === 0 && <p className="muted">No teams yet.</p>}
+            {teams.map((team) => (
+              <button
+                key={team.id}
+                className={team.id === selectedTeamId ? "team-item active" : "team-item"}
+                onClick={() => {
+                  setSelectedTeamId(team.id);
+                  setRunLookupId("");
+                }}
+              >
+                <span className="team-name">{team.name}</span>
+                <span className="team-id mono">{team.id}</span>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <div className="teams-main">
+          {!selectedTeam && (
+            <div className="card">
+              <h2>Team Workbench</h2>
+              <p>Select a team from the left panel to manage runs, steps, and messages.</p>
+            </div>
+          )}
+
+          {selectedTeam && (
+            <>
+              <div className="card">
+                <div className="toolbar">
+                  <h2>{selectedTeam.name}</h2>
+                  <span className="mono">{selectedTeam.id}</span>
+                </div>
+                <div className="teams-run-create">
+                  <h3>Create / Load Run</h3>
+                  <div className="form-row">
+                    <input
+                      placeholder="context_id (optional)"
+                      value={runContextId}
+                      onChange={(event) => setRunContextId(event.target.value)}
+                    />
+                    <button onClick={onCreateRun} disabled={busy === "create-run"}>
+                      Create Run
+                    </button>
+                  </div>
+                  <textarea
+                    className="mono"
+                    rows={4}
+                    value={runInput}
+                    onChange={(event) => setRunInput(event.target.value)}
+                  />
+                  <div className="form-row">
+                    <input
+                      placeholder="existing run_id"
+                      value={runLookupId}
+                      onChange={(event) => setRunLookupId(event.target.value)}
+                    />
+                    <button onClick={onLoadRunById} disabled={busy === "load-run"}>
+                      Load Run
+                    </button>
+                  </div>
+                </div>
+                <div className="teams-run-list">
+                  <h3>Runs In This Browser Session</h3>
+                  {visibleRuns.length === 0 && (
+                    <p className="muted">No runs loaded yet. Create one or load by run_id.</p>
+                  )}
+                  {visibleRuns.map((run) => (
+                    <button
+                      key={run.id}
+                      className={run.id === activeRunId ? "team-item active" : "team-item"}
+                      onClick={() => setActiveRunId(run.id)}
+                    >
+                      <span className="team-name mono">{run.id}</span>
+                      <span className="team-status">{run.status}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {activeRun && (
+                <>
+                  <div className="card">
+                    <div className="toolbar">
+                      <h3>Active Run</h3>
+                      <div className="actions">
+                        <button
+                          onClick={() => {
+                            if (!activeRunId) return;
+                            void refreshRun(activeRunId).catch((err) =>
+                              setError(parseErrorMessage(err))
+                            );
+                          }}
+                        >
+                          Refresh Run
+                        </button>
+                        <button
+                          onClick={onCancelRun}
+                          disabled={busy === "cancel-run" || activeRun.status === "canceled"}
+                        >
+                          Cancel Run
+                        </button>
+                      </div>
+                    </div>
+                    <div className="teams-run-meta">
+                      <span>
+                        <strong>ID:</strong> <code>{activeRun.id}</code>
+                      </span>
+                      <span>
+                        <strong>Status:</strong> {activeRun.status}
+                      </span>
+                      <span>
+                        <strong>Context:</strong> {activeRun.context_id}
+                      </span>
+                      <span>
+                        <strong>Created:</strong> {formatTs(activeRun.created_at)}
+                      </span>
+                      <span>
+                        <strong>Started:</strong> {formatTs(activeRun.started_at)}
+                      </span>
+                      <span>
+                        <strong>Ended:</strong> {formatTs(activeRun.ended_at)}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="tab-bar">
+                    <button
+                      className={tab === "events" ? "tab active" : "tab"}
+                      onClick={() => setTab("events")}
+                    >
+                      Events
+                    </button>
+                    <button
+                      className={tab === "steps" ? "tab active" : "tab"}
+                      onClick={() => setTab("steps")}
+                    >
+                      Steps
+                    </button>
+                    <button
+                      className={tab === "messages" ? "tab active" : "tab"}
+                      onClick={() => setTab("messages")}
+                    >
+                      Messages
+                    </button>
+                  </div>
+
+                  {tab === "events" && (
+                    <div className="card">
+                      <div className="toolbar">
+                        <h3>Run Events</h3>
+                        <div className="actions">
+                          <label className="checkbox">
+                            <input
+                              type="checkbox"
+                              checked={eventsAutoRefresh}
+                              onChange={(event) =>
+                                setEventsAutoRefresh(event.target.checked)
+                              }
+                            />
+                            Auto refresh
+                          </label>
+                          <button
+                            onClick={() => void refreshEvents(activeRun.id)}
+                            disabled={eventsLoading}
+                          >
+                            Refresh
+                          </button>
+                          <button
+                            onClick={() => void refreshEvents(activeRun.id, "prepend")}
+                            disabled={eventsLoading || !eventsHasMore || oldestEventId == null}
+                          >
+                            Load Older
+                          </button>
+                        </div>
+                      </div>
+                      {events.length === 0 && <p className="muted">No events.</p>}
+                      <ul className="teams-event-list">
+                        {events.map((event) => (
+                          <li key={event.event_id}>
+                            <div className="teams-event-head">
+                              <span className="mono">#{event.event_id}</span>
+                              <span>{event.event_type}</span>
+                              <span>{formatTs(event.ts)}</span>
+                            </div>
+                            <pre className="mono">{toPrettyJson(event.payload)}</pre>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {tab === "steps" && (
+                    <div className="card">
+                      <div className="toolbar">
+                        <h3>Steps</h3>
+                        <button onClick={() => void refreshSteps(activeRun.id)}>Refresh</button>
+                      </div>
+
+                      <div className="teams-step-grid">
+                        <div className="teams-step-panel">
+                          <h4>Submit Step</h4>
+                          <input
+                            placeholder="step_key"
+                            value={stepKey}
+                            onChange={(event) => setStepKey(event.target.value)}
+                          />
+                          <input
+                            placeholder="member_id"
+                            value={stepMemberId}
+                            onChange={(event) => setStepMemberId(event.target.value)}
+                          />
+                          <input
+                            placeholder="depends_on (comma separated)"
+                            value={stepDependsOn}
+                            onChange={(event) => setStepDependsOn(event.target.value)}
+                          />
+                          <textarea
+                            className="mono"
+                            rows={4}
+                            value={stepInput}
+                            onChange={(event) => setStepInput(event.target.value)}
+                          />
+                          <button onClick={onSubmitStep} disabled={busy === "submit-step"}>
+                            Submit Step
+                          </button>
+                        </div>
+
+                        <div className="teams-step-panel">
+                          <h4>Step Action</h4>
+                          <select
+                            value={selectedStepId}
+                            onChange={(event) => setSelectedStepId(event.target.value)}
+                          >
+                            <option value="">Select step</option>
+                            {steps.map((step) => (
+                              <option key={step.id} value={step.id}>
+                                {step.step_key} ({step.status})
+                              </option>
+                            ))}
+                          </select>
+                          <select
+                            value={stepAction}
+                            onChange={(event) =>
+                              setStepAction(event.target.value as StepAction)
+                            }
+                          >
+                            <option value="start">start</option>
+                            <option value="complete">complete</option>
+                            <option value="fail">fail</option>
+                            <option value="input_required">input_required</option>
+                            <option value="resume">resume</option>
+                          </select>
+
+                          {stepAction === "start" && (
+                            <input
+                              placeholder="remote_task_id (optional)"
+                              value={stepRemoteTaskId}
+                              onChange={(event) =>
+                                setStepRemoteTaskId(event.target.value)
+                              }
+                            />
+                          )}
+
+                          {stepAction === "complete" && (
+                            <textarea
+                              className="mono"
+                              rows={4}
+                              value={stepOutput}
+                              onChange={(event) => setStepOutput(event.target.value)}
+                            />
+                          )}
+
+                          {stepAction === "fail" && (
+                            <input
+                              placeholder="error_text"
+                              value={stepFailText}
+                              onChange={(event) => setStepFailText(event.target.value)}
+                            />
+                          )}
+
+                          {stepAction === "input_required" && (
+                            <>
+                              <input
+                                placeholder="reason (optional)"
+                                value={stepInputReason}
+                                onChange={(event) =>
+                                  setStepInputReason(event.target.value)
+                                }
+                              />
+                              <textarea
+                                className="mono"
+                                rows={4}
+                                value={stepInputRequiredPayload}
+                                onChange={(event) =>
+                                  setStepInputRequiredPayload(event.target.value)
+                                }
+                              />
+                            </>
+                          )}
+
+                          {stepAction === "resume" && (
+                            <textarea
+                              className="mono"
+                              rows={4}
+                              value={stepResumePayload}
+                              onChange={(event) =>
+                                setStepResumePayload(event.target.value)
+                              }
+                            />
+                          )}
+
+                          <button onClick={onApplyStepAction}>
+                            Apply Step Action
+                          </button>
+                        </div>
+                      </div>
+
+                      <ul className="teams-step-list">
+                        {steps.map((step) => (
+                          <li key={step.id}>
+                            <div className="teams-step-head">
+                              <span className="mono">{step.id}</span>
+                              <span>{step.step_key}</span>
+                              <span>{step.status}</span>
+                            </div>
+                            <div className="teams-step-body mono">
+                              <div>member_id: {step.member_id}</div>
+                              <div>attempt: {step.attempt}</div>
+                              <div>
+                                depends_on: {step.depends_on.length ? step.depends_on.join(", ") : "-"}
+                              </div>
+                              <div>remote_task_id: {step.remote_task_id ?? "-"}</div>
+                              {step.error_text && <div>error_text: {step.error_text}</div>}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {tab === "messages" && (
+                    <div className="card">
+                      <div className="toolbar">
+                        <h3>Messages</h3>
+                      </div>
+
+                      <div className="teams-message-grid">
+                        <div className="teams-message-panel">
+                          <h4>Send Message</h4>
+                          <input
+                            placeholder="from_actor_id"
+                            value={msgFromActorId}
+                            onChange={(event) => setMsgFromActorId(event.target.value)}
+                          />
+                          <input
+                            placeholder="to_actor_id"
+                            value={msgToActorId}
+                            onChange={(event) => setMsgToActorId(event.target.value)}
+                          />
+                          <input
+                            placeholder="channel (default)"
+                            value={msgChannel}
+                            onChange={(event) => setMsgChannel(event.target.value)}
+                          />
+                          <select
+                            value={msgTransport}
+                            onChange={(event) =>
+                              setMsgTransport(event.target.value as "local" | "remote")
+                            }
+                          >
+                            <option value="local">local</option>
+                            <option value="remote">remote</option>
+                          </select>
+                          <textarea
+                            className="mono"
+                            rows={3}
+                            placeholder="route JSON (required for remote)"
+                            value={msgRoute}
+                            onChange={(event) => setMsgRoute(event.target.value)}
+                          />
+                          <textarea
+                            className="mono"
+                            rows={4}
+                            placeholder="payload JSON"
+                            value={msgPayload}
+                            onChange={(event) => setMsgPayload(event.target.value)}
+                          />
+                          <input
+                            placeholder="idempotency_key (optional)"
+                            value={msgIdempotencyKey}
+                            onChange={(event) =>
+                              setMsgIdempotencyKey(event.target.value)
+                            }
+                          />
+                          <button onClick={onSendMessage} disabled={busy === "send-message"}>
+                            Send Message
+                          </button>
+                        </div>
+
+                        <div className="teams-message-panel">
+                          <h4>Inbox</h4>
+                          <input
+                            placeholder="actor_id"
+                            value={inboxActorId}
+                            onChange={(event) => setInboxActorId(event.target.value)}
+                          />
+                          <input
+                            placeholder="limit"
+                            value={inboxLimit}
+                            onChange={(event) => setInboxLimit(event.target.value)}
+                          />
+                          <input
+                            placeholder="after_id (optional)"
+                            value={inboxAfterId}
+                            onChange={(event) => setInboxAfterId(event.target.value)}
+                          />
+                          <label className="checkbox">
+                            <input
+                              type="checkbox"
+                              checked={inboxIncludeDelivered}
+                              onChange={(event) =>
+                                setInboxIncludeDelivered(event.target.checked)
+                              }
+                            />
+                            include_delivered
+                          </label>
+                          <button
+                            onClick={onRefreshInbox}
+                            disabled={busy === "refresh-inbox"}
+                          >
+                            Refresh Inbox
+                          </button>
+                        </div>
+                      </div>
+
+                      <ul className="teams-message-list">
+                        {inbox.map((message) => (
+                          <li key={message.message_id}>
+                            <div className="teams-message-head">
+                              <span className="mono">#{message.message_id}</span>
+                              <span>
+                                {message.from_actor_id} → {message.to_actor_id}
+                              </span>
+                              <span>{message.status}</span>
+                            </div>
+                            <pre className="mono">{toPrettyJson(message.payload)}</pre>
+                            <div className="actions">
+                              <button
+                                onClick={() => void onAckMessage(message)}
+                                disabled={
+                                  message.status === "delivered" ||
+                                  busy === `ack-${message.message_id}`
+                                }
+                              >
+                                Ack
+                              </button>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2525,6 +2525,158 @@ select:not([class*="mantine-"]):focus-visible {
   padding: 4px 8px;
 }
 
+.teams-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  gap: 16px;
+  min-height: 0;
+}
+
+.teams-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.teams-form,
+.teams-run-create,
+.teams-run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.teams-main {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.teams-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.team-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  border: 1px solid #d8d8d8;
+  background: #f7f7f7;
+  color: #1c1c1c;
+  border-radius: 10px;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.team-item.active {
+  border-color: #161616;
+  background: #161616;
+  color: #fff;
+}
+
+.team-item .team-name {
+  font-weight: 600;
+}
+
+.team-item .team-id,
+.team-item .team-status {
+  font-size: 12px;
+  opacity: 0.88;
+}
+
+.teams-run-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.teams-event-list,
+.teams-step-list,
+.teams-message-list {
+  max-height: 420px;
+  overflow: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.teams-event-list li,
+.teams-step-list li,
+.teams-message-list li {
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 8px;
+  background: #fafafa;
+}
+
+.teams-event-head,
+.teams-step-head,
+.teams-message-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.teams-step-grid,
+.teams-message-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.teams-step-panel,
+.teams-message-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid #ececec;
+  border-radius: 10px;
+  padding: 10px;
+  background: #fcfcfc;
+}
+
+.teams-step-panel select,
+.teams-message-panel select,
+.teams-step-panel input,
+.teams-message-panel input,
+.teams-step-panel textarea,
+.teams-message-panel textarea,
+.teams-form input,
+.teams-form textarea,
+.teams-run-create input,
+.teams-run-create textarea {
+  width: 100%;
+}
+
+.teams-step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.muted {
+  color: #6f6f6f;
+}
+
 @media (max-width: 600px) {
   header {
     flex-direction: row;
@@ -2605,5 +2757,9 @@ select:not([class*="mantine-"]):focus-visible {
 
   .acp-diff-view {
     font-size: 10.5px;
+  }
+
+  .teams-layout {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

This PR delivers Team Workbench end-to-end foundations:

- adds a dedicated `/teams` workbench page in web UI
- adds backend API for listing runs by team (`GET /api/teams/:id/runs`)
- adds authenticated OpenAPI discovery endpoints (`/api/openapi.json`, `/api/openapi/docs`)

## Changes

### Web Team Workbench

- Add Team page and route entry for `/teams`
- Add Team API client bindings
- Support Team create/select, run create/load/cancel, event replay, step lifecycle operations, and actor mailbox interactions
- Load run list from backend list API instead of local-only reconstruction

### Team Runs List API

- Add `GET /api/teams/:id/runs`
- Query support:
  - `limit` (default 100, clamped to `1..500`)
  - `status` (`submitted|working|input_required|completed|failed|canceled`)
  - `before_created_at` (cursor)
- Add manager-layer query for deterministic pagination (`created_at DESC, id DESC`)
- Add API tests for status filtering, cursor paging, invalid status, and missing-team handling

### OpenAPI Discovery

- Add `GET /api/openapi.json` (Bearer-auth required)
- Add `GET /api/openapi/docs` (viewer page that fetches `/api/openapi.json` using `localStorage.agenthub_auth` token)
- Add Team-focused OpenAPI path/schema coverage, including `/api/teams/{id}/runs`
- Add unit tests for auth requirement and key path presence

## Validation

- `npm --prefix web run lint`
- `npm --prefix web run test`
- `npm --prefix web run build`
- `cargo test list_runs_supports_status_filter_and_cursor -- --nocapture`
- `cargo test team_runs_api_lists_team_runs_with_status_filter_and_cursor -- --nocapture`
- `cargo test teams_router_http_contract -- --nocapture`
- `cargo test openapi_json_requires_authorization -- --nocapture`
- `cargo test openapi_json_contains_team_runs_list_path -- --nocapture`

## Docs

- `docs/features/2026-02-16-team-workbench-ui.md`
- `docs/features/2026-02-16-team-runs-list-api.md`
- `docs/features/2026-02-16-openapi-discovery-endpoints.md`
- `docs/todo.md`
