### PR TITLE
refactor(web): expand tailwind design-token presets for core panels

### DIFF
--- a/docs/features/2026-02-23-web-tailwind-design-token-rollout-wave1.md
+++ b/docs/features/2026-02-23-web-tailwind-design-token-rollout-wave1.md
@@ -1,0 +1,56 @@
+# Web Tailwind Design Token Rollout (Wave 1)
+
+## Background
+
+Recent Team/ACP UI work still had two maintainability gaps:
+
+1. long utility-class strings repeated in multiple components;
+2. direct color/spacing literals (`slate-*`, `amber-*`, fixed paddings) spread across reusable class presets.
+
+This made global style adjustments expensive and increased review noise.
+
+## Scope
+
+Wave 1 standardizes shared style presets for high-traffic web surfaces:
+
+- Team workbench sidebar and Team create flow presets
+- ACP panel/debug/conversation presets
+- Agents list panel presets
+- Output header/body presets
+- Input dock presets
+
+No runtime behavior or interaction contract changed.
+
+## Key Decisions
+
+1. Introduce semantic Tailwind tokens in `web/tailwind.config.cjs`:
+   - `brand.*` for primary brand surfaces
+   - `ui.*` for neutral surface/border/text system
+   - `state.*` for info/warning/success states
+   - `spacing.ctrl-*` and `fontSize.ui-*` for control density consistency
+2. Keep utility-first consumption through `web/src/ui/tailwind_classes.ts` instead of adding new handcrafted global CSS blocks.
+3. Migrate component-local class constants into centralized presets to reduce inline repetition and improve change locality.
+
+## Files Changed
+
+- `web/tailwind.config.cjs`
+- `web/src/ui/tailwind_classes.ts`
+- `web/src/components/agents_panel.tsx`
+- `web/src/components/output_header.tsx`
+- `web/src/components/output_body.tsx`
+- `web/src/components/input_dock.tsx`
+- `web/src/pages/team_sidebar.tsx`
+
+## Validation
+
+Local validation performed:
+
+- `pnpm -C web run lint`
+- `pnpm -C web run build`
+- `pnpm -C web exec vitest run src/acp_panel.test.tsx src/acp_debug.test.tsx src/acp_conversation_render.test.tsx`
+- `pnpm -C web exec vitest run src/agents_panel.test.tsx src/output_header.test.tsx src/output_body.test.tsx src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts src/pages/team_panels.test.tsx`
+
+## Follow-ups
+
+- Continue token migration for remaining Mantine-adjacent pages where shared class presets are still duplicated.
+- After merge, record push + PR CI run IDs in PR evidence before marking the TODO item done.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] Verify web Tailwind design-token rollout wave-1 remains stable across Team/ACP/Agents shared components (`tailwind.config.cjs` semantic tokens + `tailwind_classes.ts` preset migration) and record push + PR CI run IDs after merge (see `docs/features/2026-02-23-web-tailwind-design-token-rollout-wave1.md`).
 - [ ] Continue `docs/features` compact wave-2: merge remaining Team UI extraction/reducer phase notes into domain-level canonical specs and replace merged notes with `Superseded by ...` pointers (follow `docs/features/README.md`).
 - [ ] Verify Team role responsibility contract is enforced in skills/prompts: leader behaves as architect/reviewer (no default feature-code implementation path), worker remains implementation executor, and leader-only emergency coding exceptions are explicitly documented when used (see `docs/features/2026-02-24-team-role-skill-runtime-spec.md`).
 - [ ] Verify Team leader planning quality gate is enforced in skills/prompts: `Decision Complete`, `Explore Before Asking`, and delegation clearance checklist are present and applied before worker dispatch (see `docs/features/2026-02-24-team-role-skill-runtime-spec.md`).

--- a/web/src/components/agents_panel.tsx
+++ b/web/src/components/agents_panel.tsx
@@ -3,6 +3,15 @@ import { AgentRecord } from "../api";
 import { isAgentActiveStatus } from "../agent_ws";
 import { formatAgentModelLabel } from "../agent_presets";
 import { StatusBadge, resolveAgentStatusTone } from "./status_badge";
+import {
+  AGENTS_CREATE_BUTTON_CLASS,
+  AGENTS_PANEL_COLLAPSED_CLASS,
+  AGENTS_PANEL_EXPANDED_CLASS,
+  AGENTS_ROW_ACTIVE_CLASS,
+  AGENTS_ROW_CLASS,
+  AGENTS_TOOLBAR_ACTIONS_CLASS,
+  AGENTS_TOOLBAR_CLASS,
+} from "../ui/tailwind_classes";
 
 type AgentsPanelProps = {
   agents: AgentRecord[];
@@ -19,19 +28,6 @@ type AgentsPanelProps = {
   onStopAgent: (id: string) => void;
   onDeleteAgent: (id: string) => void;
 };
-
-const AGENTS_PANEL_EXPANDED_CLASS =
-  "workspace-left rounded-2xl border border-slate-200/80 bg-white/85 shadow-sm backdrop-blur";
-const AGENTS_PANEL_COLLAPSED_CLASS =
-  "workspace-left collapsed rounded-2xl border border-slate-200/80 bg-white/85 shadow-sm backdrop-blur";
-const AGENTS_TOOLBAR_CLASS = "mb-3 flex items-center justify-between gap-2";
-const AGENTS_TOOLBAR_ACTIONS_CLASS = "flex items-center gap-2";
-const AGENTS_CREATE_BUTTON_CLASS =
-  "rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800";
-const AGENTS_ROW_CLASS =
-  "agent-row rounded-xl border border-slate-200 bg-white px-3 py-3 transition hover:border-slate-300";
-const AGENTS_ROW_ACTIVE_CLASS =
-  "agent-row active rounded-xl border border-slate-300 bg-slate-50 px-3 py-3";
 
 export const AgentsPanel = React.memo(function AgentsPanel({
   agents,

--- a/web/src/components/input_dock.tsx
+++ b/web/src/components/input_dock.tsx
@@ -1,4 +1,12 @@
 import React from "react";
+import {
+  INPUT_DOCK_HISTORY_BUTTON_CLASS,
+  INPUT_DOCK_HISTORY_ITEM_CLASS,
+  INPUT_DOCK_HISTORY_MENU_CLASS,
+  INPUT_DOCK_INTERRUPT_BUTTON_CLASS,
+  INPUT_DOCK_ROOT_CLASS,
+  INPUT_DOCK_TEXTAREA_CLASS,
+} from "../ui/tailwind_classes";
 
 type InputDockProps = {
   input: string;
@@ -14,19 +22,6 @@ type InputDockProps = {
   showConversationJump: boolean;
   isComposingRef: React.MutableRefObject<boolean>;
 };
-
-const INPUT_DOCK_ROOT_CLASS =
-  "input docked rounded-2xl border border-slate-200/80 bg-white/85 p-3 shadow-sm backdrop-blur";
-const INPUT_DOCK_INTERRUPT_BUTTON_CLASS =
-  "acp-interrupt-button input-interrupt-button rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-800 hover:border-amber-400";
-const INPUT_DOCK_HISTORY_BUTTON_CLASS =
-  "history-toggle rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 hover:border-slate-500";
-const INPUT_DOCK_HISTORY_MENU_CLASS =
-  "input-history-menu rounded-lg border border-slate-300 bg-white p-1 shadow";
-const INPUT_DOCK_HISTORY_ITEM_CLASS =
-  "input-history-item block w-full rounded-md px-2 py-1 text-left text-sm hover:bg-slate-100";
-const INPUT_DOCK_TEXTAREA_CLASS =
-  "min-h-16 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200";
 
 type VerticalRect = {
   top: number;

--- a/web/src/components/output_body.tsx
+++ b/web/src/components/output_body.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import { AcpPanel, AcpPanelProps } from "./acp_panel";
 import { TerminalOutput } from "./terminal_output";
 import { OutputLine } from "../output_cache";
+import {
+  OUTPUT_BODY_EMPTY_CLASS,
+  OUTPUT_BODY_LOADING_CLASS,
+  OUTPUT_BODY_ROOT_CLASS,
+} from "../ui/tailwind_classes";
 
 type OutputBodyProps = {
   terminalRef: React.RefObject<HTMLDivElement>;
@@ -12,13 +17,6 @@ type OutputBodyProps = {
   acpPanelProps: AcpPanelProps;
 };
 
-const OUTPUT_BODY_CLASS =
-  "output-body rounded-2xl border border-slate-200/80 bg-white/85 shadow-sm backdrop-blur";
-const OUTPUT_LOADING_CLASS =
-  "output-loading flex h-full min-h-40 flex-col items-center justify-center gap-2 text-slate-600";
-const OUTPUT_EMPTY_CLASS =
-  "output-empty flex h-full min-h-40 flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-slate-300 bg-slate-50/60 p-4 text-center";
-
 export const OutputBody = React.memo(function OutputBody({
   terminalRef,
   onTerminalScroll,
@@ -28,16 +26,16 @@ export const OutputBody = React.memo(function OutputBody({
   acpPanelProps,
 }: OutputBodyProps) {
   return (
-    <div className={OUTPUT_BODY_CLASS}>
+    <div className={OUTPUT_BODY_ROOT_CLASS}>
       {isOutputLoading ? (
-        <div className={OUTPUT_LOADING_CLASS}>
+        <div className={OUTPUT_BODY_LOADING_CLASS}>
           <i className="bi bi-hourglass-split spinner" aria-hidden="true" />
           <div className="label">Waiting for output</div>
         </div>
       ) : acpPanelProps.acpView.hasAcp ? (
         <AcpPanel {...acpPanelProps} />
       ) : outputs.length === 0 ? (
-        <div className={OUTPUT_EMPTY_CLASS}>
+        <div className={OUTPUT_BODY_EMPTY_CLASS}>
           <div className="title">No output yet</div>
           <div className="meta">Send input or start the agent to see output.</div>
         </div>

--- a/web/src/components/output_header.tsx
+++ b/web/src/components/output_header.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import { AgentRecord } from "../api";
 import { StatusBadge, resolveAgentStatusTone } from "./status_badge";
+import {
+  OUTPUT_HEADER_META_CLASS,
+  OUTPUT_HEADER_PILL_CLASS,
+  OUTPUT_HEADER_ROOT_CLASS,
+  OUTPUT_HEADER_SUBTITLE_CLASS,
+  OUTPUT_HEADER_SUBTITLE_ROW_CLASS,
+  OUTPUT_HEADER_TITLE_CLASS,
+  OUTPUT_HEADER_TITLE_MAIN_CLASS,
+} from "../ui/tailwind_classes";
 
 type OutputHeaderProps = {
   activeAgent: AgentRecord | null;
@@ -11,16 +20,6 @@ type OutputHeaderProps = {
   modelLabel?: string | null;
   onToggleAgents: () => void;
 };
-
-const OUTPUT_HEADER_CLASS =
-  "output-header rounded-xl border border-slate-200/80 bg-white/80 px-3 py-2 shadow-sm";
-const OUTPUT_TITLE_CLASS = "output-title flex items-center gap-2";
-const OUTPUT_TITLE_MAIN_CLASS = "output-title-main flex items-center gap-2";
-const OUTPUT_META_CLASS = "output-meta flex flex-wrap items-center gap-2";
-const OUTPUT_PILL_CLASS =
-  "output-pill rounded-full border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-700";
-const OUTPUT_SUBTITLE_ROW_CLASS = "output-subtitle-row mt-1";
-const OUTPUT_SUBTITLE_CLASS = "output-subtitle text-sm text-slate-600";
 
 export const OutputHeader = React.memo(function OutputHeader({
   activeAgent,
@@ -44,8 +43,8 @@ export const OutputHeader = React.memo(function OutputHeader({
       ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - thinkingStartTs))}s`
       : null;
   return (
-    <div className={OUTPUT_HEADER_CLASS}>
-      <div className={OUTPUT_TITLE_CLASS}>
+    <div className={OUTPUT_HEADER_ROOT_CLASS}>
+      <div className={OUTPUT_HEADER_TITLE_CLASS}>
         <button
           className="icon-button small output-agents-toggle"
           onClick={onToggleAgents}
@@ -60,7 +59,7 @@ export const OutputHeader = React.memo(function OutputHeader({
           />
         </button>
         <div className="output-title-text">
-          <div className={OUTPUT_TITLE_MAIN_CLASS}>
+          <div className={OUTPUT_HEADER_TITLE_MAIN_CLASS}>
             <h2>{titleText}</h2>
             {modelLabel ? (
               <span className="agent-tag">{modelLabel}</span>
@@ -69,14 +68,14 @@ export const OutputHeader = React.memo(function OutputHeader({
         </div>
       </div>
       {activeAgent ? (
-        <div className={OUTPUT_META_CLASS}>
+        <div className={OUTPUT_HEADER_META_CLASS}>
           <StatusBadge
             label={activeAgent.status}
             tone={resolveAgentStatusTone(activeAgent.status)}
             className={`agent-status status-${activeAgent.status}`}
             title={`status: ${activeAgent.status}`}
           />
-          <span className={OUTPUT_PILL_CLASS}>
+          <span className={OUTPUT_HEADER_PILL_CLASS}>
             Code mode {activeAgent.code_mode ? "on" : "off"}
           </span>
           {thinkingLabel && (
@@ -91,8 +90,8 @@ export const OutputHeader = React.memo(function OutputHeader({
         </div>
       ) : null}
       {!hasAcp ? (
-        <div className={OUTPUT_SUBTITLE_ROW_CLASS}>
-          <span className={OUTPUT_SUBTITLE_CLASS}>{subtitleText}</span>
+        <div className={OUTPUT_HEADER_SUBTITLE_ROW_CLASS}>
+          <span className={OUTPUT_HEADER_SUBTITLE_CLASS}>{subtitleText}</span>
         </div>
       ) : null}
     </div>

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TeamDefinitionRecord } from "../api";
 import {
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_LIST_ITEM_ACTIVE_CLASS,
   TEAM_LIST_ITEM_IDLE_CLASS,
   TEAM_LIST_ITEM_META_CLASS,
@@ -9,6 +10,12 @@ import {
   TEAM_PANEL_GHOST_BUTTON_CLASS,
   TEAM_PANEL_PRIMARY_BUTTON_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
+  TEAM_SIDEBAR_FORGE_CARD_CLASS,
+  TEAM_SIDEBAR_INFO_CARD_CLASS,
+  TEAM_SIDEBAR_INFO_LABEL_CLASS,
+  TEAM_SIDEBAR_INFO_TEXT_CLASS,
+  TEAM_SIDEBAR_META_GRID_CLASS,
+  TEAM_SIDEBAR_ROOT_CLASS,
 } from "../ui/tailwind_classes";
 
 type TeamMemberSummary = {
@@ -61,7 +68,7 @@ export function TeamSidebar(props: TeamSidebarProps) {
   const hasTeamFilter = normalizedTeamFilter.length > 0;
 
   return (
-    <aside className="teams-sidebar flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+    <aside className={TEAM_SIDEBAR_ROOT_CLASS}>
       <div className="mode-switch mb-3 flex items-center gap-2">
         <a className="mode-tag" href="/">
           Agents
@@ -86,14 +93,14 @@ export function TeamSidebar(props: TeamSidebarProps) {
         </button>
       </div>
 
-      <div className="teams-form teams-create-launch flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+      <div className={TEAM_SIDEBAR_FORGE_CARD_CLASS}>
         <h3 className="text-base font-semibold text-slate-900">Team Forge</h3>
-        <p className="muted">Choose a creation entry: guided wizard or direct manual spec.</p>
-        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+        <p className={TEAM_MUTED_TEXT_CLASS}>Choose a creation entry: guided wizard or direct manual spec.</p>
+        <div className={TEAM_SIDEBAR_INFO_CARD_CLASS}>
+          <p className={TEAM_SIDEBAR_INFO_LABEL_CLASS}>
             Operating Model
           </p>
-          <p className="mt-1 text-sm text-slate-700">
+          <p className={TEAM_SIDEBAR_INFO_TEXT_CLASS}>
             Leader plans and talks to human actor. Workers execute delegated tasks and report
             evidence back to leader.
           </p>
@@ -112,7 +119,7 @@ export function TeamSidebar(props: TeamSidebarProps) {
             Manual Spec
           </button>
         </div>
-        <div className="teams-create-launch-meta mono mt-3 grid gap-1 text-xs text-slate-600">
+        <div className={TEAM_SIDEBAR_META_GRID_CLASS}>
           <span>draft_team={draftTeamName.trim() || "-"}</span>
           <span>leader={leaderMemberId.trim() || "-"}</span>
           <span>workers={configuredWorkerCount}</span>
@@ -141,12 +148,12 @@ export function TeamSidebar(props: TeamSidebarProps) {
       </div>
 
       <div className="teams-list flex min-h-0 flex-1 flex-col gap-2 overflow-auto">
-        {teams.length === 0 && <p className="muted">No teams yet.</p>}
+        {teams.length === 0 && <p className={TEAM_MUTED_TEXT_CLASS}>No teams yet.</p>}
         {teams.length > 0 && filteredTeams.length === 0 && (
-          <p className="muted">No teams match current filter.</p>
+          <p className={TEAM_MUTED_TEXT_CLASS}>No teams match current filter.</p>
         )}
         {hasTeamFilter && filteredTeams.length > 0 && (
-          <p className="muted mono">{`filtered=${filteredTeams.length} total=${teams.length}`}</p>
+          <p className={`${TEAM_MUTED_TEXT_CLASS} mono`}>{`filtered=${filteredTeams.length} total=${teams.length}`}</p>
         )}
         {filteredTeams.map((team) => {
           const summary = teamMemberSummaryByTeamId.get(team.id);

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -189,3 +189,80 @@ export const ACP_TERMINAL_PRE_CLASS =
 
 export const ACP_DIFF_PRE_CLASS =
   "acp-content acp-diff-view overflow-auto rounded-md border border-ui-border bg-brand-primary p-2 text-ui-xs text-ui-text-inverse";
+
+export const TEAM_MUTED_TEXT_CLASS = "muted text-ui-sm text-ui-text-muted";
+
+export const TEAM_SIDEBAR_ROOT_CLASS =
+  "teams-sidebar flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden rounded-2xl border border-ui-border bg-ui-surface p-4 shadow-sm";
+
+export const TEAM_SIDEBAR_FORGE_CARD_CLASS =
+  "teams-form teams-create-launch flex flex-col gap-2 rounded-xl border border-ui-border bg-ui-surface-soft/70 p-4";
+
+export const TEAM_SIDEBAR_INFO_CARD_CLASS =
+  "rounded-lg border border-ui-border bg-ui-surface px-ctrl-x py-ctrl-y";
+
+export const TEAM_SIDEBAR_INFO_LABEL_CLASS =
+  "text-[11px] font-semibold uppercase tracking-wide text-ui-text-muted";
+
+export const TEAM_SIDEBAR_INFO_TEXT_CLASS = "mt-1 text-ui-sm text-ui-text-secondary";
+
+export const TEAM_SIDEBAR_META_GRID_CLASS =
+  "teams-create-launch-meta mono mt-3 grid gap-1 text-ui-xs text-ui-text-muted";
+
+export const AGENTS_PANEL_EXPANDED_CLASS =
+  "workspace-left rounded-2xl border border-ui-border/80 bg-ui-surface/85 shadow-sm backdrop-blur";
+
+export const AGENTS_PANEL_COLLAPSED_CLASS =
+  "workspace-left collapsed rounded-2xl border border-ui-border/80 bg-ui-surface/85 shadow-sm backdrop-blur";
+
+export const AGENTS_TOOLBAR_CLASS = "mb-3 flex items-center justify-between gap-2";
+export const AGENTS_TOOLBAR_ACTIONS_CLASS = "flex items-center gap-2";
+
+export const AGENTS_CREATE_BUTTON_CLASS =
+  "rounded-lg bg-brand-primary px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-inverse hover:bg-brand-primary-hover";
+
+export const AGENTS_ROW_CLASS =
+  "agent-row rounded-xl border border-ui-border bg-ui-surface px-ctrl-x py-3 transition hover:border-ui-border-strong";
+
+export const AGENTS_ROW_ACTIVE_CLASS =
+  "agent-row active rounded-xl border border-ui-border-strong bg-ui-surface-soft px-ctrl-x py-3";
+
+export const OUTPUT_HEADER_ROOT_CLASS =
+  "output-header rounded-xl border border-ui-border/80 bg-ui-surface/80 px-ctrl-x py-ctrl-y shadow-sm";
+
+export const OUTPUT_HEADER_TITLE_CLASS = "output-title flex items-center gap-2";
+export const OUTPUT_HEADER_TITLE_MAIN_CLASS = "output-title-main flex items-center gap-2";
+export const OUTPUT_HEADER_META_CLASS = "output-meta flex flex-wrap items-center gap-2";
+
+export const OUTPUT_HEADER_PILL_CLASS =
+  "output-pill rounded-full border border-ui-border-strong bg-ui-surface px-2 py-1 text-ui-xs font-medium text-ui-text-secondary";
+
+export const OUTPUT_HEADER_SUBTITLE_ROW_CLASS = "output-subtitle-row mt-1";
+export const OUTPUT_HEADER_SUBTITLE_CLASS = "output-subtitle text-ui-sm text-ui-text-muted";
+
+export const OUTPUT_BODY_ROOT_CLASS =
+  "output-body rounded-2xl border border-ui-border/80 bg-ui-surface/85 shadow-sm backdrop-blur";
+
+export const OUTPUT_BODY_LOADING_CLASS =
+  "output-loading flex h-full min-h-40 flex-col items-center justify-center gap-2 text-ui-text-muted";
+
+export const OUTPUT_BODY_EMPTY_CLASS =
+  "output-empty flex h-full min-h-40 flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-ui-border-strong bg-ui-surface-soft/60 p-4 text-center";
+
+export const INPUT_DOCK_ROOT_CLASS =
+  "input docked rounded-2xl border border-ui-border/80 bg-ui-surface/85 p-3 shadow-sm backdrop-blur";
+
+export const INPUT_DOCK_INTERRUPT_BUTTON_CLASS =
+  "acp-interrupt-button input-interrupt-button rounded-lg border border-state-warning-border bg-state-warning-bg px-ctrl-x py-ctrl-y text-ui-sm font-medium text-state-warning-text hover:border-ui-border-emphasis";
+
+export const INPUT_DOCK_HISTORY_BUTTON_CLASS =
+  "history-toggle rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm font-medium text-ui-text-secondary hover:border-ui-border-emphasis";
+
+export const INPUT_DOCK_HISTORY_MENU_CLASS =
+  "input-history-menu rounded-lg border border-ui-border-strong bg-ui-surface p-1 shadow";
+
+export const INPUT_DOCK_HISTORY_ITEM_CLASS =
+  "input-history-item block w-full rounded-md px-2 py-1 text-left text-ui-sm hover:bg-ui-surface-muted";
+
+export const INPUT_DOCK_TEXTAREA_CLASS =
+  "min-h-16 w-full rounded-lg border border-ui-border-strong bg-ui-surface px-ctrl-x py-ctrl-y text-ui-sm text-ui-text-primary outline-none transition focus:border-ui-border-emphasis focus:ring-2 focus:ring-ui-border";


### PR DESCRIPTION
## Summary

Roll out Tailwind design-token usage to additional shared web panels/components (not only Team create/ACP), and centralize repeated utility bundles into `tailwind_classes` presets.

## What Changed

### 1) Shared style preset migration

Moved component-local utility strings into centralized presets in:

- `web/src/ui/tailwind_classes.ts`

Applied in:

- `web/src/components/agents_panel.tsx`
- `web/src/components/output_header.tsx`
- `web/src/components/output_body.tsx`
- `web/src/components/input_dock.tsx`
- `web/src/pages/team_sidebar.tsx`

### 2) Design token usage expansion

Preset definitions now consistently use semantic token classes (`brand.*`, `ui.*`, `state.*`, `spacing.ctrl-*`, `fontSize.ui-*`) rather than scattered palette literals in these shared panels.

### 3) Documentation

- Added feature note: `docs/features/2026-02-23-web-tailwind-design-token-rollout-wave1.md`
- Added verification backlog item at top of `docs/todo.md`

## Why

- Reduce JSX/className entropy in shared surfaces.
- Keep style updates centralized so brand/system adjustments are low-cost.
- Align with utility-first + reusable preset direction already used in Team/ACP refactors.

## Validation

- `pnpm -C web run lint`
- `pnpm -C web run build`
- `pnpm -C web exec vitest run src/acp_panel.test.tsx src/acp_debug.test.tsx src/acp_conversation_render.test.tsx`
- `pnpm -C web exec vitest run src/agents_panel.test.tsx src/output_header.test.tsx src/output_body.test.tsx src/input_dock_render.test.tsx src/input_dock_keyboard.test.ts src/pages/team_panels.test.tsx`

