### PR TITLE
fix: prevent team delete 500 from member session FK dependencies

### DIFF
--- a/docs/features/2026-02-23-team-delete-member-session-fk-hardening.md
+++ b/docs/features/2026-02-23-team-delete-member-session-fk-hardening.md
@@ -1,0 +1,42 @@
+# Team Delete Member Session FK Hardening
+
+## Background
+
+`DELETE /api/teams/:id` could return `500` when Team member agents had runtime history rows linked to active sessions.
+
+The delete flow removed `agent_sessions` for Team members before removing dependent rows in:
+
+- `agent_events` (`session_id` FK to `agent_sessions.id`)
+- `acp_permission_requests` (`session_id` FK to `agent_sessions.id`)
+
+In SQLite with foreign keys enabled, this produced FK violations and the API surfaced a generic internal error.
+
+## Scope
+
+This change only hardens Team delete cleanup ordering and regression coverage.
+
+No API contract changes, payload changes, or UI changes were introduced.
+
+## Key Decisions
+
+- Update Team delete cleanup order in `src/api/teams.rs`:
+  - delete `acp_permission_requests` by `agent_id`
+  - delete `agent_events` by `agent_id`
+  - delete `agent_sessions` by `agent_id`
+- Extend Team delete API regression test (`teams_api_delete_team_cascades_related_run_data`) to insert and verify cleanup of:
+  - member `agent_events`
+  - member `acp_permission_requests`
+- Keep test schema aligned with runtime schema by adding `acp_permission_requests` table in `src/api/teams/tests.rs`.
+
+## Validation
+
+Executed local checks:
+
+- `cargo test teams_api_delete_team_cascades_related_run_data -- --nocapture`
+- `cargo test delete_team -- --nocapture`
+
+Both passed after the cleanup-order fix.
+
+## Follow-ups
+
+- Verify the same path in CI (`push` + `pull_request`) and record workflow run IDs before closing the TODO item.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify `DELETE /api/teams/:id` no longer returns `500` when member agents have dependent `agent_events` / `acp_permission_requests` rows, and record push + PR CI run IDs after merge (see `docs/features/2026-02-23-team-delete-member-session-fk-hardening.md`).
 - [ ] Verify Team run ownership hardening covers run-scoped APIs (`get/cancel/resume/restart/snapshot/events/steps/messages/context flush`) and that new shared crate `agenthub-text` remains stable in both Cargo and Bazel CI (see `docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md`).
 - [ ] [LOW] Defer Team ACL hardening (explicit owner/member permission matrix across Team main-task/run/mailbox APIs and UI visibility) until the chat-first baseline workflow and core Team features are complete.
 - [ ] Verify single-mode ACP sessions no longer inject Team role skills from global `~/.agenthub/skills.json`, while Team actor sessions still inject `team-leader-orchestrator`/`team-worker-executor` + `team-deliberation-rules` by role context (see `docs/features/2026-02-22-team-role-skill-single-mode-isolation.md`).

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -471,6 +471,16 @@ async fn delete_team(
         let _ = state.agents.stop_agent(member_id).await;
     }
     for member_id in &member_ids {
+        sqlx::query("DELETE FROM acp_permission_requests WHERE agent_id = ?1")
+            .bind(member_id)
+            .execute(&state.db)
+            .await
+            .map_err(|err| map_team_internal_error(anyhow::Error::from(err)))?;
+        sqlx::query("DELETE FROM agent_events WHERE agent_id = ?1")
+            .bind(member_id)
+            .execute(&state.db)
+            .await
+            .map_err(|err| map_team_internal_error(anyhow::Error::from(err)))?;
         sqlx::query("DELETE FROM agent_sessions WHERE agent_id = ?1")
             .bind(member_id)
             .execute(&state.db)

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -255,6 +255,29 @@ async fn init_test_schema(db: &SqlitePool) {
 
     sqlx::query(
         r#"
+        CREATE TABLE acp_permission_requests (
+            id TEXT PRIMARY KEY,
+            agent_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            acp_session_id TEXT,
+            tool_call_id TEXT,
+            options_json TEXT NOT NULL,
+            tool_call_json TEXT,
+            status TEXT NOT NULL,
+            selected_option_id TEXT,
+            created_at INTEGER NOT NULL,
+            responded_at INTEGER,
+            FOREIGN KEY(agent_id) REFERENCES agents(id),
+            FOREIGN KEY(session_id) REFERENCES agent_sessions(id)
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create acp_permission_requests");
+
+    sqlx::query(
+        r#"
         CREATE TABLE team_definitions (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL UNIQUE,

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -117,6 +117,51 @@ async fn teams_api_delete_team_cascades_related_run_data() {
     .await
     .expect("insert member session");
 
+    sqlx::query(
+        r#"
+        INSERT INTO agent_events (agent_id, session_id, seq, ts, stream, message)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind(member_agent_id)
+    .bind(&session_id)
+    .bind("1")
+    .bind(now)
+    .bind("stdout")
+    .bind("event payload")
+    .execute(&state.db)
+    .await
+    .expect("insert member event");
+
+    let permission_request_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        r#"
+        INSERT INTO acp_permission_requests (
+            id,
+            agent_id,
+            session_id,
+            acp_session_id,
+            tool_call_id,
+            options_json,
+            tool_call_json,
+            status,
+            selected_option_id,
+            created_at,
+            responded_at
+        )
+        VALUES (?1, ?2, ?3, NULL, NULL, ?4, NULL, ?5, NULL, ?6, NULL)
+        "#,
+    )
+    .bind(&permission_request_id)
+    .bind(member_agent_id)
+    .bind(&session_id)
+    .bind("[]")
+    .bind("pending")
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .expect("insert acp permission request");
+
     let Json(team) = create_team(
         State(state.clone()),
         headers.clone(),
@@ -308,6 +353,22 @@ async fn teams_api_delete_team_cascades_related_run_data() {
     .await
     .expect("count member sessions");
     assert_eq!(session_count, 0);
+
+    let event_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent_events WHERE agent_id = ?1")
+            .bind(member_agent_id)
+            .fetch_one(&state.db)
+            .await
+            .expect("count member events");
+    assert_eq!(event_count, 0);
+
+    let permission_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM acp_permission_requests WHERE agent_id = ?1")
+            .bind(member_agent_id)
+            .fetch_one(&state.db)
+            .await
+            .expect("count permission requests");
+    assert_eq!(permission_count, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR fixes a `500` error on `DELETE /api/teams/:id` when Team member agents still have session-linked runtime rows.

Root cause:
- Team delete flow removed `agent_sessions` directly.
- But `agent_events.session_id` and `acp_permission_requests.session_id` still referenced those sessions.
- SQLite FK checks failed and API returned generic internal error (`500`).

## Changes

- `src/api/teams.rs`
  - Hardened member cleanup order before deleting `agent_sessions`:
    1. `DELETE FROM acp_permission_requests WHERE agent_id = ?`
    2. `DELETE FROM agent_events WHERE agent_id = ?`
    3. `DELETE FROM agent_sessions WHERE agent_id = ?`

- `src/api/teams/tests_core.rs`
  - Extended `teams_api_delete_team_cascades_related_run_data`:
    - Inserted member `agent_events` and `acp_permission_requests` fixtures.
    - Verified both tables are cleaned after team deletion.

- `src/api/teams/tests.rs`
  - Added `acp_permission_requests` table to test schema bootstrap to match runtime schema.

- Docs
  - Added feature note: `docs/features/2026-02-23-team-delete-member-session-fk-hardening.md`
  - Added verification TODO entry in `docs/todo.md`

## Validation

Local checks:

- `cargo fmt --all`
- `cargo test teams_api_delete_team_cascades_related_run_data -- --nocapture`
- `cargo test delete_team -- --nocapture`

All passed.

## Risk

Low. This is a delete-order hardening change only, scoped to Team delete member-session cleanup path.
