### PR TITLE
feat: add sqlite history retention cleanup with optional vacuum

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,17 @@ Default UI address: `http://localhost:8080`.
 AgentHub reads config from `config.toml`.
 
 ```toml
-listen_addr = "0.0.0.0:8080"
+[server]
+listen = "0.0.0.0:8080"
 
 safe_paths = [
   "/home/foo",
   "/home/foo/projects"
 ]
+
+[history]
+event_retention_days = 5
+vacuum_on_cleanup = false
 ```
 
 Runtime state (database, local artifacts) defaults to `~/.agenthub/`.

--- a/docs/features/2026-02-20-sqlite-history-retention-cleanup.md
+++ b/docs/features/2026-02-20-sqlite-history-retention-cleanup.md
@@ -1,0 +1,61 @@
+# SQLite History Retention Cleanup
+
+## Summary
+
+Add startup retention cleanup for `agent_events` with configurable history window,
+defaulting to 5 days. Support optional post-cleanup database compaction via
+`VACUUM` for operators who prefer reclaiming file size aggressively.
+
+## Background
+
+Long-running AgentHub deployments accumulate large `agent_events` volume,
+especially ACP streams. Without retention, SQLite file growth becomes significant
+and WAL checkpoint alone cannot reclaim historical rows that should no longer be
+kept.
+
+## Scope
+
+- Add `history` config section in `AppConfig`:
+  - `history.event_retention_days` (default `5`; `0` disables cleanup)
+  - `history.vacuum_on_cleanup` (default `false`)
+- Add DB helper to delete old `agent_events` rows by `ts` cutoff.
+- Add startup hook in `AppState::init` to run cleanup once per process start.
+- Add index `idx_agent_events_ts` to keep retention delete scans bounded.
+- Add unit coverage for config defaults/overrides and cleanup cutoff behavior.
+
+## Key Decisions
+
+1. Keep retention focused on `agent_events` only.
+   - This table dominates growth and is safe to prune independently.
+2. Use startup-triggered cleanup instead of periodic background worker.
+   - Minimal runtime complexity and no extra scheduling state.
+3. Make `VACUUM` opt-in.
+   - `VACUUM` can be expensive on large files; default should favor startup
+     predictability.
+4. Treat cleanup failures as non-fatal.
+   - Startup continues, but warning logs preserve diagnostics.
+
+## Validation
+
+Suggested commands:
+
+```bash
+cargo test history_
+cargo test cleanup_agent_event_history_deletes_rows_older_than_retention
+cargo build
+```
+
+Manual config check example:
+
+```toml
+[history]
+event_retention_days = 5
+vacuum_on_cleanup = false
+```
+
+## Follow-ups
+
+- Consider periodic incremental cleanup with bounded delete batch size for very
+  large deployments that run continuously without restarts.
+- Consider additional retention knobs for high-volume audit-like tables if they
+  become primary growth contributors.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify startup history retention cleanup (`history.event_retention_days`) deletes `agent_events` older than configured window (default `5` days) and optional `history.vacuum_on_cleanup` compaction behavior remains stable on non-empty cleanup runs (see `docs/features/2026-02-20-sqlite-history-retention-cleanup.md`).
 - [x] Verify `TeamMemberConsolePanel` and `TeamMailboxPanel` reuse shared Team Tailwind panel constants while keeping panel interaction tests green (`team_panels`) and passing `web` lint/build (see `docs/features/2026-02-20-web-team-member-mailbox-shared-tailwind-classes.md`).
 - [ ] Verify Codecov upload strict mode (`fail_ci_if_error: true`) stays stable for `Rust`/`Web`/`Web E2E` workflows on both `push` and `pull_request` events; record workflow run IDs before marking done (see `docs/features/2026-02-20-ci-codecov-fail-fast-upload.md`).
 - [x] Verify Team workbench shared Tailwind class extraction across `TeamRunPanel`/`TeamOverviewPanel`/`TeamEventsPanel`/`TeamStepsPanel` keeps interaction tests green (`team_panels`), passes `web` lint/build, and preserves existing callback/reducer behavior (see `docs/features/2026-02-20-web-team-panel-shared-tailwind-classes.md`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::collections::HashSet;
 
 const DEFAULT_SAFE_PATH: &str = "~/.agenthub/worktrees";
+const DEFAULT_HISTORY_EVENT_RETENTION_DAYS: u32 = 5;
 
 #[derive(Debug, Clone)]
 pub struct ConfigLoadInfo {
@@ -17,6 +18,7 @@ pub struct AppConfig {
     pub proxy: Option<ProxyConfig>,
     pub worktree: Option<WorktreeConfig>,
     pub codex_acp: Option<CodexAcpConfig>,
+    pub history: Option<HistoryConfig>,
     pub push: Option<PushConfig>,
     pub internal_grpc: Option<InternalGrpcConfig>,
     pub safe_paths: Option<Vec<String>>,
@@ -58,6 +60,12 @@ pub struct CodexAcpConfig {
 pub struct PushConfig {
     pub subject: Option<String>,
     pub keys_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HistoryConfig {
+    pub event_retention_days: Option<u32>,
+    pub vacuum_on_cleanup: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -206,6 +214,25 @@ impl AppConfig {
             .map(|value| value.to_string())
     }
 
+    pub fn history_event_retention_days(&self) -> Option<u32> {
+        let days = self
+            .history
+            .as_ref()
+            .and_then(|history| history.event_retention_days)
+            .unwrap_or(DEFAULT_HISTORY_EVENT_RETENTION_DAYS);
+        if days == 0 {
+            return None;
+        }
+        Some(days)
+    }
+
+    pub fn history_vacuum_on_cleanup(&self) -> bool {
+        self.history
+            .as_ref()
+            .and_then(|history| history.vacuum_on_cleanup)
+            .unwrap_or(false)
+    }
+
     pub fn internal_grpc_enabled(&self) -> bool {
         self.internal_grpc
             .as_ref()
@@ -339,6 +366,8 @@ fn detect_env_overrides() -> Vec<String> {
         "AGENTHUB_LOG_PATH",
         "AGENTHUB_CODEX_ACP_BINARY",
         "AGENTHUB_CODEX_ACP_DEFAULT_MODE",
+        "AGENTHUB_HISTORY_EVENT_RETENTION_DAYS",
+        "AGENTHUB_HISTORY_VACUUM_ON_CLEANUP",
         "AGENTHUB_INTERNAL_GRPC_ENABLED",
         "AGENTHUB_INTERNAL_GRPC_LISTEN",
         "AGENTHUB_INTERNAL_GRPC_SECURITY_MODE",
@@ -379,7 +408,7 @@ fn expand_tilde(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppConfig, WorktreeConfig};
+    use super::{AppConfig, HistoryConfig, WorktreeConfig};
 
     #[test]
     fn default_worktree_root_uses_builtin_default() {
@@ -445,5 +474,37 @@ mod tests {
         assert!(config.internal_grpc_auth_issuer().is_none());
         assert!(config.internal_grpc_auth_audience().is_none());
         assert!(config.internal_grpc_bootstrap_token().is_none());
+    }
+
+    #[test]
+    fn history_defaults_use_five_days_and_no_vacuum() {
+        let config = AppConfig::default();
+        assert_eq!(config.history_event_retention_days(), Some(5));
+        assert!(!config.history_vacuum_on_cleanup());
+    }
+
+    #[test]
+    fn history_config_applies_custom_values() {
+        let config = AppConfig {
+            history: Some(HistoryConfig {
+                event_retention_days: Some(14),
+                vacuum_on_cleanup: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(config.history_event_retention_days(), Some(14));
+        assert!(config.history_vacuum_on_cleanup());
+    }
+
+    #[test]
+    fn history_retention_can_be_disabled_with_zero() {
+        let config = AppConfig {
+            history: Some(HistoryConfig {
+                event_retention_days: Some(0),
+                vacuum_on_cleanup: Some(false),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(config.history_event_retention_days(), None);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,13 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentEventCleanupResult {
+    pub cutoff_ts: i64,
+    pub deleted_rows: u64,
+    pub vacuum_ran: bool,
+}
+
 pub async fn init_db() -> anyhow::Result<SqlitePool> {
     let db_path = default_db_path();
     init_db_at_path(&db_path).await
@@ -343,6 +350,17 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
             err
         );
     }
+    if let Err(err) = sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_agent_events_ts
+        ON agent_events(ts);
+        "#,
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!("db init: failed to create idx_agent_events_ts: {}", err);
+    }
 
     if let Err(err) = sqlx::query(
         r#"
@@ -566,6 +584,51 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     Ok(pool)
 }
 
+pub async fn cleanup_agent_event_history(
+    pool: &SqlitePool,
+    retention_days: u32,
+    vacuum_on_cleanup: bool,
+) -> anyhow::Result<AgentEventCleanupResult> {
+    const SECONDS_PER_DAY: i64 = 24 * 60 * 60;
+    let retention_seconds = i64::from(retention_days).saturating_mul(SECONDS_PER_DAY);
+    let cutoff_ts = chrono::Utc::now()
+        .timestamp()
+        .saturating_sub(retention_seconds);
+
+    let deleted_rows = sqlx::query(
+        r#"
+        DELETE FROM agent_events
+        WHERE ts < ?1
+        "#,
+    )
+    .bind(cutoff_ts)
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    if let Err(err) = sqlx::query("PRAGMA wal_checkpoint(PASSIVE)")
+        .execute(pool)
+        .await
+    {
+        tracing::warn!("db cleanup: wal checkpoint failed: {}", err);
+    }
+
+    let mut vacuum_ran = false;
+    if vacuum_on_cleanup && deleted_rows > 0 {
+        if let Err(err) = sqlx::query("VACUUM").execute(pool).await {
+            tracing::warn!("db cleanup: vacuum failed: {}", err);
+        } else {
+            vacuum_ran = true;
+        }
+    }
+
+    Ok(AgentEventCleanupResult {
+        cutoff_ts,
+        deleted_rows,
+        vacuum_ran,
+    })
+}
+
 async fn add_column_if_missing(pool: &SqlitePool, sql: &str, column: &str) {
     if let Err(err) = sqlx::query(sql).execute(pool).await {
         let message = err.to_string();
@@ -612,7 +675,7 @@ fn create_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{create_parent_dir, init_db_at_path, try_connect};
+    use super::{cleanup_agent_event_history, create_parent_dir, init_db_at_path, try_connect};
     use sqlx::Row;
     use uuid::Uuid;
 
@@ -710,6 +773,110 @@ mod tests {
                 .expect("check parent exists"),
             "parent directory should exist"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn cleanup_agent_event_history_deletes_rows_older_than_retention() {
+        let dir = unique_temp_dir("db-cleanup");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let db_path = dir.join("cleanup.db");
+        let pool = init_db_at_path(&db_path).await.expect("init db");
+
+        let now = chrono::Utc::now().timestamp();
+        let old_ts = now - (10 * 24 * 60 * 60);
+        let new_ts = now - (2 * 24 * 60 * 60);
+
+        sqlx::query(
+            r#"
+            INSERT INTO agents (
+                id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref,
+                code_mode, source, status, created_at, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            "#,
+        )
+        .bind("agent-cleanup")
+        .bind("cleanup-agent")
+        .bind("/tmp")
+        .bind("echo")
+        .bind("[]")
+        .bind("reuse_worktree")
+        .bind(None::<String>)
+        .bind(None::<String>)
+        .bind(0_i64)
+        .bind("manual")
+        .bind("stopped")
+        .bind(now)
+        .bind(now)
+        .execute(&pool)
+        .await
+        .expect("insert agent");
+
+        sqlx::query(
+            r#"
+            INSERT INTO agent_sessions (id, agent_id, status, started_at, ended_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )
+        .bind("session-cleanup")
+        .bind("agent-cleanup")
+        .bind("running")
+        .bind(now)
+        .bind(None::<i64>)
+        .execute(&pool)
+        .await
+        .expect("insert session");
+
+        sqlx::query(
+            r#"
+            INSERT INTO agent_events (agent_id, session_id, seq, ts, stream, message)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+        )
+        .bind("agent-cleanup")
+        .bind("session-cleanup")
+        .bind("seq-old")
+        .bind(old_ts)
+        .bind("acp")
+        .bind("old")
+        .execute(&pool)
+        .await
+        .expect("insert old event");
+
+        sqlx::query(
+            r#"
+            INSERT INTO agent_events (agent_id, session_id, seq, ts, stream, message)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+        )
+        .bind("agent-cleanup")
+        .bind("session-cleanup")
+        .bind("seq-new")
+        .bind(new_ts)
+        .bind("acp")
+        .bind("new")
+        .execute(&pool)
+        .await
+        .expect("insert new event");
+
+        let result = cleanup_agent_event_history(&pool, 5, false)
+            .await
+            .expect("cleanup history");
+        assert_eq!(result.deleted_rows, 1);
+        assert!(!result.vacuum_ran);
+        assert!(result.cutoff_ts > old_ts);
+        assert!(result.cutoff_ts < new_ts);
+
+        let remaining: i64 = sqlx::query("SELECT COUNT(*) AS cnt FROM agent_events")
+            .fetch_one(&pool)
+            .await
+            .expect("count remaining events")
+            .get("cnt");
+        assert_eq!(remaining, 1);
+
+        pool.close().await;
+        let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,6 +26,31 @@ pub struct AppState {
 impl AppState {
     pub async fn init(config: crate::config::AppConfig) -> anyhow::Result<Self> {
         let db = crate::db::init_db().await?;
+        if let Some(retention_days) = config.history_event_retention_days() {
+            let vacuum_on_cleanup = config.history_vacuum_on_cleanup();
+            match crate::db::cleanup_agent_event_history(&db, retention_days, vacuum_on_cleanup)
+                .await
+            {
+                Ok(result) => {
+                    if result.deleted_rows > 0 || result.vacuum_ran {
+                        tracing::info!(
+                            "history cleanup applied: retention_days={} cutoff_ts={} deleted_rows={} vacuum_ran={}",
+                            retention_days,
+                            result.cutoff_ts,
+                            result.deleted_rows,
+                            result.vacuum_ran
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "history cleanup skipped due to error: retention_days={} error={}",
+                        retention_days,
+                        err
+                    );
+                }
+            }
+        }
         let push = Arc::new(PushService::new(db.clone(), &config)?);
         let acp_permissions = Arc::new(AcpPermissionService::new(db.clone()));
         let auth = Arc::new(AuthService::new(db.clone(), &config).await?);


### PR DESCRIPTION
## Summary

- add startup history retention cleanup for `agent_events` with configurable window (`history.event_retention_days`)
- default retention to 5 days, with `0` meaning disabled cleanup
- add optional `history.vacuum_on_cleanup` for post-delete compaction
- add `idx_agent_events_ts` to support efficient retention deletes
- document behavior and add follow-up verification TODO

## Why

`agent_events` grows quickly in long-running deployments (especially ACP stream output). This change adds a safe default cleanup policy to control SQLite growth while keeping compaction optional.

## Changes

- config: add `history` section in `AppConfig`
- state init: run best-effort startup cleanup before runtime services start
- db: implement cleanup helper (`DELETE ... WHERE ts < cutoff`) + WAL checkpoint + optional vacuum
- tests: add config and cleanup unit coverage
- docs: add feature note and update TODO/README config snippets

## Compatibility

- default behavior now keeps 5 days of `agent_events`
- set `history.event_retention_days = 0` to keep all history (disable cleanup)
- `vacuum_on_cleanup` defaults to `false` to avoid startup latency spikes

## Validation

- `cargo test history_`
- `cargo test cleanup_agent_event_history_deletes_rows_older_than_retention`
- `cargo build`

## Related

- Issue: N/A
