### PR TITLE
feat: add team snapshot api and member console workbench

### DIFF
--- a/docs/features/2026-02-16-team-snapshot-member-console.md
+++ b/docs/features/2026-02-16-team-snapshot-member-console.md
@@ -1,0 +1,56 @@
+# Team Snapshot And Member Console
+
+## Background
+
+The standalone `/teams` workbench exists, but team-level observability is fragmented:
+
+- Team create is JSON-first and does not provide a guided leader/worker authoring flow.
+- The UI fetches run/events/steps/mailbox separately, which makes member status and mailbox
+  overview harder to reason about.
+- There is no direct member-centric output console to inspect worker/leader session output.
+
+## Scope
+
+- Extend Team spec validation to support richer member metadata:
+  - `leader_member_id`
+  - `spec.members[].role` (`leader` / `worker`)
+  - `spec.members[].model`
+  - `spec.members[].prompt`
+  - `spec.members[].skills`
+- Add Team run snapshot API:
+  - `GET /api/teams/runs/{run_id}/snapshot`
+  - Returns run/team/steps/latest events/mailbox summary/member snapshots in one payload.
+- Expose snapshot API in OpenAPI and Team API client wrappers.
+- Update `/teams` page:
+  - Guided create-team form for leader + workers (with model/prompt/skills)
+  - Output tabs: `Overview`, `Events`, `Steps`, `Mailbox`, `Member Console`
+  - Member Console fetches agent event stream for selected member session.
+
+## Key Decisions
+
+- Keep compatibility with existing orchestrator bootstrap:
+  - `entrypoint` + `members` remain valid as before.
+  - Rich member fields are additive and validated for shape/consistency.
+- Use a dedicated snapshot endpoint to reduce front-end fan-out and align the UI around
+  one server-side aggregated run view.
+- Keep Team page as an independent workspace (`/teams`) and avoid cross-coupling with
+  Agent workspace state.
+
+## Validation
+
+Suggested checks:
+
+```bash
+cargo test team_run_snapshot_api_returns_member_status_and_mailbox_summary -- --nocapture
+cargo test teams_router_http_contract -- --nocapture
+cargo test openapi_json_contains_team_runs_list_path -- --nocapture
+npm --prefix web run lint
+npm --prefix web run build
+```
+
+Manual checks:
+
+1. Create a team using leader/worker form fields and confirm generated spec is accepted.
+2. Create a run and verify `Overview` shows member status/mailbox counters.
+3. Send mailbox messages and verify `Mailbox` tab summary and list update.
+4. Select a member with an active session and verify `Member Console` shows agent events.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -65,6 +65,8 @@
 - [x] Restore `npm ci` in workflows after updating `web/package-lock.json` (see `docs/features/2026-02-12-codecov-ci.md`).
 - [x] Verify A2A Agent Team phase-1 APIs and event ordering (see `docs/features/2026-02-12-a2a-agent-team-phase1.md`).
 - [ ] Verify Team Workbench UI (`/teams`) create/run/step/message interaction flow end-to-end in a real browser (see `docs/features/2026-02-16-team-workbench-ui.md`).
+- [ ] Verify Team create flow supports structured leader/worker config (`leader_member_id`, per-member `model`/`prompt`/`skills`) and generated spec remains compatible with run bootstrap/orchestrator dispatch (see `docs/features/2026-02-16-team-snapshot-member-console.md`).
+- [ ] Verify Team run snapshot API (`GET /api/teams/runs/:run_id/snapshot`) and `/teams` Overview/Mailbox/Member Console tabs stay consistent under active run updates (see `docs/features/2026-02-16-team-snapshot-member-console.md`).
 - [ ] Verify Team run list API (`GET /api/teams/:id/runs`) pagination/filter behavior in staging with real run volumes (see `docs/features/2026-02-16-team-runs-list-api.md`).
 - [ ] Verify OpenAPI discovery endpoints (`/api/openapi.json`, `/api/openapi/docs`) auth behavior and docs-page token fetch flow in a real browser (see `docs/features/2026-02-16-openapi-discovery-endpoints.md`).
 - [ ] Refactor `web/src/pages/team_page.tsx` into smaller feature-focused components (`TeamSidebar`, `RunPanel`, tab subviews) and a reducer-based state model for maintainability (see `docs/features/2026-02-16-team-workbench-ui.md`).

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -146,6 +146,72 @@ fn openapi_spec() -> Value {
               "delivered_at": { "type": ["integer", "null"], "format": "int64" }
             }
           },
+          "TeamMailboxSnapshot": {
+            "type": "object",
+            "required": ["pending", "delivered", "dead_letter", "recent_messages"],
+            "properties": {
+              "pending": { "type": "integer", "format": "int64" },
+              "delivered": { "type": "integer", "format": "int64" },
+              "dead_letter": { "type": "integer", "format": "int64" },
+              "recent_messages": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+              }
+            }
+          },
+          "TeamMemberSnapshot": {
+            "type": "object",
+            "required": [
+              "member_id",
+              "role",
+              "skills",
+              "pending_inbox_count",
+              "status"
+            ],
+            "properties": {
+              "member_id": { "type": "string" },
+              "role": { "type": "string", "enum": ["leader", "worker"] },
+              "model": { "type": ["string", "null"] },
+              "prompt": { "type": ["string", "null"] },
+              "skills": { "type": "array", "items": { "type": "string" } },
+              "pending_inbox_count": { "type": "integer", "format": "int64" },
+              "status": { "type": "string" },
+              "latest_step": {
+                "allOf": [{ "$ref": "#/components/schemas/TeamStepRecord" }],
+                "nullable": true
+              },
+              "session_status": { "type": ["string", "null"] }
+            }
+          },
+          "TeamRunSnapshotResponse": {
+            "type": "object",
+            "required": [
+              "run",
+              "team",
+              "members",
+              "steps",
+              "latest_events",
+              "mailbox"
+            ],
+            "properties": {
+              "run": { "$ref": "#/components/schemas/TeamRunRecord" },
+              "team": { "$ref": "#/components/schemas/TeamDefinitionRecord" },
+              "leader_member_id": { "type": ["string", "null"] },
+              "members": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/TeamMemberSnapshot" }
+              },
+              "steps": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/TeamStepRecord" }
+              },
+              "latest_events": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/TeamRunEventRecord" }
+              },
+              "mailbox": { "$ref": "#/components/schemas/TeamMailboxSnapshot" }
+            }
+          },
           "CreateTeamRequest": {
             "type": "object",
             "required": ["name", "spec"],
@@ -386,6 +452,27 @@ fn openapi_spec() -> Value {
                 "content": {
                   "application/json": {
                     "schema": { "$ref": "#/components/schemas/TeamRunRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/runs/{run_id}/snapshot": {
+          "get": {
+            "tags": ["teams"],
+            "summary": "Get run snapshot",
+            "parameters": [
+              { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "event_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } },
+              { "name": "message_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } }
+            ],
+            "responses": {
+              "200": {
+                "description": "Run snapshot",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/TeamRunSnapshotResponse" }
                   }
                 }
               }
@@ -816,5 +903,6 @@ mod tests {
         let value: Value = serde_json::from_slice(&bytes).expect("decode openapi json");
         assert_eq!(value["openapi"], Value::from("3.0.3"));
         assert!(value["paths"]["/api/teams/{id}/runs"].is_object());
+        assert!(value["paths"]["/api/teams/runs/{run_id}/snapshot"].is_object());
     }
 }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -7,7 +7,7 @@ use axum::{
     http::HeaderMap,
     routing::{get, post},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Error as SqlxError;
 
@@ -17,7 +17,7 @@ use crate::state::AppState;
 use crate::team::{
     TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport,
     TeamDefinitionConfig, TeamDefinitionRecord, TeamManager, TeamRunEventRecord, TeamRunRecord,
-    TeamStepRecord,
+    TeamStepRecord, TeamStepStatus,
 };
 
 const TEAM_SPEC_VERSION_V1: i64 = 1;
@@ -48,6 +48,12 @@ pub struct ListTeamRunsQuery {
 pub struct ListTeamRunEventsQuery {
     pub limit: Option<i64>,
     pub before_id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TeamRunSnapshotQuery {
+    pub event_limit: Option<i64>,
+    pub message_limit: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,6 +114,38 @@ pub struct AckTeamRunMessageRequest {
     pub actor_id: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct TeamRunSnapshotResponse {
+    pub run: TeamRunRecord,
+    pub team: TeamDefinitionRecord,
+    pub leader_member_id: Option<String>,
+    pub members: Vec<TeamMemberSnapshot>,
+    pub steps: Vec<TeamStepRecord>,
+    pub latest_events: Vec<TeamRunEventRecord>,
+    pub mailbox: TeamMailboxSnapshot,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamMemberSnapshot {
+    pub member_id: String,
+    pub role: String,
+    pub model: Option<String>,
+    pub prompt: Option<String>,
+    pub skills: Vec<String>,
+    pub pending_inbox_count: i64,
+    pub status: String,
+    pub latest_step: Option<TeamStepRecord>,
+    pub session_status: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamMailboxSnapshot {
+    pub pending: i64,
+    pub delivered: i64,
+    pub dead_letter: i64,
+    pub recent_messages: Vec<TeamActorMessageRecord>,
+}
+
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/", post(create_team).get(list_teams))
@@ -115,6 +153,7 @@ pub fn router(state: AppState) -> Router {
         .route("/:id/runs", post(create_team_run).get(list_team_runs))
         .route("/runs/:run_id", get(get_team_run))
         .route("/runs/:run_id/cancel", post(cancel_team_run))
+        .route("/runs/:run_id/snapshot", get(get_team_run_snapshot))
         .route("/runs/:run_id/events", get(list_team_run_events))
         .route(
             "/runs/:run_id/steps",
@@ -270,6 +309,121 @@ async fn cancel_team_run(
         .await
         .map_err(|err| map_not_found_error(err, "run not found"))?;
     Ok(Json(run))
+}
+
+async fn get_team_run_snapshot(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(run_id): Path<String>,
+    Query(query): Query<TeamRunSnapshotQuery>,
+) -> Result<Json<TeamRunSnapshotResponse>, ApiError> {
+    let _user = require_user(&headers, &state).await?;
+
+    let run = state
+        .teams
+        .get_run(&run_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "run not found"))?;
+    let team = state
+        .teams
+        .get_team(&run.team_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    validate_team_spec(&team.spec)?;
+
+    let spec_obj = team
+        .spec
+        .as_object()
+        .ok_or_else(|| ApiError::bad_request("spec must be an object"))?;
+    let member_specs = parse_member_specs(spec_obj.get("members"))?;
+    let leader_member_id = parse_spec_leader_member_id(spec_obj, &member_specs)?;
+
+    let steps = state
+        .teams
+        .list_steps(&run_id)
+        .await
+        .map_err(map_team_internal_error)?;
+    let latest_step_by_member = index_latest_steps_by_member(&steps);
+
+    let pending_counts = state
+        .teams
+        .list_actor_pending_counts_by_actor(&run_id)
+        .await
+        .map_err(map_team_internal_error)?;
+    let status_counts = state
+        .teams
+        .list_actor_message_status_counts(&run_id)
+        .await
+        .map_err(map_team_internal_error)?;
+
+    let event_limit = query.event_limit.unwrap_or(120).clamp(1, 500);
+    let message_limit = query.message_limit.unwrap_or(120).clamp(1, 500);
+    let latest_events = state
+        .teams
+        .list_run_events(&run_id, event_limit, None)
+        .await
+        .map_err(map_team_internal_error)?;
+    let recent_messages = state
+        .teams
+        .list_actor_messages_for_run(&run_id, message_limit)
+        .await
+        .map_err(map_team_internal_error)?;
+
+    let mut members = Vec::with_capacity(member_specs.len());
+    for member in member_specs {
+        let latest_step = latest_step_by_member
+            .get(member.member_id.as_str())
+            .cloned();
+        let session_status = if let Some(session_id) = latest_step
+            .as_ref()
+            .and_then(|step| step.remote_task_id.as_deref())
+        {
+            state
+                .teams
+                .get_agent_session_status(session_id)
+                .await
+                .map_err(map_team_internal_error)?
+        } else {
+            None
+        };
+        let status = latest_step
+            .as_ref()
+            .map(|step| step_status_to_str(&step.status).to_string())
+            .unwrap_or_else(|| "idle".to_string());
+        let role = if leader_member_id.as_deref() == Some(member.member_id.as_str()) {
+            "leader"
+        } else {
+            member.role.as_deref().unwrap_or("worker")
+        };
+        members.push(TeamMemberSnapshot {
+            member_id: member.member_id.clone(),
+            role: role.to_string(),
+            model: member.model.clone(),
+            prompt: member.prompt.clone(),
+            skills: member.skills.clone(),
+            pending_inbox_count: pending_counts.get(&member.member_id).copied().unwrap_or(0),
+            status,
+            latest_step,
+            session_status,
+        });
+    }
+
+    let mailbox = TeamMailboxSnapshot {
+        pending: status_counts.get("pending").copied().unwrap_or(0),
+        delivered: status_counts.get("delivered").copied().unwrap_or(0),
+        dead_letter: status_counts.get("dead_letter").copied().unwrap_or(0),
+        recent_messages,
+    };
+
+    Ok(Json(TeamRunSnapshotResponse {
+        run,
+        team,
+        leader_member_id,
+        members,
+        steps,
+        latest_events,
+        mailbox,
+    }))
 }
 
 async fn list_team_run_events(
@@ -749,6 +903,15 @@ struct TeamStepSpec {
     depends_on: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+struct TeamMemberSpec {
+    member_id: String,
+    role: Option<String>,
+    model: Option<String>,
+    prompt: Option<String>,
+    skills: Vec<String>,
+}
+
 fn normalize_team_spec(spec: &mut Value) -> Result<(), ApiError> {
     let spec_obj = spec
         .as_object_mut()
@@ -769,7 +932,12 @@ fn validate_team_spec(spec: &Value) -> Result<(), ApiError> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| ApiError::bad_request("spec.entrypoint is required"))?;
-    let member_ids = parse_member_ids(spec_obj.get("members"))?;
+    let member_specs = parse_member_specs(spec_obj.get("members"))?;
+    let member_ids = member_specs
+        .iter()
+        .map(|member| member.member_id.clone())
+        .collect::<HashSet<_>>();
+    let leader_member_id = parse_spec_leader_member_id(spec_obj, &member_specs)?;
 
     if let Some(steps_value) = spec_obj.get("steps") {
         validate_steps(entrypoint, steps_value, &member_ids)?;
@@ -777,6 +945,12 @@ fn validate_team_spec(spec: &Value) -> Result<(), ApiError> {
         return Err(ApiError::bad_request(
             "spec.entrypoint must reference spec.members[].member_id when spec.steps is omitted",
         ));
+    } else if let Some(leader_id) = leader_member_id.as_deref() {
+        if entrypoint != leader_id {
+            return Err(ApiError::bad_request(
+                "spec.entrypoint must equal leader_member_id when spec.steps is omitted",
+            ));
+        }
     }
 
     Ok(())
@@ -798,6 +972,14 @@ fn parse_team_spec_version(version_value: Option<&Value>) -> Result<i64, ApiErro
 }
 
 fn parse_member_ids(members_value: Option<&Value>) -> Result<HashSet<String>, ApiError> {
+    let member_specs = parse_member_specs(members_value)?;
+    Ok(member_specs
+        .into_iter()
+        .map(|member| member.member_id)
+        .collect())
+}
+
+fn parse_member_specs(members_value: Option<&Value>) -> Result<Vec<TeamMemberSpec>, ApiError> {
     let members = members_value
         .and_then(Value::as_array)
         .ok_or_else(|| ApiError::bad_request("spec.members must be an array"))?;
@@ -805,7 +987,8 @@ fn parse_member_ids(members_value: Option<&Value>) -> Result<HashSet<String>, Ap
         return Err(ApiError::bad_request("spec.members must not be empty"));
     }
 
-    let mut member_ids = HashSet::with_capacity(members.len());
+    let mut seen_member_ids = HashSet::with_capacity(members.len());
+    let mut out = Vec::with_capacity(members.len());
     for member in members {
         let member = member
             .as_object()
@@ -815,14 +998,160 @@ fn parse_member_ids(members_value: Option<&Value>) -> Result<HashSet<String>, Ap
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| ApiError::bad_request("spec.members[].member_id is required"))?;
-        if !member_ids.insert(member_id.to_string()) {
+            .ok_or_else(|| ApiError::bad_request("spec.members[].member_id is required"))?
+            .to_string();
+        if !seen_member_ids.insert(member_id.clone()) {
             return Err(ApiError::bad_request(
                 "spec.members[].member_id must be unique",
             ));
         }
+
+        let role = parse_optional_member_role(member.get("role"))?;
+        let model = parse_optional_member_text(member.get("model"), "model")?;
+        let prompt = parse_optional_member_text(member.get("prompt"), "prompt")?;
+        let skills = parse_optional_member_skills(member.get("skills"))?;
+
+        out.push(TeamMemberSpec {
+            member_id,
+            role,
+            model,
+            prompt,
+            skills,
+        });
     }
-    Ok(member_ids)
+    Ok(out)
+}
+
+fn parse_optional_member_text(
+    value: Option<&Value>,
+    field: &str,
+) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let raw = value.as_str().ok_or_else(|| {
+        ApiError::bad_request(&format!(
+            "spec.members[].{field} must be a non-empty string when provided"
+        ))
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ApiError::bad_request(&format!(
+            "spec.members[].{field} must be a non-empty string when provided"
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+fn parse_optional_member_role(value: Option<&Value>) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let raw = value
+        .as_str()
+        .ok_or_else(|| ApiError::bad_request("spec.members[].role must be 'leader' or 'worker'"))?
+        .trim();
+    if raw.is_empty() {
+        return Err(ApiError::bad_request(
+            "spec.members[].role must be 'leader' or 'worker'",
+        ));
+    }
+    if raw != "leader" && raw != "worker" {
+        return Err(ApiError::bad_request(
+            "spec.members[].role must be 'leader' or 'worker'",
+        ));
+    }
+    Ok(Some(raw.to_string()))
+}
+
+fn parse_optional_member_skills(value: Option<&Value>) -> Result<Vec<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let skills = value
+        .as_array()
+        .ok_or_else(|| ApiError::bad_request("spec.members[].skills must be an array"))?;
+    let mut out = Vec::with_capacity(skills.len());
+    let mut seen = HashSet::with_capacity(skills.len());
+    for skill in skills {
+        let skill = skill
+            .as_str()
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .ok_or_else(|| {
+                ApiError::bad_request("spec.members[].skills entries must be non-empty strings")
+            })?;
+        if !seen.insert(skill.to_string()) {
+            return Err(ApiError::bad_request(
+                "spec.members[].skills must not contain duplicates",
+            ));
+        }
+        out.push(skill.to_string());
+    }
+    Ok(out)
+}
+
+fn parse_spec_leader_member_id(
+    spec_obj: &serde_json::Map<String, Value>,
+    member_specs: &[TeamMemberSpec],
+) -> Result<Option<String>, ApiError> {
+    let member_ids = member_specs
+        .iter()
+        .map(|member| member.member_id.as_str())
+        .collect::<HashSet<_>>();
+    let explicit_leader = match spec_obj.get("leader_member_id") {
+        None => None,
+        Some(value) => {
+            let leader = value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    ApiError::bad_request("spec.leader_member_id must be a non-empty string")
+                })?;
+            if !member_ids.contains(leader) {
+                return Err(ApiError::bad_request(
+                    "spec.leader_member_id must reference spec.members[].member_id",
+                ));
+            }
+            Some(leader.to_string())
+        }
+    };
+
+    let member_role_leaders = member_specs
+        .iter()
+        .filter_map(|member| match member.role.as_deref() {
+            Some("leader") => Some(member.member_id.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if member_role_leaders.len() > 1 {
+        return Err(ApiError::bad_request(
+            "spec.members[].role may include at most one 'leader'",
+        ));
+    }
+
+    if let Some(explicit) = explicit_leader.as_deref() {
+        if let Some(role_leader) = member_role_leaders.first() {
+            if explicit != *role_leader {
+                return Err(ApiError::bad_request(
+                    "spec.leader_member_id must match spec.members[].role='leader'",
+                ));
+            }
+        }
+        return Ok(Some(explicit.to_string()));
+    }
+
+    if let Some(role_leader) = member_role_leaders.first() {
+        return Ok(Some((*role_leader).to_string()));
+    }
+
+    let entrypoint_member = spec_obj
+        .get("entrypoint")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| member_ids.contains(value));
+    Ok(entrypoint_member.map(str::to_string))
 }
 
 fn validate_steps(
@@ -972,6 +1301,45 @@ fn ensure_acyclic_steps(steps: &[TeamStepSpec]) -> Result<(), ApiError> {
         Err(ApiError::bad_request(
             "spec.steps must form an acyclic dependency graph",
         ))
+    }
+}
+
+fn index_latest_steps_by_member(steps: &[TeamStepRecord]) -> HashMap<&str, TeamStepRecord> {
+    let mut by_member: HashMap<&str, TeamStepRecord> = HashMap::new();
+    for step in steps {
+        let key = step.member_id.as_str();
+        match by_member.get(key) {
+            None => {
+                by_member.insert(key, step.clone());
+            }
+            Some(existing) => {
+                if step_order_tuple(step) > step_order_tuple(existing) {
+                    by_member.insert(key, step.clone());
+                }
+            }
+        }
+    }
+    by_member
+}
+
+fn step_order_tuple(step: &TeamStepRecord) -> (i64, i64, i64) {
+    let ts = step.ended_at.or(step.started_at).unwrap_or(0);
+    let active_rank = match step.status {
+        TeamStepStatus::Working | TeamStepStatus::InputRequired => 2,
+        TeamStepStatus::Submitted => 1,
+        TeamStepStatus::Completed | TeamStepStatus::Failed | TeamStepStatus::Canceled => 0,
+    };
+    (active_rank, ts, step.attempt)
+}
+
+fn step_status_to_str(status: &TeamStepStatus) -> &'static str {
+    match status {
+        TeamStepStatus::Submitted => "submitted",
+        TeamStepStatus::Working => "working",
+        TeamStepStatus::InputRequired => "input_required",
+        TeamStepStatus::Completed => "completed",
+        TeamStepStatus::Failed => "failed",
+        TeamStepStatus::Canceled => "canceled",
     }
 }
 

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -28,11 +28,11 @@ use super::{
     AckTeamRunMessageRequest, CompleteTeamRunStepRequest, CreateTeamRequest, CreateTeamRunRequest,
     FailTeamRunStepRequest, ListTeamRunEventsQuery, ListTeamRunInboxQuery, ListTeamRunsQuery,
     ResumeTeamRunStepRequest, SendTeamRunMessageRequest, SetTeamRunStepInputRequiredRequest,
-    StartTeamRunStepRequest, SubmitTeamRunStepRequest, ack_team_run_message, cancel_team_run,
-    complete_team_run_step, create_team, create_team_run, fail_team_run_step, get_team,
-    get_team_run, list_team_run_events, list_team_run_inbox, list_team_run_steps, list_team_runs,
-    list_teams, resume_team_run_step, send_team_run_message, set_team_run_step_input_required,
-    start_team_run_step, submit_team_run_step,
+    StartTeamRunStepRequest, SubmitTeamRunStepRequest, TeamRunSnapshotQuery, ack_team_run_message,
+    cancel_team_run, complete_team_run_step, create_team, create_team_run, fail_team_run_step,
+    get_team, get_team_run, get_team_run_snapshot, list_team_run_events, list_team_run_inbox,
+    list_team_run_steps, list_team_runs, list_teams, resume_team_run_step, send_team_run_message,
+    set_team_run_step_input_required, start_team_run_step, submit_team_run_step,
 };
 
 pub(crate) async fn build_test_state() -> AppState {

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -74,6 +74,10 @@ async fn teams_api_rejects_invalid_spec() {
         json!({"entrypoint":"step-a","members":[{"member_id":"planner"}],"steps":[{"step_key":"step-a","member_id":"planner","depends_on":["step-b"]},{"step_key":"step-b","member_id":"planner","depends_on":["step-a"]}]}),
         json!({"spec_version":"1","entrypoint":"planner","members":[{"member_id":"planner"}]}),
         json!({"spec_version":2,"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        json!({"entrypoint":"planner","leader_member_id":"missing","members":[{"member_id":"planner"}]}),
+        json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"captain"}]}),
+        json!({"entrypoint":"planner","members":[{"member_id":"planner","skills":["a","a"]}]}),
+        json!({"entrypoint":"planner","leader_member_id":"leader","members":[{"member_id":"planner"},{"member_id":"leader"}]}),
     ];
     for (index, spec) in invalid_specs.into_iter().enumerate() {
         let err = create_team(
@@ -1256,4 +1260,187 @@ async fn team_run_messages_api_supports_idempotency_key() {
         invalid_idempotency_err.into_response().status(),
         StatusCode::BAD_REQUEST
     );
+}
+
+#[tokio::test]
+async fn team_run_snapshot_api_returns_member_status_and_mailbox_summary() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "snapshot-team".to_string(),
+            description: Some("team snapshot coverage".to_string()),
+            spec: json!({
+                "entrypoint":"leader-agent",
+                "leader_member_id":"leader-agent",
+                "members":[
+                    {
+                        "member_id":"leader-agent",
+                        "role":"leader",
+                        "model":"gpt-5",
+                        "prompt":"Lead the plan",
+                        "skills":["planning","review"]
+                    },
+                    {
+                        "member_id":"worker-agent",
+                        "role":"worker",
+                        "model":"gpt-4.1",
+                        "prompt":"Execute tasks",
+                        "skills":["coding"]
+                    }
+                ]
+            }),
+        }),
+    )
+    .await
+    .expect("create snapshot team");
+
+    let Json(run) = create_team_run(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-snapshot".to_string()),
+            input: Some(json!({"goal":"ship feature"})),
+        }),
+    )
+    .await
+    .expect("create snapshot run");
+
+    let Json(step) = submit_team_run_step(
+        State(state.clone()),
+        headers.clone(),
+        Path(run.id.clone()),
+        Json(SubmitTeamRunStepRequest {
+            step_key: "plan-step".to_string(),
+            member_id: "leader-agent".to_string(),
+            depends_on: Some(vec![]),
+            input: Some(json!({"task":"plan"})),
+        }),
+    )
+    .await
+    .expect("submit snapshot step");
+
+    let Json(_started) = start_team_run_step(
+        State(state.clone()),
+        headers.clone(),
+        Path((run.id.clone(), step.id.clone())),
+        Json(StartTeamRunStepRequest {
+            remote_task_id: Some("session-leader-1".to_string()),
+        }),
+    )
+    .await
+    .expect("start snapshot step");
+
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, status, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 0, ?7, ?8, ?9)
+        "#,
+    )
+    .bind("leader-agent")
+    .bind("leader-agent")
+    .bind("/tmp")
+    .bind("/bin/sh")
+    .bind("[]")
+    .bind("use_existing")
+    .bind("running")
+    .bind(now)
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .expect("insert leader agent row");
+
+    sqlx::query(
+        r#"
+        INSERT INTO agent_sessions (id, agent_id, status, started_at)
+        VALUES (?1, ?2, ?3, ?4)
+        "#,
+    )
+    .bind("session-leader-1")
+    .bind("leader-agent")
+    .bind("working")
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .expect("insert agent session for snapshot");
+
+    let Json(_message) = send_team_run_message(
+        State(state.clone()),
+        headers.clone(),
+        Path(run.id.clone()),
+        Json(SendTeamRunMessageRequest {
+            from_actor_id: "leader-agent".to_string(),
+            to_actor_id: "worker-agent".to_string(),
+            channel: Some("coordination".to_string()),
+            transport: Some("local".to_string()),
+            route: None,
+            payload: json!({"kind":"assign","text":"implement"}),
+            idempotency_key: Some("snapshot-msg-1".to_string()),
+        }),
+    )
+    .await
+    .expect("send snapshot message");
+
+    let Json(snapshot) = get_team_run_snapshot(
+        State(state.clone()),
+        headers.clone(),
+        Path(run.id.clone()),
+        Query(TeamRunSnapshotQuery {
+            event_limit: Some(100),
+            message_limit: Some(100),
+        }),
+    )
+    .await
+    .expect("get team run snapshot");
+
+    assert_eq!(snapshot.run.id, run.id);
+    assert_eq!(snapshot.team.id, team.id);
+    assert_eq!(
+        snapshot.leader_member_id.as_deref(),
+        Some("leader-agent")
+    );
+    assert_eq!(snapshot.members.len(), 2);
+    assert!(snapshot.latest_events.len() >= 3);
+    assert_eq!(snapshot.mailbox.pending, 1);
+    assert_eq!(snapshot.mailbox.delivered, 0);
+    assert_eq!(snapshot.mailbox.dead_letter, 0);
+    assert_eq!(snapshot.mailbox.recent_messages.len(), 1);
+
+    let leader = snapshot
+        .members
+        .iter()
+        .find(|member| member.member_id == "leader-agent")
+        .expect("find leader");
+    assert_eq!(leader.role, "leader");
+    assert_eq!(leader.model.as_deref(), Some("gpt-5"));
+    assert_eq!(leader.prompt.as_deref(), Some("Lead the plan"));
+    assert_eq!(leader.skills, vec!["planning".to_string(), "review".to_string()]);
+    assert_eq!(leader.pending_inbox_count, 0);
+    assert_eq!(leader.status, "working");
+    assert_eq!(leader.session_status.as_deref(), Some("working"));
+    assert_eq!(
+        leader
+            .latest_step
+            .as_ref()
+            .and_then(|step| step.remote_task_id.as_deref()),
+        Some("session-leader-1")
+    );
+
+    let worker = snapshot
+        .members
+        .iter()
+        .find(|member| member.member_id == "worker-agent")
+        .expect("find worker");
+    assert_eq!(worker.role, "worker");
+    assert_eq!(worker.model.as_deref(), Some("gpt-4.1"));
+    assert_eq!(worker.pending_inbox_count, 1);
+    assert_eq!(worker.status, "idle");
+    assert!(worker.latest_step.is_none());
 }

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -103,6 +103,22 @@ async fn teams_router_http_contract() {
     let run_id = run["id"].as_str().expect("run id").to_string();
     assert_eq!(run["status"], "submitted");
 
+    let snapshot_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/runs/{run_id}/snapshot?event_limit=100&message_limit=100"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("get run snapshot via router");
+    assert_eq!(snapshot_resp.status(), StatusCode::OK);
+    let snapshot = decode_json_body(snapshot_resp).await;
+    assert_eq!(snapshot["run"]["id"], run_id);
+    assert_eq!(snapshot["mailbox"]["pending"], Value::from(0));
+    assert_eq!(snapshot["members"][0]["member_id"], "planner");
+
     let list_runs_resp = app
         .clone()
         .oneshot(build_json_request(

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -4,6 +4,8 @@ mod mailbox;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashMap;
+
 use chrono::Utc;
 use serde_json::Value;
 use sqlx::{QueryBuilder, Row, SqlitePool};
@@ -12,12 +14,12 @@ use uuid::Uuid;
 pub use mailbox::TeamRemoteRelayWorkerSettings;
 
 use self::codec::{
-    parse_run_event_row, parse_team_definition_row, parse_team_run_row, parse_team_step_row,
-    team_run_status_to_str, team_step_status_to_str,
+    parse_run_event_row, parse_team_actor_message_row, parse_team_definition_row,
+    parse_team_run_row, parse_team_step_row, team_run_status_to_str, team_step_status_to_str,
 };
 use super::{
-    TeamDefinitionConfig, TeamDefinitionRecord, TeamRunEventRecord, TeamRunRecord, TeamRunStatus,
-    TeamStepRecord, TeamStepStatus,
+    TeamActorMessageRecord, TeamDefinitionConfig, TeamDefinitionRecord, TeamRunEventRecord,
+    TeamRunRecord, TeamRunStatus, TeamStepRecord, TeamStepStatus,
 };
 
 #[derive(Clone)]
@@ -1035,5 +1037,92 @@ impl TeamManager {
         }
         events.reverse();
         Ok(events)
+    }
+
+    pub async fn list_actor_messages_for_run(
+        &self,
+        run_id: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<TeamActorMessageRecord>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id,
+                run_id,
+                from_actor_id,
+                to_actor_id,
+                channel,
+                transport,
+                route_json,
+                payload_json,
+                status,
+                created_at,
+                delivered_at
+            FROM team_actor_messages
+            WHERE run_id = ?1
+            ORDER BY id DESC
+            LIMIT ?2
+            "#,
+        )
+        .bind(run_id)
+        .bind(limit.max(1))
+        .fetch_all(&self.db)
+        .await?;
+        let mut messages = Vec::with_capacity(rows.len());
+        for row in rows {
+            messages.push(parse_team_actor_message_row(&row)?);
+        }
+        Ok(messages)
+    }
+
+    pub async fn list_actor_message_status_counts(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<HashMap<String, i64>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT status, COUNT(*) AS cnt
+            FROM team_actor_messages
+            WHERE run_id = ?1
+            GROUP BY status
+            "#,
+        )
+        .bind(run_id)
+        .fetch_all(&self.db)
+        .await?;
+
+        let mut counts = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let status: String = row.get("status");
+            let count: i64 = row.get("cnt");
+            counts.insert(status, count);
+        }
+        Ok(counts)
+    }
+
+    pub async fn list_actor_pending_counts_by_actor(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<HashMap<String, i64>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT to_actor_id, COUNT(*) AS cnt
+            FROM team_actor_messages
+            WHERE run_id = ?1
+              AND status = 'pending'
+            GROUP BY to_actor_id
+            "#,
+        )
+        .bind(run_id)
+        .fetch_all(&self.db)
+        .await?;
+
+        let mut counts = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let actor_id: String = row.get("to_actor_id");
+            let count: i64 = row.get("cnt");
+            counts.insert(actor_id, count);
+        }
+        Ok(counts)
     }
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -203,6 +203,35 @@ export type TeamActorMessageRecord = {
   delivered_at?: number | null;
 };
 
+export type TeamMemberSnapshot = {
+  member_id: string;
+  role: string;
+  model?: string | null;
+  prompt?: string | null;
+  skills: string[];
+  pending_inbox_count: number;
+  status: string;
+  latest_step?: TeamStepRecord | null;
+  session_status?: string | null;
+};
+
+export type TeamMailboxSnapshot = {
+  pending: number;
+  delivered: number;
+  dead_letter: number;
+  recent_messages: TeamActorMessageRecord[];
+};
+
+export type TeamRunSnapshotRecord = {
+  run: TeamRunRecord;
+  team: TeamDefinitionRecord;
+  leader_member_id?: string | null;
+  members: TeamMemberSnapshot[];
+  steps: TeamStepRecord[];
+  latest_events: TeamRunEventRecord[];
+  mailbox: TeamMailboxSnapshot;
+};
+
 function parseApiErrorText(raw: string): string | null {
   if (!raw) return null;
   if (!raw.trim().startsWith("{")) return raw;
@@ -359,6 +388,24 @@ export const api = {
     }),
   getTeamRun: (token: string, runId: string) =>
     apiFetch<TeamRunRecord>(`/api/teams/runs/${runId}`, token),
+  getTeamRunSnapshot: (
+    token: string,
+    runId: string,
+    payload?: { event_limit?: number; message_limit?: number }
+  ) => {
+    const params = new URLSearchParams();
+    if (payload?.event_limit != null) {
+      params.set("event_limit", String(payload.event_limit));
+    }
+    if (payload?.message_limit != null) {
+      params.set("message_limit", String(payload.message_limit));
+    }
+    const suffix = params.size > 0 ? `?${params.toString()}` : "";
+    return apiFetch<TeamRunSnapshotRecord>(
+      `/api/teams/runs/${runId}/snapshot${suffix}`,
+      token
+    );
+  },
   cancelTeamRun: (token: string, runId: string) =>
     apiFetch<TeamRunRecord>(`/api/teams/runs/${runId}/cancel`, token, {
       method: "POST",

--- a/web/src/components/agents_panel.tsx
+++ b/web/src/components/agents_panel.tsx
@@ -69,6 +69,14 @@ export const AgentsPanel = React.memo(function AgentsPanel({
           </div>
         ) : (
           <>
+            <div className="mode-switch">
+              <a className="mode-tag active" href="/">
+                Agents
+              </a>
+              <a className="mode-tag" href="/teams">
+                Teams
+              </a>
+            </div>
             <div className="toolbar">
               <h2>Agents</h2>
               <div className="toolbar-actions">

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -856,10 +856,7 @@ export function TeamPage(props: TeamPageProps) {
   };
 
   const onRemoveWorker = (index: number) => {
-    setWorkers((prev) => {
-      if (prev.length <= 1) return prev;
-      return prev.filter((_, workerIndex) => workerIndex !== index);
-    });
+    setWorkers((prev) => prev.filter((_, workerIndex) => workerIndex !== index));
   };
 
   return (
@@ -978,12 +975,15 @@ export function TeamPage(props: TeamPageProps) {
                 />
                 <button
                   onClick={() => onRemoveWorker(index)}
-                  disabled={useSpecOverride || workers.length <= 1}
+                  disabled={useSpecOverride}
                 >
                   Remove Worker
                 </button>
               </div>
             ))}
+            {workers.length === 0 && (
+              <p className="muted">No workers configured. Team will run with leader only.</p>
+            )}
             <label className="checkbox">
               <input
                 type="checkbox"
@@ -1228,8 +1228,7 @@ export function TeamPage(props: TeamPageProps) {
                                 </span>
                                 <span className="team-status">{member.status}</span>
                                 <span className="team-id mono">
-                                  model={member.model ?? "-"} pending=
-                                  {member.pending_inbox_count}
+                                  {`model=${member.model ?? "-"} pending=${member.pending_inbox_count}`}
                                 </span>
                               </button>
                             ))}

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  AgentEvent,
   api,
   TeamActorMessageRecord,
   TeamDefinitionRecord,
   TeamRunEventRecord,
   TeamRunRecord,
+  TeamRunSnapshotRecord,
   TeamStepRecord,
 } from "../api";
 import { ErrorBanner } from "../error_banner";
@@ -16,7 +18,7 @@ type TeamPageProps = {
   onLogout: () => void;
 };
 
-type TeamTab = "events" | "steps" | "messages";
+type TeamTab = "overview" | "events" | "steps" | "mailbox" | "member_console";
 type StepAction =
   | "start"
   | "complete"
@@ -25,15 +27,14 @@ type StepAction =
   | "resume";
 
 const EVENT_PAGE_LIMIT = 100;
-const DEFAULT_TEAM_SPEC = `{
-  "spec_version": 1,
-  "entrypoint": "planner",
-  "members": [
-    {
-      "member_id": "planner"
-    }
-  ]
-}`;
+const MEMBER_EVENT_PAGE_LIMIT = 300;
+
+type WorkerDraft = {
+  member_id: string;
+  model: string;
+  prompt: string;
+  skills: string;
+};
 
 function sortRuns(runs: TeamRunRecord[]): TeamRunRecord[] {
   return [...runs].sort((a, b) => b.created_at - a.created_at);
@@ -55,6 +56,61 @@ function upsertEventList(
     byId.set(event.event_id, event);
   }
   return [...byId.values()].sort((a, b) => a.event_id - b.event_id);
+}
+
+function upsertAgentEventList(
+  prev: AgentEvent[],
+  next: AgentEvent[],
+  mode: "replace" | "prepend"
+): AgentEvent[] {
+  const merged = mode === "replace" ? [...next] : [...next, ...prev];
+  const byId = new Map<number, AgentEvent>();
+  for (const event of merged) {
+    byId.set(event.event_id, event);
+  }
+  return [...byId.values()].sort((a, b) => a.event_id - b.event_id);
+}
+
+function buildTeamSpecFromForm(
+  leaderMemberId: string,
+  leaderModel: string,
+  leaderPrompt: string,
+  leaderSkills: string,
+  workers: WorkerDraft[]
+): unknown {
+  const leaderId = leaderMemberId.trim();
+  const normalizedWorkers = workers
+    .map((worker) => ({
+      member_id: worker.member_id.trim(),
+      model: worker.model.trim(),
+      prompt: worker.prompt.trim(),
+      skills: parseCsvList(worker.skills),
+    }))
+    .filter((worker) => worker.member_id.length > 0);
+
+  const members = [
+    {
+      member_id: leaderId,
+      role: "leader",
+      model: leaderModel.trim() || undefined,
+      prompt: leaderPrompt.trim() || undefined,
+      skills: parseCsvList(leaderSkills),
+    },
+    ...normalizedWorkers.map((worker) => ({
+      member_id: worker.member_id,
+      role: "worker",
+      model: worker.model || undefined,
+      prompt: worker.prompt || undefined,
+      skills: worker.skills,
+    })),
+  ];
+
+  return {
+    spec_version: 1,
+    entrypoint: leaderId,
+    leader_member_id: leaderId,
+    members,
+  };
 }
 
 function parseErrorMessage(err: unknown): string {
@@ -136,13 +192,21 @@ export function TeamPage(props: TeamPageProps) {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
 
-  const [tab, setTab] = useState<TeamTab>("events");
+  const [tab, setTab] = useState<TeamTab>("overview");
   const [teams, setTeams] = useState<TeamDefinitionRecord[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
 
   const [newTeamName, setNewTeamName] = useState("");
   const [newTeamDescription, setNewTeamDescription] = useState("");
-  const [newTeamSpec, setNewTeamSpec] = useState(DEFAULT_TEAM_SPEC);
+  const [useSpecOverride, setUseSpecOverride] = useState(false);
+  const [newTeamSpec, setNewTeamSpec] = useState("{}");
+  const [leaderMemberId, setLeaderMemberId] = useState("leader");
+  const [leaderModel, setLeaderModel] = useState("");
+  const [leaderPrompt, setLeaderPrompt] = useState("");
+  const [leaderSkills, setLeaderSkills] = useState("");
+  const [workers, setWorkers] = useState<WorkerDraft[]>([
+    { member_id: "worker-1", model: "", prompt: "", skills: "" },
+  ]);
 
   const [runContextId, setRunContextId] = useState("");
   const [runInput, setRunInput] = useState("{}");
@@ -150,6 +214,8 @@ export function TeamPage(props: TeamPageProps) {
 
   const [runs, setRuns] = useState<TeamRunRecord[]>([]);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<TeamRunSnapshotRecord | null>(null);
+  const [snapshotLoading, setSnapshotLoading] = useState(false);
 
   const [events, setEvents] = useState<TeamRunEventRecord[]>([]);
   const [eventsHasMore, setEventsHasMore] = useState(false);
@@ -185,6 +251,11 @@ export function TeamPage(props: TeamPageProps) {
   const [inboxIncludeDelivered, setInboxIncludeDelivered] = useState(false);
   const [inbox, setInbox] = useState<TeamActorMessageRecord[]>([]);
   const eventsRef = useRef<TeamRunEventRecord[]>([]);
+  const [selectedMemberId, setSelectedMemberId] = useState("");
+  const [memberEvents, setMemberEvents] = useState<AgentEvent[]>([]);
+  const [memberEventsHasMore, setMemberEventsHasMore] = useState(false);
+  const [memberEventsLoading, setMemberEventsLoading] = useState(false);
+  const memberEventsRef = useRef<AgentEvent[]>([]);
 
   const selectedTeam = useMemo(
     () => teams.find((team) => team.id === selectedTeamId) ?? null,
@@ -201,7 +272,33 @@ export function TeamPage(props: TeamPageProps) {
     return runs.filter((run) => run.team_id === selectedTeamId);
   }, [runs, selectedTeamId]);
 
+  const builtTeamSpec = useMemo(
+    () =>
+      buildTeamSpecFromForm(
+        leaderMemberId,
+        leaderModel,
+        leaderPrompt,
+        leaderSkills,
+        workers
+      ),
+    [leaderMemberId, leaderModel, leaderPrompt, leaderSkills, workers]
+  );
+
+  const displayedTeamSpec = useMemo(() => {
+    if (useSpecOverride) {
+      return newTeamSpec;
+    }
+    return JSON.stringify(builtTeamSpec, null, 2);
+  }, [builtTeamSpec, newTeamSpec, useSpecOverride]);
+
+  const selectedMemberSnapshot = useMemo(
+    () => snapshot?.members.find((member) => member.member_id === selectedMemberId) ?? null,
+    [selectedMemberId, snapshot]
+  );
+
   const oldestEventId = events.length > 0 ? events[0].event_id : null;
+  const oldestMemberEventId =
+    memberEvents.length > 0 ? memberEvents[0].event_id : null;
 
   const refreshTeams = useCallback(async () => {
     setBusy("refresh-teams");
@@ -279,9 +376,30 @@ export function TeamPage(props: TeamPageProps) {
     [props.token]
   );
 
+  const refreshSnapshot = useCallback(
+    async (runId: string) => {
+      setSnapshotLoading(true);
+      try {
+        const next = await api.getTeamRunSnapshot(props.token, runId, {
+          event_limit: 200,
+          message_limit: 200,
+        });
+        setSnapshot(next);
+        return next;
+      } finally {
+        setSnapshotLoading(false);
+      }
+    },
+    [props.token]
+  );
+
   useEffect(() => {
     eventsRef.current = events;
   }, [events]);
+
+  useEffect(() => {
+    memberEventsRef.current = memberEvents;
+  }, [memberEvents]);
 
   const loadInbox = useCallback(async () => {
     if (!activeRunId) return;
@@ -307,6 +425,41 @@ export function TeamPage(props: TeamPageProps) {
     props.token,
   ]);
 
+  const loadMemberEvents = useCallback(
+    async (mode: "replace" | "prepend" = "replace") => {
+      if (!selectedMemberSnapshot) {
+        setMemberEvents([]);
+        setMemberEventsHasMore(false);
+        return;
+      }
+      const memberAgentId = selectedMemberSnapshot.member_id;
+      const sessionId = selectedMemberSnapshot.latest_step?.remote_task_id ?? undefined;
+      if (!sessionId) {
+        setMemberEvents([]);
+        setMemberEventsHasMore(false);
+        return;
+      }
+
+      setMemberEventsLoading(true);
+      try {
+        const beforeId =
+          mode === "prepend" ? memberEventsRef.current[0]?.event_id : undefined;
+        const list = await api.listAgentEvents(
+          props.token,
+          memberAgentId,
+          MEMBER_EVENT_PAGE_LIMIT,
+          sessionId,
+          beforeId
+        );
+        setMemberEvents((prev) => upsertAgentEventList(prev, list, mode));
+        setMemberEventsHasMore(list.length >= MEMBER_EVENT_PAGE_LIMIT);
+      } finally {
+        setMemberEventsLoading(false);
+      }
+    },
+    [props.token, selectedMemberSnapshot]
+  );
+
   useEffect(() => {
     void refreshTeams();
   }, [refreshTeams]);
@@ -318,6 +471,9 @@ export function TeamPage(props: TeamPageProps) {
       setEvents([]);
       setSteps([]);
       setInbox([]);
+      setSnapshot(null);
+      setSelectedMemberId("");
+      setMemberEvents([]);
       return;
     }
     let canceled = false;
@@ -359,6 +515,9 @@ export function TeamPage(props: TeamPageProps) {
       setEvents([]);
       setSteps([]);
       setInbox([]);
+      setSnapshot(null);
+      setSelectedMemberId("");
+      setMemberEvents([]);
       return;
     }
     let canceled = false;
@@ -370,7 +529,11 @@ export function TeamPage(props: TeamPageProps) {
         if (run.team_id !== selectedTeamId) {
           setSelectedTeamId(run.team_id);
         }
-        await Promise.all([refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+        await Promise.all([
+          refreshSteps(activeRunId),
+          refreshEvents(activeRunId),
+          refreshSnapshot(activeRunId),
+        ]);
       } catch (err) {
         if (!canceled) {
           setError(parseErrorMessage(err));
@@ -381,18 +544,46 @@ export function TeamPage(props: TeamPageProps) {
     return () => {
       canceled = true;
     };
-  }, [activeRunId, refreshEvents, refreshRun, refreshSteps, selectedTeamId]);
+  }, [
+    activeRunId,
+    refreshEvents,
+    refreshRun,
+    refreshSnapshot,
+    refreshSteps,
+    selectedTeamId,
+  ]);
 
   useEffect(() => {
     if (!activeRunId || !eventsAutoRefresh) return;
     const timer = window.setInterval(() => {
       void refreshRun(activeRunId).catch(() => undefined);
       void refreshEvents(activeRunId).catch(() => undefined);
+      void refreshSnapshot(activeRunId).catch(() => undefined);
     }, 4000);
     return () => {
       window.clearInterval(timer);
     };
-  }, [activeRunId, eventsAutoRefresh, refreshEvents, refreshRun]);
+  }, [activeRunId, eventsAutoRefresh, refreshEvents, refreshRun, refreshSnapshot]);
+
+  useEffect(() => {
+    if (!snapshot) {
+      setSelectedMemberId("");
+      setMemberEvents([]);
+      return;
+    }
+    setSelectedMemberId((prev) => {
+      if (prev && snapshot.members.some((member) => member.member_id === prev)) {
+        return prev;
+      }
+      return snapshot.members[0]?.member_id ?? "";
+    });
+  }, [snapshot]);
+
+  useEffect(() => {
+    void loadMemberEvents("replace").catch((err) => {
+      setError(parseErrorMessage(err));
+    });
+  }, [loadMemberEvents]);
 
   const onCreateTeam = async () => {
     const name = newTeamName.trim();
@@ -400,18 +591,32 @@ export function TeamPage(props: TeamPageProps) {
       setError("Team name is required");
       return;
     }
+    if (!useSpecOverride && !leaderMemberId.trim()) {
+      setError("Leader member_id is required");
+      return;
+    }
     setBusy("create-team");
     setError(null);
     try {
+      const specPayload = useSpecOverride
+        ? parseRequiredJson(newTeamSpec, "Team spec")
+        : builtTeamSpec;
       const created = await api.createTeam(props.token, {
         name,
         description: newTeamDescription.trim() || undefined,
-        spec: parseRequiredJson(newTeamSpec, "Team spec"),
+        spec: specPayload,
       });
       setTeams((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
       setSelectedTeamId(created.id);
       setNewTeamName("");
       setNewTeamDescription("");
+      setLeaderMemberId("leader");
+      setLeaderModel("");
+      setLeaderPrompt("");
+      setLeaderSkills("");
+      setWorkers([{ member_id: "worker-1", model: "", prompt: "", skills: "" }]);
+      setUseSpecOverride(false);
+      setNewTeamSpec("{}");
     } catch (err) {
       setError(parseErrorMessage(err));
     } finally {
@@ -467,7 +672,7 @@ export function TeamPage(props: TeamPageProps) {
     try {
       const canceled = await api.cancelTeamRun(props.token, activeRunId);
       setRuns((prev) => upsertRun(prev, canceled));
-      await refreshEvents(activeRunId);
+      await Promise.all([refreshEvents(activeRunId), refreshSnapshot(activeRunId)]);
     } catch (err) {
       setError(parseErrorMessage(err));
     } finally {
@@ -497,7 +702,12 @@ export function TeamPage(props: TeamPageProps) {
         depends_on: parseCsvList(stepDependsOn),
         input: parseOptionalJson(stepInput, "Step input"),
       });
-      await Promise.all([refreshRun(activeRunId), refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+      await Promise.all([
+        refreshRun(activeRunId),
+        refreshSteps(activeRunId),
+        refreshEvents(activeRunId),
+        refreshSnapshot(activeRunId),
+      ]);
       setSelectedStepId(created.id);
     } catch (err) {
       setError(parseErrorMessage(err));
@@ -544,7 +754,12 @@ export function TeamPage(props: TeamPageProps) {
           input: parseOptionalJson(stepResumePayload, "Resume payload"),
         });
       }
-      await Promise.all([refreshRun(activeRunId), refreshSteps(activeRunId), refreshEvents(activeRunId)]);
+      await Promise.all([
+        refreshRun(activeRunId),
+        refreshSteps(activeRunId),
+        refreshEvents(activeRunId),
+        refreshSnapshot(activeRunId),
+      ]);
     } catch (err) {
       setError(parseErrorMessage(err));
     } finally {
@@ -575,7 +790,7 @@ export function TeamPage(props: TeamPageProps) {
         payload: parseRequiredJson(msgPayload, "Message payload"),
         idempotency_key: msgIdempotencyKey.trim() || undefined,
       });
-      await refreshEvents(activeRunId);
+      await Promise.all([refreshEvents(activeRunId), refreshSnapshot(activeRunId)]);
       if (inboxActorId.trim()) {
         await loadInbox();
       }
@@ -609,12 +824,42 @@ export function TeamPage(props: TeamPageProps) {
     setError(null);
     try {
       await api.ackTeamRunMessage(props.token, activeRunId, message.message_id, actorId);
-      await Promise.all([loadInbox(), refreshEvents(activeRunId)]);
+      await Promise.all([
+        loadInbox(),
+        refreshEvents(activeRunId),
+        refreshSnapshot(activeRunId),
+      ]);
     } catch (err) {
       setError(parseErrorMessage(err));
     } finally {
       setBusy(null);
     }
+  };
+
+  const onUpdateWorker = (
+    index: number,
+    field: keyof WorkerDraft,
+    value: string
+  ) => {
+    setWorkers((prev) =>
+      prev.map((worker, workerIndex) =>
+        workerIndex === index ? { ...worker, [field]: value } : worker
+      )
+    );
+  };
+
+  const onAddWorker = () => {
+    setWorkers((prev) => [
+      ...prev,
+      { member_id: `worker-${prev.length + 1}`, model: "", prompt: "", skills: "" },
+    ]);
+  };
+
+  const onRemoveWorker = (index: number) => {
+    setWorkers((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((_, workerIndex) => workerIndex !== index);
+    });
   };
 
   return (
@@ -634,6 +879,14 @@ export function TeamPage(props: TeamPageProps) {
 
       <section className="teams-layout">
         <aside className="card teams-sidebar">
+          <div className="mode-switch">
+            <a className="mode-tag" href="/">
+              Agents
+            </a>
+            <a className="mode-tag active" href="/teams">
+              Teams
+            </a>
+          </div>
           <div className="toolbar">
             <h2>Teams</h2>
             <button onClick={() => void refreshTeams()} disabled={busy === "refresh-teams"}>
@@ -653,11 +906,98 @@ export function TeamPage(props: TeamPageProps) {
               value={newTeamDescription}
               onChange={(event) => setNewTeamDescription(event.target.value)}
             />
+            <h4>Leader</h4>
+            <input
+              placeholder="leader member_id"
+              value={leaderMemberId}
+              onChange={(event) => setLeaderMemberId(event.target.value)}
+              disabled={useSpecOverride}
+            />
+            <input
+              placeholder="leader model (optional)"
+              value={leaderModel}
+              onChange={(event) => setLeaderModel(event.target.value)}
+              disabled={useSpecOverride}
+            />
+            <input
+              placeholder="leader skills (comma separated)"
+              value={leaderSkills}
+              onChange={(event) => setLeaderSkills(event.target.value)}
+              disabled={useSpecOverride}
+            />
+            <textarea
+              className="mono"
+              rows={3}
+              placeholder="leader prompt"
+              value={leaderPrompt}
+              onChange={(event) => setLeaderPrompt(event.target.value)}
+              disabled={useSpecOverride}
+            />
+
+            <div className="toolbar">
+              <h4>Workers</h4>
+              <button onClick={onAddWorker} disabled={useSpecOverride}>
+                Add Worker
+              </button>
+            </div>
+            {workers.map((worker, index) => (
+              <div key={`worker-${index}`} className="teams-worker-card">
+                <input
+                  placeholder="worker member_id"
+                  value={worker.member_id}
+                  onChange={(event) =>
+                    onUpdateWorker(index, "member_id", event.target.value)
+                  }
+                  disabled={useSpecOverride}
+                />
+                <input
+                  placeholder="worker model (optional)"
+                  value={worker.model}
+                  onChange={(event) =>
+                    onUpdateWorker(index, "model", event.target.value)
+                  }
+                  disabled={useSpecOverride}
+                />
+                <input
+                  placeholder="worker skills (comma separated)"
+                  value={worker.skills}
+                  onChange={(event) =>
+                    onUpdateWorker(index, "skills", event.target.value)
+                  }
+                  disabled={useSpecOverride}
+                />
+                <textarea
+                  className="mono"
+                  rows={2}
+                  placeholder="worker prompt"
+                  value={worker.prompt}
+                  onChange={(event) =>
+                    onUpdateWorker(index, "prompt", event.target.value)
+                  }
+                  disabled={useSpecOverride}
+                />
+                <button
+                  onClick={() => onRemoveWorker(index)}
+                  disabled={useSpecOverride || workers.length <= 1}
+                >
+                  Remove Worker
+                </button>
+              </div>
+            ))}
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                checked={useSpecOverride}
+                onChange={(event) => setUseSpecOverride(event.target.checked)}
+              />
+              Edit spec JSON manually
+            </label>
             <textarea
               className="mono"
               rows={10}
-              value={newTeamSpec}
+              value={displayedTeamSpec}
               onChange={(event) => setNewTeamSpec(event.target.value)}
+              readOnly={!useSpecOverride}
             />
             <button onClick={onCreateTeam} disabled={busy === "create-team"}>
               Create Team
@@ -792,6 +1132,12 @@ export function TeamPage(props: TeamPageProps) {
 
                   <div className="tab-bar">
                     <button
+                      className={tab === "overview" ? "tab active" : "tab"}
+                      onClick={() => setTab("overview")}
+                    >
+                      Overview
+                    </button>
+                    <button
                       className={tab === "events" ? "tab active" : "tab"}
                       onClick={() => setTab("events")}
                     >
@@ -804,12 +1150,94 @@ export function TeamPage(props: TeamPageProps) {
                       Steps
                     </button>
                     <button
-                      className={tab === "messages" ? "tab active" : "tab"}
-                      onClick={() => setTab("messages")}
+                      className={tab === "mailbox" ? "tab active" : "tab"}
+                      onClick={() => setTab("mailbox")}
                     >
-                      Messages
+                      Mailbox
+                    </button>
+                    <button
+                      className={tab === "member_console" ? "tab active" : "tab"}
+                      onClick={() => setTab("member_console")}
+                    >
+                      Member Console
                     </button>
                   </div>
+
+                  {tab === "overview" && (
+                    <div className="card">
+                      <div className="toolbar">
+                        <h3>Team Snapshot</h3>
+                        <div className="actions">
+                          <button
+                            onClick={() => {
+                              if (!activeRunId) return;
+                              void refreshSnapshot(activeRunId).catch((err) =>
+                                setError(parseErrorMessage(err))
+                              );
+                            }}
+                            disabled={snapshotLoading}
+                          >
+                            Refresh Snapshot
+                          </button>
+                        </div>
+                      </div>
+
+                      {!snapshot && <p className="muted">No snapshot yet.</p>}
+
+                      {snapshot && (
+                        <>
+                          <div className="teams-run-meta">
+                            <span>
+                              <strong>Leader:</strong>{" "}
+                              <code>{snapshot.leader_member_id ?? "-"}</code>
+                            </span>
+                            <span>
+                              <strong>Members:</strong> {snapshot.members.length}
+                            </span>
+                            <span>
+                              <strong>Pending Mailbox:</strong> {snapshot.mailbox.pending}
+                            </span>
+                            <span>
+                              <strong>Delivered:</strong> {snapshot.mailbox.delivered}
+                            </span>
+                            <span>
+                              <strong>Dead Letter:</strong> {snapshot.mailbox.dead_letter}
+                            </span>
+                            <span>
+                              <strong>Recent Events:</strong>{" "}
+                              {snapshot.latest_events.length}
+                            </span>
+                          </div>
+
+                          <div className="teams-member-list">
+                            {snapshot.members.map((member) => (
+                              <button
+                                key={member.member_id}
+                                className={
+                                  selectedMemberId === member.member_id
+                                    ? "team-item active"
+                                    : "team-item"
+                                }
+                                onClick={() => {
+                                  setSelectedMemberId(member.member_id);
+                                  setTab("member_console");
+                                }}
+                              >
+                                <span className="team-name">
+                                  {member.member_id} ({member.role})
+                                </span>
+                                <span className="team-status">{member.status}</span>
+                                <span className="team-id mono">
+                                  model={member.model ?? "-"} pending=
+                                  {member.pending_inbox_count}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
 
                   {tab === "events" && (
                     <div className="card">
@@ -1005,11 +1433,29 @@ export function TeamPage(props: TeamPageProps) {
                     </div>
                   )}
 
-                  {tab === "messages" && (
+                  {tab === "mailbox" && (
                     <div className="card">
                       <div className="toolbar">
-                        <h3>Messages</h3>
+                        <h3>Mailbox</h3>
                       </div>
+
+                      {snapshot && (
+                        <div className="teams-run-meta">
+                          <span>
+                            <strong>Pending:</strong> {snapshot.mailbox.pending}
+                          </span>
+                          <span>
+                            <strong>Delivered:</strong> {snapshot.mailbox.delivered}
+                          </span>
+                          <span>
+                            <strong>Dead Letter:</strong> {snapshot.mailbox.dead_letter}
+                          </span>
+                          <span>
+                            <strong>Recent Messages:</strong>{" "}
+                            {snapshot.mailbox.recent_messages.length}
+                          </span>
+                        </div>
+                      )}
 
                       <div className="teams-message-grid">
                         <div className="teams-message-panel">
@@ -1101,6 +1547,18 @@ export function TeamPage(props: TeamPageProps) {
                       </div>
 
                       <ul className="teams-message-list">
+                        {snapshot?.mailbox.recent_messages.map((message) => (
+                          <li key={`snapshot-${message.message_id}`}>
+                            <div className="teams-message-head">
+                              <span className="mono">#{message.message_id}</span>
+                              <span>
+                                {message.from_actor_id} → {message.to_actor_id}
+                              </span>
+                              <span>{message.status}</span>
+                            </div>
+                            <pre className="mono">{toPrettyJson(message.payload)}</pre>
+                          </li>
+                        ))}
                         {inbox.map((message) => (
                           <li key={message.message_id}>
                             <div className="teams-message-head">
@@ -1122,6 +1580,99 @@ export function TeamPage(props: TeamPageProps) {
                                 Ack
                               </button>
                             </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {tab === "member_console" && (
+                    <div className="card">
+                      <div className="toolbar">
+                        <h3>Member Console</h3>
+                        <div className="actions">
+                          <button
+                            onClick={() => void loadMemberEvents("replace")}
+                            disabled={memberEventsLoading}
+                          >
+                            Refresh
+                          </button>
+                          <button
+                            onClick={() => void loadMemberEvents("prepend")}
+                            disabled={
+                              memberEventsLoading ||
+                              !memberEventsHasMore ||
+                              oldestMemberEventId == null
+                            }
+                          >
+                            Load Older
+                          </button>
+                        </div>
+                      </div>
+
+                      <div className="form-row">
+                        <select
+                          value={selectedMemberId}
+                          onChange={(event) => setSelectedMemberId(event.target.value)}
+                        >
+                          <option value="">Select member</option>
+                          {snapshot?.members.map((member) => (
+                            <option key={member.member_id} value={member.member_id}>
+                              {member.member_id} ({member.role})
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      {selectedMemberSnapshot && (
+                        <div className="teams-step-body mono">
+                          <div>member_id: {selectedMemberSnapshot.member_id}</div>
+                          <div>role: {selectedMemberSnapshot.role}</div>
+                          <div>model: {selectedMemberSnapshot.model ?? "-"}</div>
+                          <div>status: {selectedMemberSnapshot.status}</div>
+                          <div>
+                            session_status: {selectedMemberSnapshot.session_status ?? "-"}
+                          </div>
+                          <div>
+                            remote_task_id:{" "}
+                            {selectedMemberSnapshot.latest_step?.remote_task_id ?? "-"}
+                          </div>
+                          <div>
+                            skills:{" "}
+                            {selectedMemberSnapshot.skills.length > 0
+                              ? selectedMemberSnapshot.skills.join(", ")
+                              : "-"}
+                          </div>
+                          <div>prompt: {selectedMemberSnapshot.prompt ?? "-"}</div>
+                        </div>
+                      )}
+
+                      {!selectedMemberSnapshot && (
+                        <p className="muted">Select a member to inspect output.</p>
+                      )}
+
+                      {selectedMemberSnapshot &&
+                        !selectedMemberSnapshot.latest_step?.remote_task_id && (
+                          <p className="muted">
+                            Selected member has no associated session yet.
+                          </p>
+                        )}
+
+                      {selectedMemberSnapshot &&
+                        selectedMemberSnapshot.latest_step?.remote_task_id &&
+                        memberEvents.length === 0 && (
+                          <p className="muted">No member events yet.</p>
+                        )}
+
+                      <ul className="teams-event-list">
+                        {memberEvents.map((event) => (
+                          <li key={event.event_id}>
+                            <div className="teams-event-head">
+                              <span className="mono">#{event.event_id}</span>
+                              <span>{event.stream}</span>
+                              <span>{formatTs(event.ts)}</span>
+                            </div>
+                            <pre className="mono">{event.message}</pre>
                           </li>
                         ))}
                       </ul>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -297,6 +297,37 @@ section {
   width: 100%;
 }
 
+.mode-switch {
+  display: inline-flex;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.mode-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #d0d6dd;
+  border-radius: 999px;
+  padding: 4px 10px;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 600;
+  color: #3a4654;
+  background: #f8fafc;
+}
+
+.mode-tag:hover {
+  border-color: #7f95ad;
+  color: #1f2c3d;
+}
+
+.mode-tag.active {
+  border-color: #1b3a57;
+  background: #1b3a57;
+  color: #fff;
+}
+
 .agents-rail-metric {
   display: grid;
   gap: 2px;


### PR DESCRIPTION
## Summary

This PR extends the `/teams` standalone workbench with team-level snapshot visibility and member-centric output inspection.

### Backend

- Add `GET /api/teams/runs/{run_id}/snapshot` to return:
  - run + team metadata
  - leader identity
  - member snapshots (role/model/prompt/skills/status/pending inbox count)
  - latest events + all current steps
  - mailbox status counters and recent messages
- Extend team spec validation to support and validate:
  - `leader_member_id`
  - `spec.members[].role` (`leader` / `worker`)
  - `spec.members[].model`
  - `spec.members[].prompt`
  - `spec.members[].skills`
- Extend OpenAPI schema and paths for snapshot payloads.

### Frontend

- Add guided Create Team form for:
  - leader (member_id/model/prompt/skills)
  - multiple workers with independent model/prompt/skills
- Add Team output tabs:
  - `Overview`, `Events`, `Steps`, `Mailbox`, `Member Console`
- Add `Member Console` to inspect selected member session output via agent event stream.
- Add mode switch tags (`Agents` / `Teams`) in the left panel.

### Docs

- Add feature note: `docs/features/2026-02-16-team-snapshot-member-console.md`
- Add follow-up verification TODO items in `docs/todo.md`

## Testing

- `cargo test teams_ -- --nocapture`
- `cargo test team_run_snapshot_api_returns_member_status_and_mailbox_summary -- --nocapture`
- `cargo test openapi_json_contains_team_runs_list_path -- --nocapture`
- `npm --prefix web run lint`
- `npm --prefix web run build`

## Notes

- `npm --prefix web run lint` still reports two pre-existing warnings in `web/src/app.tsx` (`react-hooks/exhaustive-deps`), unchanged by this PR.
