### PR TITLE
fix: remove mobile input bottom blank gap

### DIFF
--- a/docs/features/2026-02-18-mobile-input-safe-bottom-inset-suppression.md
+++ b/docs/features/2026-02-18-mobile-input-safe-bottom-inset-suppression.md
@@ -1,0 +1,54 @@
+# Mobile Input Safe-Bottom Inset Suppression
+
+## Summary
+
+Prevent large white gaps under the input dock on mobile keyboards by suppressing
+app-shell bottom safe-area padding during keyboard-overlap states.
+
+## Background
+
+The app shell applies mobile bottom padding using `safe-area-inset-bottom`.
+During some keyboard transitions, viewport/layout deltas can make this bottom
+inset visually over-apply, leaving a large blank area below the dock and making
+the dock look detached from the bottom edge.
+
+## Scope
+
+- `web/src/app.tsx`
+- `web/src/styles.css`
+- `web/src/app.permission_scope.test.ts`
+- `web/src/app.runtime_effects.test.tsx`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. Add runtime bottom-inset suppression logic:
+   - detect keyboard-overlap states when `layoutHeight - viewportHeight` crosses
+     a threshold;
+   - set `--agenthub-safe-bottom` to `0px` in keyboard-overlap states;
+   - restore `--agenthub-safe-bottom` to `env(safe-area-inset-bottom, 0px)` for
+     normal states.
+2. Keep viewport size sync logic unchanged for `--agenthub-vh` / `--agenthub-vw`
+   to avoid collateral layout regressions.
+3. Remove default `section` bottom gap from `.workspace` to keep the output panel
+   and input dock naturally flush with the shell bottom.
+4. Use `--agenthub-safe-bottom` in mobile `.app` padding so safe-area behavior is
+   centrally controlled by runtime state.
+
+## Validation
+
+```bash
+cd web
+npm run test -- src/app.permission_scope.test.ts src/app.runtime_effects.test.tsx
+npm run lint -- src/app.tsx src/app.permission_scope.test.ts src/app.runtime_effects.test.tsx
+
+cd ..
+cargo test --test web_assets
+```
+
+Expected outcomes:
+
+- Keyboard-open states no longer show large blank space under the input dock.
+- Non-keyboard mobile states still honor bottom safe-area inset.
+- Input dock remains visually bottom-anchored with stable viewport transitions.
+- Runtime viewport/style guard tests remain green.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,7 @@
 
 - [x] Verify mobile/tablet expanded agents drawer exposes an in-panel `Hide agents` control and can be collapsed without tapping backdrop (see `docs/features/2026-02-17-mobile-agents-collapse-access.md`).
 - [x] Verify focused message textarea remains visible during mobile virtual-keyboard viewport transitions (resize/pan) and does not drop below visible area while typing (see `docs/features/2026-02-17-mobile-input-focus-visibility.md`).
+- [ ] Verify mobile keyboard open/close transitions suppress app-shell bottom safe-area inset while keeping normal inset on non-keyboard states, so input dock stays flush to viewport bottom without large white gaps (see `docs/features/2026-02-18-mobile-input-safe-bottom-inset-suppression.md`).
 - [x] Verify conversation auto-stick keeps following bottom during live content growth when user has not intentionally scrolled up, and only detaches after meaningful upward movement (see `docs/features/2026-02-17-conversation-stickiness-hysteresis.md`).
 - [x] Verify Playwright E2E coverage upload publishes `web-e2e` flag with `web/coverage/e2e/lcov.info` in CI push/PR runs (see `docs/features/2026-02-17-playwright-e2e-coverage-codecov.md`).
 - [x] Verify ACP conversation groups consecutive tool calls under one shared fold, preserves nested tool-call jump targeting, and keeps fold animation lightweight (`conversation.test.ts`, `acp_conversation_render.test.tsx`, `use_acp_conversation*.test.ts`) (see `docs/features/2026-02-17-acp-tool-call-group-fold-animation.md`).

--- a/web/src/app.permission_scope.test.ts
+++ b/web/src/app.permission_scope.test.ts
@@ -16,6 +16,7 @@ import {
   schedulePermissionPollLoop,
   setupLayoutAnchorVarSync,
   setupRuntimeViewportVarSync,
+  shouldSuppressRuntimeBottomSafeInset,
   shouldSyncRuntimeViewportSize,
   toNonNegativeRoundedPx,
 } from "./app";
@@ -420,12 +421,18 @@ describe("app helper decisions", () => {
     );
     expect(style.values.get("--agenthub-vh")).toBe("700px");
     expect(style.values.get("--agenthub-vw")).toBe("390px");
+    expect(style.values.get("--agenthub-safe-bottom")).toBe(
+      "env(safe-area-inset-bottom, 0px)"
+    );
 
     runtimeWindow.visualViewport.height = 666;
     runtimeWindow.visualViewport.width = 360;
     runtimeWindow.visualViewport.emit("resize");
     expect(style.values.get("--agenthub-vh")).toBe("666px");
     expect(style.values.get("--agenthub-vw")).toBe("360px");
+    expect(style.values.get("--agenthub-safe-bottom")).toBe(
+      "env(safe-area-inset-bottom, 0px)"
+    );
 
     cleanup();
     expect(runtimeWindow.listenerCount("resize")).toBe(0);
@@ -501,10 +508,54 @@ describe("app helper decisions", () => {
     );
     expect(values.get("--agenthub-vh")).toBe("700px");
     expect(values.get("--agenthub-vw")).toBe("390px");
+    expect(values.get("--agenthub-safe-bottom")).toBe(
+      "env(safe-area-inset-bottom, 0px)"
+    );
     setProperty.mockClear();
 
     runtimeWindow.visualViewport.emit("resize");
     expect(setProperty).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("suppresses bottom safe inset when keyboard overlap is large", () => {
+    expect(shouldSuppressRuntimeBottomSafeInset(520, 700)).toBe(true);
+    expect(shouldSuppressRuntimeBottomSafeInset(666, 700)).toBe(false);
+    expect(shouldSuppressRuntimeBottomSafeInset(Number.NaN, 700)).toBe(false);
+    expect(shouldSuppressRuntimeBottomSafeInset(520, Number.NaN)).toBe(false);
+  });
+
+  it("updates safe bottom inset css var during keyboard transitions", () => {
+    const runtimeWindow = new MockEventTarget() as MockEventTarget & {
+      innerHeight: number;
+      innerWidth: number;
+      visualViewport: MockEventTarget & { height: number; width: number };
+    };
+    runtimeWindow.innerHeight = 700;
+    runtimeWindow.innerWidth = 390;
+    runtimeWindow.visualViewport = Object.assign(new MockEventTarget(), {
+      height: 700,
+      width: 390,
+    });
+    const style = createStyleTarget();
+
+    const cleanup = setupRuntimeViewportVarSync(
+      runtimeWindow as unknown as Parameters<typeof setupRuntimeViewportVarSync>[0],
+      style.target
+    );
+    expect(style.values.get("--agenthub-safe-bottom")).toBe(
+      "env(safe-area-inset-bottom, 0px)"
+    );
+
+    runtimeWindow.visualViewport.height = 500;
+    runtimeWindow.visualViewport.emit("resize");
+    expect(style.values.get("--agenthub-safe-bottom")).toBe("0px");
+
+    runtimeWindow.visualViewport.height = 680;
+    runtimeWindow.visualViewport.emit("resize");
+    expect(style.values.get("--agenthub-safe-bottom")).toBe(
+      "env(safe-area-inset-bottom, 0px)"
+    );
     cleanup();
   });
 

--- a/web/src/app.runtime_effects.test.tsx
+++ b/web/src/app.runtime_effects.test.tsx
@@ -74,6 +74,7 @@ describe("App runtime viewport effects", () => {
     }
     document.documentElement.style.removeProperty("--agenthub-vh");
     document.documentElement.style.removeProperty("--agenthub-vw");
+    document.documentElement.style.removeProperty("--agenthub-safe-bottom");
     vi.restoreAllMocks();
   });
 
@@ -91,6 +92,9 @@ describe("App runtime viewport effects", () => {
     expect(
       document.documentElement.style.getPropertyValue("--agenthub-vw")
     ).toBe("390px");
+    expect(
+      document.documentElement.style.getPropertyValue("--agenthub-safe-bottom")
+    ).toBe("env(safe-area-inset-bottom, 0px)");
 
     mockViewport.height = 666;
     mockViewport.width = 360;
@@ -105,6 +109,36 @@ describe("App runtime viewport effects", () => {
     expect(
       document.documentElement.style.getPropertyValue("--agenthub-vw")
     ).toBe("360px");
+    expect(
+      document.documentElement.style.getPropertyValue("--agenthub-safe-bottom")
+    ).toBe("env(safe-area-inset-bottom, 0px)");
+  });
+
+  it("suppresses bottom safe inset while keyboard overlap is large", async () => {
+    await act(async () => {
+      root.render(<App />);
+      await Promise.resolve();
+    });
+
+    mockViewport.height = 500;
+    await act(async () => {
+      mockViewport.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue("--agenthub-safe-bottom")
+    ).toBe("0px");
+
+    mockViewport.height = 680;
+    await act(async () => {
+      mockViewport.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue("--agenthub-safe-bottom")
+    ).toBe("env(safe-area-inset-bottom, 0px)");
   });
 
   it("does not collapse runtime viewport vars when visual viewport reports tiny transient values", async () => {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -99,6 +99,7 @@ const PERMISSION_JUMP_RETRY_DELAY_MS = 120;
 const GLOBAL_PERMISSION_POLL_INTERVAL_MS = 5000;
 const GLOBAL_PERMISSION_POLL_INTERVAL_COLLAPSED_MS = 10000;
 const GLOBAL_PERMISSION_POLL_MAX_CONCURRENCY = 4;
+const BOTTOM_SAFE_INSET_SUPPRESSION_THRESHOLD_PX = 120;
 
 type PendingPermissionJumpState = {
   toolCallId: string;
@@ -212,6 +213,21 @@ export function shouldSyncRuntimeViewportSize(
 ): boolean {
   if (!previous) return true;
   return previous.height !== next.height || previous.width !== next.width;
+}
+
+export function shouldSuppressRuntimeBottomSafeInset(
+  viewportHeight: number,
+  layoutHeight: number
+): boolean {
+  if (!Number.isFinite(viewportHeight) || !Number.isFinite(layoutHeight)) {
+    return false;
+  }
+  if (viewportHeight <= 0 || layoutHeight <= 0) {
+    return false;
+  }
+  return (
+    layoutHeight - viewportHeight >= BOTTOM_SAFE_INSET_SUPPRESSION_THRESHOLD_PX
+  );
 }
 
 export function toNonNegativeRoundedPx(value: number | null | undefined): number | null {
@@ -352,12 +368,24 @@ export function setupRuntimeViewportVarSync(
   const viewport = runtimeWindow.visualViewport;
   let rafId: number | null = null;
   let previousSize: RuntimeViewportSize | null = null;
+  let previousBottomSafeInset: string | null = null;
   const syncViewportSizeNow = () => {
     const nextSize = resolveRuntimeViewportSize(
       viewport,
       runtimeWindow.innerHeight,
       runtimeWindow.innerWidth
     );
+    const suppressBottomSafeInset = shouldSuppressRuntimeBottomSafeInset(
+      nextSize.height,
+      runtimeWindow.innerHeight
+    );
+    const nextBottomSafeInset = suppressBottomSafeInset
+      ? "0px"
+      : "env(safe-area-inset-bottom, 0px)";
+    if (previousBottomSafeInset !== nextBottomSafeInset) {
+      previousBottomSafeInset = nextBottomSafeInset;
+      styleTarget.setProperty("--agenthub-safe-bottom", nextBottomSafeInset);
+    }
     if (!shouldSyncRuntimeViewportSize(previousSize, nextSize)) {
       return;
     }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7,6 +7,7 @@
   color: #161616;
   --agenthub-vh: 100vh;
   --agenthub-vw: 100vw;
+  --agenthub-safe-bottom: env(safe-area-inset-bottom, 0px);
   --agenthub-header-height: 56px;
   --agenthub-workspace-top: calc(
     var(--agenthub-header-height) + env(safe-area-inset-top, 0px)
@@ -256,6 +257,7 @@ section {
   gap: 6px;
   align-items: stretch;
   padding: 0;
+  margin-bottom: 0;
   flex: 1;
   min-height: 0;
 }
@@ -2402,7 +2404,7 @@ select:not([class*="mantine-"]):focus-visible {
 @media (max-width: 1024px) {
   .app {
     padding: calc(2px + env(safe-area-inset-top, 0px)) 6px
-      calc(6px + env(safe-area-inset-bottom, 0px));
+      calc(6px + var(--agenthub-safe-bottom, env(safe-area-inset-bottom, 0px)));
   }
 
   .workspace {
@@ -2436,7 +2438,8 @@ select:not([class*="mantine-"]):focus-visible {
 
 @media (max-width: 720px) {
   .app {
-    padding: calc(2px + env(safe-area-inset-top, 0px)) 4px calc(4px + env(safe-area-inset-bottom, 0px));
+    padding: calc(2px + env(safe-area-inset-top, 0px)) 4px
+      calc(4px + var(--agenthub-safe-bottom, env(safe-area-inset-bottom, 0px)));
   }
 
   header {


### PR DESCRIPTION
## Summary

This PR fixes the Agent page mobile input dock bottom gap issue (large blank space below the input when keyboard is open/closing).

## What Changed

- Add runtime keyboard-overlap detection and dynamically control bottom safe inset:
  - Introduce `--agenthub-safe-bottom` runtime var.
  - Suppress bottom inset to `0px` when viewport/layout delta indicates keyboard overlap.
  - Restore normal `env(safe-area-inset-bottom, 0px)` in non-keyboard states.
- Keep existing runtime viewport var sync (`--agenthub-vh/--agenthub-vw`) behavior intact.
- Remove inherited bottom spacing on `.workspace` to keep input dock flush to panel bottom.
- Wire mobile `.app` bottom padding to `--agenthub-safe-bottom`.

## Scope

- `web/src/app.tsx`
- `web/src/styles.css`
- `web/src/app.permission_scope.test.ts`
- `web/src/app.runtime_effects.test.tsx`
- `docs/features/2026-02-18-mobile-input-safe-bottom-inset-suppression.md`
- `docs/todo.md`

## Validation

- `cargo check`
- `cargo test --test web_assets`
- `cd web && npm test -- app.permission_scope.test.ts app.runtime_effects.test.tsx`
- `cd web && npm run lint -- src/app.tsx src/app.permission_scope.test.ts src/app.runtime_effects.test.tsx`
- `cd web && npm run build`

## Notes

- This change targets Agent workspace layout only, not Team pages.
