### PR TITLE
web: merge running/thinking badge and harden SSE reconnect state

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -111,6 +111,7 @@ const GLOBAL_PERMISSION_POLL_INTERVAL_MS = 5000;
 const GLOBAL_PERMISSION_POLL_INTERVAL_COLLAPSED_MS = 10000;
 const GLOBAL_PERMISSION_POLL_MAX_CONCURRENCY = 4;
 const SSE_STALE_RECONNECT_THRESHOLD_MS = 45_000;
+const AGENT_STATUS_REFRESH_INTERVAL_MS = 10_000;
 type PendingPermissionJumpState = {
   toolCallId: string;
   sessionId: string | null;
@@ -884,8 +885,7 @@ export function App() {
     () => deriveConnectionBadge(networkOnline, hasSseTarget, sseState),
     [networkOnline, hasSseTarget, sseState]
   );
-  const thinkingStartTs =
-    activeAgentStatus === "running" ? acpView.thinkingStartTs : null;
+  const thinkingStartTs = acpView.thinkingStartTs;
   const canControlAcp = Boolean(activeAgent && isAgentActive);
   const hasInProgressToolCall = acpView.toolCalls.some(
     (call) => call.status === "in_progress"
@@ -930,19 +930,35 @@ export function App() {
     inputHistoryDraftRef.current = "";
   }, [activeAgent, activeSessionId]);
 
-  const refreshAgents = useCallback(async () => {
-    if (!token) return;
-    try {
-      const items = await api.listAgents(token);
-      setAgents(items);
-    } catch (err) {
-      setError(formatWorktreeError(err) ?? parseApiErrorMessage(err) ?? String(err));
-    }
-  }, [token]);
+  const refreshAgents = useCallback(
+    async (opts?: { silent?: boolean }): Promise<AgentRecord[] | null> => {
+      if (!token) return null;
+      const silent = opts?.silent === true;
+      try {
+        const items = await api.listAgents(token);
+        setAgents(items);
+        return items;
+      } catch (err) {
+        if (!silent) {
+          setError(formatWorktreeError(err) ?? parseApiErrorMessage(err) ?? String(err));
+        }
+        return null;
+      }
+    },
+    [token]
+  );
 
   useEffect(() => {
     if (!token) return;
-    refreshAgents();
+    void refreshAgents();
+  }, [token, refreshAgents]);
+
+  useEffect(() => {
+    if (!token) return;
+    const timer = window.setInterval(() => {
+      void refreshAgents({ silent: true });
+    }, AGENT_STATUS_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
   }, [token, refreshAgents]);
 
   useEffect(() => {
@@ -1457,15 +1473,28 @@ export function App() {
         const online = getNavigatorOnline();
         setNetworkOnline(online);
         setSseState("reconnecting");
-        setError(
-          online
-            ? UPSTREAM_HTML_MESSAGE
-            : OFFLINE_MESSAGE
-        );
         source.close();
         sseRef.current = null;
         schedulePoll(getAdaptivePollInterval(pollState.idleCount));
-        scheduleReconnect();
+        const nextError = online ? UPSTREAM_HTML_MESSAGE : OFFLINE_MESSAGE;
+        void (async () => {
+          const latestAgents = await refreshAgents({ silent: true });
+          if (cancelled) return;
+          if (latestAgents) {
+            const nextTargets = buildSseTargetAgentIds(latestAgents);
+            if (nextTargets.length === 0) {
+              setSseState("idle");
+              setError((prev) =>
+                prev === OFFLINE_MESSAGE || prev === UPSTREAM_HTML_MESSAGE
+                  ? null
+                  : prev
+              );
+              return;
+            }
+          }
+          setError(nextError);
+          scheduleReconnect();
+        })();
       };
     };
     openSource();
@@ -1568,6 +1597,7 @@ export function App() {
     hasSseTarget,
     streamAgentIdsQuery,
     loadAgentEvents,
+    refreshAgents,
     updateOutputCacheEntry,
     updateAcpOutputCacheEntry,
   ]);
@@ -1699,13 +1729,12 @@ export function App() {
 
   useEffect(() => {
     if (!thinkingStartTs) return;
-    if (activeAgentStatus !== "running") return;
     setThinkingTick(0);
     const timer = window.setInterval(() => {
       setThinkingTick((prev) => prev + 1);
     }, 1000);
     return () => window.clearInterval(timer);
-  }, [thinkingStartTs, activeAgentStatus]);
+  }, [thinkingStartTs]);
 
   useEffect(() => {
     if (!token || !activeAgent) return;
@@ -2628,6 +2657,7 @@ export function App() {
               agentsCollapsed={agentsCollapsed}
               hasAcp={acpView.hasAcp}
               thinkingStartTs={thinkingStartTs}
+              runStatus={acpView.runStatus?.status ?? null}
               modelLabel={activeAgentModelLabel}
               onToggleAgents={handleToggleAgents}
             />

--- a/web/src/components/output_header.tsx
+++ b/web/src/components/output_header.tsx
@@ -17,6 +17,7 @@ type OutputHeaderProps = {
   agentsCollapsed: boolean;
   hasAcp: boolean;
   thinkingStartTs: number | null;
+  runStatus?: string | null;
   modelLabel?: string | null;
   onToggleAgents: () => void;
 };
@@ -27,6 +28,7 @@ export const OutputHeader = React.memo(function OutputHeader({
   agentsCollapsed,
   hasAcp,
   thinkingStartTs,
+  runStatus,
   modelLabel,
   onToggleAgents,
 }: OutputHeaderProps) {
@@ -42,6 +44,15 @@ export const OutputHeader = React.memo(function OutputHeader({
     thinkingStartTs
       ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - thinkingStartTs))}s`
       : null;
+  const mergedStatus = (
+    runStatus?.trim().toLowerCase() ||
+    activeAgent?.status.trim().toLowerCase() ||
+    "unknown"
+  );
+  const mergedStatusLabel = thinkingLabel
+    ? `${mergedStatus} · ${thinkingLabel}`
+    : mergedStatus;
+  const mergedStatusClassToken = mergedStatus.replace(/[^a-z0-9_-]+/g, "-");
   return (
     <div className={OUTPUT_HEADER_ROOT_CLASS}>
       <div className={OUTPUT_HEADER_TITLE_CLASS}>
@@ -70,17 +81,14 @@ export const OutputHeader = React.memo(function OutputHeader({
       {activeAgent ? (
         <div className={OUTPUT_HEADER_META_CLASS}>
           <StatusBadge
-            label={activeAgent.status}
-            tone={resolveAgentStatusTone(activeAgent.status)}
-            className={`agent-status status-${activeAgent.status}`}
-            title={`status: ${activeAgent.status}`}
+            label={mergedStatusLabel}
+            tone={resolveAgentStatusTone(mergedStatus)}
+            className={`agent-status status-${mergedStatusClassToken}`}
+            title={`status: ${mergedStatusLabel}`}
           />
           <span className={OUTPUT_HEADER_PILL_CLASS}>
             Code mode {activeAgent.code_mode ? "on" : "off"}
           </span>
-          {thinkingLabel && (
-            <span className="acp-thinking">{thinkingLabel}</span>
-          )}
           {sessionLabel && (
             <span className="output-session mono">Session {sessionLabel}</span>
           )}

--- a/web/src/output_header.test.tsx
+++ b/web/src/output_header.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { OutputHeader } from "./components/output_header";
 import { AgentRecord } from "./api";
 
@@ -74,5 +74,13 @@ describe("OutputHeader", () => {
   it("renders model tag when label is provided", () => {
     const html = renderHeader({ modelLabel: "gpt-4o" });
     expect(html).toContain("gpt-4o");
+  });
+
+  it("merges run and thinking state into a single status badge", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(15_000);
+    const html = renderHeader({ runStatus: "running", thinkingStartTs: 10 });
+    expect(html).toContain("running · thinking 5s");
+    expect(html).not.toContain("class=\"acp-thinking\"");
+    nowSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

This PR improves agent runtime status UX and reduces noisy SSE reconnect loops.

## Changes

- Merge separate `running` + `thinking` indicators into a single status badge in output header.
  - Badge now shows combined label, e.g. `running · thinking 5s`.
  - Remove standalone `acp-thinking` tag.
- Keep `thinking` timer live whenever ACP thinking is active (not gated by agent status string).
- Improve SSE recovery behavior:
  - On SSE error, refresh agent list silently before scheduling reconnect.
  - If no active SSE targets remain after refresh, switch to `idle` instead of reconnect loop.
  - Add periodic silent agent status refresh (`10s`) to reduce stale `running` status drift.

## Why

- `running` and `thinking` represented the same runtime state surface and were visually redundant.
- When backend state changed but frontend target list was stale, UI could keep reconnecting SSE indefinitely.
- This keeps runtime status clearer and reconnect behavior closer to real backend state.

## Validation

- `npm --prefix web run test -- src/output_header.test.tsx`
- `npm --prefix web run test -- src/connection_status.test.ts src/event_polling.test.ts`
- `npm --prefix web run lint`
- `npm --prefix web run build`

## Scope

- Frontend only
- Files:
  - `web/src/app.tsx`
  - `web/src/components/output_header.tsx`
  - `web/src/output_header.test.tsx`
