### PR TITLE
style(teams): align teams workbench panels with ui tokens

### DIFF
--- a/web/src/pages/team_events_panel.tsx
+++ b/web/src/pages/team_events_panel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TeamRunEventRecord } from "../api";
 import {
   TEAM_PANEL_CARD_CLASS,
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_PRE_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
   TEAM_PANEL_SECONDARY_BUTTON_CLASS,
@@ -25,11 +26,12 @@ type TeamEventsPanelProps = {
   toPrettyJson: (value: unknown) => string;
 };
 
-const EVENTS_LIST_CLASS = "teams-event-list rounded-xl border border-slate-200 bg-slate-50/50 p-3";
-const EVENTS_CHECKBOX_LABEL_CLASS = "checkbox inline-flex items-center gap-2 text-sm text-slate-700";
-const EVENTS_EMPTY_TEXT_CLASS = "muted text-sm text-slate-600";
-const EVENTS_ITEM_CLASS = "rounded-lg border border-slate-200 bg-white p-2";
-const EVENTS_ITEM_HEAD_CLASS = "teams-event-head mb-1 flex items-center gap-2 text-xs text-slate-600";
+const EVENTS_LIST_CLASS = "teams-event-list rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
+const EVENTS_CHECKBOX_LABEL_CLASS =
+  "checkbox inline-flex items-center gap-2 text-ui-sm text-ui-text-secondary";
+const EVENTS_ITEM_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
+const EVENTS_ITEM_HEAD_CLASS =
+  "teams-event-head mb-1 flex flex-wrap items-center gap-2 text-ui-xs text-ui-text-muted";
 
 export function TeamEventsPanel(props: TeamEventsPanelProps) {
   const {
@@ -84,12 +86,12 @@ export function TeamEventsPanel(props: TeamEventsPanelProps) {
         </div>
       </div>
       {previewMode && (
-        <p className={EVENTS_EMPTY_TEXT_CLASS}>
+        <p className={TEAM_MUTED_TEXT_CLASS}>
           Showing latest {previewLimit} records. For full event history, select a member in the
           Member Console tab.
         </p>
       )}
-      {displayedRunEvents.length === 0 && <p className={EVENTS_EMPTY_TEXT_CLASS}>No events.</p>}
+      {displayedRunEvents.length === 0 && <p className={TEAM_MUTED_TEXT_CLASS}>No events.</p>}
       <ul className={EVENTS_LIST_CLASS}>
         {displayedRunEvents.map((event) => (
           <li key={event.event_id} className={EVENTS_ITEM_CLASS}>

--- a/web/src/pages/team_mailbox_panel.tsx
+++ b/web/src/pages/team_mailbox_panel.tsx
@@ -7,6 +7,7 @@ import {
   TEAM_LIST_ITEM_BASE_CLASS,
   TEAM_LIST_ITEM_META_CLASS,
   TEAM_LIST_ITEM_TITLE_CLASS,
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_PRE_CLASS,
   TEAM_PANEL_PRIMARY_BUTTON_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
@@ -77,23 +78,27 @@ type TeamMailboxPanelProps = {
 };
 
 const MAILBOX_META_CLASS =
-  "mb-3 grid min-w-0 gap-2 rounded-xl border border-slate-200 bg-slate-50/70 p-3 text-sm text-slate-700 sm:grid-cols-2 xl:grid-cols-4";
-const MAILBOX_MEMBER_LIST_CLASS = "teams-chat-members rounded-xl border border-slate-200 bg-slate-50/60 p-3";
-const MAILBOX_PANEL_CLASS = "teams-chat-panel rounded-xl border border-slate-200 bg-slate-50/60 p-3";
-const MAILBOX_MEMBER_BUTTON_BASE_CLASS =
-  `${TEAM_LIST_ITEM_BASE_CLASS} border-slate-200`;
+  "mb-3 grid min-w-0 gap-2 rounded-xl border border-ui-border bg-ui-surface-soft/70 p-3 text-ui-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-4";
+const MAILBOX_MEMBER_LIST_CLASS = "teams-chat-members rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
+const MAILBOX_PANEL_CLASS = "teams-chat-panel rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
+const MAILBOX_MEMBER_BUTTON_BASE_CLASS = `${TEAM_LIST_ITEM_BASE_CLASS}`;
 const MAILBOX_MEMBER_BUTTON_ACTIVE_CLASS =
-  `${MAILBOX_MEMBER_BUTTON_BASE_CLASS} border-slate-300 ring-1 ring-slate-200`;
+  `${MAILBOX_MEMBER_BUTTON_BASE_CLASS} border-ui-border-strong bg-ui-surface-soft ring-1 ring-ui-border`;
 const MAILBOX_MEMBER_BUTTON_IDLE_CLASS =
-  `${MAILBOX_MEMBER_BUTTON_BASE_CLASS} hover:border-slate-300`;
-const MAILBOX_UNREAD_ACTIVE_CLASS = "teams-member-unread mono text-amber-700";
-const MAILBOX_UNREAD_MUTED_CLASS = "teams-member-unread mono muted text-slate-500";
+  `${MAILBOX_MEMBER_BUTTON_BASE_CLASS} hover:border-ui-border-strong`;
+const MAILBOX_UNREAD_ACTIVE_CLASS =
+  "teams-member-unread mono text-ui-xs text-[color:var(--status-warning-ink)]";
+const MAILBOX_UNREAD_MUTED_CLASS = "teams-member-unread mono text-ui-xs text-ui-text-muted";
 const MAILBOX_CHAT_JUMP_BUTTON_CLASS =
-  "ghost teams-chat-jump-bottom rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium hover:border-slate-500 disabled:cursor-not-allowed disabled:opacity-60";
-const MAILBOX_CONVERSATION_EMPTY_CLASS = "teams-chat-empty muted text-sm text-slate-600";
+  "ghost teams-chat-jump-bottom rounded-lg border border-ui-border-strong bg-ui-surface px-3 py-2 text-ui-sm font-medium text-ui-text-secondary shadow-sm transition hover:border-ui-border-emphasis hover:bg-ui-surface-soft disabled:cursor-not-allowed disabled:opacity-60";
+const MAILBOX_CONVERSATION_EMPTY_CLASS = `teams-chat-empty ${TEAM_MUTED_TEXT_CLASS}`;
 const MAILBOX_ADVANCED_GRID_CLASS = "teams-message-grid grid gap-3 lg:grid-cols-2";
 const MAILBOX_ADVANCED_PANEL_CLASS =
-  "teams-message-panel flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50/70 p-3";
+  "teams-message-panel flex flex-col gap-2 rounded-xl border border-ui-border bg-ui-surface-soft/70 p-3";
+const MAILBOX_SECTION_TITLE_CLASS = "text-ui-sm font-semibold text-ui-text-primary";
+const MAILBOX_CHECKBOX_LABEL_CLASS = "checkbox inline-flex items-center gap-2 text-ui-sm text-ui-text-secondary";
+const MAILBOX_ADVANCED_HINT_CLASS =
+  "mt-3 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2 text-ui-sm text-state-warning-text";
 
 export function TeamMailboxPanel(props: TeamMailboxPanelProps) {
   const {
@@ -245,7 +250,7 @@ export function TeamMailboxPanel(props: TeamMailboxPanelProps) {
           value={inboxAfterId}
           onChange={(event) => onInboxAfterIdChange(event.target.value)}
         />
-        <label className="checkbox inline-flex items-center gap-2 text-sm text-slate-700">
+        <label className={MAILBOX_CHECKBOX_LABEL_CLASS}>
           <input
             type="checkbox"
             checked={inboxIncludeDelivered}
@@ -293,147 +298,147 @@ export function TeamMailboxPanel(props: TeamMailboxPanelProps) {
       {showConversation && (
         <div className="teams-chat-shell">
           <div className={MAILBOX_MEMBER_LIST_CLASS}>
-          <h4>Agents</h4>
-          {snapshot?.members.map((member) => {
-            const unread = unreadByMemberId[member.member_id] ?? 0;
-            return (
-              <button
-                key={member.member_id}
-                className={
-                  selectedMemberId === member.member_id
-                    ? MAILBOX_MEMBER_BUTTON_ACTIVE_CLASS
-                    : MAILBOX_MEMBER_BUTTON_IDLE_CLASS
-                }
-                onClick={() => onSelectMember(member.member_id)}
-              >
-                <span className={TEAM_LIST_ITEM_TITLE_CLASS}>
-                  {member.member_id} ({member.role})
-                </span>
-                <StatusBadge
-                  label={member.status}
-                  tone={resolveTeamRunStatusTone(member.status)}
-                  className="team-status"
-                  title={`member status: ${member.status}`}
-                />
-                <span className={TEAM_LIST_ITEM_META_CLASS}>pending={member.pending_inbox_count}</span>
-                <span className={unread > 0 ? MAILBOX_UNREAD_ACTIVE_CLASS : MAILBOX_UNREAD_MUTED_CLASS}>
-                  unread={unread}
-                </span>
-              </button>
-            );
-          })}
-          {(!snapshot || snapshot.members.length === 0) && (
-            <p className="muted text-sm text-slate-600">No members available.</p>
-          )}
+            <h4 className={MAILBOX_SECTION_TITLE_CLASS}>Agents</h4>
+            {snapshot?.members.map((member) => {
+              const unread = unreadByMemberId[member.member_id] ?? 0;
+              return (
+                <button
+                  key={member.member_id}
+                  className={
+                    selectedMemberId === member.member_id
+                      ? MAILBOX_MEMBER_BUTTON_ACTIVE_CLASS
+                      : MAILBOX_MEMBER_BUTTON_IDLE_CLASS
+                  }
+                  onClick={() => onSelectMember(member.member_id)}
+                >
+                  <span className={TEAM_LIST_ITEM_TITLE_CLASS}>
+                    {member.member_id} ({member.role})
+                  </span>
+                  <StatusBadge
+                    label={member.status}
+                    tone={resolveTeamRunStatusTone(member.status)}
+                    className="team-status"
+                    title={`member status: ${member.status}`}
+                  />
+                  <span className={TEAM_LIST_ITEM_META_CLASS}>pending={member.pending_inbox_count}</span>
+                  <span className={unread > 0 ? MAILBOX_UNREAD_ACTIVE_CLASS : MAILBOX_UNREAD_MUTED_CLASS}>
+                    unread={unread}
+                  </span>
+                </button>
+              );
+            })}
+            {(!snapshot || snapshot.members.length === 0) && (
+              <p className={TEAM_MUTED_TEXT_CLASS}>No members available.</p>
+            )}
           </div>
 
           <div className={MAILBOX_PANEL_CLASS}>
-          <div className="teams-chat-head">
-            <div>
-              <strong>
-                {chatActors.fromActorId || "-"} → {chatActors.toActorId || "-"}
-              </strong>
-            </div>
-            <div className="mono">inbox_actor_id={chatActors.inboxActorId || "-"}</div>
-            <div className="mono">auto_follow={chatStickToBottom ? "on" : "off"}</div>
-            <button
-              type="button"
-              className={MAILBOX_CHAT_JUMP_BUTTON_CLASS}
-              onClick={onJumpToBottom}
-              disabled={conversationMessages.length === 0}
-              title="Jump to latest message"
-            >
-              Jump to bottom
-            </button>
-          </div>
-          <ul
-            className="teams-chat-messages"
-            ref={chatMessagesRef}
-            onScroll={() => onConversationScroll()}
-          >
-            {conversationMessages.map((message) => {
-              const isOutgoing = message.from_actor_id === chatActors.fromActorId;
-              const payload =
-                typeof message.payload === "object" &&
-                message.payload !== null &&
-                "type" in message.payload &&
-                (message.payload as { type?: unknown }).type === "chat_message" &&
-                "text" in message.payload
-                  ? String((message.payload as { text?: unknown }).text ?? "")
-                  : toPrettyJson(message.payload);
-              return (
-                <li
-                  key={message.message_id}
-                  className={isOutgoing ? "teams-chat-bubble outgoing" : "teams-chat-bubble incoming"}
-                >
-                  <div className="teams-message-head">
-                    <span className="mono">#{message.message_id}</span>
-                    <span>
-                      {message.from_actor_id} → {message.to_actor_id}
-                    </span>
-                    <span>{message.status}</span>
-                    <span>{formatTs(message.created_at)}</span>
-                  </div>
-                  <pre className={TEAM_PANEL_PRE_CLASS}>{payload}</pre>
-                  {message.status !== "delivered" && (
-                    <div className="flex flex-wrap items-center gap-2">
-                      <button
-                        onClick={() => {
-                          void onAckMessage(message);
-                        }}
-                        disabled={busy === `ack-${message.message_id}`}
-                        className={TEAM_PANEL_SECONDARY_BUTTON_CLASS}
-                      >
-                        Ack
-                      </button>
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-            {conversationMessages.length === 0 && (
-              <li className={MAILBOX_CONVERSATION_EMPTY_CLASS}>
-                No conversation records yet for this pair.
-              </li>
-            )}
-          </ul>
-          <div className="teams-chat-compose">
-            <textarea
-              className={TEAM_PANEL_TEXTAREA_CLASS}
-              rows={3}
-              placeholder="Type a message to selected agent"
-              value={chatDraft}
-              onChange={(event) => onChatDraftChange(event.target.value)}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-                  event.preventDefault();
-                  void onSendChatMessage();
-                }
-              }}
-            />
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="teams-chat-head">
+              <div>
+                <strong>
+                  {chatActors.fromActorId || "-"} → {chatActors.toActorId || "-"}
+                </strong>
+              </div>
+              <div className="mono">inbox_actor_id={chatActors.inboxActorId || "-"}</div>
+              <div className="mono">auto_follow={chatStickToBottom ? "on" : "off"}</div>
               <button
-                className={TEAM_PANEL_PRIMARY_BUTTON_CLASS}
-                onClick={onSendChatMessage}
-                disabled={busy === "send-chat"}
+                type="button"
+                className={MAILBOX_CHAT_JUMP_BUTTON_CLASS}
+                onClick={onJumpToBottom}
+                disabled={conversationMessages.length === 0}
+                title="Jump to latest message"
               >
-                Send Chat
+                Jump to bottom
               </button>
             </div>
-          </div>
+            <ul
+              className="teams-chat-messages"
+              ref={chatMessagesRef}
+              onScroll={() => onConversationScroll()}
+            >
+              {conversationMessages.map((message) => {
+                const isOutgoing = message.from_actor_id === chatActors.fromActorId;
+                const payload =
+                  typeof message.payload === "object" &&
+                  message.payload !== null &&
+                  "type" in message.payload &&
+                  (message.payload as { type?: unknown }).type === "chat_message" &&
+                  "text" in message.payload
+                    ? String((message.payload as { text?: unknown }).text ?? "")
+                    : toPrettyJson(message.payload);
+                return (
+                  <li
+                    key={message.message_id}
+                    className={isOutgoing ? "teams-chat-bubble outgoing" : "teams-chat-bubble incoming"}
+                  >
+                    <div className="teams-message-head">
+                      <span className="mono">#{message.message_id}</span>
+                      <span>
+                        {message.from_actor_id} → {message.to_actor_id}
+                      </span>
+                      <span>{message.status}</span>
+                      <span>{formatTs(message.created_at)}</span>
+                    </div>
+                    <pre className={TEAM_PANEL_PRE_CLASS}>{payload}</pre>
+                    {message.status !== "delivered" && (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          onClick={() => {
+                            void onAckMessage(message);
+                          }}
+                          disabled={busy === `ack-${message.message_id}`}
+                          className={TEAM_PANEL_SECONDARY_BUTTON_CLASS}
+                        >
+                          Ack
+                        </button>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+              {conversationMessages.length === 0 && (
+                <li className={MAILBOX_CONVERSATION_EMPTY_CLASS}>
+                  No conversation records yet for this pair.
+                </li>
+              )}
+            </ul>
+            <div className="teams-chat-compose">
+              <textarea
+                className={TEAM_PANEL_TEXTAREA_CLASS}
+                rows={3}
+                placeholder="Type a message to selected agent"
+                value={chatDraft}
+                onChange={(event) => onChatDraftChange(event.target.value)}
+                onKeyDown={(event) => {
+                  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                    event.preventDefault();
+                    void onSendChatMessage();
+                  }
+                }}
+              />
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  className={TEAM_PANEL_PRIMARY_BUTTON_CLASS}
+                  onClick={onSendChatMessage}
+                  disabled={busy === "send-chat"}
+                >
+                  Send Chat
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}
 
       {showConversation && (
-        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <div className={MAILBOX_ADVANCED_HINT_CLASS}>
           Advanced mailbox tools were moved to <strong>Debug -&gt; Mailbox Raw</strong>.
         </div>
       )}
 
       {showAdvancedControls && (
         <div className="teams-message-advanced mt-3">
-          <h4 className="mb-2 text-sm font-semibold text-slate-900">Advanced mailbox controls</h4>
+          <h4 className={`mb-2 ${MAILBOX_SECTION_TITLE_CLASS}`}>Advanced mailbox controls</h4>
           {advancedControls}
         </div>
       )}

--- a/web/src/pages/team_main_task_panel.tsx
+++ b/web/src/pages/team_main_task_panel.tsx
@@ -4,6 +4,7 @@ import {
   TeamMainTaskRecord,
 } from "../api";
 import {
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_GHOST_BUTTON_CLASS,
   TEAM_PANEL_INPUT_CLASS,
@@ -61,6 +62,18 @@ const MAIN_TASK_MODE_OPTIONS: Array<{
   { value: "to_member", label: "to_member" },
   { value: "group_chat", label: "group_chat" },
 ];
+
+const MAIN_TASK_HINT_TEXT_CLASS = "mono text-ui-xs text-ui-text-muted";
+const MAIN_TASK_STATUS_META_CLASS =
+  "mono mt-2 rounded-lg border border-ui-border bg-ui-surface-soft px-3 py-2 text-ui-xs text-ui-text-secondary";
+const MAIN_TASK_COMPOSER_PANEL_CLASS =
+  "mt-3 rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
+const MAIN_TASK_TARGET_INFO_CLASS =
+  "rounded-lg border border-ui-border bg-ui-surface px-3 py-2 text-ui-sm text-ui-text-muted";
+const MAIN_TASK_SHORTCUT_CLASS = "text-ui-xs text-ui-text-muted";
+const MAIN_TASK_MESSAGE_ITEM_CLASS = "rounded-lg border border-ui-border bg-ui-surface px-3 py-2";
+const MAIN_TASK_MESSAGE_EMPTY_CLASS =
+  "rounded-lg border border-dashed border-ui-border-strong bg-ui-surface px-3 py-2 text-ui-sm text-ui-text-muted";
 
 function resolveMessageText(
   message: TeamConversationMessageRecord,
@@ -138,7 +151,7 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
         </div>
       </div>
 
-      <p className="mb-3 text-sm text-slate-600">
+      <p className={`mb-3 ${TEAM_MUTED_TEXT_CLASS}`}>
         Use conversation planning to sync with the leader before compiling a run.
       </p>
 
@@ -182,7 +195,7 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
         >
           Create Conversation
         </button>
-        <span className="mono text-xs text-slate-500">
+        <span className={MAIN_TASK_HINT_TEXT_CLASS}>
           creator=user route defaults are enforced by backend contract
         </span>
       </div>
@@ -213,12 +226,12 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
       </div>
 
       {selectedTask && (
-        <div className="mono mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700">
+        <div className={MAIN_TASK_STATUS_META_CLASS}>
           status={selectedTask.status} created_by={selectedTask.created_by_actor_id}
         </div>
       )}
 
-      <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3">
+      <div className={MAIN_TASK_COMPOSER_PANEL_CLASS}>
         <div className="mb-2 grid gap-2 lg:grid-cols-3">
           <select
             className={TEAM_PANEL_INPUT_CLASS}
@@ -247,7 +260,7 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
               ))}
             </select>
           ) : (
-            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-500">
+            <div className={MAIN_TASK_TARGET_INFO_CLASS}>
               {messageRoute === "to_leader"
                 ? "Target is resolved to leader automatically."
                 : "Message goes to group channel with no direct target."}
@@ -288,7 +301,7 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
           >
             Send Message
           </button>
-          <span className="text-xs text-slate-500">shortcut: Ctrl/Cmd + Enter</span>
+          <span className={MAIN_TASK_SHORTCUT_CLASS}>shortcut: Ctrl/Cmd + Enter</span>
         </div>
       </div>
 
@@ -296,7 +309,7 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
         {messages.map((message) => (
           <li
             key={message.message_id}
-            className="rounded-lg border border-slate-200 bg-white px-3 py-2"
+            className={MAIN_TASK_MESSAGE_ITEM_CLASS}
           >
             <div className="teams-message-head">
               <span className="mono">#{message.message_id}</span>
@@ -310,12 +323,12 @@ export function TeamMainTaskPanel(props: TeamMainTaskPanelProps) {
           </li>
         ))}
         {!messagesLoading && messages.length === 0 && (
-          <li className="rounded-lg border border-dashed border-slate-300 bg-white px-3 py-2 text-sm text-slate-600">
+          <li className={MAIN_TASK_MESSAGE_EMPTY_CLASS}>
             No conversation messages yet.
           </li>
         )}
         {messagesLoading && (
-          <li className="rounded-lg border border-dashed border-slate-300 bg-white px-3 py-2 text-sm text-slate-600">
+          <li className={MAIN_TASK_MESSAGE_EMPTY_CLASS}>
             Loading conversation messages...
           </li>
         )}

--- a/web/src/pages/team_member_console_panel.tsx
+++ b/web/src/pages/team_member_console_panel.tsx
@@ -9,6 +9,7 @@ import {
 import {
   TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_INPUT_CLASS,
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_PRE_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
   TEAM_PANEL_SECONDARY_BUTTON_CLASS,
@@ -38,20 +39,24 @@ type TeamMemberConsolePanelProps = {
 };
 
 const MEMBER_CONSOLE_DETAIL_CLASS =
-  "teams-step-body mono rounded-xl border border-slate-200 bg-slate-50/70 p-3";
+  "teams-step-body mono rounded-xl border border-ui-border bg-ui-surface-soft/70 p-3";
 const MEMBER_CONSOLE_DETAIL_GRID_CLASS = "grid gap-2 md:grid-cols-2";
-const MEMBER_CONSOLE_DETAIL_ITEM_CLASS = "rounded-lg border border-slate-200 bg-white p-2";
-const MEMBER_CONSOLE_DETAIL_LABEL_CLASS = "text-[11px] font-semibold uppercase tracking-wide text-slate-500";
+const MEMBER_CONSOLE_DETAIL_ITEM_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
+const MEMBER_CONSOLE_DETAIL_LABEL_CLASS =
+  "text-[11px] font-semibold uppercase tracking-wide text-ui-text-muted";
 const MEMBER_CONSOLE_DETAIL_VALUE_CLASS =
-  "mono mt-1 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-slate-800";
+  "mono mt-1 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-ui-text-primary";
 const MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS =
-  "mono mt-1 block min-w-0 whitespace-pre-wrap break-words text-slate-800";
-const MEMBER_CONSOLE_DISCOVERY_CLASS = "mt-2 rounded-lg border border-slate-200 bg-white p-2";
-const MEMBER_CONSOLE_LIST_CLASS = "teams-event-list rounded-xl border border-slate-200 bg-slate-50/50 p-3";
-const MEMBER_CONSOLE_LIST_ITEM_CLASS = "rounded-lg border border-slate-200 bg-white p-2";
+  "mono mt-1 block min-w-0 whitespace-pre-wrap break-words text-ui-text-primary";
+const MEMBER_CONSOLE_DISCOVERY_CLASS = "mt-2 rounded-lg border border-ui-border bg-ui-surface p-2";
+const MEMBER_CONSOLE_LIST_CLASS = "teams-event-list rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
+const MEMBER_CONSOLE_LIST_ITEM_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
 const MEMBER_CONSOLE_EVENT_HEAD_CLASS =
-  "teams-event-head mb-1 flex items-center gap-2 text-xs text-slate-600";
-const MEMBER_CONSOLE_EMPTY_TEXT_CLASS = "muted text-sm text-slate-600";
+  "teams-event-head mb-1 flex flex-wrap items-center gap-2 text-ui-xs text-ui-text-muted";
+const MEMBER_CONSOLE_EMPTY_TEXT_CLASS = TEAM_MUTED_TEXT_CLASS;
+const MEMBER_CONSOLE_PROMPT_DETAILS_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
+const MEMBER_CONSOLE_PROMPT_SUMMARY_CLASS =
+  "cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-ui-text-muted";
 
 export function TeamMemberConsolePanel(props: TeamMemberConsolePanelProps) {
   const {
@@ -187,8 +192,8 @@ export function TeamMemberConsolePanel(props: TeamMemberConsolePanelProps) {
               </span>
             </div>
           </div>
-          <details className="rounded-lg border border-slate-200 bg-white p-2">
-            <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          <details className={MEMBER_CONSOLE_PROMPT_DETAILS_CLASS}>
+            <summary className={MEMBER_CONSOLE_PROMPT_SUMMARY_CLASS}>
               prompt
             </summary>
             <pre className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
@@ -198,7 +203,7 @@ export function TeamMemberConsolePanel(props: TeamMemberConsolePanelProps) {
           <div className={MEMBER_CONSOLE_DISCOVERY_CLASS}>
             <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>a2a_discovery_card</div>
             {memberDiscoveryCardLoading && (
-              <p className="mt-1 text-sm text-slate-600">Loading discovery card...</p>
+              <p className={`mt-1 ${TEAM_MUTED_TEXT_CLASS}`}>Loading discovery card...</p>
             )}
             {!memberDiscoveryCardLoading && memberDiscoveryCard && (
               <div className={MEMBER_CONSOLE_DETAIL_GRID_CLASS}>
@@ -249,7 +254,7 @@ export function TeamMemberConsolePanel(props: TeamMemberConsolePanelProps) {
               </div>
             )}
             {!memberDiscoveryCardLoading && !memberDiscoveryCard && (
-              <p className="mt-1 text-sm text-slate-600">
+              <p className={`mt-1 ${TEAM_MUTED_TEXT_CLASS}`}>
                 Discovery card unavailable for this member.
               </p>
             )}

--- a/web/src/pages/team_member_status_strip.tsx
+++ b/web/src/pages/team_member_status_strip.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from "react";
 import { StatusBadge, type StatusTone } from "../components/status_badge";
 import { TeamMemberAgentStatus } from "./team/member_helpers";
-import { TEAM_PANEL_CARD_CLASS, TEAM_PANEL_TITLE_CLASS } from "../ui/tailwind_classes";
+import {
+  TEAM_MUTED_TEXT_CLASS,
+  TEAM_PANEL_CARD_CLASS,
+  TEAM_PANEL_TITLE_CLASS,
+} from "../ui/tailwind_classes";
 
 type TeamMemberStatusStripProps = {
   members: TeamMemberAgentStatus[];
@@ -25,12 +29,22 @@ const TEAM_MEMBER_SUMMARY_STATUSES: TeamMemberLifecycle[] = [
 ];
 
 const TEAM_MEMBER_SUMMARY_BADGE_CLASS: Record<TeamMemberLifecycle, string> = {
-  working: "border-emerald-200 bg-emerald-50",
-  idle: "border-amber-200 bg-amber-50",
-  stopped: "border-slate-200 bg-slate-50",
-  missing: "border-rose-200 bg-rose-50",
-  unknown: "border-slate-200 bg-slate-50",
+  working:
+    "border-[color:var(--status-active-border)] bg-[color:var(--status-active-bg)] text-[color:var(--status-active-ink)]",
+  idle: "border-[color:var(--status-warning-border)] bg-[color:var(--status-warning-bg)] text-[color:var(--status-warning-ink)]",
+  stopped:
+    "border-[color:var(--status-inactive-border)] bg-[color:var(--status-inactive-bg)] text-[color:var(--status-inactive-ink)]",
+  missing:
+    "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger-ink)]",
+  unknown:
+    "border-[color:var(--status-neutral-border)] bg-[color:var(--status-neutral-bg)] text-[color:var(--status-neutral-ink)]",
 };
+
+const TEAM_MEMBER_SUMMARY_CLASS = "mono flex flex-wrap items-center gap-2 text-ui-xs text-ui-text-muted";
+const TEAM_MEMBER_CARD_CLASS =
+  "flex min-w-0 flex-col gap-1 rounded-lg border border-ui-border bg-ui-surface-soft/60 px-3 py-2";
+const TEAM_MEMBER_NAME_CLASS = "min-w-0 flex-1 truncate text-ui-sm font-semibold text-ui-text-primary";
+const TEAM_MEMBER_META_CLASS = "mono truncate text-ui-xs text-ui-text-muted";
 
 export function normalizeTeamMemberLifecycle(member: TeamMemberAgentStatus): TeamMemberLifecycle {
   if (member.missing_agent) {
@@ -84,7 +98,7 @@ export function TeamMemberStatusStrip({ members }: TeamMemberStatusStripProps) {
     <div className={`${TEAM_PANEL_CARD_CLASS} p-4`}>
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <h3 className={TEAM_PANEL_TITLE_CLASS}>Member Status</h3>
-        <div className="mono flex flex-wrap items-center gap-2 text-xs text-slate-600">
+        <div className={TEAM_MEMBER_SUMMARY_CLASS}>
           {TEAM_MEMBER_SUMMARY_STATUSES.map((status) => (
             <span
               key={status}
@@ -96,7 +110,7 @@ export function TeamMemberStatusStrip({ members }: TeamMemberStatusStripProps) {
         </div>
       </div>
       {members.length === 0 ? (
-        <p className="text-sm text-slate-600">No team members found in current team spec.</p>
+        <p className={TEAM_MUTED_TEXT_CLASS}>No team members found in current team spec.</p>
       ) : (
         <div className="grid min-w-0 gap-2 sm:grid-cols-2 xl:grid-cols-3">
           {members.map((member) => {
@@ -104,10 +118,10 @@ export function TeamMemberStatusStrip({ members }: TeamMemberStatusStripProps) {
             return (
               <div
                 key={member.member_id}
-                className="flex min-w-0 flex-col gap-1 rounded-lg border border-slate-200 bg-slate-50/60 px-3 py-2"
+                className={TEAM_MEMBER_CARD_CLASS}
               >
                 <div className="flex min-w-0 items-center justify-between gap-2">
-                  <span className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900">
+                  <span className={TEAM_MEMBER_NAME_CLASS}>
                     {member.member_id}
                   </span>
                   <StatusBadge
@@ -117,7 +131,7 @@ export function TeamMemberStatusStrip({ members }: TeamMemberStatusStripProps) {
                     title={`member status: ${member.status}`}
                   />
                 </div>
-                <div className="mono truncate text-xs text-slate-600">
+                <div className={TEAM_MEMBER_META_CLASS}>
                   role={member.role} agent={member.agent_name ?? "-"}
                 </div>
               </div>

--- a/web/src/pages/team_overview_panel.tsx
+++ b/web/src/pages/team_overview_panel.tsx
@@ -6,6 +6,7 @@ import {
   TEAM_LIST_ITEM_BASE_CLASS,
   TEAM_LIST_ITEM_META_CLASS,
   TEAM_LIST_ITEM_TITLE_CLASS,
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
   TEAM_PANEL_TITLE_CLASS,
   TEAM_PANEL_TOOLBAR_ACTIONS_CLASS,
@@ -21,20 +22,20 @@ type TeamOverviewPanelProps = {
 };
 
 const OVERVIEW_META_CLASS =
-  "teams-overview-meta mb-3 grid min-w-0 gap-2 rounded-xl border border-slate-200 bg-slate-50/70 p-3 text-sm text-slate-700 sm:grid-cols-2 xl:grid-cols-3";
+  "teams-overview-meta mb-3 grid min-w-0 gap-2 rounded-xl border border-ui-border bg-ui-surface-soft/70 p-3 text-ui-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3";
 const OVERVIEW_PLAYBOOK_CLASS =
-  "teams-overview-playbook mb-3 rounded-xl border border-slate-200 bg-white p-3";
+  "teams-overview-playbook mb-3 rounded-xl border border-ui-border bg-ui-surface p-3";
 const OVERVIEW_PLAYBOOK_GRID_CLASS = "grid gap-3 md:grid-cols-2";
-const OVERVIEW_PLAYBOOK_CARD_CLASS = "rounded-lg border border-slate-200 bg-slate-50/70 p-3";
-const OVERVIEW_PLAYBOOK_TITLE_CLASS = "text-xs font-semibold uppercase tracking-wide text-slate-500";
-const OVERVIEW_PLAYBOOK_LIST_CLASS = "mt-2 list-decimal space-y-1 pl-5 text-sm text-slate-700";
+const OVERVIEW_PLAYBOOK_CARD_CLASS = "rounded-lg border border-ui-border bg-ui-surface-soft/70 p-3";
+const OVERVIEW_PLAYBOOK_TITLE_CLASS =
+  "text-ui-xs font-semibold uppercase tracking-wide text-ui-text-muted";
+const OVERVIEW_PLAYBOOK_LIST_CLASS = "mt-2 list-decimal space-y-1 pl-5 text-ui-sm text-ui-text-secondary";
 const OVERVIEW_MEMBER_LIST_CLASS = "teams-member-list flex flex-col gap-2";
-const OVERVIEW_MEMBER_BUTTON_BASE_CLASS =
-  `team-member-row ${TEAM_LIST_ITEM_BASE_CLASS} border-slate-200`;
+const OVERVIEW_MEMBER_BUTTON_BASE_CLASS = `team-member-row ${TEAM_LIST_ITEM_BASE_CLASS}`;
 const OVERVIEW_MEMBER_BUTTON_ACTIVE_CLASS =
-  `${OVERVIEW_MEMBER_BUTTON_BASE_CLASS} border-slate-300 ring-1 ring-slate-200`;
+  `${OVERVIEW_MEMBER_BUTTON_BASE_CLASS} border-ui-border-strong bg-ui-surface-soft ring-1 ring-ui-border`;
 const OVERVIEW_MEMBER_BUTTON_IDLE_CLASS =
-  `${OVERVIEW_MEMBER_BUTTON_BASE_CLASS} hover:border-slate-300`;
+  `${OVERVIEW_MEMBER_BUTTON_BASE_CLASS} hover:border-ui-border-strong`;
 
 export function TeamOverviewPanel(props: TeamOverviewPanelProps) {
   const {
@@ -66,8 +67,8 @@ export function TeamOverviewPanel(props: TeamOverviewPanelProps) {
       </div>
 
       <div className={OVERVIEW_PLAYBOOK_CLASS}>
-        <h4 className="text-sm font-semibold text-slate-900">Cold Start Playbook</h4>
-        <p className="muted mt-1 text-sm text-slate-600">
+        <h4 className="text-ui-sm font-semibold text-ui-text-primary">Cold Start Playbook</h4>
+        <p className={`mt-1 ${TEAM_MUTED_TEXT_CLASS}`}>
           On each process start, both roles should check unfinished TODO items before consuming new
           mailbox tasks.
         </p>
@@ -93,7 +94,7 @@ export function TeamOverviewPanel(props: TeamOverviewPanelProps) {
         </div>
       </div>
 
-      {!snapshot && <p className="muted text-sm text-slate-600">No snapshot yet.</p>}
+      {!snapshot && <p className={TEAM_MUTED_TEXT_CLASS}>No snapshot yet.</p>}
 
       {snapshot && (
         <>

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -2028,6 +2028,32 @@ export function TeamPage(props: TeamPageProps) {
     `${teamDebugTabBaseClassName} bg-brand-primary text-ui-text-inverse shadow-sm`;
   const teamDebugTabIdleClassName =
     `${teamDebugTabBaseClassName} text-ui-text-muted hover:bg-ui-surface hover:text-ui-text-primary`;
+  const teamCreateModalHeaderClassName =
+    "modal-head flex flex-wrap items-start justify-between gap-3 border-b border-ui-border pb-3";
+  const teamCreateModalTitleClassName =
+    "text-lg font-semibold tracking-tight text-ui-text-primary";
+  const teamCreateStageClassName =
+    "team-create-stage flex min-h-[64px] flex-col items-start gap-1 rounded-xl border px-3 py-2 text-left transition";
+  const teamCreateStageActiveClassName =
+    `${teamCreateStageClassName} active border-brand-primary bg-brand-primary text-ui-text-inverse shadow-sm`;
+  const teamCreateStageCompletedClassName =
+    `${teamCreateStageClassName} completed border-[color:var(--status-active-border)] bg-[color:var(--status-active-bg)] text-[color:var(--status-active-ink)]`;
+  const teamCreateStageLockedClassName =
+    `${teamCreateStageClassName} locked cursor-not-allowed border-ui-border bg-ui-surface-muted text-ui-text-muted`;
+  const teamCreateStageIdleClassName =
+    `${teamCreateStageClassName} border-ui-border-strong bg-ui-surface text-ui-text-secondary hover:border-ui-border-emphasis hover:bg-ui-surface-soft`;
+  const teamCreateCheckItemReadyClassName =
+    "team-create-check-item ready flex items-center gap-2 rounded-lg border border-[color:var(--status-active-border)] bg-[color:var(--status-active-bg)] px-3 py-2 text-sm text-[color:var(--status-active-ink)]";
+  const teamCreateCheckItemPendingClassName =
+    "team-create-check-item pending flex items-center gap-2 rounded-lg border border-ui-border bg-ui-surface-soft px-3 py-2 text-sm text-ui-text-muted";
+  const teamCreateAgentEntryClassName =
+    "team-create-agent-entry rounded-xl border border-ui-border bg-ui-surface-soft/70 p-4";
+  const teamCreateForgeMetaClassName =
+    "team-create-forge-agent-meta mono mt-2 grid grid-cols-2 gap-2 rounded-lg border border-ui-border bg-ui-surface px-3 py-2 text-xs text-ui-text-muted";
+  const teamCreateLaunchMetaClassName =
+    "mono mt-3 grid min-w-0 gap-2 text-xs text-ui-text-secondary sm:grid-cols-3";
+  const teamCreateLaunchMetaItemClassName =
+    "rounded-lg border border-ui-border bg-ui-surface px-3 py-2";
   const modalFieldClassName =
     "w-full rounded-lg border border-ui-border-strong bg-ui-surface px-3 py-2 text-sm text-ui-text-primary shadow-sm outline-none transition focus:border-ui-border-emphasis focus:ring-2 focus:ring-ui-border disabled:cursor-not-allowed disabled:bg-ui-surface-muted disabled:text-ui-text-muted";
   const modalMonoFieldClassName = `${modalFieldClassName} font-mono text-xs leading-5`;
@@ -2378,7 +2404,7 @@ export function TeamPage(props: TeamPageProps) {
             </a>
           )}
           <button
-            className="rounded-[var(--radius-sm)] border-0 bg-[var(--ink)] px-[14px] py-2 font-semibold tracking-[0.01em] text-white transition hover:bg-slate-800"
+            className="rounded-[var(--radius-sm)] border-0 bg-[var(--ink)] px-[14px] py-2 font-semibold tracking-[0.01em] text-white transition hover:opacity-90"
             onClick={props.onLogout}
           >
             Logout
@@ -2927,8 +2953,8 @@ export function TeamPage(props: TeamPageProps) {
             aria-modal="true"
             aria-labelledby="team-create-title"
           >
-            <div className="modal-head flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-3">
-              <h3 id="team-create-title" className="text-lg font-semibold tracking-tight text-slate-900">
+            <div className={teamCreateModalHeaderClassName}>
+              <h3 id="team-create-title" className={teamCreateModalTitleClassName}>
                 Team Forge
               </h3>
               <div className="team-create-head-meta flex flex-wrap items-center gap-2">
@@ -2952,14 +2978,14 @@ export function TeamPage(props: TeamPageProps) {
                 return (
                   <button
                     key={title}
-                    className={`team-create-stage flex min-h-[64px] flex-col items-start gap-1 rounded-xl border px-3 py-2 text-left transition ${
+                    className={`${
                       isActive
-                        ? "active border-slate-900 bg-slate-900 text-white shadow-sm"
+                        ? teamCreateStageActiveClassName
                         : isCompleted
-                          ? "completed border-emerald-300 bg-emerald-50 text-emerald-700"
+                          ? teamCreateStageCompletedClassName
                           : isLocked
-                            ? "locked cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
-                          : "border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-50"
+                            ? teamCreateStageLockedClassName
+                          : teamCreateStageIdleClassName
                     }`}
                     onClick={() => onSelectCreateTeamStage(stageIndex)}
                     type="button"
@@ -2986,10 +3012,10 @@ export function TeamPage(props: TeamPageProps) {
                 {questChecklist.map((item) => (
                   <div
                     key={item.key}
-                    className={`team-create-check-item flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                    className={`${
                       item.ready
-                        ? "ready border-emerald-300 bg-emerald-50 text-emerald-700"
-                        : "pending border-slate-200 bg-slate-50 text-slate-600"
+                        ? teamCreateCheckItemReadyClassName
+                        : teamCreateCheckItemPendingClassName
                     }`}
                   >
                     <span
@@ -3004,9 +3030,9 @@ export function TeamPage(props: TeamPageProps) {
               </div>
 
               {createTeamStage !== 0 && !useSpecOverride && (
-                <div className="team-create-agent-entry rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+                <div className={teamCreateAgentEntryClassName}>
                   <div className="team-create-agent-entry-head flex flex-wrap items-center justify-between gap-2">
-                    <h4 className="text-base font-semibold text-slate-900">Agent Forge</h4>
+                    <h4 className={teamSectionTitleClassName}>Agent Forge</h4>
                     <button
                       className={panelSecondaryButtonClassName}
                       onClick={showForgeAgentForm ? closeForgeAgentForm : openForgeAgentForm}
@@ -3016,13 +3042,13 @@ export function TeamPage(props: TeamPageProps) {
                       {showForgeAgentForm ? "Hide" : "New Agent"}
                     </button>
                   </div>
-                  <p className="muted mt-2 text-sm text-slate-600">
+                  <p className={teamSectionBodyTextClassName}>
                     Role tag follows the current stage. In Team, worker is a role assigned to a
                     forged agent.
                   </p>
-                  <div className="team-create-forge-agent-meta mono mt-2 grid grid-cols-2 gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
+                  <div className={teamCreateForgeMetaClassName}>
                     <span>role_tag</span>
-                    <span className="text-slate-900">{forgeRoleTag ?? "-"}</span>
+                    <span className="text-ui-text-primary">{forgeRoleTag ?? "-"}</span>
                   </div>
                   {!canForgeAgentsInStage && (
                     <div className={TEAM_CREATE_NOTE_WARNING_CLASS}>
@@ -3039,9 +3065,9 @@ export function TeamPage(props: TeamPageProps) {
 
               {createTeamStage === 0 && (
                 <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
-                  <h4 className="text-base font-semibold text-slate-900">Mission Brief</h4>
+                  <h4 className={teamSectionTitleClassName}>Mission Brief</h4>
                   <div className="team-create-mission-intro mt-2">
-                    <p className="muted text-sm text-slate-600">
+                    <p className="text-sm text-ui-text-muted">
                       Pick a team name and description first. This is the party identity shown in
                       the workbench.
                     </p>
@@ -3073,8 +3099,8 @@ export function TeamPage(props: TeamPageProps) {
 
               {createTeamStage === 1 && (
                 <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
-                  <h4 className="text-base font-semibold text-slate-900">Leader Forge</h4>
-                  <p className="muted mt-2 text-sm text-slate-600">
+                  <h4 className={teamSectionTitleClassName}>Leader Forge</h4>
+                  <p className={teamSectionBodyTextClassName}>
                     Choose the leader from member agents created in this Team Forge session only.
                   </p>
                   {!isLeaderForgeReady && hasForgeAgents && (
@@ -3083,7 +3109,7 @@ export function TeamPage(props: TeamPageProps) {
                     </p>
                   )}
                   {!hasForgeAgents && (
-                    <p className="muted mt-2 text-sm text-slate-600">
+                    <p className={teamSectionBodyTextClassName}>
                       No forged agents yet. Create one in the Agent Forge entry above.
                     </p>
                   )}
@@ -3167,7 +3193,7 @@ export function TeamPage(props: TeamPageProps) {
               {createTeamStage === 2 && (
                 <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
                   <div className="flex flex-wrap items-center justify-between gap-3">
-                    <h4 className="text-base font-semibold text-slate-900">Recruit Workers</h4>
+                    <h4 className={teamSectionTitleClassName}>Recruit Workers</h4>
                     <div className="flex flex-wrap gap-2">
                       <button
                         className={panelSecondaryButtonClassName}
@@ -3188,7 +3214,7 @@ export function TeamPage(props: TeamPageProps) {
                       </button>
                     </div>
                   </div>
-                  <p className="muted mt-2 text-sm text-slate-600">
+                  <p className={teamSectionBodyTextClassName}>
                     Build your party from Team Forge member agents only. Worker is a role
                     assignment for those agents, and model/prompt/skills can still be customized at
                     team level.
@@ -3329,7 +3355,7 @@ export function TeamPage(props: TeamPageProps) {
                     })}
                   </div>
                   {workers.length === 0 && (
-                    <p className="muted mt-3 text-sm text-slate-600">
+                    <p className="mt-3 text-sm text-ui-text-muted">
                       No workers configured. Team will run with leader only.
                     </p>
                   )}
@@ -3353,27 +3379,27 @@ export function TeamPage(props: TeamPageProps) {
 
               {createTeamStage === 3 && (
                 <div className={TEAM_CREATE_PANEL_CARD_CLASS}>
-                  <h4 className="text-base font-semibold text-slate-900">Launch Team</h4>
-                  <p className="muted mt-2 text-sm text-slate-600">
+                  <h4 className={teamSectionTitleClassName}>Launch Team</h4>
+                  <p className={teamSectionBodyTextClassName}>
                     Final review before deployment.
                   </p>
-                  <div className="mono mt-3 grid min-w-0 gap-2 text-xs text-slate-700 sm:grid-cols-3">
-                    <span className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                  <div className={teamCreateLaunchMetaClassName}>
+                    <span className={teamCreateLaunchMetaItemClassName}>
                       team={newTeamName.trim() || "-"}
                     </span>
-                    <span className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                    <span className={teamCreateLaunchMetaItemClassName}>
                       leader={leaderMemberId.trim() || "-"}
                     </span>
-                    <span className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                    <span className={teamCreateLaunchMetaItemClassName}>
                       workers={configuredWorkerCount}
                     </span>
                   </div>
                   {useSpecOverride ? (
-                    <p className="muted mt-3 text-sm text-slate-600">
+                    <p className="mt-3 text-sm text-ui-text-muted">
                       Manual Spec entry: edit full team spec JSON directly.
                     </p>
                   ) : (
-                    <p className="muted mt-3 text-sm text-slate-600">
+                    <p className="mt-3 text-sm text-ui-text-muted">
                       Guided wizard generated this spec:
                       `leader_plan` → `worker_*` → `leader_synthesize`.
                     </p>

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -144,6 +144,7 @@ import {
   TEAM_CREATE_STEP_PREVIEW_CLASS,
   TEAM_CREATE_STEP_PREVIEW_MUTED_CLASS,
   TEAM_CREATE_WORKER_CARD_CLASS,
+  TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_GHOST_BUTTON_CLASS,
   TEAM_PANEL_INPUT_CLASS,
   TEAM_PANEL_PRIMARY_BUTTON_CLASS,
@@ -2002,16 +2003,33 @@ export function TeamPage(props: TeamPageProps) {
 
   const panelPrimaryButtonClassName = TEAM_PANEL_PRIMARY_BUTTON_CLASS;
   const panelSecondaryButtonClassName = TEAM_PANEL_SECONDARY_BUTTON_CLASS;
-  const panelInputClassName =
-    `${TEAM_PANEL_INPUT_CLASS} shadow-sm focus:border-slate-400 focus:ring-slate-300`;
+  const panelInputClassName = `${TEAM_PANEL_INPUT_CLASS} shadow-sm`;
   const runInputValidation = useMemo(() => validateRunInputJson(runInput), [runInput]);
   const runInputHasError = runInputValidation.error !== null;
   const canCreateRun = busy !== "create-run" && !runInputHasError;
   const canCompileMainTask = busy !== "compile-main-task" && selectedConversation !== null;
   const panelRefreshButtonClassName = TEAM_PANEL_REFRESH_BUTTON_CLASS;
   const panelGhostButtonClassName = TEAM_PANEL_GHOST_BUTTON_CLASS;
+  const teamSectionCardClassName =
+    "min-h-0 min-w-0 rounded-2xl border border-ui-border bg-ui-surface p-4 shadow-sm";
+  const teamSectionCardLargeClassName =
+    "min-h-0 rounded-2xl border border-ui-border bg-ui-surface p-5 shadow-sm";
+  const teamSectionHeadingClassName = "text-sm font-semibold text-ui-text-primary";
+  const teamSectionTitleClassName = "text-base font-semibold text-ui-text-primary";
+  const teamSectionBodyTextClassName = "mt-2 text-sm text-ui-text-muted";
+  const teamSectionHintTextClassName = "mt-2 text-xs text-ui-text-muted";
+  const teamRunMetaItemClassName =
+    "rounded-lg border border-ui-border bg-ui-surface-soft px-3 py-2";
+  const teamDebugTabsClassName =
+    "flex flex-wrap items-center gap-2 rounded-lg border border-ui-border bg-ui-surface-soft p-1";
+  const teamDebugTabBaseClassName =
+    "rounded-md px-3 py-1.5 text-xs font-medium transition sm:text-sm";
+  const teamDebugTabActiveClassName =
+    `${teamDebugTabBaseClassName} bg-brand-primary text-ui-text-inverse shadow-sm`;
+  const teamDebugTabIdleClassName =
+    `${teamDebugTabBaseClassName} text-ui-text-muted hover:bg-ui-surface hover:text-ui-text-primary`;
   const modalFieldClassName =
-    "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500";
+    "w-full rounded-lg border border-ui-border-strong bg-ui-surface px-3 py-2 text-sm text-ui-text-primary shadow-sm outline-none transition focus:border-ui-border-emphasis focus:ring-2 focus:ring-ui-border disabled:cursor-not-allowed disabled:bg-ui-surface-muted disabled:text-ui-text-muted";
   const modalMonoFieldClassName = `${modalFieldClassName} font-mono text-xs leading-5`;
   const onRefreshMainTasks = useCallback(async () => {
     if (!selectedTeamId) {
@@ -2123,9 +2141,9 @@ export function TeamPage(props: TeamPageProps) {
         formatTs={formatTs}
         toPrettyJson={toPrettyJson}
       />
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        <h4 className="text-sm font-semibold text-slate-900">Compile Conversation</h4>
-        <p className="muted mt-2 text-sm text-slate-600">
+      <div className={`${TEAM_PANEL_CARD_CLASS} p-4`}>
+        <h4 className={teamSectionHeadingClassName}>Compile Conversation</h4>
+        <p className={teamSectionBodyTextClassName}>
           Compile chat-approved conversation into a deterministic run payload preview.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -2136,7 +2154,7 @@ export function TeamPage(props: TeamPageProps) {
           >
             Compile Preview
           </button>
-          <span className="mono text-xs text-slate-500">
+          <span className="mono text-xs text-ui-text-muted">
             {selectedConversation
               ? `selected_conversation=${selectedConversation.title} [${selectedConversation.status}]`
               : "selected_conversation=-"}
@@ -2149,8 +2167,8 @@ export function TeamPage(props: TeamPageProps) {
           onChange={(event) => setCompilePreviewContextId(event.target.value)}
         />
         {compiledRunPreview ? (
-          <div className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <div className="mono text-xs text-slate-700">
+          <div className="mt-3 space-y-2 rounded-lg border border-ui-border bg-ui-surface-soft p-3">
+            <div className="mono text-xs text-ui-text-secondary">
               <div>
                 <strong>conversation_id:</strong> {compiledRunPreview.conversation_id}
               </div>
@@ -2175,7 +2193,7 @@ export function TeamPage(props: TeamPageProps) {
                 Create Run from Preview
               </button>
             </div>
-            <pre className="teams-step-body mono max-h-72 overflow-auto rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700">
+            <pre className="teams-step-body mono max-h-72 overflow-auto rounded-lg border border-ui-border bg-ui-surface px-3 py-2 text-xs text-ui-text-secondary">
               {toPrettyJson({
                 conversation_id: compiledRunPreview.conversation_id,
                 run_payload: compiledRunPreview.run_payload,
@@ -2183,7 +2201,7 @@ export function TeamPage(props: TeamPageProps) {
             </pre>
           </div>
         ) : (
-          <p className="mt-2 text-xs text-slate-500">
+          <p className={teamSectionHintTextClassName}>
             Select a conversation to preview compiled run payload.
           </p>
         )}
@@ -2193,9 +2211,9 @@ export function TeamPage(props: TeamPageProps) {
 
   const runOpsPanel = (
     <div className="space-y-3">
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        <h4 className="text-sm font-semibold text-slate-900">Create Run</h4>
-        <p className="muted mt-2 text-sm text-slate-600">
+      <div className={`${TEAM_PANEL_CARD_CLASS} p-4`}>
+        <h4 className={teamSectionHeadingClassName}>Create Run</h4>
+        <p className={teamSectionBodyTextClassName}>
           Debug entry for manually starting a Team run.
         </p>
         <div className="form-row mt-3">
@@ -2214,7 +2232,7 @@ export function TeamPage(props: TeamPageProps) {
             Create Run
           </button>
         </div>
-        <p className="mt-2 text-xs text-slate-500">
+        <p className={teamSectionHintTextClassName}>
           <code>context_id</code> can be empty. Use one when you want retries/resume grouped
           under the same context.
         </p>
@@ -2238,7 +2256,7 @@ export function TeamPage(props: TeamPageProps) {
             {runInputValidation.error}
           </p>
         ) : (
-          <p className="mt-2 text-xs text-slate-500">
+          <p className={teamSectionHintTextClassName}>
             Accepts any valid JSON value. Shortcut: Ctrl/Cmd + Enter to create run.
           </p>
         )}
@@ -2295,13 +2313,13 @@ export function TeamPage(props: TeamPageProps) {
             Clear
           </button>
         </div>
-        <p className="mt-2 text-xs text-slate-500">
+        <p className={teamSectionHintTextClassName}>
           Leave empty to submit default empty input <code>{`{}`}</code>.
         </p>
       </div>
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        <h4 className="text-sm font-semibold text-slate-900">Load Existing Run</h4>
-        <p className="muted mt-2 text-sm text-slate-600">
+      <div className={`${TEAM_PANEL_CARD_CLASS} p-4`}>
+        <h4 className={teamSectionHeadingClassName}>Load Existing Run</h4>
+        <p className={teamSectionBodyTextClassName}>
           Load by <code>run_id</code> for the currently selected team only.
         </p>
         <div className="form-row mt-3">
@@ -2411,9 +2429,11 @@ export function TeamPage(props: TeamPageProps) {
 
         <div className="teams-main flex min-h-0 min-w-0 flex-col gap-5 overflow-y-auto pb-2 pr-1 [&>*]:shrink-0">
           {!selectedTeam && (
-            <div className="min-h-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-              <h2 className="text-lg font-semibold text-slate-900">Team Workbench</h2>
-              <p className="mt-2 text-sm text-slate-600">
+            <div className={teamSectionCardLargeClassName}>
+              <h2 className="text-lg font-semibold tracking-tight text-ui-text-primary">
+                Team Workbench
+              </h2>
+              <p className={teamSectionBodyTextClassName}>
                 Select a team from the left panel to manage runs, steps, and messages.
               </p>
             </div>
@@ -2446,24 +2466,26 @@ export function TeamPage(props: TeamPageProps) {
               />
 
               {runsLoading && !activeRunForSelectedTeam && (
-                <div className="min-h-0 min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                  <p className="text-sm text-slate-600">Loading run context for selected team...</p>
+                <div className={teamSectionCardClassName}>
+                  <p className="text-sm text-ui-text-muted">
+                    Loading run context for selected team...
+                  </p>
                 </div>
               )}
 
               {!activeRunForSelectedTeam && !runsLoading && (
                 <>
-                  <div className="min-h-0 min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <h3 className="text-base font-semibold text-slate-900">Conversation</h3>
-                    <p className="mt-2 text-sm text-slate-600">
+                  <div className={teamSectionCardClassName}>
+                    <h3 className={teamSectionTitleClassName}>Conversation</h3>
+                    <p className={teamSectionBodyTextClassName}>
                       No active run is selected. Start with conversation planning before launching
                       a run.
                     </p>
                     <div className="mt-3">{conversationPanel}</div>
                   </div>
-                  <div className="min-h-0 min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <h3 className="text-base font-semibold text-slate-900">Debug Run Ops</h3>
-                    <p className="mt-2 text-sm text-slate-600">
+                  <div className={teamSectionCardClassName}>
+                    <h3 className={teamSectionTitleClassName}>Debug Run Ops</h3>
+                    <p className={teamSectionBodyTextClassName}>
                       Internal operations for manually creating or loading runs.
                     </p>
                     <div className="mt-3">{runOpsPanel}</div>
@@ -2473,9 +2495,9 @@ export function TeamPage(props: TeamPageProps) {
 
               {activeRunForSelectedTeam && !runsLoading && (
                 <>
-                  <div className="min-h-0 min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                  <div className={teamSectionCardClassName}>
                     <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-                      <h3 className="text-base font-semibold text-slate-900">Active Run</h3>
+                      <h3 className={teamSectionTitleClassName}>Active Run</h3>
                       <div className="flex flex-wrap items-center gap-2">
                         <button
                           className={panelRefreshButtonClassName}
@@ -2527,11 +2549,11 @@ export function TeamPage(props: TeamPageProps) {
                         </button>
                       </div>
                     </div>
-                    <div className="mt-3 grid min-w-0 gap-2 text-sm text-slate-700 sm:grid-cols-2 xl:grid-cols-3">
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                    <div className="mt-3 grid min-w-0 gap-2 text-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>ID:</strong> <code>{activeRunForSelectedTeam.id}</code>
                       </span>
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>Status:</strong>{" "}
                         <StatusBadge
                           label={activeRunForSelectedTeam.status}
@@ -2540,16 +2562,16 @@ export function TeamPage(props: TeamPageProps) {
                           title={`run status: ${activeRunForSelectedTeam.status}`}
                         />
                       </span>
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>Context:</strong> {activeRunForSelectedTeam.context_id}
                       </span>
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>Created:</strong> {formatTs(activeRunForSelectedTeam.created_at)}
                       </span>
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>Started:</strong> {formatTs(activeRunForSelectedTeam.started_at)}
                       </span>
-                      <span className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                      <span className={teamRunMetaItemClassName}>
                         <strong>Ended:</strong> {formatTs(activeRunForSelectedTeam.ended_at)}
                       </span>
                     </div>
@@ -2750,36 +2772,36 @@ export function TeamPage(props: TeamPageProps) {
 
                     {tab === "debug" && (
                       <>
-                        <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+                        <div className={`${TEAM_PANEL_CARD_CLASS} p-3`}>
                           <div className="flex flex-wrap items-center justify-between gap-3">
-                            <h3 className="text-sm font-semibold text-slate-900">Debug Tools</h3>
-                            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 p-1">
+                            <h3 className={teamSectionHeadingClassName}>Debug Tools</h3>
+                            <div className={teamDebugTabsClassName}>
                               <button
-                                className={`rounded-md px-3 py-1.5 text-xs font-medium transition sm:text-sm ${
+                                className={
                                   teamDebugTag === "run_ops"
-                                    ? "bg-slate-900 text-white shadow-sm"
-                                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-                                }`}
+                                    ? teamDebugTabActiveClassName
+                                    : teamDebugTabIdleClassName
+                                }
                                 onClick={() => setTeamDebugTag("run_ops")}
                               >
                                 Run Ops
                               </button>
                               <button
-                                className={`rounded-md px-3 py-1.5 text-xs font-medium transition sm:text-sm ${
+                                className={
                                   teamDebugTag === "step_ops"
-                                    ? "bg-slate-900 text-white shadow-sm"
-                                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-                                }`}
+                                    ? teamDebugTabActiveClassName
+                                    : teamDebugTabIdleClassName
+                                }
                                 onClick={() => setTeamDebugTag("step_ops")}
                               >
                                 Step Ops
                               </button>
                               <button
-                                className={`rounded-md px-3 py-1.5 text-xs font-medium transition sm:text-sm ${
+                                className={
                                   teamDebugTag === "mailbox_raw"
-                                    ? "bg-slate-900 text-white shadow-sm"
-                                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-                                }`}
+                                    ? teamDebugTabActiveClassName
+                                    : teamDebugTabIdleClassName
+                                }
                                 onClick={() => setTeamDebugTag("mailbox_raw")}
                               >
                                 Mailbox Raw

--- a/web/src/pages/team_run_panel.tsx
+++ b/web/src/pages/team_run_panel.tsx
@@ -6,6 +6,7 @@ import {
   TEAM_LIST_ITEM_ACTIVE_CLASS,
   TEAM_LIST_ITEM_IDLE_CLASS,
   TEAM_LIST_ITEM_TITLE_CLASS,
+  TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
   TEAM_PANEL_SECONDARY_BUTTON_CLASS,
   TEAM_PANEL_TOOLBAR_ACTIONS_CLASS,
@@ -20,13 +21,16 @@ type TeamRunStatusFilterOption = {
 };
 
 const RUN_PANEL_DELETE_BUTTON_CLASS =
-  "rounded-md border border-rose-200 bg-rose-50 px-2 py-1 text-sm text-rose-700 hover:border-rose-300 disabled:cursor-not-allowed disabled:opacity-60";
+  "rounded-md border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-1 text-sm text-[color:var(--status-danger-ink)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60";
 const RUN_PANEL_LIST_CLASS =
-  "teams-run-list flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50/50 p-4";
+  "teams-run-list flex flex-col gap-2 rounded-xl border border-ui-border bg-ui-surface-soft/60 p-4";
 const RUN_PANEL_LIST_HEAD_CLASS =
   "teams-run-list-head mb-2 flex flex-wrap items-center justify-between gap-2";
 const RUN_PANEL_LIST_ITEMS_CLASS = "teams-run-list-items flex max-h-80 flex-col gap-2 overflow-y-auto pr-1";
-const RUN_PANEL_SUBTITLE_CLASS = "mb-2 text-xs font-medium uppercase tracking-wide text-slate-500";
+const RUN_PANEL_SUBTITLE_CLASS = "mb-2 text-xs font-medium uppercase tracking-wide text-ui-text-muted";
+const RUN_PANEL_HINT_TEXT_CLASS = "text-sm text-ui-text-muted";
+const RUN_PANEL_LIST_TITLE_CLASS = "text-sm font-semibold text-ui-text-primary";
+const RUN_PANEL_FOOT_META_CLASS = "mono text-ui-xs text-ui-text-muted";
 
 type TeamRunPanelProps = {
   selectedTeam: TeamDefinitionRecord;
@@ -92,12 +96,12 @@ export function TeamRunPanel(props: TeamRunPanelProps) {
       </div>
       <div className={RUN_PANEL_LIST_CLASS}>
         <p className={RUN_PANEL_SUBTITLE_CLASS}>Run Browser</p>
-        <p className="muted text-sm">
+        <p className={TEAM_MUTED_TEXT_CLASS}>
           Team execution is agent-driven. You can quick-start here, or use <code>Debug → Run Ops</code>{" "}
           for manual run debugging.
         </p>
         <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-          <span className="text-sm text-slate-600">Quick start a new run for this team.</span>
+          <span className={RUN_PANEL_HINT_TEXT_CLASS}>Quick start a new run for this team.</span>
           <button
             onClick={() => {
               void onStartTeam();
@@ -111,7 +115,7 @@ export function TeamRunPanel(props: TeamRunPanelProps) {
           </button>
         </div>
         <div className={RUN_PANEL_LIST_HEAD_CLASS}>
-          <h3>Runs</h3>
+          <h3 className={RUN_PANEL_LIST_TITLE_CLASS}>Runs</h3>
           <div className={TEAM_PANEL_TOOLBAR_ACTIONS_CLASS}>
             <select
               className={`${TEAM_PANEL_INPUT_CLASS} min-w-0 sm:min-w-[164px]`}
@@ -141,10 +145,12 @@ export function TeamRunPanel(props: TeamRunPanelProps) {
         </div>
         <div className={RUN_PANEL_LIST_ITEMS_CLASS}>
           {visibleRuns.length === 0 && (
-            <p className="muted">No runs loaded yet. Use Debug → Run Ops to create or load runs.</p>
+            <p className={TEAM_MUTED_TEXT_CLASS}>
+              No runs loaded yet. Use Debug → Run Ops to create or load runs.
+            </p>
           )}
           {isActiveRunHiddenByFilter && activeRun && (
-            <p className="muted">
+            <p className={TEAM_MUTED_TEXT_CLASS}>
               Active run `{activeRun.id}` is hidden by filter `{runStatusFilter}`.
             </p>
           )}
@@ -169,7 +175,7 @@ export function TeamRunPanel(props: TeamRunPanelProps) {
           ))}
         </div>
         <div className="teams-run-list-foot flex flex-wrap items-center justify-between gap-2">
-          <span className="mono">
+          <span className={RUN_PANEL_FOOT_META_CLASS}>
             showing={visibleRuns.length} loaded={totalLoadedRunsForTeam} limit={pageLimit}
           </span>
           <button

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -94,7 +94,7 @@ export function TeamSidebar(props: TeamSidebarProps) {
       </div>
 
       <div className={TEAM_SIDEBAR_FORGE_CARD_CLASS}>
-        <h3 className="text-base font-semibold text-slate-900">Team Forge</h3>
+        <h3 className="text-base font-semibold text-ui-text-primary">Team Forge</h3>
         <p className={TEAM_MUTED_TEXT_CLASS}>Choose a creation entry: guided wizard or direct manual spec.</p>
         <div className={TEAM_SIDEBAR_INFO_CARD_CLASS}>
           <p className={TEAM_SIDEBAR_INFO_LABEL_CLASS}>

--- a/web/src/pages/team_steps_panel.tsx
+++ b/web/src/pages/team_steps_panel.tsx
@@ -46,11 +46,13 @@ type TeamStepsPanelProps = {
   onApplyStepAction: () => Promise<void> | void;
 };
 
-const STEPS_PANEL_CLASS = "teams-step-panel rounded-xl border border-slate-200 bg-slate-50/70 p-3";
-const STEPS_LIST_CLASS = "teams-step-list rounded-xl border border-slate-200 bg-slate-50/50 p-3";
+const STEPS_PANEL_CLASS = "teams-step-panel rounded-xl border border-ui-border bg-ui-surface-soft/70 p-3";
+const STEPS_LIST_CLASS = "teams-step-list rounded-xl border border-ui-border bg-ui-surface-soft/60 p-3";
 const STEPS_GRID_CLASS = "teams-step-grid grid gap-3 lg:grid-cols-2";
-const STEPS_PANEL_TITLE_CLASS = "mb-2 text-base font-semibold text-slate-900";
-const STEPS_ITEM_CLASS = "rounded-lg border border-slate-200 bg-white p-2";
+const STEPS_PANEL_TITLE_CLASS = "mb-2 text-ui-sm font-semibold text-ui-text-primary";
+const STEPS_ITEM_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
+const STEPS_LIST_ONLY_NOTE_CLASS =
+  "mb-3 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2 text-ui-sm text-state-warning-text";
 
 export function TeamStepsPanel(props: TeamStepsPanelProps) {
   const {
@@ -236,7 +238,7 @@ export function TeamStepsPanel(props: TeamStepsPanelProps) {
       )}
 
       {mode === "list_only" && (
-        <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <div className={STEPS_LIST_ONLY_NOTE_CLASS}>
           Step operations were moved to <strong>Debug -&gt; Step Ops</strong>.
         </div>
       )}


### PR DESCRIPTION
## Summary
This PR continues the Teams page style migration so Teams workbench visuals align with the Agents page token system.

Main direction in this wave:
- replace remaining `slate-*`/hardcoded panel styles in core Teams panels with shared `ui-*` and status tokens
- keep existing interaction/data flow unchanged (style-only scope)
- keep existing structural selectors (`teams-*`) used by behavior/tests

## Why
The Teams and Agents pages still had visible style drift in several workbench panels.
This change reduces style fragmentation and moves panels to shared design tokens, improving consistency and future maintainability.

## Scope
Updated files:
- `web/src/pages/team_page.tsx`
- `web/src/pages/team_run_panel.tsx`
- `web/src/pages/team_events_panel.tsx`
- `web/src/pages/team_member_status_strip.tsx`
- `web/src/pages/team_overview_panel.tsx`
- `web/src/pages/team_steps_panel.tsx`
- `web/src/pages/team_mailbox_panel.tsx`
- `web/src/pages/team_member_console_panel.tsx`
- `web/src/pages/team_main_task_panel.tsx`
- `web/src/pages/team_sidebar.tsx`

Notable panel migrations in this wave:
- run browser panel
- run events panel
- member status strip
- overview panel
- steps panel
- mailbox panel
- member console panel
- human-leader conversation panel
- team sidebar heading token alignment

## Validation
Local checks:

```bash
npm --prefix web run build
npm --prefix web run test -- team_panels team_page.runs
```

Result:
- build passed
- tests passed (`36/36`)

## Chrome DevTools MCP Verification
Used `agenthub.hawkingrei.com` for runtime verification.

Checked pages:
- `https://agenthub.hawkingrei.com/teams` (logged-in, no teams)

Observed:
- page loads correctly and reflects new built assets
- no new runtime console errors introduced by this PR
- existing known issue still present: form field missing `id`/`name`

## Related Issues
- N/A
