### PR TITLE
refactor(api): phase2 split teams error mapping module

### DIFF
--- a/docs/features/2026-02-21-api-teams-error-mapping-module-split.md
+++ b/docs/features/2026-02-21-api-teams-error-mapping-module-split.md
@@ -1,0 +1,48 @@
+# API Teams Error Mapping Module Split
+
+## Background
+
+`src/api/teams.rs` carried both HTTP handlers and low-level error mapping helpers
+(unique-constraint detection, row-not-found mapping, actor-service status mapping).
+This mixed transport flow with mapping details and increased file size/maintenance cost.
+
+## Scope
+
+- Extract Teams API error mapping helpers from `src/api/teams.rs` into
+  `src/api/teams/errors.rs`.
+- Keep handler behavior and HTTP responses unchanged.
+- Keep constants and constraint semantics unchanged.
+
+## Key Decisions
+
+1. Introduce `mod errors;` under Teams API module and re-export helper functions
+   via `use self::errors::{...}` in `src/api/teams.rs`.
+2. Move these helpers to `src/api/teams/errors.rs`:
+   - `map_create_team_error`
+   - `map_submit_step_error`
+   - `map_actor_service_api_error`
+   - `map_not_found_error`
+   - `map_resume_run_error`
+   - `map_team_internal_error`
+   - unique/row-not-found detector helpers
+3. Keep `SQLITE_CONSTRAINT_UNIQUE_CODE` source-of-truth in `teams.rs`, referenced
+   from `errors.rs` via `super::SQLITE_CONSTRAINT_UNIQUE_CODE`.
+
+## Validation
+
+Executed locally:
+
+```bash
+cargo test -q teams_api_create_list_get_and_reject_duplicate_name
+cargo test -q team_runs_api_supports_resume_and_restart_strategy
+cargo test -q teams_router_http_contract
+```
+
+All passed.
+
+## Follow-up
+
+- Continue phase-2 split by extracting Team API payload structs and conversion
+  helpers into dedicated submodules while preserving router behavior.
+- Phase-3 will migrate cohesive API/service domains into `crates/*` with Bazel
+  package alignment.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [x] Verify `src/api/teams.rs` error mapping module split (`src/api/teams/errors.rs`) keeps duplicate-name conflict, resume/restart conflict mapping, and router HTTP contract behavior unchanged (see `docs/features/2026-02-21-api-teams-error-mapping-module-split.md`).
 - [x] Verify typed-error mapping replaces string-based conflict detection for Team run resume (`completed` => `409`) and Agent send-input stale session (`session mismatch` => `409`) with focused Rust tests (see `docs/features/2026-02-21-rust-error-typing-teams-agents.md`).
 - [ ] Verify Bazel-first Rust crate decomposition policy is applied to new domain migrations: extract cohesive domain libraries under `crates/*`, keep `src/main.rs` thin-bootstrap only, and align Bazel package/target boundaries with crate boundaries in the same PR (see `docs/features/2026-02-21-bazel-first-domain-crate-policy.md`).
 - [x] Verify Teams workbench style isolation after Tailwind v4 migration: legacy global form-control selectors (`button/input/textarea/select:not([class*="mantine-"])`) no longer override `/teams` Tailwind controls, and Teams shell layout remains stable after removing legacy `app` wrapper coupling (`team_page.tsx`, `styles.css`) with web Team regression tests + web build green (see `docs/features/2026-02-20-team-page-legacy-form-style-isolation.md`).

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1,8 +1,14 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+mod errors;
+
+use self::errors::{
+    map_actor_service_api_error, map_create_team_error, map_not_found_error, map_resume_run_error,
+    map_submit_step_error, map_team_internal_error,
+};
 use agenthub_team_actor::{
     ActorAckRequest, ActorInboxRequest, ActorMailboxService, ActorMessageStatus, ActorSendRequest,
-    ActorServiceError, ActorServiceErrorCode, parse_actor_transport,
+    parse_actor_transport,
 };
 use axum::{
     Json, Router,
@@ -12,15 +18,14 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::Error as SqlxError;
 
 use crate::api::authz::require_user;
 use crate::api::error::ApiError;
 use crate::state::AppState;
 use crate::team::{
     TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport,
-    TeamDefinitionConfig, TeamDefinitionRecord, TeamRunEventRecord, TeamRunRecord,
-    TeamRunResumeError, TeamStepRecord, TeamStepStatus,
+    TeamDefinitionConfig, TeamDefinitionRecord, TeamRunEventRecord, TeamRunRecord, TeamStepRecord,
+    TeamStepStatus,
 };
 
 const TEAM_SPEC_VERSION_V1: i64 = 1;
@@ -1309,88 +1314,6 @@ async fn ensure_step_in_run(state: &AppState, run_id: &str, step_id: &str) -> Re
         return Err(ApiError::not_found("step not found"));
     }
     Ok(())
-}
-
-fn map_create_team_error(err: anyhow::Error) -> ApiError {
-    if is_unique_team_name_violation(&err) {
-        return ApiError::conflict("team name already exists");
-    }
-    map_team_internal_error(err)
-}
-
-fn map_submit_step_error(err: anyhow::Error) -> ApiError {
-    if is_unique_step_attempt_violation(&err) {
-        return ApiError::conflict("step already exists for run");
-    }
-    map_team_internal_error(err)
-}
-
-fn map_actor_service_api_error(err: ActorServiceError) -> ApiError {
-    match err.code {
-        ActorServiceErrorCode::BadRequest | ActorServiceErrorCode::UnprocessableEntity => {
-            ApiError::bad_request(&err.message)
-        }
-        ActorServiceErrorCode::Unauthorized | ActorServiceErrorCode::Forbidden => {
-            ApiError::unauthorized(&err.message)
-        }
-        ActorServiceErrorCode::NotFound | ActorServiceErrorCode::Gone => {
-            ApiError::not_found(&err.message)
-        }
-        ActorServiceErrorCode::Conflict => ApiError::conflict(&err.message),
-        ActorServiceErrorCode::TooManyRequests | ActorServiceErrorCode::Internal => {
-            map_team_internal_error(anyhow::anyhow!("{}", err.message))
-        }
-    }
-}
-
-fn map_not_found_error(err: anyhow::Error, msg: &str) -> ApiError {
-    if is_row_not_found(&err) {
-        return ApiError::not_found(msg);
-    }
-    map_team_internal_error(err)
-}
-
-fn map_resume_run_error(err: anyhow::Error) -> ApiError {
-    if matches!(
-        err.downcast_ref::<TeamRunResumeError>(),
-        Some(TeamRunResumeError::CompletedRun)
-    ) {
-        return ApiError::conflict("completed run cannot be resumed; use restart");
-    }
-    map_not_found_error(err, "run not found")
-}
-
-fn map_team_internal_error(err: anyhow::Error) -> ApiError {
-    tracing::error!("team api internal error: {}", err);
-    ApiError::from(anyhow::anyhow!("internal server error"))
-}
-
-fn is_row_not_found(err: &anyhow::Error) -> bool {
-    matches!(
-        err.downcast_ref::<SqlxError>(),
-        Some(SqlxError::RowNotFound)
-    )
-}
-
-fn is_unique_team_name_violation(err: &anyhow::Error) -> bool {
-    is_unique_violation_for(err, "team_definitions.name")
-}
-
-fn is_unique_step_attempt_violation(err: &anyhow::Error) -> bool {
-    is_unique_violation_for(
-        err,
-        "team_steps.run_id, team_steps.step_key, team_steps.attempt",
-    )
-}
-
-fn is_unique_violation_for(err: &anyhow::Error, constraint: &str) -> bool {
-    match err.downcast_ref::<SqlxError>() {
-        Some(SqlxError::Database(db_err)) => {
-            db_err.code().as_deref() == Some(SQLITE_CONSTRAINT_UNIQUE_CODE)
-                && db_err.message().contains(constraint)
-        }
-        _ => false,
-    }
 }
 
 fn parse_depends_on_keys(depends_on: Option<Vec<String>>) -> Result<Vec<String>, ApiError> {

--- a/src/api/teams/errors.rs
+++ b/src/api/teams/errors.rs
@@ -1,0 +1,87 @@
+use agenthub_team_actor::{ActorServiceError, ActorServiceErrorCode};
+use sqlx::Error as SqlxError;
+
+use crate::api::error::ApiError;
+use crate::team::TeamRunResumeError;
+
+pub(super) fn map_create_team_error(err: anyhow::Error) -> ApiError {
+    if is_unique_team_name_violation(&err) {
+        return ApiError::conflict("team name already exists");
+    }
+    map_team_internal_error(err)
+}
+
+pub(super) fn map_submit_step_error(err: anyhow::Error) -> ApiError {
+    if is_unique_step_attempt_violation(&err) {
+        return ApiError::conflict("step already exists for run");
+    }
+    map_team_internal_error(err)
+}
+
+pub(super) fn map_actor_service_api_error(err: ActorServiceError) -> ApiError {
+    match err.code {
+        ActorServiceErrorCode::BadRequest | ActorServiceErrorCode::UnprocessableEntity => {
+            ApiError::bad_request(&err.message)
+        }
+        ActorServiceErrorCode::Unauthorized | ActorServiceErrorCode::Forbidden => {
+            ApiError::unauthorized(&err.message)
+        }
+        ActorServiceErrorCode::NotFound | ActorServiceErrorCode::Gone => {
+            ApiError::not_found(&err.message)
+        }
+        ActorServiceErrorCode::Conflict => ApiError::conflict(&err.message),
+        ActorServiceErrorCode::TooManyRequests | ActorServiceErrorCode::Internal => {
+            map_team_internal_error(anyhow::anyhow!("{}", err.message))
+        }
+    }
+}
+
+pub(super) fn map_not_found_error(err: anyhow::Error, msg: &str) -> ApiError {
+    if is_row_not_found(&err) {
+        return ApiError::not_found(msg);
+    }
+    map_team_internal_error(err)
+}
+
+pub(super) fn map_resume_run_error(err: anyhow::Error) -> ApiError {
+    if matches!(
+        err.downcast_ref::<TeamRunResumeError>(),
+        Some(TeamRunResumeError::CompletedRun)
+    ) {
+        return ApiError::conflict("completed run cannot be resumed; use restart");
+    }
+    map_not_found_error(err, "run not found")
+}
+
+pub(super) fn map_team_internal_error(err: anyhow::Error) -> ApiError {
+    tracing::error!("team api internal error: {}", err);
+    ApiError::from(anyhow::anyhow!("internal server error"))
+}
+
+fn is_row_not_found(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<SqlxError>(),
+        Some(SqlxError::RowNotFound)
+    )
+}
+
+fn is_unique_team_name_violation(err: &anyhow::Error) -> bool {
+    is_unique_violation_for(err, "team_definitions.name")
+}
+
+fn is_unique_step_attempt_violation(err: &anyhow::Error) -> bool {
+    is_unique_violation_for(
+        err,
+        "team_steps.run_id, team_steps.step_key, team_steps.attempt",
+    )
+}
+
+fn is_unique_violation_for(err: &anyhow::Error, constraint: &str) -> bool {
+    match err.downcast_ref::<SqlxError>() {
+        Some(SqlxError::Database(db_err)) => {
+            db_err.code().as_deref() == Some(super::SQLITE_CONSTRAINT_UNIQUE_CODE)
+                && db_err.message().contains(constraint)
+        }
+        _ => false,
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of Rust maintainability split (2/3): module split only, no behavior change.

- extract Teams API error mapping helpers from `src/api/teams.rs` into `src/api/teams/errors.rs`
- keep handler flow and API response semantics unchanged
- keep unique-constraint and row-not-found mapping semantics unchanged
- add feature note and TODO verification record

## Changes

- `src/api/teams.rs`
  - add `mod errors;`
  - import mapping helpers from `self::errors::{...}`
  - remove in-file error mapping/helper function block
- `src/api/teams/errors.rs`
  - host all Teams API error mapping helpers and detectors
  - keep `SQLITE_CONSTRAINT_UNIQUE_CODE` reference via `super::...`
- docs
  - `docs/features/2026-02-21-api-teams-error-mapping-module-split.md`
  - `docs/todo.md` verification entry

## Why

Reduce `teams.rs` file complexity and keep transport handlers focused, while preserving existing behavior before deeper crate migration in phase 3.

## Validation

```bash
cargo test -q teams_api_create_list_get_and_reject_duplicate_name
cargo test -q team_runs_api_supports_resume_and_restart_strategy
cargo test -q teams_router_http_contract
```

All passed locally.

## Next PR

- Phase 3: migrate cohesive domain module(s) into `crates/*` with Bazel boundary alignment.
