### PR TITLE
chore: converge cargo/bazel proto codegen workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.93.1
+      - name: Verify internal protobuf codegen
+        run: make proto-check
       - name: Setup Rust coverage tool
         run: |
           rustup component add llvm-tools-preview

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-web run run-web build test lint lint-web proto-check
+.PHONY: build-web run run-web build test lint lint-web proto-gen proto-check
 .PHONY: bazel-rust bazel-ci
 .PHONY: reset
 
@@ -32,8 +32,11 @@ bazel-ci:
 	bazel build //...
 	bazel test //...
 
+proto-gen:
+	./scripts/check_team_proto_codegen.sh --write
+
 proto-check:
-	./scripts/check_team_proto_codegen.sh
+	./scripts/check_team_proto_codegen.sh --check
 
 
 reset:

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ bazel test //...
 
 ## Internal Proto Codegen Guard
 
-`proto/internal/v1/team.proto` is compiled via `build.rs` (`tonic-build`) at build time.
-Generated Rust protobuf source is tracked at `src/internal/proto/agenthub.internal.v1.rs`
-and must stay in sync with schema and generator output.
+`proto/internal/v1/team.proto` is compiled by `build.rs` (`tonic-build`) to produce
+a fresh reference output in `OUT_DIR` for drift checking.
+Application/runtime compilation uses the tracked generated file
+`src/internal/proto/agenthub.internal.v1.rs`, which must stay in sync with schema
+and generator output.
 
 ```bash
 # regenerate tracked proto file from latest codegen output

--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ bazel test //...
 ## Internal Proto Codegen Guard
 
 `proto/internal/v1/team.proto` is compiled via `build.rs` (`tonic-build`) at build time.
-Generated Rust protobuf sources are not checked into git.
+Generated Rust protobuf source is tracked at `src/internal/proto/agenthub.internal.v1.rs`
+and must stay in sync with schema and generator output.
 
 ```bash
-# verify codegen consistency and tracked-file guard
+# regenerate tracked proto file from latest codegen output
+make proto-gen
+
+# verify codegen consistency with tracked generated file
 make proto-check
 ```
 

--- a/docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md
+++ b/docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md
@@ -8,6 +8,10 @@ Converge Cargo and Bazel protobuf usage on a single contract:
 - `src/internal/proto/agenthub.internal.v1.rs` is the tracked generated artifact.
 - CI verifies the tracked artifact is byte-identical to fresh codegen output.
 
+This feature note **supersedes** `docs/features/2026-02-15-team-proto-codegen-check.md`,
+which described the previous "generated Rust files are not checked into git"
+policy.
+
 ## Background
 
 After Bazel migration, runtime proto inclusion moved to the tracked generated file

--- a/docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md
+++ b/docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md
@@ -1,0 +1,55 @@
+# Proto Codegen Cargo/Bazel Convergence
+
+## Summary
+
+Converge Cargo and Bazel protobuf usage on a single contract:
+
+- `proto/internal/v1/team.proto` is the source of truth.
+- `src/internal/proto/agenthub.internal.v1.rs` is the tracked generated artifact.
+- CI verifies the tracked artifact is byte-identical to fresh codegen output.
+
+## Background
+
+After Bazel migration, runtime proto inclusion moved to the tracked generated file
+path, while some docs and workflow checks still reflected the old
+"generated file is not checked in" model. This caused ambiguity in developer
+workflow and left Rust CI without an active proto drift gate.
+
+## Scope
+
+- `scripts/check_team_proto_codegen.sh`
+- `Makefile`
+- `.github/workflows/rust.yml`
+- `README.md`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Keep `team.proto` as schema source and keep tracked generated Rust output at
+   `src/internal/proto/agenthub.internal.v1.rs`.
+2. Extend `scripts/check_team_proto_codegen.sh` with explicit modes:
+   - `--write`: refresh tracked generated file from latest codegen output
+   - `--check`: verify tracked generated file matches latest codegen output
+3. Add `make proto-gen` and keep `make proto-check` as the standard workflow.
+4. Re-enable Rust CI proto verification with `Verify internal protobuf codegen`
+   step (`make proto-check`) before regular Cargo build/test steps.
+5. Update README to document tracked generated file policy and the new
+   `proto-gen` + `proto-check` commands.
+
+## Validation
+
+```bash
+make proto-check
+```
+
+Expected:
+
+- command succeeds when tracked generated file matches current codegen output;
+- command fails when `team.proto` changes are not reflected in
+  `src/internal/proto/agenthub.internal.v1.rs`;
+- Rust CI fails early on proto drift.
+
+## Follow-ups
+
+- Consider extracting shared proto generation logic into a dedicated helper to
+  avoid relying on Cargo build output path discovery.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -142,7 +142,8 @@
 - [x] Fix post-merge CI compatibility: declare `agenthub-codex-acp` markdown prompt files as Bazel compile inputs and relax proto codegen check to tracked-file parity mode (see `docs/features/2026-02-16-bazel-codex-md-and-proto-check-compat.md`).
 - [x] Fix Bazel `web_assets_test` sandbox path resolution by reading `styles.css` from runfiles and declaring CSS test data explicitly (see `docs/features/2026-02-16-bazel-web-assets-test-runfiles.md`).
 - [x] Align root Bazel Rust targets to typedb-style `rust_library` + `rust_test(crate=...)` and pass `web/dist` as compile data so `RustEmbed` works in opt/test sandbox builds (see `docs/features/2026-02-16-bazel-root-rust-library-and-rustembed-compile-data.md`).
-- [ ] Unify Cargo/Bazel proto generation dependency stack and re-enable Rust CI `Verify internal protobuf codegen` step (see `docs/features/2026-02-16-bazel-codex-md-and-proto-check-compat.md`).
+- [x] Unify Cargo/Bazel proto generation contract around tracked generated proto file and re-enable Rust CI `Verify internal protobuf codegen` step (see `docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md`).
+- [ ] Verify restored Rust CI proto-check step (`make proto-check`) remains stable on PR/main runs and catches `team.proto` drift before merge (see `docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md`).
 - [ ] Verify agent model tag shows model flag or provider fallback (see `docs/features/2026-02-10-agent-model-tag.md`).
 - [ ] Verify agents panel list scrolls internally without page scroll (see `docs/features/2026-02-10-agents-panel-scroll.md`).
 - [ ] Verify start handles already-running agents without stale UI state (see `docs/features/2026-02-10-agent-start-already-running.md`).

--- a/scripts/check_team_proto_codegen.sh
+++ b/scripts/check_team_proto_codegen.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mode="${1:---check}"
-if [[ "${mode}" != "--check" && "${mode}" != "--write" ]]; then
-  echo "usage: $0 [--check|--write]"
+if [[ $# -gt 1 || ($# -eq 1 && "$1" != "--check" && "$1" != "--write") ]]; then
+  echo "usage: $0 [--check|--write]" >&2
   exit 1
 fi
+mode="${1:-"--check"}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"

--- a/scripts/check_team_proto_codegen.sh
+++ b/scripts/check_team_proto_codegen.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mode="${1:---check}"
+if [[ "${mode}" != "--check" && "${mode}" != "--write" ]]; then
+  echo "usage: $0 [--check|--write]"
+  exit 1
+fi
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
@@ -68,14 +74,25 @@ if ! grep -q 'pub struct SendActorMessageRequest' "${latest_generated}"; then
 fi
 
 tracked_generated="src/internal/proto/agenthub.internal.v1.rs"
-if [[ -f "${tracked_generated}" ]]; then
-  if ! cmp -s "${tracked_generated}" "${latest_generated}"; then
-    echo "tracked proto file is out of date: ${tracked_generated}"
-    echo "latest generated file: ${latest_generated}"
-    echo "please refresh tracked proto output to match current codegen"
-    exit 1
-  fi
-  echo "tracked proto file is up to date: ${tracked_generated}"
+if [[ "${mode}" == "--write" ]]; then
+  cp "${latest_generated}" "${tracked_generated}"
+  echo "updated tracked proto file: ${tracked_generated}"
+  echo "source generated file: ${latest_generated}"
+  exit 0
 fi
 
+if [[ ! -f "${tracked_generated}" ]]; then
+  echo "tracked proto file missing: ${tracked_generated}"
+  echo "run './scripts/check_team_proto_codegen.sh --write' to regenerate"
+  exit 1
+fi
+
+if ! cmp -s "${tracked_generated}" "${latest_generated}"; then
+  echo "tracked proto file is out of date: ${tracked_generated}"
+  echo "latest generated file: ${latest_generated}"
+  echo "run './scripts/check_team_proto_codegen.sh --write' to regenerate"
+  exit 1
+fi
+
+echo "tracked proto file is up to date: ${tracked_generated}"
 echo "protobuf codegen check passed: ${latest_generated}"


### PR DESCRIPTION
## Summary

Converge Cargo/Bazel protobuf workflow to a single contract and restore Rust CI proto drift guard.

## Background

After Bazel migration, runtime protobuf usage had already moved to tracked generated file
`src/internal/proto/agenthub.internal.v1.rs`, but workflow/docs were partially inconsistent.
Rust CI also no longer enforced proto drift checks.

## Changes

- `scripts/check_team_proto_codegen.sh`
  - Add explicit modes:
    - `--check` (verify tracked generated file matches latest codegen output)
    - `--write` (refresh tracked generated file)
- `Makefile`
  - Add `proto-gen` target (`--write`)
  - Keep `proto-check` target (`--check`)
- `.github/workflows/rust.yml`
  - Re-enable `Verify internal protobuf codegen` step via `make proto-check`
- `README.md`
  - Update proto section to reflect tracked generated file policy
  - Document `make proto-gen` + `make proto-check`
- `docs/todo.md`
  - Mark convergence item as done
  - Add follow-up verification item for CI stability
- `docs/features/2026-02-16-proto-codegen-cargo-bazel-convergence.md`
  - Add feature note for decisions, scope, and validation

## Validation

```bash
make proto-gen
make proto-check
```

Observed:

- `proto-gen` updates tracked generated proto file from latest codegen output.
- `proto-check` passes and verifies byte-level parity.

## Risk / Compatibility

- No API/schema behavior change.
- Change is workflow/guardrail oriented: improves drift detection and developer reproducibility.
