### PR TITLE
test: verify create_worktree restart reuse after state rebuild

### DIFF
--- a/docs/features/2026-02-15-create-worktree-restart-reuse.md
+++ b/docs/features/2026-02-15-create-worktree-restart-reuse.md
@@ -26,8 +26,9 @@ their already-created worktree paths, so the next start failed with
    `git worktree list --porcelain` on the configured repo.
 3. If the target workdir is already present in that worktree list, treat it as
    a valid reuse path and continue start flow.
-4. Add a router-level regression test to cover repeated
-   `start -> stop -> start` for a `create_worktree` agent.
+4. Add router-level regression tests to cover repeated
+   `start -> stop -> start` and `state rebuild -> start` for
+   a `create_worktree` agent.
 5. Harden reuse safety: reject reuse when the same workdir is already bound to
    another agent record.
 6. Validate existing worktree ref against configured `worktree_ref` (except
@@ -39,6 +40,7 @@ their already-created worktree paths, so the next start failed with
 
 ```bash
 cargo test create_worktree_agent_can_start_again_after_stop -- --nocapture
+cargo test create_worktree_agent_can_start_after_state_rebuild -- --nocapture
 cargo test create_worktree_rejects_reuse_by_other_agent -- --nocapture
 cargo test parse_worktree_list_extracts_entries -- --nocapture
 cargo test worktree_ref_matches_ -- --nocapture

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -220,7 +220,7 @@
 - [x] Verify worktree-default helper logic (`runtime defaults` + `create modal prefill`) with dedicated web unit tests to keep coverage stable (see `docs/features/2026-02-15-worktree-default-root.md`).
 - [x] Verify `create_worktree` modal defaults to non-editable workdir display and exposes override only via `Customize path` (see `docs/features/2026-02-15-worktree-default-root.md`).
 - [x] Verify `use_existing` mode no longer auto-fills workdir with default root on modal open or mode switch (see `docs/features/2026-02-15-worktree-default-root.md`).
-- [ ] Verify `create_worktree` agents can restart after process reboot without failing `workdir is not empty` when the target path is already a valid git worktree for the configured repo (see `docs/features/2026-02-15-create-worktree-restart-reuse.md`).
+- [x] Verify `create_worktree` agents can restart after process reboot without failing `workdir is not empty` when the target path is already a valid git worktree for the configured repo (see `docs/features/2026-02-15-create-worktree-restart-reuse.md`).
 - [x] Verify runtime default safe paths always include `~/.agenthub/worktrees` and keep configured safe path entries deduplicated (see `docs/features/2026-02-15-safe-path-default-worktrees.md`).
 - [x] Fix Rust CI test compile failure after `AppState` default root field expansion by updating `api/agents` test state builder (see `docs/features/2026-02-15-rust-ci-appstate-default-worktree-root.md`).
 - [x] Canonicalize default actor CLI path so Bazel/macOS path aliases (`/var` vs `/private/var`) do not break actor-runtime API tests (see `docs/features/2026-02-15-bazel-actor-cli-path-canonicalization.md`).

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -531,6 +531,7 @@ fn parse_start_actor_runtime_context(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::process::Command as StdCommand;
     use std::sync::Arc;
     use std::time::Duration;
@@ -728,16 +729,32 @@ mod tests {
         let _ = err;
     }
 
-    async fn create_test_db() -> SqlitePool {
-        let options = SqliteConnectOptions::new()
-            .filename(":memory:")
-            .create_if_missing(true)
-            .foreign_keys(true);
+    async fn create_test_db_with_options(options: SqliteConnectOptions) -> SqlitePool {
         SqlitePoolOptions::new()
             .max_connections(1)
             .connect_with(options)
             .await
             .expect("connect sqlite")
+    }
+
+    async fn create_test_db() -> SqlitePool {
+        create_test_db_with_options(
+            SqliteConnectOptions::new()
+                .filename(":memory:")
+                .create_if_missing(true)
+                .foreign_keys(true),
+        )
+        .await
+    }
+
+    async fn create_test_db_at(path: &Path) -> SqlitePool {
+        create_test_db_with_options(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true)
+                .foreign_keys(true),
+        )
+        .await
     }
 
     async fn init_test_schema(db: &SqlitePool) {
@@ -887,9 +904,7 @@ mod tests {
         .expect("create team_steps");
     }
 
-    async fn build_test_state() -> AppState {
-        let db = create_test_db().await;
-        init_test_schema(&db).await;
+    async fn build_test_state_with_db(db: SqlitePool) -> AppState {
         let keys_dir = std::env::temp_dir().join(format!("agenthub-api-agents-{}", Uuid::new_v4()));
         std::fs::create_dir_all(&keys_dir).expect("create keys dir");
         let keys_path = keys_dir.join("vapid.json");
@@ -932,6 +947,12 @@ mod tests {
             acp_permissions: permissions,
             default_worktree_root: config.default_worktree_root(),
         }
+    }
+
+    async fn build_test_state() -> AppState {
+        let db = create_test_db().await;
+        init_test_schema(&db).await;
+        build_test_state_with_db(db).await
     }
 
     fn remove_dir_best_effort(path: &std::path::Path) {
@@ -1132,6 +1153,136 @@ mod tests {
             .expect("stop create_worktree agent (second)");
         assert_eq!(stop_second.status(), StatusCode::OK);
 
+        remove_dir_best_effort(&base);
+    }
+
+    #[tokio::test]
+    async fn create_worktree_agent_can_start_after_state_rebuild() {
+        if !is_git_available() {
+            eprintln!(
+                "skipping create_worktree_agent_can_start_after_state_rebuild: `git` is not available on PATH"
+            );
+            return;
+        }
+
+        let base =
+            std::env::temp_dir().join(format!("agenthub-create-worktree-rebuild-{}", Uuid::new_v4()));
+        let repo_dir = base.join("repo");
+        let workdir = base.join("worktree-agent");
+        let db_path = base.join("agents.sqlite");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        run_git(&repo_dir, &["init"]);
+        run_git(
+            &repo_dir,
+            &["config", "user.email", "agenthub-test@example.com"],
+        );
+        run_git(&repo_dir, &["config", "user.name", "AgentHub Test"]);
+        std::fs::write(repo_dir.join("README.md"), "seed\n").expect("write seed file");
+        run_git(&repo_dir, &["add", "README.md"]);
+        run_git(&repo_dir, &["commit", "-m", "init"]);
+
+        let db = create_test_db_at(&db_path).await;
+        init_test_schema(&db).await;
+        let state = build_test_state_with_db(db).await;
+        let token = create_auth_token(&state).await;
+        let app = router(state.clone());
+
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(repo_dir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert repo safe path");
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(workdir.to_string_lossy().to_string())
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .expect("insert workdir safe path");
+
+        let create_resp = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "create-worktree-state-rebuild",
+                    "workdir": workdir.to_string_lossy().to_string(),
+                    "command": "/bin/sh",
+                    "args": ["-lc", "sleep 30"],
+                    "worktree_mode": "create_worktree",
+                    "worktree_repo": repo_dir.to_string_lossy().to_string(),
+                    "worktree_ref": "HEAD",
+                    "code_mode": true
+                })),
+            ))
+            .await
+            .expect("create create_worktree agent");
+        assert_eq!(create_resp.status(), StatusCode::OK);
+        let created = decode_json_body(create_resp).await;
+        let agent_id = created["id"].as_str().expect("agent id").to_string();
+
+        let start_first = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start create_worktree agent (first)");
+        assert_eq!(start_first.status(), StatusCode::OK);
+
+        let stop_first = app
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/stop"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("stop create_worktree agent (first)");
+        assert_eq!(stop_first.status(), StatusCode::OK);
+
+        drop(state);
+
+        let reloaded_db = create_test_db_at(&db_path).await;
+        let reloaded_state = build_test_state_with_db(reloaded_db).await;
+        reloaded_state
+            .agents
+            .mark_exited_on_startup()
+            .await
+            .expect("mark exited on startup");
+        let reloaded_app = router(reloaded_state.clone());
+
+        let start_after_rebuild = reloaded_app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/start"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("start create_worktree agent (after state rebuild)");
+        assert_eq!(start_after_rebuild.status(), StatusCode::OK);
+
+        let stop_after_rebuild = reloaded_app
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/stop"),
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("stop create_worktree agent (after state rebuild)");
+        assert_eq!(stop_after_rebuild.status(), StatusCode::OK);
+
+        drop(reloaded_state);
         remove_dir_best_effort(&base);
     }
 

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1070,18 +1070,14 @@ mod tests {
         run_git(&repo_dir, &["commit", "-m", "init"]);
 
         let now = chrono::Utc::now().timestamp();
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind(repo_dir.to_string_lossy().to_string())
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert repo safe path");
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind(workdir.to_string_lossy().to_string())
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert workdir safe path");
+        for path in [&repo_dir, &workdir] {
+            sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+                .bind(path.to_string_lossy().to_string())
+                .bind(now)
+                .execute(&state.db)
+                .await
+                .expect("insert safe path");
+        }
 
         let create_resp = app
             .clone()

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1185,18 +1185,14 @@ mod tests {
         let app = router(state.clone());
 
         let now = chrono::Utc::now().timestamp();
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind(repo_dir.to_string_lossy().to_string())
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert repo safe path");
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind(workdir.to_string_lossy().to_string())
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert workdir safe path");
+        for path in [&repo_dir, &workdir] {
+            sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+                .bind(path.to_string_lossy().to_string())
+                .bind(now)
+                .execute(&state.db)
+                .await
+                .expect("insert safe path");
+        }
 
         let create_resp = app
             .clone()


### PR DESCRIPTION
## Summary

This PR closes the remaining verification gap for create-worktree restart reuse by adding a router-level regression test that simulates process-state rebuild and re-start.

## Why

`create_worktree` reuse behavior was already fixed, but TODO tracking still required explicit verification for the reboot/rebuild scenario where the target workdir is already a valid git worktree.

## Changes

- refactor `api/agents` test helpers to support file-backed sqlite pools reused across rebuilt app state
- add `create_worktree_agent_can_start_after_state_rebuild` to verify:
  - first `start -> stop` succeeds
  - rebuild state from same sqlite file + `mark_exited_on_startup`
  - second `start -> stop` still succeeds without `workdir is not empty`
- mark TODO item as completed in `docs/todo.md`
- update feature note validation and decision text

## Testing

- `cargo test create_worktree_ -- --nocapture`

## Related

- `docs/features/2026-02-15-create-worktree-restart-reuse.md`
