### PR TITLE
docs: refresh README and expand userdocs deployment/advanced guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,58 @@
 # AgentHub
 
-AgentHub is a single-binary service for managing and interacting with remote AI agents. It provides a web UI, ACP-based structured output rendering, and persistent sessions backed by SQLite. It also supports A2A (agent-to-agent) orchestration for multi-agent workflows.
+AgentHub is a single-binary service for managing and interacting with remote AI agents.
+It provides a Rust backend, an embedded React web UI, ACP-based structured output rendering,
+and SQLite-backed persistent sessions.
 
-## Features
+## What You Can Do
 
 - Create, start, stop, and delete agents
-- ACP event rendering (messages, tool calls, plan, commands, debug)
-- A2A orchestration for multi-agent collaboration
-- Session persistence even when the browser is closed
-- Passkey-based login with device join flow
-- Safe path enforcement and audit logging
-- Web Push notifications (VAPID management UI)
-- Embedded frontend (Vite build served by Rust)
+- Run long-lived tasks that continue after the browser tab closes
+- Inspect ACP events (messages, plans, tool calls, command output, debug stream)
+- Run multi-agent workflows with A2A team orchestration
+- Receive completion notifications in the web UI
+- Keep operational history with auditable logs and persisted session state
 
-## Requirements
+## Documentation Map
 
-- Rust (stable)
-- Node.js 20+ (for the web build)
-- Bazel / Bazelisk (optional, for Bazel-driven Rust build + test entrypoints)
+- End-user docs site: `userdocs/`
+- Internal engineering notes: `docs/features/`
+- Internal backlog / follow-ups: `docs/todo.md`
+- API payload naming conventions: `docs/api_naming.md`
 
-## Quick Start
-
-```bash
-# Build the web UI
-cd web
-npm install
-npm run build
-
-# Run the server
-cd ..
-cargo run
-```
-
-The server serves the UI on `http://localhost:8080`.
-
-## User Documentation Site (Docusaurus)
-
-AgentHub includes an end-user documentation site under `userdocs/`.
+For user-facing documentation preview/build:
 
 ```bash
 cd userdocs
 npm install
-npm run start
+npm run start   # local preview
+npm run build   # static output at userdocs/build
 ```
 
-The Docusaurus dev server will print a local preview URL (default:
-`http://localhost:3000`).
+## Requirements
+
+- Rust (stable)
+- Node.js 20+ (for web and userdocs build)
+- Bazel / Bazelisk (optional, for Bazel-driven checks)
+
+## Quick Start (Local)
+
+```bash
+# 1) Build web assets
+cd web
+npm install
+npm run build
+
+# 2) Run AgentHub
+cd ..
+cargo run
+```
+
+Default UI address: `http://localhost:8080`.
 
 ## Configuration
 
-AgentHub reads configuration from a `config.toml` file. Example:
+AgentHub reads config from `config.toml`.
 
 ```toml
 listen_addr = "0.0.0.0:8080"
@@ -60,45 +63,47 @@ safe_paths = [
 ]
 ```
 
-The database and runtime state live under `~/.agenthub/` by default.
+Runtime state (database, local artifacts) defaults to `~/.agenthub/`.
 
-## Development
+## Common Development Commands
 
 ```bash
-# Rust tests
+# Run Rust tests
 cargo test
 
-# Web tests
+# Run frontend unit tests
 cd web
-npm run test
+npm test
 
-# Bazel-driven checks
+# Lint frontend
+npm run lint
+
+# Bazel checks (optional)
+cd ..
 bazel build //...
 bazel test //...
 ```
 
-## Internal Proto Codegen
+## Internal Proto Codegen Guard
 
-`proto/internal/v1/team.proto` is compiled at build-time by `build.rs` through
-`tonic-build` and is not checked into git as generated Rust code.
+`proto/internal/v1/team.proto` is compiled via `build.rs` (`tonic-build`) at build time.
+Generated Rust protobuf sources are not checked into git.
 
 ```bash
-# verify protobuf codegen path and generated symbols
+# verify codegen consistency and tracked-file guard
 make proto-check
-
-# manual regeneration trigger (generated output under target/*/build/*/out/)
-cargo check --locked
 ```
 
-## Project Layout
+## Repository Layout
 
-```
+```text
 agenthub/
   src/                # Rust server
   web/                # Vite + React frontend
-  agenthub-codex-acp/ # ACP adapter (workspace member)
-  migrations/         # DB migrations
-  AGENTS.md
+  userdocs/           # Docusaurus user documentation site
+  agenthub-codex-acp/ # ACP adapter workspace member
+  docs/               # Internal engineering docs and change notes
+  migrations/         # SQLite migrations
 ```
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# Documentation Guide
+
+This folder contains engineering-facing documentation for AgentHub contributors.
+
+## Structure
+
+- `docs/features/`: append-only implementation notes with date-prefixed filenames
+- `docs/todo.md`: follow-up verification and backlog checklist
+- `docs/api_naming.md`: payload naming conventions for AgentHub-owned APIs
+- `userdocs/`: end-user documentation site (Docusaurus, generated static pages)
+
+## When You Change Code
+
+Use this checklist for every non-trivial change:
+
+1. Add or update a feature note in `docs/features/`.
+2. Add a follow-up item in `docs/todo.md` when verification or continuation is needed.
+3. If API payloads changed, ensure naming still conforms to `docs/api_naming.md`.
+4. If behavior is user-visible, update `userdocs/docs/` accordingly.
+
+## Feature Note Convention
+
+- Filename: `YYYY-MM-DD-topic.md`
+- Keep notes concise and operational:
+  - Summary
+  - Background
+  - Scope
+  - Key decisions
+  - Validation
+  - Follow-ups
+
+## Working With User Docs
+
+`userdocs/` is the static documentation site generator target.
+
+```bash
+cd userdocs
+npm install
+npm run start
+npm run build
+```
+
+Build artifacts are generated at `userdocs/build/`.

--- a/docs/features/2026-02-16-readme-docs-structure-refresh.md
+++ b/docs/features/2026-02-16-readme-docs-structure-refresh.md
@@ -1,0 +1,53 @@
+# README and Docs Structure Refresh
+
+## Summary
+
+Refresh repository documentation entry points so contributors and users can find
+setup, development, and docs workflows faster with fewer context switches.
+
+## Background
+
+The root `README.md` had useful information but lacked a clear documentation
+map and consistent onboarding flow across runtime, development, and user docs.
+`docs/` also lacked an index page describing internal documentation policy and
+how `docs/` and `userdocs/` should be maintained together.
+
+## Scope
+
+- `README.md`
+- `docs/README.md`
+- `userdocs/README.md`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Reorganize root README around practical user journeys: capabilities,
+   quick start, configuration, common commands, docs map, and repository layout.
+2. Add `docs/README.md` as the internal documentation index and maintenance
+   checklist for contributors.
+3. Clarify `userdocs/` as a static-site-generator workflow and include
+   explicit Vercel static hosting settings.
+4. Keep command examples aligned with existing scripts/targets (`cargo`, `web`,
+   `make proto-check`) to reduce command drift.
+
+## Validation
+
+```bash
+# verify markdown changes are tracked as expected
+git -c core.fsmonitor=false status -sb
+
+# verify user docs can still produce static build output
+cd userdocs
+npm run build
+```
+
+Expected outcomes:
+
+- Root README provides a clear docs map and standard development entry points.
+- `docs/README.md` defines internal documentation workflow.
+- `userdocs/README.md` is directly usable for static deployment setup.
+
+## Follow-ups
+
+- Verify README command snippets remain aligned with future script changes.
+- Consider adding markdown lint/link check workflow for root/docs/userdocs docs.

--- a/docs/features/2026-02-16-userdocs-deployment-advanced-expansion.md
+++ b/docs/features/2026-02-16-userdocs-deployment-advanced-expansion.md
@@ -1,0 +1,54 @@
+# User Docs Deployment and Advanced Expansion
+
+## Summary
+
+Expand `userdocs` information architecture with deployment and advanced-usage
+tracks, and strengthen troubleshooting guidance for connection-state recovery.
+
+## Background
+
+The user docs already covered core day-to-day single-agent workflows, but
+deployment, automation, and multi-agent advanced usage paths were under-documented.
+Operators and advanced users lacked a clear path for production rollout and
+integration workflows.
+
+## Scope
+
+- `userdocs/sidebars.js`
+- `userdocs/docs/intro.md`
+- `userdocs/docs/operations/troubleshooting.md`
+- `userdocs/docs/deployment/overview-and-topology.md`
+- `userdocs/docs/deployment/production-checklist.md`
+- `userdocs/docs/deployment/vercel-static-userdocs.md`
+- `userdocs/docs/advanced/team-workbench.md`
+- `userdocs/docs/advanced/openapi-and-automation.md`
+- `userdocs/docs/advanced/connection-status-and-recovery.md`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Add dedicated `Deployment` category to separate rollout runbooks from core
+   usage steps.
+2. Add `Advanced Usage` category for Team Workbench, OpenAPI integration, and
+   connection-status recovery.
+3. Keep all docs action-oriented, using concrete UI labels and endpoint paths.
+4. Cross-link troubleshooting with connection-state docs to reduce debugging
+   ambiguity between transport state and user-visible errors.
+
+## Validation
+
+```bash
+cd userdocs
+npm run build
+```
+
+Expected outcomes:
+
+- Docusaurus build succeeds without broken links.
+- New categories and pages appear in sidebar navigation.
+- Existing core docs remain reachable and coherent.
+
+## Follow-ups
+
+- Add screenshots/GIFs for Team Workbench and connection badge states.
+- Add docs lint/link check in CI for `userdocs` markdown quality.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,7 @@
 # TODO
 
 - [ ] Verify refreshed README/docs navigation and command snippets (`README.md`, `docs/README.md`, `userdocs/README.md`) remain aligned with current scripts and deployment workflow (see `docs/features/2026-02-16-readme-docs-structure-refresh.md`).
+- [ ] Verify new userdocs `Deployment` and `Advanced Usage` tracks (sidebar order, cross-links, and page accuracy) in real browser navigation (see `docs/features/2026-02-16-userdocs-deployment-advanced-expansion.md`).
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
 - [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify ACP debug runtime metrics refresh cache hit/miss counters when conversation rendered window changes (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify refreshed README/docs navigation and command snippets (`README.md`, `docs/README.md`, `userdocs/README.md`) remain aligned with current scripts and deployment workflow (see `docs/features/2026-02-16-readme-docs-structure-refresh.md`).
 - [ ] Verify storage quota guard in real browser: when `localStorage` is near/full, output cache persistence degrades gracefully and app actions (send/login/join) no longer surface uncaught `QuotaExceededError` (see `docs/features/2026-02-16-storage-quota-guard.md`).
 - [ ] Verify web render isolation optimization reduces unnecessary re-renders for `AgentsPanel`/`OutputHeader`/`OutputBody` while typing in input dock, and confirm ACP interactions still behave identically (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).
 - [ ] Verify ACP debug runtime metrics refresh cache hit/miss counters when conversation rendered window changes (see `docs/features/2026-02-16-web-render-isolation-memoization.md`).

--- a/userdocs/README.md
+++ b/userdocs/README.md
@@ -1,6 +1,7 @@
 # AgentHub User Docs (Docusaurus)
 
-This directory contains a Docusaurus site for end-user documentation.
+This directory contains the end-user documentation site for AgentHub.
+It is used as a static site generator (no runtime backend required for hosting docs).
 
 ## Local Preview
 
@@ -10,11 +11,36 @@ npm install
 npm run start
 ```
 
-## Build
+Default preview URL is `http://localhost:3000`.
+
+## Build Static Site
 
 ```bash
 cd userdocs
 npm run build
 ```
 
-The generated static site is written to `userdocs/build/`.
+Static output is generated at `userdocs/build/`.
+
+## Serve Built Output Locally
+
+```bash
+cd userdocs
+npm run serve
+```
+
+## Deploy on Vercel (Static Hosting)
+
+Recommended project settings:
+
+- Root Directory: `userdocs`
+- Install Command: `npm install`
+- Build Command: `npm run build`
+- Output Directory: `build`
+
+## Content Organization
+
+- `docs/`: user-facing pages
+- `sidebars.js`: navigation structure
+- `docusaurus.config.js`: site-level config
+- `src/css/custom.css`: docs site styling

--- a/userdocs/docs/advanced/connection-status-and-recovery.md
+++ b/userdocs/docs/advanced/connection-status-and-recovery.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 3
+---
+
+# Connection Status and Recovery
+
+AgentHub surfaces connection health as a status badge. Use it as the first
+signal before opening low-level debug output.
+
+## Badge States
+
+- `Online · SSE connected`: stream is healthy
+- `Online · SSE connecting`: stream is opening
+- `Online · SSE reconnecting`: stream is retrying after interruption
+- `Online · SSE idle`: no active stream target selected
+- `Offline · SSE disconnected`: browser/network is offline
+
+## Error Banner vs Connection Badge
+
+Connectivity issues are intentionally represented by connection status whenever
+possible.
+
+Example:
+
+- `Connection unavailable (gateway response). Reconnecting...`
+
+This message should be reflected by badge transitions (connecting/reconnecting)
+instead of staying as a persistent error banner.
+
+## Recovery Workflow
+
+1. Check the connection badge first.
+2. If reconnecting, wait a short period for stream recovery.
+3. If still unstable, refresh the active session view.
+4. If offline, restore network and re-open AgentHub.
+5. If needed, open `Debug / Raw` to inspect transport events.
+
+## When to Escalate
+
+Escalate to backend/runtime investigation when:
+
+- Badge oscillates between `connecting` and `reconnecting` for long periods
+- Session status advances but no new output arrives
+- Multiple agents show stale stream behavior simultaneously
+
+## Related Pages
+
+- [Troubleshooting](../operations/troubleshooting.md)
+- [View Execution Output](../core/view-output.md)

--- a/userdocs/docs/advanced/openapi-and-automation.md
+++ b/userdocs/docs/advanced/openapi-and-automation.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 2
+---
+
+# OpenAPI and Automation
+
+AgentHub exposes authenticated OpenAPI discovery endpoints for integration and
+automation workflows.
+
+## Endpoints
+
+- JSON spec: `/api/openapi.json`
+- Lightweight docs page: `/api/openapi/docs`
+
+Both endpoints require authentication.
+
+## Fetch Spec With Token
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  http://localhost:8080/api/openapi.json
+```
+
+Replace `<token>` with a valid AgentHub auth token.
+
+## What You Can Automate
+
+- Team definitions and runs
+- Step lifecycle operations
+- Actor mailbox send/inbox/ack flows
+- API contract checks in CI
+
+## Integration Pattern
+
+1. Login once and get auth token.
+2. Pull OpenAPI spec.
+3. Generate typed client or API test stubs.
+4. Use generated client in scripts or internal tools.
+5. Re-sync spec after AgentHub upgrades.
+
+## Reliability Tips
+
+- Treat OpenAPI as the source of truth for payload shapes.
+- Pin generated client version per release.
+- Add contract tests for high-risk API paths.
+
+## Related Pages
+
+- [Team Workbench](./team-workbench.md)
+- [Deployment Overview and Topology](../deployment/overview-and-topology.md)

--- a/userdocs/docs/advanced/team-workbench.md
+++ b/userdocs/docs/advanced/team-workbench.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+---
+
+# Team Workbench
+
+Team Workbench (`/teams`) is the multi-agent workflow area for orchestrated
+team runs.
+
+## When to Use Team Workbench
+
+Use Team Workbench when a task is better modeled as coordinated steps across
+multiple actors, not a single linear agent session.
+
+Examples:
+
+- Planner + implementer + reviewer pipelines
+- Message-driven worker collaboration
+- Step dependencies and explicit run-state transitions
+
+## Main UI Areas
+
+- **Teams**: create/select team definitions
+- **Create / Load Run**: start new runs or load existing run IDs
+- **Active Run**: run metadata and cancel action
+- **Tabs**:
+  - `Events`: event timeline with optional auto refresh
+  - `Steps`: submit steps and apply step actions
+  - `Messages`: actor mailbox send/inbox/ack flow
+
+## Basic Workflow
+
+1. Open `/teams`.
+2. Create or select a team.
+3. Create a run with optional `context_id`.
+4. Watch `Events` for lifecycle progress.
+5. Inspect or operate `Steps` as needed.
+6. Use `Messages` for actor-level coordination.
+
+## Step Actions in UI
+
+Available actions:
+
+- `start`
+- `complete`
+- `fail`
+- `input_required`
+- `resume`
+
+Use these only when you understand the current run state and transition
+expectations.
+
+## Operational Tips
+
+- Keep team specs small for first rollout.
+- Prefer explicit step dependencies over implicit ordering assumptions.
+- Keep event logs for audit and run replay.
+- Use idempotency keys for repeated message send operations when needed.
+
+## Related Pages
+
+- [OpenAPI and Automation](./openapi-and-automation.md)
+- [Session Lifecycle](../core/session-lifecycle.md)
+- [Troubleshooting](../operations/troubleshooting.md)

--- a/userdocs/docs/deployment/overview-and-topology.md
+++ b/userdocs/docs/deployment/overview-and-topology.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 1
+---
+
+# Deployment Overview and Topology
+
+This page describes a practical deployment model for running AgentHub as a
+single service.
+
+## Architecture at a Glance
+
+AgentHub deployment is intentionally simple:
+
+- One backend process (Rust)
+- One embedded web UI served by that same process
+- One SQLite database for persisted state
+- Browser clients connected with HTTP + SSE
+
+## Runtime Components
+
+Prepare these components before rollout:
+
+1. AgentHub executable (or `cargo run` for development)
+2. A valid `config.toml`
+3. Writable runtime home (default under `~/.agenthub/`)
+4. Explicit `safe_paths` for all allowed repositories/workdirs
+
+## Deployment Modes
+
+### Local development mode
+
+Use this for daily personal work:
+
+```bash
+cd web
+npm install
+npm run build
+cd ..
+cargo run -- -c /path/to/config.toml
+```
+
+### Team internal mode
+
+Use this for shared environments:
+
+- Build and run a fixed binary
+- Run under a dedicated OS user (not root)
+- Manage process lifecycle with a supervisor (for example systemd)
+- Keep AgentHub behind an internal reverse proxy or VPN boundary
+
+## Recommended Network Shape
+
+- Reverse proxy terminates TLS and forwards to AgentHub
+- AgentHub listens on internal/private address where possible
+- Users access a single stable URL (for login, UI, and API)
+
+## Basic Startup Commands
+
+If you build a release binary:
+
+```bash
+./agenthub -c /path/to/config.toml
+```
+
+If you run from source:
+
+```bash
+cargo run -- -c /path/to/config.toml
+```
+
+## Post-Deploy Smoke Checklist
+
+1. Open AgentHub UI and verify login works.
+2. Create one agent with a safe test path.
+3. Start a short task and confirm status reaches a terminal state.
+4. Refresh browser and verify session history still exists.
+5. Confirm a path outside `safe_paths` is rejected.
+
+## Related Pages
+
+- [Production Checklist](./production-checklist.md)
+- [Troubleshooting](../operations/troubleshooting.md)
+- [Configuration Basics](../getting-started/configuration-basics.md)

--- a/userdocs/docs/deployment/production-checklist.md
+++ b/userdocs/docs/deployment/production-checklist.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 2
+---
+
+# Production Checklist
+
+Use this checklist before and after deploying AgentHub in a shared environment.
+
+## Preflight Checklist
+
+- Define explicit `safe_paths` for each team/project root.
+- Validate `worktree.default_root` exists and is writable.
+- Confirm runtime user permissions for repository paths.
+- Confirm Node/Rust build artifacts are reproducible in CI.
+- Confirm rollback plan (previous binary + config snapshot).
+
+## Security Baseline
+
+- Run AgentHub as a non-root user.
+- Keep network exposure minimal (private network + reverse proxy).
+- Use TLS at the edge.
+- Enforce strong user credentials and periodic rotation.
+- Avoid putting sensitive directories under `safe_paths`.
+
+## Data and Backup
+
+AgentHub persists runtime data under `~/.agenthub/` by default.
+
+Minimum backup targets:
+
+- `~/.agenthub/agenthub.db`
+- deployment `config.toml`
+
+Recommended cadence:
+
+- Daily snapshot for active environments
+- Extra snapshot before each upgrade
+
+## Upgrade Runbook
+
+1. Stop new task submissions.
+2. Backup `agenthub.db` and `config.toml`.
+3. Deploy new binary/config.
+4. Restart service.
+5. Run smoke checks:
+   - login
+   - create/start one test agent
+   - session replay after refresh
+6. Monitor logs for startup/runtime errors.
+
+## Failure Rollback Rule
+
+If smoke checks fail or critical flows regress:
+
+1. Restore previous binary.
+2. Restore previous config.
+3. Restore database snapshot when schema compatibility is uncertain.
+4. Re-run smoke checks before reopening service.
+
+## Related Pages
+
+- [Deployment Overview and Topology](./overview-and-topology.md)
+- [Security and Path Safety](../operations/security-and-path-safety.md)

--- a/userdocs/docs/deployment/vercel-static-userdocs.md
+++ b/userdocs/docs/deployment/vercel-static-userdocs.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+---
+
+# Deploy User Docs on Vercel (Static)
+
+This page is only for publishing the Docusaurus user documentation site.
+It does not deploy the AgentHub backend service.
+
+## Goal
+
+Use `userdocs/` as a pure static site generator and host the output on Vercel.
+
+## Local Parity Check
+
+Before pushing, verify local static build:
+
+```bash
+cd userdocs
+npm install
+npm run build
+```
+
+Build output should appear in `userdocs/build/`.
+
+## Vercel Project Settings
+
+Use these values in Vercel:
+
+- Root Directory: `userdocs`
+- Install Command: `npm install`
+- Build Command: `npm run build`
+- Output Directory: `build`
+
+## Branch Workflow Recommendation
+
+- Use preview deployments for feature branches
+- Use production deployment from your main branch
+- Review sidebar links and major pages in preview before promote
+
+## Common Failure Cases
+
+- Wrong root directory (not `userdocs`)
+- Wrong output directory (must be `build`)
+- Missing dependencies due to skipped `npm install`
+
+## Validation After Deploy
+
+1. Open the deployed URL.
+2. Navigate every sidebar category once.
+3. Confirm no broken links or 404 pages.
+4. Confirm deployment page URLs are stable after next build.
+
+## Related Pages
+
+- [AgentHub User Guide Intro](../intro.md)
+- [Troubleshooting](../operations/troubleshooting.md)

--- a/userdocs/docs/intro.md
+++ b/userdocs/docs/intro.md
@@ -14,12 +14,15 @@ This site explains how to use AgentHub from an end-user perspective.
 - Interact with running tasks and inspect structured ACP output
 - Review task history, logs, and statuses from one workspace
 - Receive completion notifications inside the app
+- Orchestrate multi-agent team runs from Team Workbench (`/teams`)
+- Integrate with OpenAPI endpoints for automation
 
 ## Who This Guide Is For
 
 - Individual developers running daily coding tasks with AI agents
 - Tech leads who need auditable agent runs and repeatable workflows
 - Teams adopting isolated worktree-based automation
+- Operators deploying AgentHub in internal environments
 
 ## Core Workflow
 
@@ -31,6 +34,14 @@ This site explains how to use AgentHub from an end-user perspective.
 
 Use the sidebar to follow this order if you are new to AgentHub.
 
+## Additional Tracks
+
+- **Deployment**: from local setup to production checklist and static docs
+  publishing
+- **Advanced Usage**: Team Workbench, OpenAPI-based integration, and connection
+  state recovery
+- **Operations**: daily runbook, security guardrails, troubleshooting, FAQ
+
 ## Reading Path Recommendation
 
 If you are new:
@@ -41,6 +52,7 @@ If you are new:
 4. `First Task Walkthrough`
 5. `Workdir and Worktree Strategy`
 6. `Task Instruction Patterns`
+7. `Daily Operations Checklist`
 
 If you already run agents daily:
 
@@ -48,3 +60,11 @@ If you already run agents daily:
 2. `Review and Apply Changes`
 3. `Troubleshooting`
 4. `FAQ`
+5. `Connection Status and Recovery`
+
+If you manage deployment/integration:
+
+1. `Deployment Overview and Topology`
+2. `Production Checklist`
+3. `OpenAPI and Automation`
+4. `Deploy User Docs on Vercel (Static)`

--- a/userdocs/docs/operations/troubleshooting.md
+++ b/userdocs/docs/operations/troubleshooting.md
@@ -31,6 +31,7 @@ Typical causes:
 ## No Output or Stale Output
 
 - Re-open the session and check status in agent cards
+- Check connection badge state in header (`connected` / `connecting` / `reconnecting`)
 - Switch to Debug/Raw output tabs for transport-level events
 - Verify server process is still alive
 
@@ -39,6 +40,8 @@ Recovery action:
 1. Keep the current failed session for evidence
 2. Create a fresh session with the same prompt
 3. Compare behavior and isolate environment differences
+
+See also: [Connection Status and Recovery](../advanced/connection-status-and-recovery.md)
 
 ## Worktree Problems
 
@@ -51,3 +54,4 @@ Recovery action:
 1. Keep the session for audit and replay
 2. Create a fresh run with a clean workdir/worktree
 3. Replay the prompt sequence in smaller steps
+4. If issue persists, verify deployment checklist and runtime config consistency

--- a/userdocs/sidebars.js
+++ b/userdocs/sidebars.js
@@ -31,6 +31,24 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Deployment',
+      items: [
+        'deployment/overview-and-topology',
+        'deployment/production-checklist',
+        'deployment/vercel-static-userdocs',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Advanced Usage',
+      items: [
+        'advanced/team-workbench',
+        'advanced/openapi-and-automation',
+        'advanced/connection-status-and-recovery',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Operations',
       items: [
         'operations/daily-operations-checklist',


### PR DESCRIPTION
## Summary

This PR improves documentation discoverability and practical usability across repository-level docs and the Docusaurus user docs site.

## What changed

### 1) Refresh root docs entry points
- Reworked `README.md` to make onboarding and navigation clearer:
  - capability overview
  - docs map
  - quick start
  - config baseline
  - common development commands
  - proto codegen guard
  - repository layout
- Added `docs/README.md` as an internal docs index and maintenance checklist.
- Expanded `userdocs/README.md` with static-site usage and explicit Vercel static hosting settings.

### 2) Expand userdocs information architecture
- Added two new sidebar categories in `userdocs/sidebars.js`:
  - `Deployment`
  - `Advanced Usage`
- Added new deployment pages:
  - `userdocs/docs/deployment/overview-and-topology.md`
  - `userdocs/docs/deployment/production-checklist.md`
  - `userdocs/docs/deployment/vercel-static-userdocs.md`
- Added new advanced usage pages:
  - `userdocs/docs/advanced/team-workbench.md`
  - `userdocs/docs/advanced/openapi-and-automation.md`
  - `userdocs/docs/advanced/connection-status-and-recovery.md`
- Updated existing docs to align with new navigation:
  - `userdocs/docs/intro.md`
  - `userdocs/docs/operations/troubleshooting.md`

### 3) Keep internal docs process aligned
- Added feature notes:
  - `docs/features/2026-02-16-readme-docs-structure-refresh.md`
  - `docs/features/2026-02-16-userdocs-deployment-advanced-expansion.md`
- Added follow-up verification items in `docs/todo.md`.

## Why

- Reduce onboarding friction for contributors and users.
- Make deployment and advanced operation guidance explicit rather than implicit.
- Keep docs updates traceable and aligned with the repository docs governance.

## Validation

```bash
cd userdocs
npm run build
```

Build succeeds and generates static files at `userdocs/build/`.

## Risk

- Low risk: docs-only changes, no runtime code or API behavior changes.
