### PR TITLE
feat(web): improve teams sidebar usability and mailbox helper coverage

### DIFF
--- a/docs/features/2026-02-23-team-sidebar-filter-and-mailbox-helper-coverage.md
+++ b/docs/features/2026-02-23-team-sidebar-filter-and-mailbox-helper-coverage.md
@@ -1,0 +1,48 @@
+# Team Sidebar Filter And Mailbox Helper Coverage
+
+## Background
+
+Teams workbench usability feedback highlighted two pain points:
+
+- Team list becomes hard to scan when many teams exist.
+- Mailbox helper module lacked direct unit coverage, making behavior regressions harder to detect.
+
+## Scope
+
+This change improves Team sidebar discoverability and adds focused unit coverage for Team mailbox helper utilities.
+
+No backend API contract or payload shape changes were introduced.
+
+## Key Decisions
+
+- Add Team sidebar filter input in `web/src/pages/team_sidebar.tsx`:
+  - New input: `Filter teams by name or id`.
+  - Supports case-insensitive matching against `team.name` and `team.id`.
+  - Adds explicit clear action (`Clear team filter`).
+  - Adds `aria-current="true"` for selected team row to improve accessibility semantics.
+  - Adds explicit empty state for filtered results (`No teams match current filter.`).
+- Extend panel interaction tests in `web/src/pages/team_panels.test.tsx`:
+  - Verify filter behavior, clear behavior, and selected-row accessibility state.
+- Add dedicated mailbox helper tests in `web/src/pages/team/mailbox_helpers.test.ts`:
+  - Covers actor resolution fallback behavior.
+  - Covers mailbox merge ordering/dedup semantics.
+  - Covers conversation selection, unread counting, payload templates, and deterministic key/payload helpers.
+
+## Validation
+
+Executed local checks:
+
+- `npm --prefix web run test -- src/pages/team_panels.test.tsx src/pages/team/mailbox_helpers.test.ts`
+- `npm --prefix web run test:coverage -- src/pages/team_panels.test.tsx src/pages/team/mailbox_helpers.test.ts`
+- `npm --prefix web run lint`
+
+All passed.
+
+Chrome DevTools MCP checks:
+
+- Baseline snapshot captured on `https://agenthub.hawkingrei.com/` login state.
+- Post-auth Teams page snapshot captured on `https://agenthub.hawkingrei.com/teams` to confirm Team workbench route and panel rendering are still reachable.
+
+## Follow-ups
+
+- Verify Web CI (`push` + `pull_request`) for lint/unit/build and record run IDs before marking TODO done.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify Teams sidebar filter UX (`Filter teams by name or id` + clear action + selected item `aria-current`) and mailbox helper coverage additions remain stable in Web CI (`lint`, unit tests, build) for both `push` and `pull_request` events (see `docs/features/2026-02-23-team-sidebar-filter-and-mailbox-helper-coverage.md`).
 - [ ] Verify `DELETE /api/teams/:id` no longer returns `500` when member agents have dependent `agent_events` / `acp_permission_requests` rows, and record push + PR CI run IDs after merge (see `docs/features/2026-02-23-team-delete-member-session-fk-hardening.md`).
 - [ ] Verify Team run ownership hardening covers run-scoped APIs (`get/cancel/resume/restart/snapshot/events/steps/messages/context flush`) and that new shared crate `agenthub-text` remains stable in both Cargo and Bazel CI (see `docs/features/2026-02-23-team-run-access-and-memory-flush-hardening.md`).
 - [ ] [LOW] Defer Team ACL hardening (explicit owner/member permission matrix across Team main-task/run/mailbox APIs and UI visibility) until the chat-first baseline workflow and core Team features are complete.

--- a/web/src/pages/team/mailbox_helpers.test.ts
+++ b/web/src/pages/team/mailbox_helpers.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { TeamActorMessageRecord } from "../../api";
+import {
+  buildMailboxChatPayload,
+  buildMailboxConversationKey,
+  buildMailboxPayloadTemplate,
+  countUnreadConversationMessages,
+  mergeMailboxMessages,
+  resolveConversationMaxMessageId,
+  resolveMailboxChatActors,
+  selectMailboxConversation,
+} from "./mailbox_helpers";
+
+function buildMessage(
+  messageId: number,
+  overrides: Partial<TeamActorMessageRecord> = {}
+): TeamActorMessageRecord {
+  return {
+    message_id: messageId,
+    run_id: "run-1",
+    from_actor_id: "leader",
+    to_actor_id: "worker",
+    channel: "default",
+    transport: "local",
+    route: null,
+    payload: { type: "chat_message", text: `msg-${messageId}` },
+    status: "pending",
+    created_at: 1000 + messageId,
+    delivered_at: null,
+    ...overrides,
+  };
+}
+
+describe("mailbox helpers", () => {
+  it("resolves mailbox chat actors with leader fallback and selection fallback", () => {
+    expect(resolveMailboxChatActors("leader", ["leader", "worker"], "worker")).toEqual({
+      fromActorId: "leader",
+      toActorId: "worker",
+      inboxActorId: "worker",
+    });
+
+    expect(resolveMailboxChatActors("unknown", ["worker-a", "worker-b"], "unknown")).toEqual({
+      fromActorId: "worker-a",
+      toActorId: "worker-a",
+      inboxActorId: "worker-a",
+    });
+
+    expect(resolveMailboxChatActors("leader", [], "worker")).toEqual({
+      fromActorId: "",
+      toActorId: "",
+      inboxActorId: "",
+    });
+  });
+
+  it("merges mailbox messages with dedup by message id and stable ascending order", () => {
+    const recent = [buildMessage(3), buildMessage(1)];
+    const inbox = [buildMessage(2), buildMessage(3, { status: "delivered" })];
+    const merged = mergeMailboxMessages(recent, inbox);
+    expect(merged.map((item) => item.message_id)).toEqual([1, 2, 3]);
+    expect(merged[2]?.status).toBe("delivered");
+  });
+
+  it("selects conversation messages only for the requested actor pair", () => {
+    const messages = [
+      buildMessage(1, { from_actor_id: "leader", to_actor_id: "worker" }),
+      buildMessage(2, { from_actor_id: "worker", to_actor_id: "leader" }),
+      buildMessage(3, { from_actor_id: "leader", to_actor_id: "other" }),
+    ];
+    expect(selectMailboxConversation(messages, "leader", "worker").map((item) => item.message_id)).toEqual([
+      1,
+      2,
+    ]);
+    expect(selectMailboxConversation(messages, "", "worker")).toEqual([]);
+  });
+
+  it("builds payload and conversation key deterministically", () => {
+    expect(buildMailboxChatPayload("hello")).toEqual({
+      type: "chat_message",
+      text: "hello",
+      source: "team_workbench",
+    });
+    expect(buildMailboxConversationKey("worker", "leader")).toBe("leader::worker");
+    expect(buildMailboxConversationKey("leader", "   ")).toBe("");
+  });
+
+  it("resolves max message id and unread counts for peer and self conversations", () => {
+    const messages = [
+      buildMessage(10, { from_actor_id: "leader", to_actor_id: "worker" }),
+      buildMessage(11, { from_actor_id: "worker", to_actor_id: "leader" }),
+      buildMessage(12, { from_actor_id: "leader", to_actor_id: "leader" }),
+      buildMessage(13, { from_actor_id: "leader", to_actor_id: "leader" }),
+    ];
+    expect(resolveConversationMaxMessageId(messages)).toBe(13);
+    expect(resolveConversationMaxMessageId([])).toBeNull();
+
+    expect(countUnreadConversationMessages(messages, "leader", "worker", 10)).toBe(1);
+    expect(countUnreadConversationMessages(messages, "leader", "leader", 11)).toBe(2);
+    expect(countUnreadConversationMessages(messages, "", "worker", 0)).toBe(0);
+  });
+
+  it("returns expected payload templates for all known keys and default branch", () => {
+    const keys = [
+      "leader_task_assignment",
+      "clarification_request",
+      "clarification_response",
+      "worker_done",
+      "worker_blocked",
+      "profile_patch_proposal",
+    ] as const;
+    for (const key of keys) {
+      const payload = buildMailboxPayloadTemplate(key);
+      expect(payload).not.toEqual({});
+    }
+    expect(buildMailboxPayloadTemplate("unknown" as never)).toEqual({});
+  });
+});

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -234,6 +234,8 @@ describe("team panels interactions", () => {
     const onOpenCreateTeamWizard = vi.fn();
     const onOpenCreateTeamManual = vi.fn();
     const onSelectTeam = vi.fn();
+    const teamOne = buildTeam();
+    const teamTwo = buildTeam({ id: "team-2", name: "Team Two" });
 
     act(() => {
       root.render(
@@ -245,14 +247,23 @@ describe("team panels interactions", () => {
           draftTeamName="alpha"
           leaderMemberId="leader-agent"
           configuredWorkerCount={2}
-          teams={[buildTeam()]}
-          selectedTeamId={null}
+          teams={[teamOne, teamTwo]}
+          selectedTeamId="team-1"
           teamMemberSummaryByTeamId={new Map([
             [
               "team-1",
               {
                 active: 1,
                 inactive: 1,
+                missing: 0,
+                total: 2,
+              },
+            ],
+            [
+              "team-2",
+              {
+                active: 2,
+                inactive: 0,
                 missing: 0,
                 total: 2,
               },
@@ -267,12 +278,53 @@ describe("team panels interactions", () => {
     clickElement(findButtonByText(container, "Guided Wizard"));
     clickElement(findButtonByText(container, "Manual Spec"));
     clickElement(required(container.querySelector(".teams-list .team-item"), "team item missing"));
+    const filterInput = required(
+      container.querySelector("input[aria-label='Filter teams']"),
+      "team filter input missing"
+    ) as HTMLInputElement;
+    changeInputValue(filterInput, "team-2");
+    expect(container.textContent).toContain("Team Two");
+    expect(container.textContent).not.toContain("Team One");
+    expect(container.textContent).toContain("filtered=1 total=2");
+    clickElement(findButtonByAriaLabel(container, "Clear team filter"));
+    expect(container.textContent).toContain("Team One");
+    expect(container.textContent).toContain("Team Two");
+    const selectedItem = required(
+      container.querySelector("button[aria-current='true']"),
+      "selected team item missing"
+    );
+    expect(selectedItem.textContent).toContain("Team One");
 
     expect(onRefreshTeams).toHaveBeenCalledTimes(1);
     expect(onOpenCreateTeamWizard).toHaveBeenCalledTimes(1);
     expect(onOpenCreateTeamManual).toHaveBeenCalledTimes(1);
     expect(onSelectTeam).toHaveBeenCalledWith("team-1");
     expect(container.textContent).toContain("active=1 inactive=1 missing=0 total=2");
+
+    act(() => {
+      root.render(
+        <TeamSidebar
+          busy={null}
+          onRefreshTeams={() => {}}
+          onOpenCreateTeamWizard={() => {}}
+          onOpenCreateTeamManual={() => {}}
+          draftTeamName=""
+          leaderMemberId=""
+          configuredWorkerCount={0}
+          teams={[buildTeam()]}
+          selectedTeamId={null}
+          teamMemberSummaryByTeamId={new Map()}
+          onSelectTeam={() => {}}
+        />
+      );
+    });
+
+    const unmatchedFilterInput = required(
+      container.querySelector("input[aria-label='Filter teams']"),
+      "team filter input missing"
+    ) as HTMLInputElement;
+    changeInputValue(unmatchedFilterInput, "missing-team");
+    expect(container.textContent).toContain("No teams match current filter.");
 
     act(() => {
       root.render(

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -4,6 +4,7 @@ import {
   TEAM_LIST_ITEM_ACTIVE_CLASS,
   TEAM_LIST_ITEM_IDLE_CLASS,
   TEAM_LIST_ITEM_META_CLASS,
+  TEAM_PANEL_INPUT_CLASS,
   TEAM_LIST_ITEM_TITLE_CLASS,
   TEAM_PANEL_GHOST_BUTTON_CLASS,
   TEAM_PANEL_PRIMARY_BUTTON_CLASS,
@@ -45,6 +46,19 @@ export function TeamSidebar(props: TeamSidebarProps) {
     teamMemberSummaryByTeamId,
     onSelectTeam,
   } = props;
+  const [teamFilter, setTeamFilter] = React.useState("");
+  const normalizedTeamFilter = teamFilter.trim().toLowerCase();
+  const filteredTeams = React.useMemo(() => {
+    if (!normalizedTeamFilter) {
+      return teams;
+    }
+    return teams.filter((team) => {
+      const name = team.name.toLowerCase();
+      const id = team.id.toLowerCase();
+      return name.includes(normalizedTeamFilter) || id.includes(normalizedTeamFilter);
+    });
+  }, [normalizedTeamFilter, teams]);
+  const hasTeamFilter = normalizedTeamFilter.length > 0;
 
   return (
     <aside className="teams-sidebar flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -96,9 +110,36 @@ export function TeamSidebar(props: TeamSidebarProps) {
         </div>
       </div>
 
+      <div className="teams-filter flex items-center gap-2">
+        <input
+          className={TEAM_PANEL_INPUT_CLASS}
+          placeholder="Filter teams by name or id"
+          aria-label="Filter teams"
+          value={teamFilter}
+          onChange={(event) => setTeamFilter(event.target.value)}
+        />
+        {hasTeamFilter && (
+          <button
+            type="button"
+            className={TEAM_PANEL_GHOST_BUTTON_CLASS}
+            onClick={() => setTeamFilter("")}
+            aria-label="Clear team filter"
+            title="Clear team filter"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
       <div className="teams-list flex min-h-0 flex-1 flex-col gap-2 overflow-auto">
         {teams.length === 0 && <p className="muted">No teams yet.</p>}
-        {teams.map((team) => {
+        {teams.length > 0 && filteredTeams.length === 0 && (
+          <p className="muted">No teams match current filter.</p>
+        )}
+        {hasTeamFilter && filteredTeams.length > 0 && (
+          <p className="muted mono">{`filtered=${filteredTeams.length} total=${teams.length}`}</p>
+        )}
+        {filteredTeams.map((team) => {
           const summary = teamMemberSummaryByTeamId.get(team.id);
           return (
             <button
@@ -109,6 +150,8 @@ export function TeamSidebar(props: TeamSidebarProps) {
                   : TEAM_LIST_ITEM_IDLE_CLASS
               }
               onClick={() => onSelectTeam(team.id)}
+              aria-current={team.id === selectedTeamId ? "true" : undefined}
+              title={team.id}
             >
               <span className={TEAM_LIST_ITEM_TITLE_CLASS}>{team.name}</span>
               <span className={TEAM_LIST_ITEM_META_CLASS}>{team.id}</span>


### PR DESCRIPTION
## Summary

This PR improves Team workbench usability and test coverage in one focused change set.

### UX improvements

- Add a Team sidebar filter input in `web/src/pages/team_sidebar.tsx`:
  - `Filter teams by name or id`
  - case-insensitive match on `team.name` and `team.id`
  - explicit clear action (`Clear team filter`)
  - explicit filtered-empty state (`No teams match current filter.`)
  - selected item now exposes `aria-current="true"` for accessibility semantics

### Coverage improvements

- Extend `web/src/pages/team_panels.test.tsx` to cover:
  - filter behavior
  - clear behavior
  - selected item `aria-current`
  - filtered-empty message
- Add new focused helper tests in `web/src/pages/team/mailbox_helpers.test.ts`:
  - actor resolution fallback behavior
  - merge ordering/dedup semantics
  - conversation selection
  - max-id and unread counting
  - payload template and deterministic key/payload helpers

### Docs

- Added feature note: `docs/features/2026-02-23-team-sidebar-filter-and-mailbox-helper-coverage.md`
- Added TODO tracking entry in `docs/todo.md`

## Validation

Local:

- `npm --prefix web run test -- src/pages/team_panels.test.tsx src/pages/team/mailbox_helpers.test.ts`
- `npm --prefix web run test:coverage -- src/pages/team_panels.test.tsx src/pages/team/mailbox_helpers.test.ts`
- `npm --prefix web run lint`
- `npm --prefix web run build`

All passed.

Chrome DevTools MCP:

- Baseline verified on `https://agenthub.hawkingrei.com/teams` (Teams route reachable and workbench rendered).
- Post-change verified on local dev page (`http://127.0.0.1:4173/teams`) that sidebar filter control renders (`Filter teams`, `Clear team filter`) and interaction state toggles correctly.

## Risk

Low. Scope is limited to Team sidebar UI behavior and frontend tests; no API contract changes.
