### PR TITLE
feat(team): harden run ownership and refactor memory flush

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,7 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(normal = True) + [
         "//crates/agenthub-acp:agenthub_acp",
+        "//crates/agenthub-text:agenthub_text",
         "//crates/agenthub-team-actor:agenthub_team_actor",
         "//crates/agenthub-team-domain:agenthub_team_domain",
         "//crates/agenthub-team-prompts:agenthub_team_prompts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "agenthub-team-actor",
  "agenthub-team-domain",
  "agenthub-team-prompts",
+ "agenthub-text",
  "anyhow",
  "argon2",
  "async-trait",
@@ -113,6 +114,7 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "agenthub-acp-core",
+ "agenthub-text",
  "anyhow",
  "async-trait",
  "chrono",
@@ -188,6 +190,10 @@ dependencies = [
 
 [[package]]
 name = "agenthub-team-prompts"
+version = "0.1.0"
+
+[[package]]
+name = "agenthub-text"
 version = "0.1.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "agenthub-codex-acp",
     "crates/agenthub-acp-core",
     "crates/agenthub-acp",
+    "crates/agenthub-text",
     "crates/agenthub-team-actor",
     "crates/agenthub-team-domain",
     "crates/agenthub-team-prompts",
@@ -49,6 +50,7 @@ hmac = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 sha2 = "0.10"
 agenthub-acp = { path = "crates/agenthub-acp" }
+agenthub-text = { path = "crates/agenthub-text" }
 agenthub-team-actor = { path = "crates/agenthub-team-actor" }
 agenthub-team-domain = { path = "crates/agenthub-team-domain" }
 agenthub-team-prompts = { path = "crates/agenthub-team-prompts" }

--- a/crates/agenthub-acp/BUILD.bazel
+++ b/crates/agenthub-acp/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(normal = True) + [
         "//crates/agenthub-acp-core:agenthub_acp_core",
+        "//crates/agenthub-text:agenthub_text",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
 )

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 agenthub-acp-core = { path = "../agenthub-acp-core" }
+agenthub-text = { path = "../agenthub-text" }
 agent-client-protocol = { version = "0.9.4", features = ["unstable"] }
 anyhow = "1"
 async-trait = "0.1"

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -1,4 +1,5 @@
 use agenthub_acp_core::{AcpSkill, build_skill};
+use agenthub_text::truncate_chars;
 
 use crate::AcpActorSkillContext;
 
@@ -55,8 +56,8 @@ fn build_continuity_section(context: &AcpActorSkillContext) -> String {
     let Some(continuity) = context.continuity.as_ref() else {
         return String::new();
     };
-    let summary = truncate_text(continuity.summary_text.as_str(), 400);
-    let history_window = truncate_text(continuity.history_window.to_string().as_str(), 800);
+    let summary = truncate_chars(continuity.summary_text.as_str(), 400);
+    let history_window = truncate_chars(continuity.history_window.to_string().as_str(), 800);
     let source_session = continuity
         .source_session_id
         .as_deref()
@@ -76,13 +77,6 @@ fn build_continuity_section(context: &AcpActorSkillContext) -> String {
         summary = summary,
         history_window = history_window,
     )
-}
-
-fn truncate_text(raw: &str, max_chars: usize) -> String {
-    if raw.is_empty() || max_chars == 0 {
-        return String::new();
-    }
-    raw.chars().take(max_chars).collect::<String>()
 }
 
 #[cfg(test)]

--- a/crates/agenthub-text/BUILD.bazel
+++ b/crates/agenthub-text/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "agenthub_text",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "agenthub_text",
+    edition = "2024",
+    aliases = aliases(),
+    deps = all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "agenthub_text_tests",
+    crate = ":agenthub_text",
+    edition = "2024",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/agenthub-text/Cargo.toml
+++ b/crates/agenthub-text/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "agenthub-text"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/agenthub-text/src/lib.rs
+++ b/crates/agenthub-text/src/lib.rs
@@ -1,0 +1,28 @@
+pub fn truncate_chars(raw: &str, max_chars: usize) -> String {
+    if raw.is_empty() || max_chars == 0 {
+        return String::new();
+    }
+    raw.chars().take(max_chars).collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_chars;
+
+    #[test]
+    fn truncate_chars_returns_empty_for_empty_or_zero_limit() {
+        assert_eq!(truncate_chars("", 10), "");
+        assert_eq!(truncate_chars("hello", 0), "");
+    }
+
+    #[test]
+    fn truncate_chars_preserves_short_input_and_cuts_long_input() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("hello", 3), "hel");
+    }
+
+    #[test]
+    fn truncate_chars_respects_char_boundaries() {
+        assert_eq!(truncate_chars("你好世界", 3), "你好世");
+    }
+}

--- a/docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md
+++ b/docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md
@@ -1,0 +1,51 @@
+# Team Run Access And Memory Flush Hardening
+
+## Background
+
+PR review for Team context/memory baseline identified five follow-up items to improve security and maintainability:
+
+1. Fix IDOR risk in `POST /api/teams/runs/:run_id/context/flush`.
+2. Enforce owner checks consistently across run-scoped Team APIs.
+3. Simplify API trigger normalization logic for memory flush.
+4. Deduplicate repeated text truncation helper logic.
+5. Split the large `TeamManager::flush_run_context` flow into clearer helper units.
+
+## Scope
+
+This change set updates Team run API authorization paths, memory-flush API normalization, shared utility reuse, and manager-side memory-flush internals. It does not introduce new user-facing API fields.
+
+## Key Decisions
+
+- Run ownership guard is centralized in API helpers:
+  - Added `load_run_for_user` and `load_run_and_team_for_user`.
+  - Replaced run existence-only checks with owner-aware checks for run-scoped routes.
+  - Updated team-scoped run creation/listing to reuse `load_team_for_user` instead of direct `get_team`.
+- Manual memory flush trigger normalization is now explicit `match`-based parsing in API layer for better readability and lower branch ambiguity.
+- Introduced shared crate `crates/agenthub-text` with `truncate_chars`:
+  - Reused by `src/team/manager.rs`, `src/team/orchestrator.rs`, and `crates/agenthub-acp/src/actor_runtime_skill.rs`.
+  - Removed duplicated local truncation implementations from those files.
+- Refactored `TeamManager::flush_run_context` by extracting query/result helpers:
+  - Request normalization helper.
+  - Team/run checkpoint/event loaders.
+  - Failure/noop finalization helpers.
+  - Checkpoint upsert helper.
+  - Pointer payload builder.
+  - Main path now focuses on orchestration and persistence sequence.
+
+## Validation
+
+Executed local checks:
+
+- `cargo fmt --all`
+- `cargo check`
+- `cargo test team_runs_api_enforces_team_owner_access`
+- `cargo test flush_run_context_`
+- `cargo test team_runs_api_supports_manual_context_flush`
+- `cargo test team_runs_api_rejects_invalid_context_flush_trigger`
+- `cargo test -p agenthub-acp actor_runtime_skill`
+- `cargo test -p agenthub-text`
+
+## Follow-ups
+
+- Keep the broader Team ACL matrix work deferred as documented in `docs/todo.md` (low-priority backlog item).
+- Verify Bazel `//...` in CI after new local crate wiring (`agenthub-text`) to ensure Cargo/Bazel dependency alignment remains stable.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify Team run ownership hardening covers run-scoped APIs (`get/cancel/resume/restart/snapshot/events/steps/messages/context flush`) and that new shared crate `agenthub-text` remains stable in both Cargo and Bazel CI (see `docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md`).
 - [ ] [LOW] Defer Team ACL hardening (explicit owner/member permission matrix across Team main-task/run/mailbox APIs and UI visibility) until the chat-first baseline workflow and core Team features are complete.
 - [ ] Verify single-mode ACP sessions no longer inject Team role skills from global `~/.agenthub/skills.json`, while Team actor sessions still inject `team-leader-orchestrator`/`team-worker-executor` + `team-deliberation-rules` by role context (see `docs/features/2026-02-22-team-role-skill-single-mode-isolation.md`).
 - [ ] Verify `scripts/setup_ck_search_context.sh` bootstraps `~/.agenthub/mcp.json` with `ck --serve` MCP server entry (`ck-search`) and preserves existing `mcpServers` entries without destructive overwrite (see `docs/features/2026-02-22-ck-search-mcp-and-info-research-layout.md`).

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -86,6 +86,34 @@ async fn load_team_for_user(
     Ok(team)
 }
 
+async fn load_run_for_user(
+    state: &AppState,
+    run_id: &str,
+    user: &UserRecord,
+) -> Result<TeamRunRecord, ApiError> {
+    let run = state
+        .teams
+        .get_run(run_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "run not found"))?;
+    load_team_for_user(state, &run.team_id, user).await?;
+    Ok(run)
+}
+
+async fn load_run_and_team_for_user(
+    state: &AppState,
+    run_id: &str,
+    user: &UserRecord,
+) -> Result<(TeamRunRecord, TeamDefinitionRecord), ApiError> {
+    let run = state
+        .teams
+        .get_run(run_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "run not found"))?;
+    let team = load_team_for_user(state, &run.team_id, user).await?;
+    Ok((run, team))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateTeamRequest {
     pub name: String,
@@ -648,12 +676,8 @@ async fn create_team_run(
     Path(team_id): Path<String>,
     Json(payload): Json<CreateTeamRunRequest>,
 ) -> Result<Json<TeamRunRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    let team = state
-        .teams
-        .get_team(&team_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    let user = require_user(&headers, &state).await?;
+    let team = load_team_for_user(&state, &team_id, &user).await?;
     validate_team_spec(&team.spec)?;
     let run = state
         .teams
@@ -673,12 +697,8 @@ async fn list_team_runs(
     Path(team_id): Path<String>,
     Query(query): Query<ListTeamRunsQuery>,
 ) -> Result<Json<Vec<TeamRunRecord>>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    state
-        .teams
-        .get_team(&team_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    let user = require_user(&headers, &state).await?;
+    load_team_for_user(&state, &team_id, &user).await?;
     let limit = query.limit.unwrap_or(100).clamp(1, 500);
     let status = normalize_optional_run_status_filter(query.status.as_deref())?;
     let runs = state
@@ -694,12 +714,8 @@ async fn get_team_run(
     headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<TeamRunRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    let run = state
-        .teams
-        .get_run(&run_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "run not found"))?;
+    let user = require_user(&headers, &state).await?;
+    let run = load_run_for_user(&state, &run_id, &user).await?;
     Ok(Json(run))
 }
 
@@ -708,7 +724,8 @@ async fn cancel_team_run(
     headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<TeamRunRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let run = state
         .teams
         .cancel_run(&run_id)
@@ -722,7 +739,8 @@ async fn resume_team_run(
     headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<TeamRunRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let run = state
         .teams
         .resume_run(&run_id)
@@ -736,7 +754,8 @@ async fn restart_team_run(
     headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<TeamRunRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let run = state
         .teams
         .restart_run(&run_id)
@@ -751,18 +770,8 @@ async fn get_team_run_snapshot(
     Path(run_id): Path<String>,
     Query(query): Query<TeamRunSnapshotQuery>,
 ) -> Result<Json<TeamRunSnapshotResponse>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-
-    let run = state
-        .teams
-        .get_run(&run_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "run not found"))?;
-    let team = state
-        .teams
-        .get_team(&run.team_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    let user = require_user(&headers, &state).await?;
+    let (run, team) = load_run_and_team_for_user(&state, &run_id, &user).await?;
     validate_team_spec(&team.spec)?;
 
     let spec_obj = team
@@ -875,12 +884,8 @@ async fn list_team_run_events(
     Path(run_id): Path<String>,
     Query(query): Query<ListTeamRunEventsQuery>,
 ) -> Result<Json<Vec<TeamRunEventRecord>>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    state
-        .teams
-        .get_run(&run_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "run not found"))?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let limit = query.limit.unwrap_or(500).clamp(1, 1000);
     let events = state
         .teams
@@ -896,7 +901,8 @@ async fn flush_team_run_context(
     Path(run_id): Path<String>,
     Json(payload): Json<FlushTeamRunContextRequest>,
 ) -> Result<Json<FlushTeamRunContextResponse>, ApiError> {
-    let _ = require_user(&headers, &state).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let member_id = payload.member_id.trim().to_string();
     if member_id.is_empty() {
         return Err(ApiError::bad_request("member_id is required"));
@@ -937,8 +943,8 @@ async fn list_team_run_steps(
     headers: HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Json<Vec<TeamStepRecord>>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     let steps = state
         .teams
         .list_steps(&run_id)
@@ -953,8 +959,8 @@ async fn submit_team_run_step(
     Path(run_id): Path<String>,
     Json(payload): Json<SubmitTeamRunStepRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
 
     let step_key = payload.step_key.trim().to_string();
     if step_key.is_empty() {
@@ -980,8 +986,8 @@ async fn start_team_run_step(
     Path((run_id, step_id)): Path<(String, String)>,
     Json(payload): Json<StartTeamRunStepRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     ensure_step_in_run(&state, &run_id, &step_id).await?;
     let remote_task_id = payload
         .remote_task_id
@@ -1002,8 +1008,8 @@ async fn complete_team_run_step(
     Path((run_id, step_id)): Path<(String, String)>,
     Json(payload): Json<CompleteTeamRunStepRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     ensure_step_in_run(&state, &run_id, &step_id).await?;
     let step = state
         .teams
@@ -1019,8 +1025,8 @@ async fn fail_team_run_step(
     Path((run_id, step_id)): Path<(String, String)>,
     Json(payload): Json<FailTeamRunStepRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     ensure_step_in_run(&state, &run_id, &step_id).await?;
     let error_text = payload.error_text.trim();
     if error_text.is_empty() {
@@ -1040,8 +1046,8 @@ async fn set_team_run_step_input_required(
     Path((run_id, step_id)): Path<(String, String)>,
     Json(payload): Json<SetTeamRunStepInputRequiredRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     ensure_step_in_run(&state, &run_id, &step_id).await?;
     let reason = normalize_optional_non_empty(payload.reason.as_deref())?.map(str::to_string);
     let step = state
@@ -1058,8 +1064,8 @@ async fn resume_team_run_step(
     Path((run_id, step_id)): Path<(String, String)>,
     Json(payload): Json<ResumeTeamRunStepRequest>,
 ) -> Result<Json<TeamStepRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    ensure_run_exists(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    ensure_run_access_for_user(&state, &run_id, &user).await?;
     ensure_step_in_run(&state, &run_id, &step_id).await?;
     let step = state
         .teams
@@ -1075,8 +1081,8 @@ async fn send_team_run_message(
     Path(run_id): Path<String>,
     Json(payload): Json<SendTeamRunMessageRequest>,
 ) -> Result<Json<TeamActorMessageRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    let (run, member_ids) = load_run_and_member_ids(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    let (run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
     let SendTeamRunMessageRequest {
         from_actor_id,
         to_actor_id,
@@ -1141,8 +1147,8 @@ async fn list_team_run_inbox(
     Path(run_id): Path<String>,
     Query(query): Query<ListTeamRunInboxQuery>,
 ) -> Result<Json<Vec<TeamActorMessageRecord>>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    let (_run, member_ids) = load_run_and_member_ids(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    let (_run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
     let actor_id = normalize_required_field(query.actor_id, "actor_id")?;
     if !member_ids.contains(actor_id.as_str()) {
         return Err(ApiError::bad_request(
@@ -1180,8 +1186,8 @@ async fn ack_team_run_message(
     Path((run_id, message_id)): Path<(String, i64)>,
     Json(payload): Json<AckTeamRunMessageRequest>,
 ) -> Result<Json<TeamActorMessageRecord>, ApiError> {
-    let _user = require_user(&headers, &state).await?;
-    let (_run, member_ids) = load_run_and_member_ids(&state, &run_id).await?;
+    let user = require_user(&headers, &state).await?;
+    let (_run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
     let actor_id = normalize_required_field(payload.actor_id, "actor_id")?;
     if !member_ids.contains(actor_id.as_str()) {
         return Err(ApiError::bad_request(
@@ -1643,12 +1649,12 @@ fn extract_run_member_profile_overrides(input: &Value) -> HashMap<String, Member
     out
 }
 
-async fn ensure_run_exists(state: &AppState, run_id: &str) -> Result<(), ApiError> {
-    state
-        .teams
-        .get_run(run_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "run not found"))?;
+async fn ensure_run_access_for_user(
+    state: &AppState,
+    run_id: &str,
+    user: &UserRecord,
+) -> Result<(), ApiError> {
+    load_run_for_user(state, run_id, user).await?;
     Ok(())
 }
 
@@ -1742,24 +1748,19 @@ fn normalize_optional_run_status_filter(value: Option<&str>) -> Result<Option<St
 }
 
 fn normalize_memory_flush_trigger(value: Option<&str>) -> Result<&'static str, ApiError> {
-    let Some(raw) = value else {
-        return Ok("manual");
-    };
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Ok("manual");
+    match value
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+    {
+        None => Ok("manual"),
+        Some("manual") => Ok("manual"),
+        Some("soft_threshold") => Ok("soft_threshold"),
+        Some("hard_error") => Ok("hard_error"),
+        Some(_) => Err(ApiError::bad_request(&format!(
+            "trigger must be one of: {}",
+            TEAM_MEMORY_FLUSH_TRIGGER_VALUES.join(", ")
+        ))),
     }
-    if TEAM_MEMORY_FLUSH_TRIGGER_VALUES.contains(&trimmed) {
-        return Ok(match trimmed {
-            "soft_threshold" => "soft_threshold",
-            "hard_error" => "hard_error",
-            _ => "manual",
-        });
-    }
-    Err(ApiError::bad_request(&format!(
-        "trigger must be one of: {}",
-        TEAM_MEMORY_FLUSH_TRIGGER_VALUES.join(", ")
-    )))
 }
 
 fn normalize_conversation_mode(value: Option<&str>) -> Result<String, ApiError> {
@@ -2344,20 +2345,12 @@ fn normalize_enum_value(
     )))
 }
 
-async fn load_run_and_member_ids(
+async fn load_run_and_member_ids_for_user(
     state: &AppState,
     run_id: &str,
+    user: &UserRecord,
 ) -> Result<(TeamRunRecord, HashSet<String>), ApiError> {
-    let run = state
-        .teams
-        .get_run(run_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "run not found"))?;
-    let team = state
-        .teams
-        .get_team(&run.team_id)
-        .await
-        .map_err(|err| map_not_found_error(err, "team not found"))?;
+    let (run, team) = load_run_and_team_for_user(state, run_id, user).await?;
     let member_ids = parse_member_ids(team.spec.get("members"))?;
     Ok((run, member_ids))
 }

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -1256,6 +1256,140 @@ async fn team_runs_api_supports_resume_and_restart_strategy() {
 }
 
 #[tokio::test]
+async fn team_runs_api_enforces_team_owner_access() {
+    let state = build_test_state().await;
+    let owner_headers = auth_headers(&state).await;
+    let outsider_headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        owner_headers.clone(),
+        Json(CreateTeamRequest {
+            name: "run-owner-enforcement-team".to_string(),
+            description: Some("owner enforcement for run endpoints".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner","role":"leader"}]
+            }),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    let Json(run) = create_team_run(
+        State(state.clone()),
+        owner_headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-owner-run".to_string()),
+            input: Some(json!({"prompt":"owner run"})),
+        }),
+    )
+    .await
+    .expect("create run");
+
+    let create_err = create_team_run(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-outsider".to_string()),
+            input: Some(json!({"prompt":"outsider run"})),
+        }),
+    )
+    .await
+    .expect_err("outsider should not create run");
+    assert_eq!(create_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let list_err = list_team_runs(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamRunsQuery {
+            limit: Some(20),
+            status: None,
+            before_created_at: None,
+        }),
+    )
+    .await
+    .expect_err("outsider should not list team runs");
+    assert_eq!(list_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let get_err = get_team_run(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+    )
+    .await
+    .expect_err("outsider should not read run");
+    assert_eq!(get_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let cancel_err = cancel_team_run(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+    )
+    .await
+    .expect_err("outsider should not cancel run");
+    assert_eq!(cancel_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let events_err = list_team_run_events(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+        Query(ListTeamRunEventsQuery {
+            limit: Some(20),
+            before_id: None,
+        }),
+    )
+    .await
+    .expect_err("outsider should not list run events");
+    assert_eq!(events_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let flush_err = flush_team_run_context(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+        Json(FlushTeamRunContextRequest {
+            member_id: "planner".to_string(),
+            session_id: Some("session-1".to_string()),
+            trigger: Some("manual".to_string()),
+            max_events: None,
+        }),
+    )
+    .await
+    .expect_err("outsider should not flush run context");
+    assert_eq!(flush_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let steps_err = list_team_run_steps(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+    )
+    .await
+    .expect_err("outsider should not list run steps");
+    assert_eq!(steps_err.into_response().status(), StatusCode::NOT_FOUND);
+
+    let send_err = send_team_run_message(
+        State(state.clone()),
+        outsider_headers.clone(),
+        Path(run.id.clone()),
+        Json(SendTeamRunMessageRequest {
+            from_actor_id: "planner".to_string(),
+            to_actor_id: "planner".to_string(),
+            channel: None,
+            transport: Some("local".to_string()),
+            route: None,
+            payload: json!({"text":"unauthorized"}),
+            idempotency_key: Some("owner-access-denied".to_string()),
+        }),
+    )
+    .await
+    .expect_err("outsider should not send run message");
+    assert_eq!(send_err.into_response().status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn team_runs_api_paginates_high_volume_without_duplicates_and_honors_status_filter() {
     const TOTAL_RUNS: usize = 120;
     const PAGE_SIZE: i64 = 17;

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -7,6 +7,7 @@ mod tests;
 use std::{collections::HashMap, path::PathBuf};
 
 pub use agenthub_team_domain::TeamRunResumeError;
+use agenthub_text::truncate_chars;
 use chrono::Utc;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -1924,32 +1925,16 @@ impl TeamManager {
         run_id: &str,
         request: TeamMemoryFlushRequest,
     ) -> anyhow::Result<TeamMemoryFlushResult> {
-        let member_id = request.member_id.trim().to_string();
-        if member_id.is_empty() {
-            return Err(anyhow::anyhow!("member_id is required"));
-        }
-        let trigger = normalize_memory_flush_trigger(request.trigger.as_str()).to_string();
-        let max_events = normalize_memory_flush_max_events(request.max_events);
+        let normalized = normalize_memory_flush_request(request)?;
         let now = Utc::now().timestamp();
         let mut tx = self.db.begin().await?;
-
-        let run_meta_row = sqlx::query(
-            r#"
-            SELECT team_id
-            FROM team_runs
-            WHERE id = ?1
-            "#,
-        )
-        .bind(run_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        let team_id: String = run_meta_row.get("team_id");
+        let team_id = load_memory_flush_team_id_tx(&mut tx, run_id).await?;
 
         let session_id = resolve_memory_flush_session_id_tx(
             &mut tx,
             run_id,
-            member_id.as_str(),
-            request.session_id.as_deref(),
+            normalized.member_id.as_str(),
+            normalized.session_id.as_deref(),
         )
         .await?;
 
@@ -1960,116 +1945,66 @@ impl TeamManager {
             "memory_flush_started",
             now,
             &serde_json::json!({
-                "team_id": team_id,
+                "team_id": team_id.as_str(),
                 "run_id": run_id,
-                "member_id": member_id,
-                "session_id": session_id,
-                "trigger": trigger,
+                "member_id": normalized.member_id.as_str(),
+                "session_id": session_id.as_deref(),
+                "trigger": normalized.trigger.as_str(),
                 "ts": now,
             }),
         )
         .await?;
 
         let Some(session_id) = session_id else {
-            let reason = "session_mapping_missing";
-            Self::append_run_event_tx(
-                &mut tx,
+            let context = MemoryFlushFinalizeContext {
                 run_id,
-                None,
-                "memory_flush_failed",
+                team_id: team_id.as_str(),
+                member_id: normalized.member_id.as_str(),
+                session_id: None,
+                trigger: normalized.trigger.as_str(),
                 now,
-                &serde_json::json!({
-                    "team_id": team_id,
-                    "run_id": run_id,
-                    "member_id": member_id,
-                    "trigger": trigger,
-                    "reason_code": reason,
-                    "ts": now,
-                }),
+            };
+            let result = finalize_memory_flush_failed_tx(
+                &mut tx,
+                &context,
+                "session_mapping_missing",
+                None,
+                0,
+                None,
             )
             .await?;
             tx.commit().await?;
-            return Ok(TeamMemoryFlushResult {
-                status: "failed".to_string(),
-                run_id: run_id.to_string(),
-                team_id,
-                member_id,
-                session_id: None,
-                trigger,
-                reason: Some(reason.to_string()),
-                artifact_pointer: None,
-                event_id_from: None,
-                event_id_to: None,
-                flushed_events: 0,
-            });
+            return Ok(result);
         };
 
-        let checkpoint_event_id = sqlx::query_scalar::<_, i64>(
-            r#"
-            SELECT last_event_id
-            FROM team_context_flush_checkpoint
-            WHERE run_id = ?1
-              AND member_id = ?2
-              AND session_id = ?3
-            "#,
+        let checkpoint_event_id = load_memory_flush_checkpoint_event_id_tx(
+            &mut tx,
+            run_id,
+            normalized.member_id.as_str(),
+            session_id.as_str(),
         )
-        .bind(run_id)
-        .bind(member_id.as_str())
-        .bind(session_id.as_str())
-        .fetch_optional(&mut *tx)
-        .await?
-        .unwrap_or(0);
-
-        let event_rows = sqlx::query(
-            r#"
-            SELECT id, stream, message
-            FROM agent_events
-            WHERE agent_id = ?1
-              AND session_id = ?2
-              AND id > ?3
-            ORDER BY id ASC
-            LIMIT ?4
-            "#,
+        .await?;
+        let event_rows = load_memory_flush_event_rows_tx(
+            &mut tx,
+            normalized.member_id.as_str(),
+            session_id.as_str(),
+            checkpoint_event_id,
+            normalized.max_events,
         )
-        .bind(member_id.as_str())
-        .bind(session_id.as_str())
-        .bind(checkpoint_event_id)
-        .bind(max_events)
-        .fetch_all(&mut *tx)
         .await?;
 
         if event_rows.is_empty() {
-            Self::append_run_event_tx(
-                &mut tx,
+            let context = MemoryFlushFinalizeContext {
                 run_id,
-                None,
-                "memory_flush_noop",
+                team_id: team_id.as_str(),
+                member_id: normalized.member_id.as_str(),
+                session_id: Some(session_id.as_str()),
+                trigger: normalized.trigger.as_str(),
                 now,
-                &serde_json::json!({
-                    "team_id": team_id,
-                    "run_id": run_id,
-                    "member_id": member_id,
-                    "session_id": session_id,
-                    "trigger": trigger,
-                    "reason": "no_new_events",
-                    "ts": now,
-                }),
-            )
-            .await?;
+            };
+            let result = finalize_memory_flush_noop_tx(&mut tx, &context).await?;
             tx.commit().await?;
-            return Ok(TeamMemoryFlushResult {
-                status: "noop".to_string(),
-                run_id: run_id.to_string(),
-                team_id,
-                member_id,
-                session_id: Some(session_id),
-                trigger,
-                reason: Some("no_new_events".to_string()),
-                artifact_pointer: None,
-                event_id_from: None,
-                event_id_to: None,
-                flushed_events: 0,
-            });
+            return Ok(result);
         }
 
         let observations = event_rows
@@ -2084,14 +2019,15 @@ impl TeamManager {
             .last()
             .map(|row| row.get::<i64, _>("id"))
             .unwrap_or(0);
+        let flushed_events = safe_i64_len(event_rows.len());
         let summary_text = build_memory_flush_summary(observations.as_slice());
         let flush_payload = serde_json::json!({
             "schema_version": 1,
-            "team_id": team_id,
+            "team_id": team_id.as_str(),
             "run_id": run_id,
-            "member_id": member_id,
-            "session_id": session_id,
-            "trigger": trigger,
+            "member_id": normalized.member_id.as_str(),
+            "session_id": session_id.as_str(),
+            "trigger": normalized.trigger.as_str(),
             "source_event_range": {
                 "from_exclusive": checkpoint_event_id,
                 "to_inclusive": event_id_to,
@@ -2107,7 +2043,7 @@ impl TeamManager {
                 ContextArtifactOwner {
                     team_id: team_id.as_str(),
                     run_id,
-                    member_id: member_id.as_str(),
+                    member_id: normalized.member_id.as_str(),
                     session_id: Some(session_id.as_str()),
                 },
                 MEMORY_FLUSH_ARTIFACT_KIND,
@@ -2118,108 +2054,61 @@ impl TeamManager {
         {
             Ok(Some(pointer)) => pointer,
             Ok(None) => {
-                let reason = "agent_workdir_missing";
-                Self::append_run_event_tx(
-                    &mut tx,
+                let context = MemoryFlushFinalizeContext {
                     run_id,
-                    None,
-                    "memory_flush_failed",
+                    team_id: team_id.as_str(),
+                    member_id: normalized.member_id.as_str(),
+                    session_id: Some(session_id.as_str()),
+                    trigger: normalized.trigger.as_str(),
                     now,
-                    &serde_json::json!({
-                        "team_id": team_id,
-                        "run_id": run_id,
-                        "member_id": member_id,
-                        "session_id": session_id,
-                        "trigger": trigger,
-                        "reason_code": reason,
-                        "ts": now,
-                    }),
+                };
+                let result = finalize_memory_flush_failed_tx(
+                    &mut tx,
+                    &context,
+                    "agent_workdir_missing",
+                    Some((event_id_from, event_id_to)),
+                    flushed_events,
+                    None,
                 )
                 .await?;
                 tx.commit().await?;
-                return Ok(TeamMemoryFlushResult {
-                    status: "failed".to_string(),
-                    run_id: run_id.to_string(),
-                    team_id,
-                    member_id,
-                    session_id: Some(session_id),
-                    trigger,
-                    reason: Some(reason.to_string()),
-                    artifact_pointer: None,
-                    event_id_from: Some(event_id_from),
-                    event_id_to: Some(event_id_to),
-                    flushed_events: i64::try_from(event_rows.len()).unwrap_or(i64::MAX),
-                });
+                return Ok(result);
             }
             Err(err) => {
-                let reason = "artifact_write_failed";
-                Self::append_run_event_tx(
-                    &mut tx,
+                let context = MemoryFlushFinalizeContext {
                     run_id,
-                    None,
-                    "memory_flush_failed",
+                    team_id: team_id.as_str(),
+                    member_id: normalized.member_id.as_str(),
+                    session_id: Some(session_id.as_str()),
+                    trigger: normalized.trigger.as_str(),
                     now,
-                    &serde_json::json!({
-                        "team_id": team_id,
-                        "run_id": run_id,
-                        "member_id": member_id,
-                        "session_id": session_id,
-                        "trigger": trigger,
-                        "reason_code": reason,
-                        "error_excerpt": truncate_continuity_text(err.to_string().as_str(), 400),
-                        "ts": now,
-                    }),
+                };
+                let result = finalize_memory_flush_failed_tx(
+                    &mut tx,
+                    &context,
+                    "artifact_write_failed",
+                    Some((event_id_from, event_id_to)),
+                    flushed_events,
+                    Some(truncate_chars(err.to_string().as_str(), 400)),
                 )
                 .await?;
                 tx.commit().await?;
-                return Ok(TeamMemoryFlushResult {
-                    status: "failed".to_string(),
-                    run_id: run_id.to_string(),
-                    team_id,
-                    member_id,
-                    session_id: Some(session_id),
-                    trigger,
-                    reason: Some(reason.to_string()),
-                    artifact_pointer: None,
-                    event_id_from: Some(event_id_from),
-                    event_id_to: Some(event_id_to),
-                    flushed_events: i64::try_from(event_rows.len()).unwrap_or(i64::MAX),
-                });
+                return Ok(result);
             }
         };
 
-        sqlx::query(
-            r#"
-            INSERT INTO team_context_flush_checkpoint (
-                team_id,
-                run_id,
-                member_id,
-                session_id,
-                last_event_id,
-                updated_at
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-            ON CONFLICT(run_id, member_id, session_id)
-            DO UPDATE SET
-                last_event_id = excluded.last_event_id,
-                updated_at = excluded.updated_at
-            "#,
+        upsert_memory_flush_checkpoint_tx(
+            &mut tx,
+            team_id.as_str(),
+            run_id,
+            normalized.member_id.as_str(),
+            session_id.as_str(),
+            event_id_to,
+            now,
         )
-        .bind(team_id.as_str())
-        .bind(run_id)
-        .bind(member_id.as_str())
-        .bind(session_id.as_str())
-        .bind(event_id_to)
-        .bind(now)
-        .execute(&mut *tx)
         .await?;
 
-        let pointer_payload = serde_json::json!({
-            "kind": pointer.artifact_kind,
-            "path": pointer.relative_path,
-            "size_bytes": pointer.artifact_size_bytes,
-            "checksum": pointer.content_checksum,
-        });
+        let pointer_payload = build_context_artifact_pointer_payload(&pointer);
         Self::append_run_event_tx(
             &mut tx,
             run_id,
@@ -2227,12 +2116,12 @@ impl TeamManager {
             "memory_flush_persisted",
             now,
             &serde_json::json!({
-                "team_id": team_id,
+                "team_id": team_id.as_str(),
                 "run_id": run_id,
-                "member_id": member_id,
-                "session_id": session_id,
-                "trigger": trigger,
-                "artifact_pointer": pointer_payload,
+                "member_id": normalized.member_id.as_str(),
+                "session_id": session_id.as_str(),
+                "trigger": normalized.trigger.as_str(),
+                "artifact_pointer": pointer_payload.clone(),
                 "artifact_size_bytes": pointer.artifact_size_bytes,
                 "event_id_from": event_id_from,
                 "event_id_to": event_id_to,
@@ -2246,14 +2135,14 @@ impl TeamManager {
             status: "persisted".to_string(),
             run_id: run_id.to_string(),
             team_id,
-            member_id,
+            member_id: normalized.member_id,
             session_id: Some(session_id),
-            trigger,
+            trigger: normalized.trigger,
             reason: None,
             artifact_pointer: Some(pointer_payload),
             event_id_from: Some(event_id_from),
             event_id_to: Some(event_id_to),
-            flushed_events: i64::try_from(event_rows.len()).unwrap_or(i64::MAX),
+            flushed_events,
         })
     }
 
@@ -2282,6 +2171,256 @@ impl TeamManager {
         }
         Ok(counts)
     }
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedMemoryFlushRequest {
+    member_id: String,
+    session_id: Option<String>,
+    trigger: String,
+    max_events: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MemoryFlushFinalizeContext<'a> {
+    run_id: &'a str,
+    team_id: &'a str,
+    member_id: &'a str,
+    session_id: Option<&'a str>,
+    trigger: &'a str,
+    now: i64,
+}
+
+fn normalize_memory_flush_request(
+    request: TeamMemoryFlushRequest,
+) -> anyhow::Result<NormalizedMemoryFlushRequest> {
+    let member_id = request.member_id.trim().to_string();
+    if member_id.is_empty() {
+        return Err(anyhow::anyhow!("member_id is required"));
+    }
+    Ok(NormalizedMemoryFlushRequest {
+        member_id,
+        session_id: request.session_id,
+        trigger: normalize_memory_flush_trigger(request.trigger.as_str()).to_string(),
+        max_events: normalize_memory_flush_max_events(request.max_events),
+    })
+}
+
+fn safe_i64_len(len: usize) -> i64 {
+    i64::try_from(len).unwrap_or(i64::MAX)
+}
+
+fn build_context_artifact_pointer_payload(pointer: &ContextArtifactPointer) -> Value {
+    serde_json::json!({
+        "kind": pointer.artifact_kind.as_str(),
+        "path": pointer.relative_path.as_str(),
+        "size_bytes": pointer.artifact_size_bytes,
+        "checksum": pointer.content_checksum.as_str(),
+    })
+}
+
+async fn load_memory_flush_team_id_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    run_id: &str,
+) -> anyhow::Result<String> {
+    let run_meta_row = sqlx::query(
+        r#"
+        SELECT team_id
+        FROM team_runs
+        WHERE id = ?1
+        "#,
+    )
+    .bind(run_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(run_meta_row.get("team_id"))
+}
+
+async fn load_memory_flush_checkpoint_event_id_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    run_id: &str,
+    member_id: &str,
+    session_id: &str,
+) -> anyhow::Result<i64> {
+    let checkpoint_event_id = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT last_event_id
+        FROM team_context_flush_checkpoint
+        WHERE run_id = ?1
+          AND member_id = ?2
+          AND session_id = ?3
+        "#,
+    )
+    .bind(run_id)
+    .bind(member_id)
+    .bind(session_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .unwrap_or(0);
+    Ok(checkpoint_event_id)
+}
+
+async fn load_memory_flush_event_rows_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    member_id: &str,
+    session_id: &str,
+    checkpoint_event_id: i64,
+    max_events: i64,
+) -> anyhow::Result<Vec<sqlx::sqlite::SqliteRow>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT id, stream, message
+        FROM agent_events
+        WHERE agent_id = ?1
+          AND session_id = ?2
+          AND id > ?3
+        ORDER BY id ASC
+        LIMIT ?4
+        "#,
+    )
+    .bind(member_id)
+    .bind(session_id)
+    .bind(checkpoint_event_id)
+    .bind(max_events)
+    .fetch_all(&mut **tx)
+    .await?;
+    Ok(rows)
+}
+
+async fn upsert_memory_flush_checkpoint_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    team_id: &str,
+    run_id: &str,
+    member_id: &str,
+    session_id: &str,
+    event_id_to: i64,
+    now: i64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO team_context_flush_checkpoint (
+            team_id,
+            run_id,
+            member_id,
+            session_id,
+            last_event_id,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(run_id, member_id, session_id)
+        DO UPDATE SET
+            last_event_id = excluded.last_event_id,
+            updated_at = excluded.updated_at
+        "#,
+    )
+    .bind(team_id)
+    .bind(run_id)
+    .bind(member_id)
+    .bind(session_id)
+    .bind(event_id_to)
+    .bind(now)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn finalize_memory_flush_failed_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    context: &MemoryFlushFinalizeContext<'_>,
+    reason: &str,
+    event_range: Option<(i64, i64)>,
+    flushed_events: i64,
+    error_excerpt: Option<String>,
+) -> anyhow::Result<TeamMemoryFlushResult> {
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "team_id".to_string(),
+        Value::String(context.team_id.to_string()),
+    );
+    payload.insert(
+        "run_id".to_string(),
+        Value::String(context.run_id.to_string()),
+    );
+    payload.insert(
+        "member_id".to_string(),
+        Value::String(context.member_id.to_string()),
+    );
+    payload.insert(
+        "trigger".to_string(),
+        Value::String(context.trigger.to_string()),
+    );
+    payload.insert("reason_code".to_string(), Value::String(reason.to_string()));
+    payload.insert("ts".to_string(), Value::from(context.now));
+    if let Some(session_id) = context.session_id {
+        payload.insert(
+            "session_id".to_string(),
+            Value::String(session_id.to_string()),
+        );
+    }
+    if let Some(error_excerpt) = error_excerpt {
+        payload.insert("error_excerpt".to_string(), Value::String(error_excerpt));
+    }
+    TeamManager::append_run_event_tx(
+        tx,
+        context.run_id,
+        None,
+        "memory_flush_failed",
+        context.now,
+        &Value::Object(payload),
+    )
+    .await?;
+    Ok(TeamMemoryFlushResult {
+        status: "failed".to_string(),
+        run_id: context.run_id.to_string(),
+        team_id: context.team_id.to_string(),
+        member_id: context.member_id.to_string(),
+        session_id: context.session_id.map(str::to_string),
+        trigger: context.trigger.to_string(),
+        reason: Some(reason.to_string()),
+        artifact_pointer: None,
+        event_id_from: event_range.map(|(event_id_from, _)| event_id_from),
+        event_id_to: event_range.map(|(_, event_id_to)| event_id_to),
+        flushed_events,
+    })
+}
+
+async fn finalize_memory_flush_noop_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    context: &MemoryFlushFinalizeContext<'_>,
+) -> anyhow::Result<TeamMemoryFlushResult> {
+    let session_id = context
+        .session_id
+        .ok_or_else(|| anyhow::anyhow!("session_id is required for noop flush"))?;
+    TeamManager::append_run_event_tx(
+        tx,
+        context.run_id,
+        None,
+        "memory_flush_noop",
+        context.now,
+        &serde_json::json!({
+            "team_id": context.team_id,
+            "run_id": context.run_id,
+            "member_id": context.member_id,
+            "session_id": session_id,
+            "trigger": context.trigger,
+            "reason": "no_new_events",
+            "ts": context.now,
+        }),
+    )
+    .await?;
+    Ok(TeamMemoryFlushResult {
+        status: "noop".to_string(),
+        run_id: context.run_id.to_string(),
+        team_id: context.team_id.to_string(),
+        member_id: context.member_id.to_string(),
+        session_id: Some(session_id.to_string()),
+        trigger: context.trigger.to_string(),
+        reason: Some("no_new_events".to_string()),
+        artifact_pointer: None,
+        event_id_from: None,
+        event_id_to: None,
+        flushed_events: 0,
+    })
 }
 
 async fn resolve_memory_flush_session_id_tx(
@@ -2344,7 +2483,7 @@ fn build_memory_flush_observation(row: &sqlx::sqlite::SqliteRow) -> Value {
             .and_then(|obj| obj.get("type"))
             .and_then(Value::as_str)
             .unwrap_or("json_message");
-        let excerpt = truncate_continuity_text(
+        let excerpt = truncate_chars(
             redacted.to_string().as_str(),
             MEMORY_FLUSH_MAX_EXCERPT_CHARS,
         );
@@ -2360,7 +2499,7 @@ fn build_memory_flush_observation(row: &sqlx::sqlite::SqliteRow) -> Value {
         "event_id": event_id,
         "stream": stream,
         "type": "text_message",
-        "excerpt": truncate_continuity_text(message.as_str(), MEMORY_FLUSH_MAX_EXCERPT_CHARS),
+        "excerpt": truncate_chars(message.as_str(), MEMORY_FLUSH_MAX_EXCERPT_CHARS),
     })
 }
 
@@ -2381,7 +2520,7 @@ fn build_memory_flush_summary(observations: &[Value]) -> String {
             .unwrap_or_default();
         lines.push(format!("#{event_id} [{observation_type}] {excerpt}"));
     }
-    truncate_continuity_text(lines.join("\n").as_str(), MEMORY_FLUSH_MAX_SUMMARY_CHARS)
+    truncate_chars(lines.join("\n").as_str(), MEMORY_FLUSH_MAX_SUMMARY_CHARS)
 }
 
 #[derive(Debug, Clone)]
@@ -2493,13 +2632,12 @@ fn build_continuity_snapshot(output: Option<&Value>) -> ContinuitySnapshot {
         .map(str::to_string)
         .or_else(|| redacted_output.as_str().map(str::to_string))
         .unwrap_or_else(|| redacted_output.to_string());
-    let summary_text =
-        truncate_continuity_text(summary_seed.as_str(), CONTINUITY_MAX_SUMMARY_CHARS);
+    let summary_text = truncate_chars(summary_seed.as_str(), CONTINUITY_MAX_SUMMARY_CHARS);
 
     let output_excerpt_seed = redacted_output.to_string();
     let history_window = serde_json::json!({
         "schema_version": 1,
-        "output_excerpt": truncate_continuity_text(
+        "output_excerpt": truncate_chars(
             output_excerpt_seed.as_str(),
             CONTINUITY_MAX_HISTORY_CHARS
         ),
@@ -2514,13 +2652,6 @@ fn build_continuity_snapshot(output: Option<&Value>) -> ContinuitySnapshot {
 
 fn should_offload_continuity_output(raw_output: &str) -> bool {
     raw_output.chars().count() > CONTINUITY_MAX_HISTORY_CHARS
-}
-
-fn truncate_continuity_text(raw: &str, max_chars: usize) -> String {
-    if max_chars == 0 {
-        return String::new();
-    }
-    raw.chars().take(max_chars).collect::<String>()
 }
 
 fn redact_sensitive_json(value: &Value) -> Value {

--- a/src/team/orchestrator.rs
+++ b/src/team/orchestrator.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use agenthub_text::truncate_chars;
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::Value;
@@ -372,7 +373,7 @@ impl TeamOrchestratorWorker {
                         mode: continuity_mode.to_string(),
                         source_run_id: state.source_run_id,
                         source_session_id: state.source_session_id,
-                        summary_text: truncate_text(
+                        summary_text: truncate_chars(
                             state.summary_text.as_str(),
                             continuity_max_chars,
                         ),
@@ -559,13 +560,6 @@ fn parse_run_continuity_max_chars(run_input: &Value) -> usize {
         return 1200;
     };
     raw.clamp(256, 20000) as usize
-}
-
-fn truncate_text(raw: &str, max_chars: usize) -> String {
-    if raw.is_empty() || max_chars == 0 {
-        return String::new();
-    }
-    raw.chars().take(max_chars).collect::<String>()
 }
 
 fn parse_step_specs(spec: &Value) -> anyhow::Result<Vec<OrchestratorStepSpec>> {


### PR DESCRIPTION
## Summary

This PR delivers the 5 follow-up review items for Team context memory in one change set:

1. Fix IDOR risk in run-context flush endpoint.
2. Enforce owner checks consistently across run-scoped Team APIs.
3. Simplify memory-flush trigger normalization logic.
4. Deduplicate text truncation helper logic across Team manager/orchestrator/ACP runtime skill.
5. Refactor large `TeamManager::flush_run_context` flow into helper units.

## Why

Recent review comments on Team memory/context baseline identified security and maintainability gaps:

- Run APIs relied on existence checks in multiple places without ownership authorization.
- `flush_run_context` endpoint could be called by any authenticated user with a known `run_id`.
- Memory-flush implementation had a large, hard-to-review function with repeated failure/result branches.
- Same truncation helper logic existed in multiple files.

## What Changed

### Security and authorization hardening

- Added run ownership loaders in `src/api/teams.rs`:
  - `load_run_for_user`
  - `load_run_and_team_for_user`
  - owner-aware `load_run_and_member_ids_for_user`
- Replaced run existence-only checks with owner-aware checks for run-scoped handlers:
  - `get/cancel/resume/restart/snapshot/events/context/flush`
  - run step endpoints (`list/submit/start/complete/fail/input_required/resume`)
  - run mailbox/message endpoints (`send/inbox/ack`)
- Updated team-scoped run handlers (`create_team_run`, `list_team_runs`) to use `load_team_for_user`.

### API clarity

- Rewrote `normalize_memory_flush_trigger` to explicit `match`-based normalization with the same accepted values:
  - `manual`
  - `soft_threshold`
  - `hard_error`

### Shared truncation utility

- Added new workspace crate: `crates/agenthub-text` with `truncate_chars`.
- Reused in:
  - `src/team/manager.rs`
  - `src/team/orchestrator.rs`
  - `crates/agenthub-acp/src/actor_runtime_skill.rs`
- Removed duplicated local truncation implementations from those files.

### Memory flush refactor

- Refactored `TeamManager::flush_run_context` by extracting helper units:
  - request normalization
  - run/team/checkpoint/event loaders
  - checkpoint upsert helper
  - failure/noop finalization helpers
  - shared pointer payload builder and length conversion helper
- Kept existing event contract and result schema behavior:
  - `memory_flush_started`
  - `memory_flush_persisted`
  - `memory_flush_noop`
  - `memory_flush_failed`

## Tests

Executed locally:

- `cargo fmt --all`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test team_runs_api_enforces_team_owner_access`
- `cargo test team_runs_api_`
- `cargo test flush_run_context_`
- `cargo test team_runs_api_supports_manual_context_flush`
- `cargo test team_runs_api_rejects_invalid_context_flush_trigger`
- `cargo test dispatch_once_attaches_continuity_when_available`
- `cargo test dispatch_once_respects_continuity_reset_mode`
- `cargo test -p agenthub-acp actor_runtime_skill`
- `cargo test -p agenthub-text`

## Docs

- Added feature note:
  - `docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md`
- Added follow-up verification item near top of TODO:
  - `docs/todo.md`

## Follow-up

- Keep broader Team ACL matrix work deferred as low-priority backlog item in `docs/todo.md`.
