### PR TITLE
fix(web): remove mobile horizontal gap and migrate output header styles

### DIFF
--- a/tests/web_assets.rs
+++ b/tests/web_assets.rs
@@ -101,7 +101,7 @@ fn styles_keep_acp_conversation_scoped() {
         "workspace right panel should stretch and clip overflow for docked input bottom alignment"
     );
     assert!(
-        css.contains(".app {\n  width: 100%;\n  max-width: var(--agenthub-vw, 100vw);\n  margin: 0;\n  padding: 2px 8px 0;\n  min-height: var(--agenthub-vh, 100vh);\n  height: var(--agenthub-vh, 100vh);\n  overflow: auto;\n  overflow-x: hidden;"),
+        css.contains(".app {\n  width: 100%;\n  max-width: var(--agenthub-vw, 100vw);\n  margin: 0;\n  padding: 2px 8px 0;\n  min-height: var(--agenthub-vh, 100vh);\n  height: var(--agenthub-vh, 100vh);\n  overflow: auto;\n  overflow-x: clip;"),
         "app should keep fixed-height scroll container behavior"
     );
     assert!(

--- a/web/src/components/output_header.tsx
+++ b/web/src/components/output_header.tsx
@@ -5,10 +5,14 @@ import {
   OUTPUT_HEADER_META_CLASS,
   OUTPUT_HEADER_PILL_CLASS,
   OUTPUT_HEADER_ROOT_CLASS,
+  OUTPUT_HEADER_SESSION_CLASS,
   OUTPUT_HEADER_SUBTITLE_CLASS,
   OUTPUT_HEADER_SUBTITLE_ROW_CLASS,
   OUTPUT_HEADER_TITLE_CLASS,
+  OUTPUT_HEADER_TITLE_HEADING_CLASS,
   OUTPUT_HEADER_TITLE_MAIN_CLASS,
+  OUTPUT_HEADER_TITLE_TEXT_CLASS,
+  OUTPUT_HEADER_UPDATED_CLASS,
 } from "../ui/tailwind_classes";
 
 type OutputHeaderProps = {
@@ -69,9 +73,9 @@ export const OutputHeader = React.memo(function OutputHeader({
             aria-hidden="true"
           />
         </button>
-        <div className="output-title-text">
+        <div className={OUTPUT_HEADER_TITLE_TEXT_CLASS}>
           <div className={OUTPUT_HEADER_TITLE_MAIN_CLASS}>
-            <h2>{titleText}</h2>
+            <h2 className={OUTPUT_HEADER_TITLE_HEADING_CLASS}>{titleText}</h2>
             {modelLabel ? (
               <span className="agent-tag">{modelLabel}</span>
             ) : null}
@@ -90,10 +94,10 @@ export const OutputHeader = React.memo(function OutputHeader({
             Code mode {activeAgent.code_mode ? "on" : "off"}
           </span>
           {sessionLabel && (
-            <span className="output-session mono">Session {sessionLabel}</span>
+            <span className={OUTPUT_HEADER_SESSION_CLASS}>Session {sessionLabel}</span>
           )}
           {updatedLabel && (
-            <span className="output-updated">Updated {updatedLabel}</span>
+            <span className={OUTPUT_HEADER_UPDATED_CLASS}>Updated {updatedLabel}</span>
           )}
         </div>
       ) : null}

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -2325,10 +2325,10 @@ export function TeamPage(props: TeamPageProps) {
 
   return (
     <div className="mx-auto flex h-[var(--agenthub-vh,100vh)] w-full max-w-[1600px] flex-col gap-5 overflow-y-auto overscroll-y-contain px-3 py-3 sm:px-4 lg:px-6 [&>*]:shrink-0">
-      <header className="mb-0 flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
+      <header>
+        <div className="flex min-w-0 items-center gap-2">
           <button
-            className="icon-button small output-agents-toggle"
+            className="icon-button output-agents-toggle"
             onClick={() => setTeamsSidebarCollapsed((previous) => !previous)}
             title={teamsSidebarCollapsed ? "Show teams panel" : "Hide teams panel"}
             aria-label={teamsSidebarCollapsed ? "Show teams panel" : "Hide teams panel"}
@@ -2338,18 +2338,31 @@ export function TeamPage(props: TeamPageProps) {
               aria-hidden="true"
             />
           </button>
-          <h1 className="whitespace-normal text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">
-            AgentHub Teams
-          </h1>
+          <h1>AgentHub Teams</h1>
         </div>
-        <div className="team-session flex max-w-full flex-wrap items-center justify-end gap-2 rounded-xl border border-slate-200 bg-white px-2 py-1.5 shadow-sm">
-          <a className="icon-button" href="/" title="Back" aria-label="Back">
+        <div className="session team-session">
+          <span
+            className="session-connection muted"
+            title="Teams console"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="session-connection-dot" aria-hidden="true" />
+            <span>Teams</span>
+          </span>
+          <span>{props.auth.username}</span>
+          <a className="icon-button" href="/" title="Agents" aria-label="Agents">
             <i className="bi bi-arrow-left" aria-hidden="true" />
           </a>
-          <span className="max-w-[44vw] truncate text-sm font-medium text-slate-700 sm:max-w-none">
-            {props.auth.username}
-          </span>
-          <button className={panelSecondaryButtonClassName} onClick={props.onLogout}>
+          {props.auth.role === "root" && (
+            <a className="icon-button" href="/admin" title="Admin" aria-label="Admin">
+              <i className="bi bi-gear" aria-hidden="true" />
+            </a>
+          )}
+          <button
+            className="rounded-[var(--radius-sm)] border-0 bg-[var(--ink)] px-[14px] py-2 font-semibold tracking-[0.01em] text-white transition hover:bg-slate-800"
+            onClick={props.onLogout}
+          >
             Logout
           </button>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -54,8 +54,6 @@
 html {
   width: 100%;
   max-width: var(--agenthub-vw, 100vw);
-  /* Keep hidden as fallback for engines without overflow-x: clip support. */
-  overflow-x: hidden;
   overflow-x: clip;
   overscroll-behavior-x: none;
 }
@@ -78,7 +76,6 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-/* Keep hidden before clip as compatibility fallback for older engines. */
 .app {
   width: 100%;
   max-width: var(--agenthub-vw, 100vw);
@@ -87,7 +84,6 @@ body {
   min-height: var(--agenthub-vh, 100vh);
   height: var(--agenthub-vh, 100vh);
   overflow: auto;
-  overflow-x: hidden;
   overflow-x: clip;
   overscroll-behavior-x: none;
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -51,6 +51,14 @@
   box-sizing: border-box;
 }
 
+html {
+  width: 100%;
+  max-width: var(--agenthub-vw, 100vw);
+  overflow-x: hidden;
+  overflow-x: clip;
+  overscroll-behavior-x: none;
+}
+
 body {
   margin: 0;
   width: 100%;
@@ -60,6 +68,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  overscroll-behavior-x: none;
 }
 
 body {
@@ -75,8 +84,10 @@ body {
   padding: 2px 8px 0;
   min-height: var(--agenthub-vh, 100vh);
   height: var(--agenthub-vh, 100vh);
-  overflow: auto;
+  overflow-y: auto;
   overflow-x: hidden;
+  overflow-x: clip;
+  overscroll-behavior-x: none;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -100,20 +111,42 @@ header {
   align-items: center;
   margin-bottom: 10px;
   gap: 12px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 h1 {
   font-size: 28px;
   margin: 0;
   white-space: nowrap;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .session {
   display: flex;
   gap: 12px;
   align-items: center;
-  flex-wrap: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  row-gap: 8px;
+}
+
+.session > * {
+  flex: 0 0 auto;
+}
+
+.session > span:not(.session-connection) {
+  min-width: 0;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -128,6 +161,8 @@ h1 {
   font-size: 12px;
   line-height: 1.2;
   padding: 4px 8px;
+  flex: 1 1 auto;
+  min-width: 0;
   max-width: min(42vw, 260px);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -927,121 +962,6 @@ body.teams-page button:not([class*="mantine-"]):disabled {
     opacity: 1;
     transform: translateY(0) scale(1);
   }
-}
-
-.output-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-rows: auto auto;
-  align-items: center;
-  justify-content: space-between;
-  column-gap: 10px;
-  row-gap: 6px;
-}
-
-.output-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  grid-column: 1;
-  grid-row: 1;
-  max-width: 100%;
-  width: fit-content;
-  max-width: clamp(160px, 32vw, 360px);
-}
-
-.output-title-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.output-title-main {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  min-width: 0;
-}
-
-.output-title-text h2,
-.output-subtitle {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.output-title-text h2 {
-  margin: 0;
-  line-height: 1.05;
-  font-size: 18px;
-}
-
-.output-subtitle {
-  font-size: 13px;
-  color: #7a7a7a;
-}
-
-.output-meta {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 8px;
-  align-items: center;
-  font-size: 12px;
-  color: var(--muted);
-  white-space: nowrap;
-  max-width: 52vw;
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: end;
-  overflow: hidden;
-}
-
-.output-subtitle-row {
-  grid-row: 2;
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  grid-column: 1;
-  justify-self: start;
-  max-width: 100%;
-}
-
-.output-actions-row {
-  grid-row: 2;
-  grid-column: 2;
-  justify-self: end;
-}
-
-.output-meta.empty {
-  color: var(--muted);
-}
-
-.output-pill {
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #e9ecef;
-  color: #495057;
-  font-size: 11px;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-.output-session {
-  font-size: 11px;
-  color: #6c757d;
-}
-
-.output-updated {
-  font-size: 11px;
-  color: #6c757d;
-}
-
-.output-resume {
-  font-size: 12px;
-  padding: 6px 10px;
 }
 
 .output-loading {
@@ -2423,43 +2343,25 @@ body.teams-page button:not([class*="mantine-"]):disabled {
 
   .session {
     gap: 8px;
+    width: 100%;
+    justify-content: flex-start;
+    row-gap: 6px;
+  }
+
+  .session > span:not(.session-connection) {
+    max-width: 88px;
   }
 
   .session-connection {
     font-size: 11px;
     padding: 3px 7px;
     gap: 5px;
+    max-width: min(56vw, 210px);
   }
 
   .session-connection-dot {
     width: 7px;
     height: 7px;
-  }
-
-  .output-meta {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-self: start;
-    max-width: 100%;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px 8px;
-    white-space: normal;
-  }
-
-  .output-subtitle-row {
-    grid-row: 3;
-  }
-
-  .output-meta > * {
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .output-meta > :nth-child(n + 5) {
-    display: none;
   }
 
   .acp-subtitle {
@@ -3411,41 +3313,24 @@ body.teams-page button:not([class*="mantine-"]):disabled {
     gap: 6px;
   }
 
+  .session {
+    row-gap: 6px;
+  }
+
+  .session > span:not(.session-connection) {
+    max-width: 68px;
+  }
+
   .session-connection {
     font-size: 10px;
     padding: 2px 6px;
     gap: 4px;
+    max-width: min(58vw, 184px);
   }
 
   .session-connection-dot {
     width: 7px;
     height: 7px;
-  }
-
-  .output-meta {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-self: start;
-    max-width: 100%;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px 8px;
-    white-space: normal;
-  }
-
-  .output-subtitle-row {
-    grid-row: 3;
-  }
-
-  .output-meta > * {
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .output-meta > :nth-child(n + 5) {
-    display: none;
   }
 
   .acp-subtitle {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -84,7 +84,7 @@ body {
   padding: 2px 8px 0;
   min-height: var(--agenthub-vh, 100vh);
   height: var(--agenthub-vh, 100vh);
-  overflow-y: auto;
+  overflow: auto;
   overflow-x: hidden;
   overflow-x: clip;
   overscroll-behavior-x: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -54,6 +54,7 @@
 html {
   width: 100%;
   max-width: var(--agenthub-vw, 100vw);
+  /* Keep hidden as fallback for engines without overflow-x: clip support. */
   overflow-x: hidden;
   overflow-x: clip;
   overscroll-behavior-x: none;
@@ -77,6 +78,7 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Keep hidden before clip as compatibility fallback for older engines. */
 .app {
   width: 100%;
   max-width: var(--agenthub-vw, 100vw);

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -246,17 +246,35 @@ export const AGENTS_ROW_ACTIVE_CLASS =
   "agent-row active rounded-xl border border-ui-border-strong bg-ui-surface-soft px-ctrl-x py-3";
 
 export const OUTPUT_HEADER_ROOT_CLASS =
-  "output-header rounded-xl border border-ui-border/80 bg-ui-surface/80 px-ctrl-x py-ctrl-y shadow-sm";
+  "output-header grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_auto] items-center justify-between gap-x-2.5 gap-y-1.5 rounded-xl border border-ui-border/80 bg-ui-surface/80 px-ctrl-x py-ctrl-y shadow-sm max-[720px]:grid-cols-1 max-[720px]:grid-rows-[auto_auto_auto]";
 
-export const OUTPUT_HEADER_TITLE_CLASS = "output-title flex items-center gap-2";
-export const OUTPUT_HEADER_TITLE_MAIN_CLASS = "output-title-main flex items-center gap-2";
-export const OUTPUT_HEADER_META_CLASS = "output-meta flex flex-wrap items-center gap-2";
+export const OUTPUT_HEADER_TITLE_CLASS =
+  "output-title col-start-1 row-start-1 inline-flex min-w-0 w-fit max-w-[clamp(160px,32vw,360px)] items-center gap-2 max-[720px]:max-w-full";
+
+export const OUTPUT_HEADER_TITLE_TEXT_CLASS =
+  "output-title-text flex min-w-0 flex-col gap-0.5";
+
+export const OUTPUT_HEADER_TITLE_MAIN_CLASS =
+  "output-title-main flex min-w-0 flex-wrap items-center gap-2";
+
+export const OUTPUT_HEADER_TITLE_HEADING_CLASS =
+  "m-0 overflow-hidden text-ellipsis whitespace-nowrap text-[18px] leading-[1.05] text-ui-text-primary";
+
+export const OUTPUT_HEADER_META_CLASS =
+  "output-meta col-start-2 row-start-1 flex max-w-[52vw] flex-nowrap items-center justify-self-end gap-2 overflow-hidden whitespace-nowrap text-ui-xs text-ui-text-muted max-[720px]:col-start-1 max-[720px]:row-start-2 max-[720px]:grid max-[720px]:max-w-full max-[720px]:grid-cols-2 max-[720px]:gap-x-2 max-[720px]:gap-y-1 max-[720px]:justify-self-start max-[720px]:whitespace-normal [&>*]:min-w-0 [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap max-[720px]:[&>*:nth-child(n+5)]:hidden";
 
 export const OUTPUT_HEADER_PILL_CLASS =
   "output-pill rounded-full border border-ui-border-strong bg-ui-surface px-2 py-1 text-ui-xs font-medium text-ui-text-secondary";
 
-export const OUTPUT_HEADER_SUBTITLE_ROW_CLASS = "output-subtitle-row mt-1";
-export const OUTPUT_HEADER_SUBTITLE_CLASS = "output-subtitle text-ui-sm text-ui-text-muted";
+export const OUTPUT_HEADER_SESSION_CLASS = "output-session mono text-[11px] text-ui-text-muted";
+
+export const OUTPUT_HEADER_UPDATED_CLASS = "output-updated text-[11px] text-ui-text-muted";
+
+export const OUTPUT_HEADER_SUBTITLE_ROW_CLASS =
+  "output-subtitle-row col-start-1 row-start-2 mt-1 flex min-w-0 items-center justify-self-start max-w-full max-[720px]:row-start-3";
+
+export const OUTPUT_HEADER_SUBTITLE_CLASS =
+  "output-subtitle overflow-hidden text-ellipsis whitespace-nowrap text-[13px] text-ui-text-muted";
 
 export const OUTPUT_BODY_ROOT_CLASS =
   "output-body rounded-2xl border border-ui-border/80 bg-ui-surface/85 shadow-sm backdrop-blur";


### PR DESCRIPTION
## Summary

This PR includes two focused frontend changes:

1. Fix mobile horizontal whitespace when swiping left/right.
2. Continue Tailwind migration for the output header styles.

## What Changed

- Mobile overflow hardening:
  - Added horizontal clipping/overscroll guards on `html`, `body`, and `.app`.
  - Switched `.app` from generic `overflow: auto` to `overflow-y: auto` + horizontal clipping.
- Header/session responsive fix:
  - Updated top-level `header`/`.session` layout to wrap safely on small screens.
  - Added truncation constraints for session labels/status to avoid viewport overflow.
- Tailwind migration (output header):
  - Moved output header title/meta/subtitle/session/updated style tokens into `web/src/ui/tailwind_classes.ts`.
  - Updated `web/src/components/output_header.tsx` to consume new Tailwind class constants.
  - Removed now-redundant legacy `.output-*` style blocks from `web/src/styles.css`.

## Why

- Mobile users could trigger a right-side blank area due to horizontal overflow in header/session composition.
- Output header styling was still partly in legacy CSS; migrating to Tailwind tokens improves consistency and maintainability.

## Validation

- Local build:
  - `npm --prefix web run build`
- Mobile regression check (Chrome DevTools MCP):
  - Verified `/` and `/teams` at mobile viewport widths (including narrow widths).
  - Confirmed `scrollWidth - clientWidth = 0` (no horizontal overflow).

## Files

- `web/src/styles.css`
- `web/src/components/output_header.tsx`
- `web/src/ui/tailwind_classes.ts`
