### PR TITLE
style(web): optimize css maintainability for team UI

### DIFF
--- a/web/src/components/acp_conversation.tsx
+++ b/web/src/components/acp_conversation.tsx
@@ -10,6 +10,18 @@ import {
   isToolCallLive,
 } from "../conversation";
 import { renderMarkdown } from "../markdown";
+import {
+  ACP_BUBBLE_PLAN_CLASS,
+  ACP_BUBBLE_THINKING_CLASS,
+  ACP_CONVERSATION_TOP_HINT_CLASS,
+  ACP_DIFF_PRE_CLASS,
+  ACP_PLAN_INDEX_BADGE_CLASS,
+  ACP_PLAN_PRIORITY_BADGE_CLASS,
+  ACP_PLAN_STATUS_BADGE_CLASS,
+  ACP_SEGMENTED_BUTTON_CLASS,
+  ACP_SEGMENTED_NOTE_WARNING_CLASS,
+  ACP_TERMINAL_PRE_CLASS,
+} from "../ui/tailwind_classes";
 
 type AcpConversationProps = {
   items: ConversationItem[];
@@ -194,7 +206,7 @@ export function AcpConversation({
     >
       <div className="acp-conversation-inner flex w-full flex-col gap-3">
         {topHint ? (
-          <div className="acp-conversation-top-hint rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+          <div className={ACP_CONVERSATION_TOP_HINT_CLASS}>
             {topHint}
           </div>
         ) : null}
@@ -276,7 +288,7 @@ const ConversationBubble = React.memo(
       const thinkingLabel = deriveThinkingLabel(msg.text);
       const label = msg.live ? `${thinkingLabel} (live)` : thinkingLabel;
       return (
-        <div className="acp-bubble agent_thinking rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 shadow-sm">
+        <div className={ACP_BUBBLE_THINKING_CLASS}>
           <div className="acp-thinking-title text-xs font-semibold uppercase tracking-wide text-slate-500">
             {label}
           </div>
@@ -849,7 +861,7 @@ const PlanBubble = React.memo(
         ? `Plan: ${preview}`
         : "Plan (collapsed)";
     return (
-      <div className="acp-bubble agent_plan rounded-xl border border-violet-200 bg-violet-50/40 px-3 py-2 shadow-sm">
+      <div className={ACP_BUBBLE_PLAN_CLASS}>
         <details className="acp-thought-fold acp-plan-fold">
           <summary className="cursor-pointer text-sm font-semibold text-violet-800">{summary}</summary>
           <div className="acp-text mt-2 text-sm text-slate-700">
@@ -876,17 +888,17 @@ const PlanBubble = React.memo(
                         key={`${idx}-${entry.content}`}
                         className={`acp-plan-item ${status} grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-start gap-3 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5`}
                       >
-                        <span className="acp-plan-index inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600">
+                        <span className={ACP_PLAN_INDEX_BADGE_CLASS}>
                           {idx + 1}
                         </span>
                         <span className="acp-plan-content text-sm text-slate-800">{entry.content}</span>
                         {entry.priority && (
-                          <span className="acp-plan-priority rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                          <span className={ACP_PLAN_PRIORITY_BADGE_CLASS}>
                             {entry.priority}
                           </span>
                         )}
                         {entry.status && (
-                          <span className="acp-plan-status rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600">
+                          <span className={ACP_PLAN_STATUS_BADGE_CLASS}>
                             {entry.status}
                           </span>
                         )}
@@ -1471,7 +1483,7 @@ function ToolTextContent({
   if (markdownText && tooLargeForMarkdown) {
     return (
       <div className="acp-segmented-block space-y-2">
-        <div className="acp-segmented-note rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+        <div className={ACP_SEGMENTED_NOTE_WARNING_CLASS}>
           Large markdown payload is rendered as plain text for performance.
         </div>
         <ToolPlainTextView text={text} asciiLike={false} />
@@ -1532,7 +1544,7 @@ function TerminalOutputView({
   );
   return (
     <div className="acp-segmented-block space-y-2">
-      <pre className="acp-content rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100">{rendered}</pre>
+      <pre className={ACP_TERMINAL_PRE_CLASS}>{rendered}</pre>
       {hasMore && (
         <SegmentedMoreFooter
           remaining={remaining}
@@ -1602,7 +1614,7 @@ function SegmentedMoreFooter({
       </span>
       <button
         type="button"
-        className="acp-segmented-button inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+        className={ACP_SEGMENTED_BUTTON_CLASS}
         onClick={onShowMore}
         aria-label={`Show ${remaining} more ${unitLabel}`}
       >
@@ -1679,7 +1691,7 @@ function ToolDiffView({ text }: { text: string }) {
   const visibleLines = lines.slice(0, visibleCount);
   return (
     <div className="acp-segmented-block space-y-2">
-      <pre className="acp-content acp-diff-view overflow-auto rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100">
+      <pre className={ACP_DIFF_PRE_CLASS}>
         {visibleLines.map((line, index) => {
           const kind = classifyDiffLine(line);
           return (

--- a/web/src/components/acp_debug.tsx
+++ b/web/src/components/acp_debug.tsx
@@ -1,6 +1,18 @@
 import React from "react";
 import { AcpRawEvent } from "../acp";
 import { AcpPermissionRecord } from "../api";
+import {
+  ACP_DEBUG_EMPTY_CLASS,
+  ACP_DEBUG_PERMISSION_SUBMETA_CLASS,
+  ACP_DEBUG_PERMISSION_TOGGLE_CLASS,
+  ACP_DEBUG_PERMISSION_WARNING_CLASS,
+  ACP_DEBUG_RAW_PRE_CLASS,
+  ACP_DEBUG_ROOT_CLASS,
+  ACP_DEBUG_SECTION_CLASS,
+  ACP_DEBUG_TABS_CLASS,
+  ACP_TAB_BUTTON_ACTIVE_CLASS,
+  ACP_TAB_BUTTON_IDLE_CLASS,
+} from "../ui/tailwind_classes";
 
 type DebugTab = "session" | "runtime" | "permissions" | "raw";
 
@@ -87,11 +99,7 @@ export function AcpDebug({
     ? Math.round((runtimeMetrics.ansiCacheHits / ansiTotal) * 100)
     : 0;
   const debugTabClassName = (isActive: boolean) =>
-    `acp-debug-tab inline-flex min-h-[30px] items-center rounded-md px-3 py-1.5 text-xs font-medium leading-tight transition sm:text-sm ${
-      isActive
-        ? "bg-slate-900 text-white shadow-sm"
-        : "text-slate-600 hover:bg-white hover:text-slate-900"
-    }`;
+    `acp-debug-tab ${isActive ? ACP_TAB_BUTTON_ACTIVE_CLASS : ACP_TAB_BUTTON_IDLE_CLASS}`;
   const debugInputClassName =
     "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-300";
   const debugSecondaryButtonClassName =
@@ -131,8 +139,8 @@ export function AcpDebug({
   }, []);
 
   return (
-    <div className="acp-debug flex min-h-0 flex-1 flex-col gap-3 p-3 sm:p-4">
-      <div className="acp-debug-tabs flex flex-wrap gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1">
+    <div className={ACP_DEBUG_ROOT_CLASS}>
+      <div className={ACP_DEBUG_TABS_CLASS}>
         <button
           className={debugTabClassName(tab === "session")}
           onClick={() => setTab("session")}
@@ -159,7 +167,7 @@ export function AcpDebug({
         </button>
       </div>
       {tab === "session" && (
-        <div className="acp-controls space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4">
+        <div className={`acp-controls ${ACP_DEBUG_SECTION_CLASS}`}>
           <h4 className="text-sm font-semibold text-slate-900 sm:text-base">Session Controls</h4>
           <div className="acp-control-meta text-sm text-slate-600">
             Current mode: {currentMode ?? "unknown"}
@@ -214,7 +222,7 @@ export function AcpDebug({
         </div>
       )}
       {tab === "runtime" && (
-        <div className="acp-runtime space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4">
+        <div className={`acp-runtime ${ACP_DEBUG_SECTION_CLASS}`}>
           <h4 className="text-sm font-semibold text-slate-900 sm:text-base">Runtime Metrics</h4>
           <div className="acp-runtime-grid grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             <RuntimeMetricCard label="Conversation (total/source/rendered)">
@@ -269,10 +277,10 @@ export function AcpDebug({
         </div>
       )}
       {tab === "permissions" && (
-        <div className="acp-permissions space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4">
+        <div className={`acp-permissions ${ACP_DEBUG_SECTION_CLASS}`}>
           <h4>Permissions</h4>
           {acpPermissionHistory.length === 0 && (
-            <div className="empty rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-5 text-sm text-slate-500">
+            <div className={ACP_DEBUG_EMPTY_CLASS}>
               No permissions yet.
             </div>
           )}
@@ -284,7 +292,7 @@ export function AcpDebug({
               <div key={permission.id} className="acp-permission rounded-xl border border-slate-200 bg-slate-50/70 p-3">
                 <div className="head flex items-start justify-between gap-2">
                   <button
-                    className="acp-permission-toggle flex min-w-0 flex-1 flex-col items-start gap-1 rounded-lg border border-transparent px-2 py-1 text-left transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+                    className={ACP_DEBUG_PERMISSION_TOGGLE_CLASS}
                     type="button"
                     onClick={() => onJumpToPermissionHistory(permission)}
                     disabled={!canJump}
@@ -302,7 +310,7 @@ export function AcpDebug({
                     {copied ? "Copied" : "Copy"}
                   </button>
                 </div>
-                <div className="acp-permission-submeta mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-600">
+                <div className={ACP_DEBUG_PERMISSION_SUBMETA_CLASS}>
                   <span className="mono">{permission.id}</span>
                   {permission.tool_call_id && (
                     <span className="mono">tool_call {permission.tool_call_id}</span>
@@ -313,7 +321,7 @@ export function AcpDebug({
                   )}
                 </div>
                 {!canJump && (
-                  <div className="acp-permission-options mono mt-2 rounded-lg border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+                  <div className={ACP_DEBUG_PERMISSION_WARNING_CLASS}>
                     no linked tool call in conversation
                   </div>
                 )}
@@ -323,7 +331,7 @@ export function AcpDebug({
         </div>
       )}
       {tab === "raw" && (
-        <div className="acp-raw-wrapper space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4">
+        <div className={`acp-raw-wrapper ${ACP_DEBUG_SECTION_CLASS}`}>
           <h4 className="text-sm font-semibold text-slate-900 sm:text-base">Raw Events</h4>
           <ul className="acp-raw max-h-[420px] space-y-2 overflow-auto pr-1" ref={rawRef}>
             {rawEvents.map((evt, idx) => (
@@ -332,7 +340,7 @@ export function AcpDebug({
                   <span>{new Date(evt.ts * 1000).toLocaleTimeString()}</span>
                   <span className="mono">{evt.type}</span>
                 </div>
-                <pre className="acp-content mt-2 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs leading-5 text-slate-700">
+                <pre className={ACP_DEBUG_RAW_PRE_CLASS}>
                   {JSON.stringify(evt.payload, null, 2)}
                 </pre>
               </li>

--- a/web/src/components/acp_panel.tsx
+++ b/web/src/components/acp_panel.tsx
@@ -2,6 +2,15 @@ import React from "react";
 import { AcpView } from "../acp";
 import { AcpDebug, AcpDebugProps } from "./acp_debug";
 import { AcpConversation, AcpConversationProps } from "./acp_conversation";
+import {
+  ACP_JUMP_BOTTOM_BUTTON_CLASS,
+  ACP_PANEL_HEAD_CLASS,
+  ACP_PANEL_ROOT_CLASS,
+  ACP_PANEL_TABS_CLASS,
+  ACP_TAB_BADGE_CLASS,
+  ACP_TAB_BUTTON_ACTIVE_CLASS,
+  ACP_TAB_BUTTON_IDLE_CLASS,
+} from "../ui/tailwind_classes";
 
 type AcpPanelProps = {
   acpView: AcpView;
@@ -25,35 +34,29 @@ function AcpPanelView({
   conversation,
   debug,
 }: AcpPanelProps) {
+  const tabButtonClassName = (selected: boolean, withGap = false) =>
+    `acp-tab-button ${withGap ? "gap-2 " : ""}${selected ? ACP_TAB_BUTTON_ACTIVE_CLASS : ACP_TAB_BUTTON_IDLE_CLASS}`;
   return (
-    <div className="acp relative flex min-h-0 flex-1 flex-col rounded-2xl border border-slate-100 bg-white/90 shadow-sm">
-      <div className="acp-head minimal flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-3 py-2 sm:px-4">
+    <div className={ACP_PANEL_ROOT_CLASS}>
+      <div className={ACP_PANEL_HEAD_CLASS}>
         <div className="acp-subtitle min-h-5 text-xs text-slate-500 sm:text-sm">
           {subtitle ?? " "}
         </div>
         <div className="acp-actions flex items-center gap-2">
-          <div className="acp-tabs flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1">
+          <div className={ACP_PANEL_TABS_CLASS}>
             <button
-              className={`acp-tab-button inline-flex min-h-[30px] items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium leading-tight transition sm:text-sm ${
-                acpTab === "conversation"
-                  ? "bg-slate-900 text-white shadow-sm"
-                  : "text-slate-600 hover:bg-white hover:text-slate-900"
-              }`}
+              className={tabButtonClassName(acpTab === "conversation", true)}
               onClick={() => onSelectTab("conversation")}
             >
               Conversation
               {showConversationBadge && (
-                <span className="acp-tab-badge rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-semibold leading-none sm:text-xs">
+                <span className={ACP_TAB_BADGE_CLASS}>
                   +{conversation.pendingCount}
                 </span>
               )}
             </button>
             <button
-              className={`acp-tab-button inline-flex min-h-[30px] items-center rounded-md px-3 py-1.5 text-xs font-medium leading-tight transition sm:text-sm ${
-                acpTab === "debug"
-                  ? "bg-slate-900 text-white shadow-sm"
-                  : "text-slate-600 hover:bg-white hover:text-slate-900"
-              }`}
+              className={tabButtonClassName(acpTab === "debug")}
               onClick={() => onSelectTab("debug")}
             >
               Debug
@@ -65,7 +68,7 @@ function AcpPanelView({
       {acpTab === "debug" && <AcpDebug {...debug} />}
       {acpTab === "conversation" && showConversationJump ? (
         <button
-          className="acp-jump-bottom absolute bottom-3 right-3 z-20 inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-800 shadow-md transition hover:border-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+          className={ACP_JUMP_BOTTOM_BUTTON_CLASS}
           onClick={onJumpToConversationBottom}
           title="Jump to bottom"
           aria-label="Jump to bottom"

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -125,6 +125,18 @@ import {
   type TeamRunBrowserState,
 } from "./team/state";
 import {
+  TEAM_CREATE_ACTIONS_BAR_CLASS,
+  TEAM_CREATE_MODAL_BACKDROP_CLASS,
+  TEAM_CREATE_MODAL_CARD_CLASS,
+  TEAM_CREATE_NOTE_INFO_CLASS,
+  TEAM_CREATE_NOTE_WARNING_CLASS,
+  TEAM_CREATE_PANEL_CARD_CLASS,
+  TEAM_CREATE_SKILL_TAG_IDLE_CLASS,
+  TEAM_CREATE_SKILL_TAG_SELECTED_CLASS,
+  TEAM_CREATE_STAGE_BADGE_CLASS,
+  TEAM_CREATE_STEP_PREVIEW_CLASS,
+  TEAM_CREATE_STEP_PREVIEW_MUTED_CLASS,
+  TEAM_CREATE_WORKER_CARD_CLASS,
   TEAM_PANEL_GHOST_BUTTON_CLASS,
   TEAM_PANEL_INPUT_CLASS,
   TEAM_PANEL_PRIMARY_BUTTON_CLASS,
@@ -2612,7 +2624,7 @@ export function TeamPage(props: TeamPageProps) {
 
       {showCreateTeamModal && (
         <div
-          className="modal-backdrop team-create-modal-backdrop fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/40 px-3 py-6 sm:py-10"
+          className={TEAM_CREATE_MODAL_BACKDROP_CLASS}
           role="presentation"
           onClick={(event) => {
             if (event.target === event.currentTarget && busy !== "create-team") {
@@ -2621,7 +2633,7 @@ export function TeamPage(props: TeamPageProps) {
           }}
         >
           <div
-            className="modal team-create-modal w-full max-w-5xl rounded-2xl border border-slate-200 bg-white p-4 shadow-2xl sm:p-5"
+            className={TEAM_CREATE_MODAL_CARD_CLASS}
             role="dialog"
             aria-modal="true"
             aria-labelledby="team-create-title"
@@ -2631,10 +2643,10 @@ export function TeamPage(props: TeamPageProps) {
                 Team Forge
               </h3>
               <div className="team-create-head-meta flex flex-wrap items-center gap-2">
-                <span className="badge rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                <span className={TEAM_CREATE_STAGE_BADGE_CLASS}>
                   Stage {createTeamStage + 1}/{CREATE_TEAM_STAGE_TITLES.length}
                 </span>
-                <span className="badge rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                <span className={TEAM_CREATE_STAGE_BADGE_CLASS}>
                   {useSpecOverride ? "Manual Spec" : "Guided Wizard"}
                 </span>
               </div>
@@ -2724,12 +2736,12 @@ export function TeamPage(props: TeamPageProps) {
                     <span className="text-slate-900">{forgeRoleTag ?? "-"}</span>
                   </div>
                   {!canForgeAgentsInStage && (
-                    <div className="team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                    <div className={TEAM_CREATE_NOTE_WARNING_CLASS}>
                       Agent Forge is available only in Leader Forge or Recruit Workers stage.
                     </div>
                   )}
                   {showForgeAgentForm && (
-                    <div className="team-create-stage-note mt-2 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700">
+                    <div className={TEAM_CREATE_NOTE_INFO_CLASS}>
                       Agent create modal is open. Submit to create and auto-assign by role tag.
                     </div>
                   )}
@@ -2737,7 +2749,7 @@ export function TeamPage(props: TeamPageProps) {
               )}
 
               {createTeamStage === 0 && (
-                <div className="team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+                <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
                   <h4 className="text-base font-semibold text-slate-900">Mission Brief</h4>
                   <div className="team-create-mission-intro mt-2">
                     <p className="muted text-sm text-slate-600">
@@ -2745,13 +2757,13 @@ export function TeamPage(props: TeamPageProps) {
                       the workbench.
                     </p>
                   </div>
-                  <p className="team-create-stage-note mt-2 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700">
+                  <p className={TEAM_CREATE_NOTE_INFO_CLASS}>
                     {useSpecOverride
                       ? "Manual Spec entry selected. Next stage jumps directly to Launch Team."
                       : "Guided Wizard entry selected. Continue to Leader Forge next."}
                   </p>
                   {!isMissionBriefReady && (
-                    <p className="team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                    <p className={TEAM_CREATE_NOTE_WARNING_CLASS}>
                       Team name is required before entering the next stage.
                     </p>
                   )}
@@ -2771,13 +2783,13 @@ export function TeamPage(props: TeamPageProps) {
               )}
 
               {createTeamStage === 1 && (
-                <div className="team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+                <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
                   <h4 className="text-base font-semibold text-slate-900">Leader Forge</h4>
                   <p className="muted mt-2 text-sm text-slate-600">
                     Choose the leader from member agents created in this Team Forge session only.
                   </p>
                   {!isLeaderForgeReady && hasForgeAgents && (
-                    <p className="team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                    <p className={TEAM_CREATE_NOTE_WARNING_CLASS}>
                       Select one forged leader agent to continue.
                     </p>
                   )}
@@ -2799,7 +2811,7 @@ export function TeamPage(props: TeamPageProps) {
                       </option>
                     ))}
                   </select>
-                  <div className="teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
+                  <div className={TEAM_CREATE_STEP_PREVIEW_CLASS}>
                     <div>agent_id: {leaderMemberId || "-"}</div>
                     <div>workdir: {leaderAgent?.workdir ?? "-"}</div>
                   </div>
@@ -2825,8 +2837,8 @@ export function TeamPage(props: TeamPageProps) {
                           type="button"
                           className={
                             selected
-                              ? "team-skill-tag selected rounded-full border border-slate-900 bg-slate-900 px-3 py-1 text-xs font-medium text-white transition"
-                              : "team-skill-tag rounded-full border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                              ? TEAM_CREATE_SKILL_TAG_SELECTED_CLASS
+                              : TEAM_CREATE_SKILL_TAG_IDLE_CLASS
                           }
                           onClick={() =>
                             setLeaderSkills((prev) =>
@@ -2864,7 +2876,7 @@ export function TeamPage(props: TeamPageProps) {
               )}
 
               {createTeamStage === 2 && (
-                <div className="team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+                <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <h4 className="text-base font-semibold text-slate-900">Recruit Workers</h4>
                     <div className="flex flex-wrap gap-2">
@@ -2893,7 +2905,7 @@ export function TeamPage(props: TeamPageProps) {
                     team level.
                   </p>
                   {unassignedWorkerSlots > 0 && (
-                    <p className="team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                    <p className={TEAM_CREATE_NOTE_WARNING_CLASS}>
                       {unassignedWorkerSlots} worker slot
                       {unassignedWorkerSlots > 1 ? "s are" : " is"} currently unassigned and will
                       be ignored unless selected.
@@ -2927,7 +2939,7 @@ export function TeamPage(props: TeamPageProps) {
                       return (
                         <div
                           key={`worker-${index}`}
-                          className="teams-worker-card rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
+                          className={TEAM_CREATE_WORKER_CARD_CLASS}
                         >
                           <div className="team-create-worker-head flex items-center justify-between gap-2">
                             <strong>Worker {index + 1}</strong>
@@ -2955,7 +2967,7 @@ export function TeamPage(props: TeamPageProps) {
                               </option>
                             ))}
                           </select>
-                          <div className="teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                          <div className={TEAM_CREATE_STEP_PREVIEW_MUTED_CLASS}>
                             <div>agent_id: {worker.member_id || "-"}</div>
                             <div>workdir: {workerAgent?.workdir ?? "-"}</div>
                           </div>
@@ -2992,8 +3004,8 @@ export function TeamPage(props: TeamPageProps) {
                                   type="button"
                                   className={
                                     selected
-                                      ? "team-skill-tag selected rounded-full border border-slate-900 bg-slate-900 px-3 py-1 text-xs font-medium text-white transition"
-                                      : "team-skill-tag rounded-full border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                                      ? TEAM_CREATE_SKILL_TAG_SELECTED_CLASS
+                                      : TEAM_CREATE_SKILL_TAG_IDLE_CLASS
                                   }
                                   onClick={() => onToggleWorkerSkill(index, skill)}
                                   disabled={useSpecOverride || isRequired}
@@ -3051,7 +3063,7 @@ export function TeamPage(props: TeamPageProps) {
               )}
 
               {createTeamStage === 3 && (
-                <div className="team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+                <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
                   <h4 className="text-base font-semibold text-slate-900">Launch Team</h4>
                   <p className="muted mt-2 text-sm text-slate-600">
                     Final review before deployment.
@@ -3088,7 +3100,7 @@ export function TeamPage(props: TeamPageProps) {
               )}
             </div>
 
-            <div className="modal-actions team-create-actions mt-4 flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 pt-3">
+            <div className={TEAM_CREATE_ACTIONS_BAR_CLASS}>
               {!canAdvanceCreateStage && currentStageBlockReason && (
                 <span className="team-create-actions-note mr-auto text-sm text-amber-700">
                   {currentStageBlockReason}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -405,43 +405,27 @@ section {
   height: 100%;
 }
 
-body:not(.teams-page) input:not([class*="mantine-"]) {
+body:not(.teams-page) :is(input, textarea, select):not([class*="mantine-"]) {
   width: 100%;
-  padding: 10px;
   border-radius: var(--radius-sm);
   border: 1px solid #d0d0d0;
-  margin-bottom: 12px;
   font-family: inherit;
   background: #fff;
   color: var(--ink);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+body:not(.teams-page) :is(input, select):not([class*="mantine-"]) {
+  padding: 10px;
+  margin-bottom: 12px;
 }
 
 body:not(.teams-page) textarea:not([class*="mantine-"]) {
-  width: 100%;
   padding: 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid #d0d0d0;
   margin-bottom: 0;
   min-height: 110px;
   line-height: 1.5;
-  font-family: inherit;
   resize: vertical;
-  background: #fff;
-  color: var(--ink);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-body:not(.teams-page) select:not([class*="mantine-"]) {
-  width: 100%;
-  padding: 10px;
-  border-radius: var(--radius-sm);
-  border: 1px solid #d0d0d0;
-  margin-bottom: 12px;
-  font-family: inherit;
-  background: #fff;
-  color: var(--ink);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 body:not(.teams-page) button:not([class*="mantine-"]) {
@@ -465,10 +449,7 @@ body:not(.teams-page) button:not([class*="mantine-"]):disabled {
   cursor: not-allowed;
 }
 
-body:not(.teams-page) button:not([class*="mantine-"]):focus-visible,
-body:not(.teams-page) input:not([class*="mantine-"]):focus-visible,
-body:not(.teams-page) textarea:not([class*="mantine-"]):focus-visible,
-body:not(.teams-page) select:not([class*="mantine-"]):focus-visible {
+body:not(.teams-page) :is(button, input, textarea, select):not([class*="mantine-"]):focus-visible {
   outline: none;
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
@@ -2926,14 +2907,19 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   min-width: 0;
 }
 
-.team-role-chip {
+.team-role-chip,
+.team-status-chip,
+.team-status.status-badge {
   border-radius: 999px;
-  border: 1px solid transparent;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.01em;
   padding: 1px 7px;
   text-transform: lowercase;
+}
+
+.team-role-chip {
+  border: 1px solid transparent;
 }
 
 .team-role-chip.leader {
@@ -2950,13 +2936,7 @@ body.teams-page button:not([class*="mantine-"]):disabled {
 
 .team-status-chip,
 .team-status.status-badge {
-  border-radius: 999px;
   border: 1px solid var(--status-neutral-border);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  padding: 1px 7px;
-  text-transform: lowercase;
   background: var(--status-neutral-bg);
   color: var(--status-neutral-ink);
   display: inline-flex;
@@ -3070,7 +3050,8 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   gap: 8px;
 }
 
-.team-create-agent-entry-head h4 {
+.team-create-agent-entry-head h4,
+.team-create-panel h4 {
   margin: 0;
 }
 
@@ -3103,10 +3084,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   font-family: "Source Code Pro", monospace;
   font-size: 12px;
   line-height: 1;
-}
-
-.team-create-panel h4 {
-  margin: 0;
 }
 
 .team-create-head-meta {
@@ -3181,7 +3158,8 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   padding: 10px;
 }
 
-.team-create-forge-agent-head {
+.team-create-forge-agent-head,
+.team-create-worker-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -3223,13 +3201,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   background: #fff;
   border-radius: 10px;
   padding: 10px;
-}
-
-.team-create-worker-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
 }
 
 .team-create-worker-head button {
@@ -3288,7 +3259,8 @@ body.teams-page button:not([class*="mantine-"]):disabled {
 
 .teams-event-list,
 .teams-step-list,
-.teams-message-list {
+.teams-message-list,
+.teams-chat-messages {
   max-height: 420px;
   overflow: auto;
   padding: 0;
@@ -3349,11 +3321,15 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   margin-bottom: 12px;
 }
 
-.teams-chat-members {
+.teams-chat-members,
+.teams-chat-panel {
   border: 1px solid #ececec;
   border-radius: 10px;
   padding: 10px;
   background: #fcfcfc;
+}
+
+.teams-chat-members {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -3378,10 +3354,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
 }
 
 .teams-chat-panel {
-  border: 1px solid #ececec;
-  border-radius: 10px;
-  padding: 10px;
-  background: #fcfcfc;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -3407,17 +3379,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
   margin-left: auto;
   white-space: nowrap;
   min-width: 120px;
-}
-
-.teams-chat-messages {
-  max-height: 420px;
-  overflow: auto;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .teams-chat-bubble {
@@ -3619,15 +3580,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
 
   .team-create-checklist {
     grid-template-columns: 1fr;
-  }
-
-  .team-member-row-main {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    row-gap: 4px;
-  }
-
-  .team-member-row-meta {
-    grid-column: 1 / -1;
   }
 
   .team-member-workline {

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -2,23 +2,23 @@ export const AUTH_PAGE_CLASS =
   "app min-h-[var(--agenthub-vh,100vh)] px-4 py-8 md:px-6 md:py-10";
 
 export const AUTH_CARD_BASE_CLASS =
-  "auth mx-auto w-full max-w-md rounded-2xl border border-slate-200/80 bg-white/90 p-6 shadow-sm backdrop-blur";
+  "auth mx-auto w-full max-w-md rounded-2xl border border-ui-border/80 bg-ui-surface/90 p-6 shadow-sm backdrop-blur";
 
 export const AUTH_FORM_CARD_CLASS = `${AUTH_CARD_BASE_CLASS} flex flex-col gap-3`;
 
 export const AUTH_INPUT_CLASS =
-  "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200";
+  "w-full rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm text-ui-text-primary outline-none transition focus:border-ui-border-emphasis focus:ring-2 focus:ring-ui-border";
 
 export const AUTH_ACTIONS_CLASS = "auth-actions mt-1 flex flex-wrap gap-2";
 
 export const AUTH_PRIMARY_BUTTON_CLASS =
-  "inline-flex items-center justify-center rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-slate-800";
+  "inline-flex items-center justify-center rounded-lg bg-brand-primary px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-inverse transition hover:bg-brand-primary-hover";
 
 export const AUTH_SECONDARY_BUTTON_CLASS =
-  "inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition hover:border-slate-500";
+  "inline-flex items-center justify-center rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-primary transition hover:border-ui-border-emphasis";
 
 export const TEAM_PANEL_CARD_CLASS =
-  "card team-panel-card min-h-0 rounded-2xl border border-slate-200 bg-white shadow-sm";
+  "card team-panel-card min-h-0 rounded-2xl border border-ui-border bg-ui-surface shadow-sm";
 
 export const TEAM_PANEL_TOOLBAR_CLASS =
   "mb-3 flex flex-wrap items-center justify-between gap-2";
@@ -27,48 +27,48 @@ export const TEAM_PANEL_TOOLBAR_ACTIONS_CLASS =
   "actions flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end";
 
 export const TEAM_PANEL_PRIMARY_BUTTON_CLASS =
-  "inline-flex items-center justify-center rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex items-center justify-center rounded-lg bg-brand-primary px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-inverse shadow-sm transition hover:bg-brand-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-border-strong disabled:cursor-not-allowed disabled:opacity-60";
 
 export const TEAM_PANEL_SECONDARY_BUTTON_CLASS =
-  "inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-500 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex items-center justify-center rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-secondary shadow-sm transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-border disabled:cursor-not-allowed disabled:opacity-60";
 
 export const TEAM_PANEL_GHOST_BUTTON_CLASS =
-  "inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-500 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex items-center justify-center rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-secondary shadow-sm transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-border disabled:cursor-not-allowed disabled:opacity-60";
 
 export const TEAM_PANEL_REFRESH_BUTTON_CLASS =
-  "inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 py-1.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-500 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200";
+  "inline-flex items-center gap-1.5 rounded-lg border border-ui-border-strong bg-ui-surface px-2.5 py-ctrl-y-sm text-ui-sm font-medium text-ui-text-secondary shadow-sm transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-border";
 
 export const TEAM_PANEL_INPUT_CLASS =
-  "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200";
+  "w-full rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm text-ui-text-primary outline-none transition focus:border-ui-border-emphasis focus:ring-2 focus:ring-ui-border";
 
 export const TEAM_PANEL_TEXTAREA_CLASS =
   `mono min-h-24 ${TEAM_PANEL_INPUT_CLASS}`;
 
-export const TEAM_PANEL_TITLE_CLASS = "text-lg font-semibold tracking-tight text-slate-900";
+export const TEAM_PANEL_TITLE_CLASS = "text-lg font-semibold tracking-tight text-ui-text-primary";
 
 export const TEAM_PANEL_PRE_CLASS =
-  "mono max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-slate-200 bg-slate-50 p-2";
+  "mono max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-ui-border bg-ui-surface-soft p-2";
 
 export const TEAM_TAB_BAR_CLASS =
-  "tab-bar team-tab-bar flex min-w-0 gap-2 overflow-x-auto rounded-xl border border-slate-200 bg-white p-2 shadow-sm";
+  "tab-bar team-tab-bar flex min-w-0 gap-2 overflow-x-auto rounded-xl border border-ui-border bg-ui-surface p-2 shadow-sm";
 
 const TEAM_TAB_BUTTON_BASE_CLASS =
-  "tab shrink-0 rounded-lg px-3 py-2 text-sm font-medium transition";
+  "tab shrink-0 rounded-lg px-ctrl-x py-ctrl-y text-ui-sm font-medium transition";
 
 export const TEAM_TAB_BUTTON_ACTIVE_CLASS =
-  `${TEAM_TAB_BUTTON_BASE_CLASS} active bg-slate-900 text-white shadow-sm`;
+  `${TEAM_TAB_BUTTON_BASE_CLASS} active bg-brand-primary text-ui-text-inverse shadow-sm`;
 
 export const TEAM_TAB_BUTTON_IDLE_CLASS =
-  `${TEAM_TAB_BUTTON_BASE_CLASS} text-slate-600 hover:bg-slate-100 hover:text-slate-900`;
+  `${TEAM_TAB_BUTTON_BASE_CLASS} text-ui-text-muted hover:bg-ui-surface-muted hover:text-ui-text-primary`;
 
 export const TEAM_LIST_ITEM_BASE_CLASS =
-  "team-item flex w-full min-w-0 flex-col items-start gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-left text-slate-900 transition";
+  "team-item flex w-full min-w-0 flex-col items-start gap-1 rounded-lg border border-ui-border bg-ui-surface px-ctrl-x py-ctrl-y text-left text-ui-text-primary transition";
 
 export const TEAM_LIST_ITEM_ACTIVE_CLASS =
-  `${TEAM_LIST_ITEM_BASE_CLASS} border-slate-300 bg-slate-50 ring-1 ring-slate-200`;
+  `${TEAM_LIST_ITEM_BASE_CLASS} border-ui-border-strong bg-ui-surface-soft ring-1 ring-ui-border`;
 
 export const TEAM_LIST_ITEM_IDLE_CLASS =
-  `${TEAM_LIST_ITEM_BASE_CLASS} hover:border-slate-300`;
+  `${TEAM_LIST_ITEM_BASE_CLASS} hover:border-ui-border-strong`;
 
 export const TEAM_LIST_ITEM_TITLE_CLASS =
   "team-name w-full min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-semibold";
@@ -77,115 +77,115 @@ export const TEAM_LIST_ITEM_META_CLASS =
   "team-id mono w-full min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs opacity-90";
 
 export const TEAM_CREATE_MODAL_BACKDROP_CLASS =
-  "modal-backdrop team-create-modal-backdrop fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/40 px-3 py-6 sm:py-10";
+  "modal-backdrop team-create-modal-backdrop fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-brand-primary/40 px-3 py-6 sm:py-10";
 
 export const TEAM_CREATE_MODAL_CARD_CLASS =
-  "modal team-create-modal w-full max-w-5xl rounded-2xl border border-slate-200 bg-white p-4 shadow-2xl sm:p-5";
+  "modal team-create-modal w-full max-w-5xl rounded-2xl border border-ui-border bg-ui-surface p-4 shadow-2xl sm:p-5";
 
 export const TEAM_CREATE_STAGE_BADGE_CLASS =
-  "badge rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700";
+  "badge rounded-full border border-ui-border-strong bg-ui-surface-muted px-2.5 py-1 text-ui-xs font-medium text-ui-text-secondary";
 
 export const TEAM_CREATE_PANEL_CARD_CLASS =
-  "team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4";
+  "team-create-panel rounded-xl border border-ui-border bg-ui-surface-soft/70 p-4";
 
 export const TEAM_CREATE_NOTE_INFO_CLASS =
-  "team-create-stage-note mt-2 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700";
+  "team-create-stage-note mt-2 rounded-lg border border-state-info-border bg-state-info-bg px-ctrl-x py-ctrl-y text-ui-sm text-state-info-text";
 
 export const TEAM_CREATE_NOTE_WARNING_CLASS =
-  "team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700";
+  "team-create-stage-note mt-2 rounded-lg border border-state-warning-border bg-state-warning-bg px-ctrl-x py-ctrl-y text-ui-sm text-state-warning-text";
 
 export const TEAM_CREATE_STEP_PREVIEW_CLASS =
-  "teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600";
+  "teams-step-body mono mt-3 rounded-lg border border-ui-border bg-ui-surface px-ctrl-x py-ctrl-y text-ui-xs text-ui-text-muted";
 
 export const TEAM_CREATE_STEP_PREVIEW_MUTED_CLASS =
-  "teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600";
+  "teams-step-body mono mt-3 rounded-lg border border-ui-border bg-ui-surface-soft px-ctrl-x py-ctrl-y text-ui-xs text-ui-text-muted";
 
 export const TEAM_CREATE_SKILL_TAG_SELECTED_CLASS =
-  "team-skill-tag selected rounded-full border border-slate-900 bg-slate-900 px-3 py-1 text-xs font-medium text-white transition";
+  "team-skill-tag selected rounded-full border border-brand-primary bg-brand-primary px-ctrl-x py-1 text-ui-xs font-medium text-ui-text-inverse transition";
 
 export const TEAM_CREATE_SKILL_TAG_IDLE_CLASS =
-  "team-skill-tag rounded-full border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50";
+  "team-skill-tag rounded-full border border-ui-border-strong bg-ui-surface px-ctrl-x py-1 text-ui-xs font-medium text-ui-text-secondary transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft";
 
 export const TEAM_CREATE_WORKER_CARD_CLASS =
-  "teams-worker-card rounded-xl border border-slate-200 bg-white p-3 shadow-sm";
+  "teams-worker-card rounded-xl border border-ui-border bg-ui-surface p-3 shadow-sm";
 
 export const TEAM_CREATE_ACTIONS_BAR_CLASS =
-  "modal-actions team-create-actions mt-4 flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 pt-3";
+  "modal-actions team-create-actions mt-4 flex flex-wrap items-center justify-end gap-2 border-t border-ui-border pt-3";
 
 export const ACP_PANEL_ROOT_CLASS =
-  "acp relative flex min-h-0 flex-1 flex-col rounded-2xl border border-slate-100 bg-white/90 shadow-sm";
+  "acp relative flex min-h-0 flex-1 flex-col rounded-2xl border border-ui-border bg-ui-surface/90 shadow-sm";
 
 export const ACP_PANEL_HEAD_CLASS =
-  "acp-head minimal flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-3 py-2 sm:px-4";
+  "acp-head minimal flex flex-wrap items-start justify-between gap-3 border-b border-ui-border px-ctrl-x py-ctrl-y sm:px-4";
 
 export const ACP_PANEL_TABS_CLASS =
-  "acp-tabs flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1";
+  "acp-tabs flex items-center gap-2 rounded-lg border border-ui-border bg-ui-surface-soft p-1";
 
 export const ACP_TAB_BUTTON_BASE_CLASS =
-  "inline-flex min-h-[30px] items-center rounded-md px-3 py-1.5 text-xs font-medium leading-tight transition sm:text-sm";
+  "inline-flex min-h-[30px] items-center rounded-md px-ctrl-x py-ctrl-y-sm text-ui-xs font-medium leading-tight transition sm:text-ui-sm";
 
 export const ACP_TAB_BUTTON_ACTIVE_CLASS =
-  `${ACP_TAB_BUTTON_BASE_CLASS} bg-slate-900 text-white shadow-sm`;
+  `${ACP_TAB_BUTTON_BASE_CLASS} bg-brand-primary text-ui-text-inverse shadow-sm`;
 
 export const ACP_TAB_BUTTON_IDLE_CLASS =
-  `${ACP_TAB_BUTTON_BASE_CLASS} text-slate-600 hover:bg-white hover:text-slate-900`;
+  `${ACP_TAB_BUTTON_BASE_CLASS} text-ui-text-muted hover:bg-ui-surface hover:text-ui-text-primary`;
 
 export const ACP_TAB_BADGE_CLASS =
   "acp-tab-badge rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-semibold leading-none sm:text-xs";
 
 export const ACP_JUMP_BOTTOM_BUTTON_CLASS =
-  "acp-jump-bottom absolute bottom-3 right-3 z-20 inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-800 shadow-md transition hover:border-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300";
+  "acp-jump-bottom absolute bottom-3 right-3 z-20 inline-flex h-8 w-8 items-center justify-center rounded-full border border-ui-border-strong bg-ui-surface text-ui-text-secondary shadow-md transition hover:border-ui-border-emphasis focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-border-strong";
 
 export const ACP_DEBUG_ROOT_CLASS =
   "acp-debug flex min-h-0 flex-1 flex-col gap-3 p-3 sm:p-4";
 
 export const ACP_DEBUG_TABS_CLASS =
-  "acp-debug-tabs flex flex-wrap gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1";
+  "acp-debug-tabs flex flex-wrap gap-2 rounded-lg border border-ui-border bg-ui-surface-soft p-1";
 
 export const ACP_DEBUG_SECTION_CLASS =
-  "space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4";
+  "space-y-3 rounded-xl border border-ui-border bg-ui-surface p-3 shadow-sm sm:p-4";
 
 export const ACP_DEBUG_EMPTY_CLASS =
-  "empty rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-5 text-sm text-slate-500";
+  "empty rounded-lg border border-dashed border-ui-border-strong bg-ui-surface-soft px-ctrl-x py-5 text-ui-sm text-ui-text-muted";
 
 export const ACP_DEBUG_PERMISSION_TOGGLE_CLASS =
-  "acp-permission-toggle flex min-w-0 flex-1 flex-col items-start gap-1 rounded-lg border border-transparent px-2 py-1 text-left transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60";
+  "acp-permission-toggle flex min-w-0 flex-1 flex-col items-start gap-1 rounded-lg border border-transparent px-2 py-1 text-left transition hover:border-ui-border-strong hover:bg-ui-surface disabled:cursor-not-allowed disabled:opacity-60";
 
 export const ACP_DEBUG_PERMISSION_SUBMETA_CLASS =
-  "acp-permission-submeta mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-600";
+  "acp-permission-submeta mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-ui-xs text-ui-text-muted";
 
 export const ACP_DEBUG_PERMISSION_WARNING_CLASS =
-  "acp-permission-options mono mt-2 rounded-lg border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700";
+  "acp-permission-options mono mt-2 rounded-lg border border-state-warning-border bg-state-warning-bg px-2 py-ctrl-y-sm text-ui-xs text-state-warning-text";
 
 export const ACP_DEBUG_RAW_PRE_CLASS =
-  "acp-content mt-2 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs leading-5 text-slate-700";
+  "acp-content mt-2 overflow-auto rounded-md border border-ui-border bg-ui-surface p-2 text-ui-xs leading-5 text-ui-text-secondary";
 
 export const ACP_CONVERSATION_TOP_HINT_CLASS =
-  "acp-conversation-top-hint rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600";
+  "acp-conversation-top-hint rounded-lg border border-ui-border bg-ui-surface-soft px-ctrl-x py-ctrl-y text-ui-xs text-ui-text-muted";
 
 export const ACP_BUBBLE_THINKING_CLASS =
-  "acp-bubble agent_thinking rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 shadow-sm";
+  "acp-bubble agent_thinking rounded-xl border border-ui-border bg-ui-surface-soft px-ctrl-x py-ctrl-y shadow-sm";
 
 export const ACP_BUBBLE_PLAN_CLASS =
   "acp-bubble agent_plan rounded-xl border border-violet-200 bg-violet-50/40 px-3 py-2 shadow-sm";
 
 export const ACP_PLAN_INDEX_BADGE_CLASS =
-  "acp-plan-index inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600";
+  "acp-plan-index inline-flex h-5 w-5 items-center justify-center rounded-full border border-ui-border-strong text-ui-xs font-semibold text-ui-text-muted";
 
 export const ACP_PLAN_PRIORITY_BADGE_CLASS =
-  "acp-plan-priority rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700";
+  "acp-plan-priority rounded-full border border-state-warning-border bg-state-warning-bg px-2 py-0.5 text-[11px] font-medium text-state-warning-text";
 
 export const ACP_PLAN_STATUS_BADGE_CLASS =
-  "acp-plan-status rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600";
+  "acp-plan-status rounded-full border border-ui-border-strong bg-ui-surface px-2 py-0.5 text-[11px] font-medium text-ui-text-muted";
 
 export const ACP_SEGMENTED_NOTE_WARNING_CLASS =
-  "acp-segmented-note rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700";
+  "acp-segmented-note rounded-md border border-state-warning-border bg-state-warning-bg px-2 py-ctrl-y-sm text-ui-xs text-state-warning-text";
 
 export const ACP_SEGMENTED_BUTTON_CLASS =
-  "acp-segmented-button inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50";
+  "acp-segmented-button inline-flex items-center justify-center rounded-md border border-ui-border-strong bg-ui-surface px-2.5 py-1 text-ui-xs font-medium text-ui-text-secondary transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft";
 
 export const ACP_TERMINAL_PRE_CLASS =
-  "acp-content rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100";
+  "acp-content rounded-md border border-ui-border bg-brand-primary p-2 text-ui-xs text-ui-text-inverse";
 
 export const ACP_DIFF_PRE_CLASS =
-  "acp-content acp-diff-view overflow-auto rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100";
+  "acp-content acp-diff-view overflow-auto rounded-md border border-ui-border bg-brand-primary p-2 text-ui-xs text-ui-text-inverse";

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -111,3 +111,81 @@ export const TEAM_CREATE_WORKER_CARD_CLASS =
 
 export const TEAM_CREATE_ACTIONS_BAR_CLASS =
   "modal-actions team-create-actions mt-4 flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 pt-3";
+
+export const ACP_PANEL_ROOT_CLASS =
+  "acp relative flex min-h-0 flex-1 flex-col rounded-2xl border border-slate-100 bg-white/90 shadow-sm";
+
+export const ACP_PANEL_HEAD_CLASS =
+  "acp-head minimal flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-3 py-2 sm:px-4";
+
+export const ACP_PANEL_TABS_CLASS =
+  "acp-tabs flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1";
+
+export const ACP_TAB_BUTTON_BASE_CLASS =
+  "inline-flex min-h-[30px] items-center rounded-md px-3 py-1.5 text-xs font-medium leading-tight transition sm:text-sm";
+
+export const ACP_TAB_BUTTON_ACTIVE_CLASS =
+  `${ACP_TAB_BUTTON_BASE_CLASS} bg-slate-900 text-white shadow-sm`;
+
+export const ACP_TAB_BUTTON_IDLE_CLASS =
+  `${ACP_TAB_BUTTON_BASE_CLASS} text-slate-600 hover:bg-white hover:text-slate-900`;
+
+export const ACP_TAB_BADGE_CLASS =
+  "acp-tab-badge rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-semibold leading-none sm:text-xs";
+
+export const ACP_JUMP_BOTTOM_BUTTON_CLASS =
+  "acp-jump-bottom absolute bottom-3 right-3 z-20 inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-800 shadow-md transition hover:border-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300";
+
+export const ACP_DEBUG_ROOT_CLASS =
+  "acp-debug flex min-h-0 flex-1 flex-col gap-3 p-3 sm:p-4";
+
+export const ACP_DEBUG_TABS_CLASS =
+  "acp-debug-tabs flex flex-wrap gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1";
+
+export const ACP_DEBUG_SECTION_CLASS =
+  "space-y-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4";
+
+export const ACP_DEBUG_EMPTY_CLASS =
+  "empty rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-5 text-sm text-slate-500";
+
+export const ACP_DEBUG_PERMISSION_TOGGLE_CLASS =
+  "acp-permission-toggle flex min-w-0 flex-1 flex-col items-start gap-1 rounded-lg border border-transparent px-2 py-1 text-left transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60";
+
+export const ACP_DEBUG_PERMISSION_SUBMETA_CLASS =
+  "acp-permission-submeta mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-600";
+
+export const ACP_DEBUG_PERMISSION_WARNING_CLASS =
+  "acp-permission-options mono mt-2 rounded-lg border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700";
+
+export const ACP_DEBUG_RAW_PRE_CLASS =
+  "acp-content mt-2 overflow-auto rounded-md border border-slate-200 bg-white p-2 text-xs leading-5 text-slate-700";
+
+export const ACP_CONVERSATION_TOP_HINT_CLASS =
+  "acp-conversation-top-hint rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600";
+
+export const ACP_BUBBLE_THINKING_CLASS =
+  "acp-bubble agent_thinking rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 shadow-sm";
+
+export const ACP_BUBBLE_PLAN_CLASS =
+  "acp-bubble agent_plan rounded-xl border border-violet-200 bg-violet-50/40 px-3 py-2 shadow-sm";
+
+export const ACP_PLAN_INDEX_BADGE_CLASS =
+  "acp-plan-index inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600";
+
+export const ACP_PLAN_PRIORITY_BADGE_CLASS =
+  "acp-plan-priority rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700";
+
+export const ACP_PLAN_STATUS_BADGE_CLASS =
+  "acp-plan-status rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600";
+
+export const ACP_SEGMENTED_NOTE_WARNING_CLASS =
+  "acp-segmented-note rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-700";
+
+export const ACP_SEGMENTED_BUTTON_CLASS =
+  "acp-segmented-button inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50";
+
+export const ACP_TERMINAL_PRE_CLASS =
+  "acp-content rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100";
+
+export const ACP_DIFF_PRE_CLASS =
+  "acp-content acp-diff-view overflow-auto rounded-md border border-slate-200 bg-slate-950 p-2 text-xs text-slate-100";

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -75,3 +75,39 @@ export const TEAM_LIST_ITEM_TITLE_CLASS =
 
 export const TEAM_LIST_ITEM_META_CLASS =
   "team-id mono w-full min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs opacity-90";
+
+export const TEAM_CREATE_MODAL_BACKDROP_CLASS =
+  "modal-backdrop team-create-modal-backdrop fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/40 px-3 py-6 sm:py-10";
+
+export const TEAM_CREATE_MODAL_CARD_CLASS =
+  "modal team-create-modal w-full max-w-5xl rounded-2xl border border-slate-200 bg-white p-4 shadow-2xl sm:p-5";
+
+export const TEAM_CREATE_STAGE_BADGE_CLASS =
+  "badge rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700";
+
+export const TEAM_CREATE_PANEL_CARD_CLASS =
+  "team-create-panel rounded-xl border border-slate-200 bg-slate-50/70 p-4";
+
+export const TEAM_CREATE_NOTE_INFO_CLASS =
+  "team-create-stage-note mt-2 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm text-sky-700";
+
+export const TEAM_CREATE_NOTE_WARNING_CLASS =
+  "team-create-stage-note mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700";
+
+export const TEAM_CREATE_STEP_PREVIEW_CLASS =
+  "teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600";
+
+export const TEAM_CREATE_STEP_PREVIEW_MUTED_CLASS =
+  "teams-step-body mono mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600";
+
+export const TEAM_CREATE_SKILL_TAG_SELECTED_CLASS =
+  "team-skill-tag selected rounded-full border border-slate-900 bg-slate-900 px-3 py-1 text-xs font-medium text-white transition";
+
+export const TEAM_CREATE_SKILL_TAG_IDLE_CLASS =
+  "team-skill-tag rounded-full border border-slate-300 bg-white px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50";
+
+export const TEAM_CREATE_WORKER_CARD_CLASS =
+  "teams-worker-card rounded-xl border border-slate-200 bg-white p-3 shadow-sm";
+
+export const TEAM_CREATE_ACTIONS_BAR_CLASS =
+  "modal-actions team-create-actions mt-4 flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 pt-3";

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -6,7 +6,52 @@ module.exports = {
     preflight: false,
   },
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          primary: "#0f172a",
+          "primary-hover": "#1e293b",
+        },
+        ui: {
+          surface: "#ffffff",
+          "surface-soft": "#f8fafc",
+          "surface-muted": "#f1f5f9",
+          border: "#e2e8f0",
+          "border-strong": "#cbd5e1",
+          "border-emphasis": "#64748b",
+          "text-primary": "#0f172a",
+          "text-secondary": "#334155",
+          "text-muted": "#64748b",
+          "text-inverse": "#ffffff",
+        },
+        state: {
+          info: {
+            bg: "#eff6ff",
+            border: "#bfdbfe",
+            text: "#1d4ed8",
+          },
+          warning: {
+            bg: "#fffbeb",
+            border: "#fde68a",
+            text: "#b45309",
+          },
+          success: {
+            bg: "#ecfdf5",
+            border: "#86efac",
+            text: "#15803d",
+          },
+        },
+      },
+      spacing: {
+        "ctrl-x": "0.75rem",
+        "ctrl-y": "0.5rem",
+        "ctrl-y-sm": "0.375rem",
+      },
+      fontSize: {
+        "ui-xs": ["0.75rem", { lineHeight: "1rem" }],
+        "ui-sm": ["0.875rem", { lineHeight: "1.25rem" }],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

This PR improves frontend style maintainability without changing behavior.

1. Deduplicate repeated selectors in `web/src/styles.css`.
2. Extract repeated Team create modal Tailwind utility bundles into reusable constants.

## What Changed

- `web/src/styles.css`
  - Merged repeated non-team form control selectors via grouped selectors.
  - Unified repeated chip/list/chat panel style blocks.
  - Removed duplicated responsive rules that were already covered in broader breakpoints.
- `web/src/ui/tailwind_classes.ts`
  - Added reusable Team-create class presets (modal backdrop/card, badges, panel cards, note styles, step preview, skill tag variants, worker card, actions bar).
- `web/src/pages/team_page.tsx`
  - Replaced repeated long inline `className` strings with imported reusable constants.

## Why

- Reduce className entropy in JSX for readability and reviewability.
- Improve reuse consistency for Team create flow UI blocks.
- Lower CSS maintenance cost by reducing duplicated declarations.

## Validation

- `pnpm -C web run lint`
- `pnpm -C web run build`

## MCP Check

- Opened `https://agenthub.hawkingrei.com/` via Chrome DevTools MCP.
- Confirmed page load and core assets return `200`.
- Console only showed existing form-accessibility hints; no new runtime errors introduced by this refactor.
