### PR TITLE
refactor(team): phase3 migrate team domain into crate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,6 +29,7 @@ rust_library(
     deps = all_crate_deps(normal = True) + [
         "//crates/agenthub-acp:agenthub_acp",
         "//crates/agenthub-team-actor:agenthub_team_actor",
+        "//crates/agenthub-team-domain:agenthub_team_domain",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "agent-client-protocol",
  "agenthub-acp",
  "agenthub-team-actor",
+ "agenthub-team-domain",
  "anyhow",
  "argon2",
  "async-trait",
@@ -173,6 +174,15 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "agenthub-team-domain"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/agenthub-acp-core",
     "crates/agenthub-acp",
     "crates/agenthub-team-actor",
+    "crates/agenthub-team-domain",
 ]
 
 [patch.crates-io]
@@ -48,6 +49,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 sha2 = "0.10"
 agenthub-acp = { path = "crates/agenthub-acp" }
 agenthub-team-actor = { path = "crates/agenthub-team-actor" }
+agenthub-team-domain = { path = "crates/agenthub-team-domain" }
 agent-client-protocol = { version = "0.9.4", features = ["unstable"] }
 prost = "0.14"
 tonic-prost = "0.14"

--- a/crates/agenthub-team-domain/BUILD.bazel
+++ b/crates/agenthub-team-domain/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "agenthub_team_domain",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "agenthub_team_domain",
+    edition = "2024",
+    aliases = aliases(),
+    deps = all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "agenthub_team_domain_tests",
+    crate = ":agenthub_team_domain",
+    edition = "2024",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/agenthub-team-domain/Cargo.toml
+++ b/crates/agenthub-team-domain/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agenthub-team-domain"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"

--- a/crates/agenthub-team-domain/src/lib.rs
+++ b/crates/agenthub-team-domain/src/lib.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const TEAM_RUN_STATUS_VALUES: [&str; 6] = [
+    "submitted",
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "canceled",
+];
+
+pub const TEAM_STEP_STATUS_VALUES: [&str; 6] = [
+    "submitted",
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "canceled",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamDefinitionConfig {
+    pub name: String,
+    pub description: Option<String>,
+    pub spec: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamDefinitionRecord {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub spec: Value,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TeamRunStatus {
+    Submitted,
+    Working,
+    InputRequired,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamRunRecord {
+    pub id: String,
+    pub team_id: String,
+    pub context_id: String,
+    pub status: TeamRunStatus,
+    pub input: Value,
+    pub created_at: i64,
+    pub started_at: Option<i64>,
+    pub ended_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamRunEventRecord {
+    pub event_id: i64,
+    pub run_id: String,
+    pub step_id: Option<String>,
+    pub event_type: String,
+    pub ts: i64,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum TeamStepStatus {
+    Submitted,
+    Working,
+    InputRequired,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct TeamStepRecord {
+    pub id: String,
+    pub run_id: String,
+    pub step_key: String,
+    pub member_id: String,
+    pub remote_task_id: Option<String>,
+    pub status: TeamStepStatus,
+    pub attempt: i64,
+    pub depends_on: Vec<String>,
+    pub input: Option<Value>,
+    pub output: Option<Value>,
+    pub error_text: Option<String>,
+    pub started_at: Option<i64>,
+    pub ended_at: Option<i64>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TeamRunResumeError {
+    #[error("completed run cannot be resumed")]
+    CompletedRun,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TEAM_RUN_STATUS_VALUES, TEAM_STEP_STATUS_VALUES, TeamRunResumeError};
+
+    #[test]
+    fn status_values_keep_expected_length() {
+        assert_eq!(TEAM_RUN_STATUS_VALUES.len(), 6);
+        assert_eq!(TEAM_STEP_STATUS_VALUES.len(), 6);
+    }
+
+    #[test]
+    fn resume_error_message_is_stable() {
+        assert_eq!(
+            TeamRunResumeError::CompletedRun.to_string(),
+            "completed run cannot be resumed"
+        );
+    }
+}

--- a/docs/features/2026-02-21-team-domain-crate-migration-phase3.md
+++ b/docs/features/2026-02-21-team-domain-crate-migration-phase3.md
@@ -1,0 +1,57 @@
+# Team Domain Crate Migration (Phase 3)
+
+## Background
+
+`src/team/mod.rs` mixed Team domain data model definitions and runtime orchestration
+exports. To progress from module split to crate-level boundaries, domain data
+models should live in an isolated crate with explicit Cargo/Bazel edges.
+
+## Scope
+
+- Introduce a new crate: `crates/agenthub-team-domain`.
+- Move Team domain models/constants/error type from `src/team/mod.rs` and
+  `src/team/manager.rs` into the new crate.
+- Keep runtime behavior unchanged by re-exporting domain types through
+  `src/team/mod.rs`.
+- Wire both Cargo workspace and Bazel dependency edges.
+
+## Key Decisions
+
+1. New crate `agenthub-team-domain` contains:
+   - Team status constants (`TEAM_RUN_STATUS_VALUES`, `TEAM_STEP_STATUS_VALUES`)
+   - Team records/config/status enums
+   - `TeamRunResumeError`
+2. Root app crate depends on the new crate and re-exports domain items from
+   `src/team/mod.rs` to avoid broad call-site churn in this phase.
+3. `src/team/manager.rs` now re-exports/uses `TeamRunResumeError` from the domain
+   crate, preserving existing API mapping behavior.
+4. Bazel boundary alignment:
+   - add `//crates/agenthub-team-domain:agenthub_team_domain`
+   - add root `agenthub_lib` dependency on this new target
+
+## Validation
+
+Executed locally:
+
+```bash
+cargo test -q -p agenthub-team-domain
+cargo test -q teams_api_create_list_get_and_reject_duplicate_name
+cargo test -q team_runs_api_supports_resume_and_restart_strategy
+cargo test -q teams_router_http_contract
+```
+
+All passed.
+
+Bazel note:
+
+- Attempted:
+  `bazel build //crates/agenthub-team-domain:agenthub_team_domain`
+- Local environment failed before analysis due `rules_rust` repository resolution
+  under local Bazel cache setup (`No MODULE.bazel ... @@rules_rust+//rust`).
+- Follow-up verification is tracked in TODO for CI/clean environment.
+
+## Follow-up
+
+- Continue phase-3 migration by moving additional cohesive Team domain logic into
+  crates with the same pattern.
+- Verify new crate Bazel target on CI or clean local Bazel environment.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,7 @@
 # TODO
 
+- [ ] Verify Bazel target for new Team domain crate (`//crates/agenthub-team-domain:agenthub_team_domain`) in CI/clean environment after phase-3 crate migration, because local Bazel cache setup currently fails on `rules_rust` repository resolution (see `docs/features/2026-02-21-team-domain-crate-migration-phase3.md`).
+- [x] Verify phase-3 Team domain crate migration keeps Team API/runtime behavior unchanged while moving domain models to `crates/agenthub-team-domain` and preserving re-export compatibility in `src/team/mod.rs` (see `docs/features/2026-02-21-team-domain-crate-migration-phase3.md`).
 - [x] Verify `src/api/teams.rs` error mapping module split (`src/api/teams/errors.rs`) keeps duplicate-name conflict, resume/restart conflict mapping, and router HTTP contract behavior unchanged (see `docs/features/2026-02-21-api-teams-error-mapping-module-split.md`).
 - [x] Verify typed-error mapping replaces string-based conflict detection for Team run resume (`completed` => `409`) and Agent send-input stale session (`session mismatch` => `409`) with focused Rust tests (see `docs/features/2026-02-21-rust-error-typing-teams-agents.md`).
 - [ ] Verify Bazel-first Rust crate decomposition policy is applied to new domain migrations: extract cohesive domain libraries under `crates/*`, keep `src/main.rs` thin-bootstrap only, and align Bazel package/target boundaries with crate boundaries in the same PR (see `docs/features/2026-02-21-bazel-first-domain-crate-policy.md`).

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -6,6 +6,7 @@ mod tests;
 
 use std::collections::HashMap;
 
+pub use agenthub_team_domain::TeamRunResumeError;
 use chrono::Utc;
 use serde_json::Value;
 use sqlx::{QueryBuilder, Row, SqlitePool};
@@ -25,12 +26,6 @@ use super::{
 #[derive(Clone)]
 pub struct TeamManager {
     db: SqlitePool,
-}
-
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum TeamRunResumeError {
-    #[error("completed run cannot be resumed")]
-    CompletedRun,
 }
 
 impl TeamManager {

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -1,112 +1,14 @@
 mod manager;
 mod orchestrator;
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
 pub use agenthub_team_actor::{
     ActorMessageRecord as TeamActorMessageRecord, ActorMessageStatus as TeamActorMessageStatus,
     ActorMessageTransport as TeamActorMessageTransport,
 };
-pub use manager::{
-    SendActorMessageInput, TeamManager, TeamRemoteRelayWorkerSettings, TeamRunResumeError,
+pub use agenthub_team_domain::{
+    TEAM_RUN_STATUS_VALUES, TEAM_STEP_STATUS_VALUES, TeamDefinitionConfig, TeamDefinitionRecord,
+    TeamRunEventRecord, TeamRunRecord, TeamRunResumeError, TeamRunStatus, TeamStepRecord,
+    TeamStepStatus,
 };
+pub use manager::{SendActorMessageInput, TeamManager, TeamRemoteRelayWorkerSettings};
 pub use orchestrator::{TeamOrchestratorWorker, TeamOrchestratorWorkerSettings};
-
-pub const TEAM_RUN_STATUS_VALUES: [&str; 6] = [
-    "submitted",
-    "working",
-    "input_required",
-    "completed",
-    "failed",
-    "canceled",
-];
-
-pub const TEAM_STEP_STATUS_VALUES: [&str; 6] = [
-    "submitted",
-    "working",
-    "input_required",
-    "completed",
-    "failed",
-    "canceled",
-];
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TeamDefinitionConfig {
-    pub name: String,
-    pub description: Option<String>,
-    pub spec: Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TeamDefinitionRecord {
-    pub id: String,
-    pub name: String,
-    pub description: Option<String>,
-    pub spec: Value,
-    pub created_at: i64,
-    pub updated_at: i64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum TeamRunStatus {
-    Submitted,
-    Working,
-    InputRequired,
-    Completed,
-    Failed,
-    Canceled,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TeamRunRecord {
-    pub id: String,
-    pub team_id: String,
-    pub context_id: String,
-    pub status: TeamRunStatus,
-    pub input: Value,
-    pub created_at: i64,
-    pub started_at: Option<i64>,
-    pub ended_at: Option<i64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TeamRunEventRecord {
-    pub event_id: i64,
-    pub run_id: String,
-    pub step_id: Option<String>,
-    pub event_type: String,
-    pub ts: i64,
-    pub payload: Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum TeamStepStatus {
-    Submitted,
-    Working,
-    InputRequired,
-    Completed,
-    Failed,
-    Canceled,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(dead_code)]
-pub struct TeamStepRecord {
-    pub id: String,
-    pub run_id: String,
-    pub step_key: String,
-    pub member_id: String,
-    pub remote_task_id: Option<String>,
-    pub status: TeamStepStatus,
-    pub attempt: i64,
-    pub depends_on: Vec<String>,
-    pub input: Option<Value>,
-    pub output: Option<Value>,
-    pub error_text: Option<String>,
-    pub started_at: Option<i64>,
-    pub ended_at: Option<i64>,
-}


### PR DESCRIPTION
## Summary

Phase 3 of Rust maintainability split (3/3): crate migration with Bazel boundary alignment.

- introduce `crates/agenthub-team-domain` for Team domain models/constants/errors
- migrate Team domain definitions out of `src/team/mod.rs`
- re-export domain types from `src/team/mod.rs` to preserve call-site compatibility
- move `TeamRunResumeError` ownership to the new domain crate
- wire Cargo workspace + root dependency and Bazel target dependency

## Changes

- New crate
  - `crates/agenthub-team-domain/Cargo.toml`
  - `crates/agenthub-team-domain/BUILD.bazel`
  - `crates/agenthub-team-domain/src/lib.rs`
- Root wiring
  - `Cargo.toml`: add workspace member + dependency `agenthub-team-domain`
  - `BUILD.bazel`: add `//crates/agenthub-team-domain:agenthub_team_domain` to `agenthub_lib` deps
- Team module integration
  - `src/team/mod.rs`: re-export domain types/constants from `agenthub_team_domain`
  - `src/team/manager.rs`: use/re-export `TeamRunResumeError` from domain crate
- Docs
  - `docs/features/2026-02-21-team-domain-crate-migration-phase3.md`
  - `docs/todo.md` updated with done item + Bazel follow-up item

## Why

This is the first concrete phase-3 crate migration step:

- Team domain data model now has an explicit crate boundary
- Cargo/Bazel edges align with that boundary
- runtime behavior remains stable via compatibility re-exports

## Validation

```bash
cargo check -q
cargo test -q -p agenthub-team-domain
cargo test -q teams_api_create_list_get_and_reject_duplicate_name
cargo test -q team_runs_api_supports_resume_and_restart_strategy
cargo test -q teams_router_http_contract
cargo test -q resume_run_handles_active_terminal_and_completed_statuses
```

All passed locally.

Bazel local note:

```bash
bazel build //crates/agenthub-team-domain:agenthub_team_domain
```

Attempted, but local environment failed before analysis due `rules_rust` repository resolution in local Bazel cache setup (`No MODULE.bazel ... @@rules_rust+//rust`). Follow-up verification is tracked in TODO and expected in CI/clean env.

## Related PRs

- 1/3: #75 (typed conflict errors)
- 2/3: #77 (teams API module split)
