### PR TITLE
sync(codex-acp): migrate recent upstream runtime updates

### DIFF
--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -136,6 +136,8 @@ impl CodexAgent {
                 McpServer::Http(McpServerHttp {
                     name, url, headers, ..
                 }) => {
+                    // Codex does not allow whitespace in MCP server names; replace with underscores.
+                    let name = name.replace(|c: char| c.is_whitespace(), "_");
                     new_mcp_servers.insert(
                         name,
                         McpServerConfig {
@@ -167,6 +169,8 @@ impl CodexAgent {
                     env,
                     ..
                 }) => {
+                    // Codex does not allow whitespace in MCP server names; replace with underscores.
+                    let name = name.replace(|c: char| c.is_whitespace(), "_");
                     new_mcp_servers.insert(
                         name,
                         McpServerConfig {

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -18,7 +18,7 @@ use agent_client_protocol::{
     SessionMode, SessionModeId, SessionModeState, SessionModelState, SessionNotification,
     SessionUpdate, StopReason, Terminal, TextResourceContents, ToolCall, ToolCallContent,
     ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
-    UnstructuredCommandInput,
+    UnstructuredCommandInput, UsageUpdate,
 };
 use codex_apply_patch::parse_patch;
 use codex_core::{
@@ -37,9 +37,9 @@ use codex_core::{
         McpStartupUpdateEvent, McpToolCallBeginEvent, McpToolCallEndEvent, ModelRerouteEvent, Op,
         PatchApplyBeginEvent, PatchApplyEndEvent, ReasoningContentDeltaEvent,
         ReasoningRawContentDeltaEvent, ReviewDecision, ReviewOutputEvent, ReviewRequest,
-        ReviewTarget, SandboxPolicy, StreamErrorEvent, TerminalInteractionEvent, TurnAbortedEvent,
-        TurnCompleteEvent, TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent,
-        WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
+        ReviewTarget, SandboxPolicy, StreamErrorEvent, TerminalInteractionEvent, TokenCountEvent,
+        TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
+        ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
     },
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
@@ -48,6 +48,7 @@ use codex_protocol::{
     approvals::ElicitationRequestEvent,
     config_types::TrustLevel,
     custom_prompts::CustomPrompt,
+    items::TurnItem,
     mcp::CallToolResult,
     models::ResponseItem,
     openai_models::{ModelPreset, ReasoningEffort},
@@ -431,7 +432,6 @@ impl PromptState {
             | EventMsg::PatchApplyEnd(..)
             | EventMsg::TurnStarted(..)
             | EventMsg::TurnComplete(..)
-            | EventMsg::TokenCount(..)
             | EventMsg::TurnDiff(..)
             | EventMsg::TurnAborted(..)
             | EventMsg::EnteredReviewMode(..)
@@ -449,6 +449,19 @@ impl PromptState {
                 ..
             }) => {
                 info!("Task started with context window of {model_context_window:?}");
+            }
+            EventMsg::TokenCount(TokenCountEvent { info, .. }) => {
+                if let Some(info) = info
+                    && let Some(size) = info.model_context_window
+                {
+                    let used = info.last_token_usage.tokens_in_context_window().max(0) as u64;
+                    client
+                        .send_notification(SessionUpdate::UsageUpdate(UsageUpdate::new(
+                            used,
+                            size as u64,
+                        )))
+                        .await;
+                }
             }
             EventMsg::ItemStarted(ItemStartedEvent { thread_id, turn_id, item }) => {
 
@@ -567,6 +580,11 @@ impl PromptState {
             }
             EventMsg::ItemCompleted(ItemCompletedEvent { thread_id, turn_id, item }) => {
                 info!("Item completed: thread_id={}, turn_id={}, item={:?}", thread_id, turn_id, item);
+                // Notify the client when context compaction completes so users see
+                // a status message rather than silence during /compact.
+                if matches!(item, TurnItem::ContextCompaction(..)) {
+                    client.send_agent_text("Context compacted".to_string()).await;
+                }
             }
             EventMsg::TurnComplete(TurnCompleteEvent {
                 last_agent_message,
@@ -642,6 +660,9 @@ impl PromptState {
             }
             EventMsg::Warning(WarningEvent { message }) => {
                 warn!("Warning: {message}");
+                // Forward warnings to the client as agent messages so users see
+                // informational notices (e.g., the post-compact advisory message).
+                client.send_agent_text(message).await;
             }
             EventMsg::McpStartupUpdate(McpStartupUpdateEvent { server, status }) => {
                 info!("MCP startup update: server={server}, status={status:?}");
@@ -669,16 +690,18 @@ impl PromptState {
                 info!("Model reroute: from={from_model}, to={to_model}, reason={reason:?}");
             }
 
+            EventMsg::ContextCompacted(..) => {
+                info!("Context compacted");
+                client.send_agent_text("Context compacted".to_string()).await;
+            }
+
             // Ignore these events
             EventMsg::AgentReasoningRawContent(..)
             | EventMsg::ThreadRolledBack(..)
-            // In the future we can use this to update usage stats
-            | EventMsg::TokenCount(..)
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
             // Revisit when we can emit status updates
             | EventMsg::BackgroundEvent(..)
-            | EventMsg::ContextCompacted(..)
             | EventMsg::SkillsUpdateAvailable
             // Old events
             | EventMsg::AgentMessageDelta(..) | EventMsg::AgentReasoningDelta(..) | EventMsg::AgentReasoningRawContentDelta(..)
@@ -2866,7 +2889,7 @@ fn extract_slash_command(content: &[UserInput]) -> Option<(&str, &str)> {
 mod tests {
     use std::sync::atomic::AtomicUsize;
 
-    use agent_client_protocol::TextContent;
+    use agent_client_protocol::{TextContent, UsageUpdate};
     use codex_core::{
         config::ConfigOverrides, protocol::AgentMessageEvent, test_support::all_model_presets,
     };
@@ -2943,10 +2966,116 @@ mod tests {
             SessionUpdate::AgentMessageChunk(ContentChunk {
                 content: ContentBlock::Text(TextContent { text, .. }),
                 ..
-            }) if text == "Compact task completed"
+            }) if text == "Context compacted"
         ));
         let ops = thread.ops.lock().unwrap();
         assert_eq!(ops.as_slice(), &[Op::Compact]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_warning_forwarded_to_client() -> anyhow::Result<()> {
+        let (session_id, client, _, message_tx, local_set) = setup(vec![]).await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["warning-event".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                let stop_reason = prompt_response_rx.await??.await??;
+                assert_eq!(stop_reason, StopReason::EndTurn);
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let notifications = client.notifications.lock().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert!(matches!(
+            &notifications[0].update,
+            SessionUpdate::AgentMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                ..
+            }) if text == "warning from test"
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_context_compacted_event_forwarded() -> anyhow::Result<()> {
+        let (session_id, client, _, message_tx, local_set) = setup(vec![]).await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["context-compacted-event".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                let stop_reason = prompt_response_rx.await??.await??;
+                assert_eq!(stop_reason, StopReason::EndTurn);
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let notifications = client.notifications.lock().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert!(matches!(
+            &notifications[0].update,
+            SessionUpdate::AgentMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                ..
+            }) if text == "Context compacted"
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_token_count_emits_usage_update() -> anyhow::Result<()> {
+        let (session_id, client, _, message_tx, local_set) = setup(vec![]).await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["token-count-event".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                let stop_reason = prompt_response_rx.await??.await??;
+                assert_eq!(stop_reason, StopReason::EndTurn);
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let notifications = client.notifications.lock().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert!(matches!(
+            &notifications[0].update,
+            SessionUpdate::UsageUpdate(UsageUpdate { used, size, .. })
+                if *used == 123 && *size == 4096
+        ));
 
         Ok(())
     }
@@ -3637,6 +3766,71 @@ mod tests {
                             turn_id: turn_id.clone(),
                             last_agent_message: None,
                         }));
+                    } else if prompt == "warning-event" {
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::Warning(WarningEvent {
+                                    message: "warning from test".to_string(),
+                                }),
+                            })
+                            .unwrap();
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                                    turn_id: id.to_string(),
+                                    last_agent_message: None,
+                                }),
+                            })
+                            .unwrap();
+                    } else if prompt == "context-compacted-event" {
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::ContextCompacted(
+                                    codex_core::protocol::ContextCompactedEvent {},
+                                ),
+                            })
+                            .unwrap();
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                                    turn_id: id.to_string(),
+                                    last_agent_message: None,
+                                }),
+                            })
+                            .unwrap();
+                    } else if prompt == "token-count-event" {
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::TokenCount(TokenCountEvent {
+                                    info: Some(codex_core::protocol::TokenUsageInfo {
+                                        total_token_usage: codex_core::protocol::TokenUsage {
+                                            total_tokens: 123,
+                                            ..Default::default()
+                                        },
+                                        last_token_usage: codex_core::protocol::TokenUsage {
+                                            total_tokens: 123,
+                                            ..Default::default()
+                                        },
+                                        model_context_window: Some(4096),
+                                    }),
+                                    rate_limits: None,
+                                }),
+                            })
+                            .unwrap();
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                                    turn_id: id.to_string(),
+                                    last_agent_message: None,
+                                }),
+                            })
+                            .unwrap();
                     } else {
                         self.op_tx
                             .send(Event {
@@ -3683,8 +3877,14 @@ mod tests {
                     self.op_tx
                         .send(Event {
                             id: id.to_string(),
-                            msg: EventMsg::AgentMessage(AgentMessageEvent {
-                                message: "Compact task completed".to_string(),
+                            msg: EventMsg::ItemCompleted(ItemCompletedEvent {
+                                thread_id: codex_protocol::ThreadId::new(),
+                                turn_id: id.to_string(),
+                                item: TurnItem::ContextCompaction(
+                                    codex_protocol::items::ContextCompactionItem {
+                                        id: "compact-item".to_string(),
+                                    },
+                                ),
                             }),
                         })
                         .unwrap();

--- a/docs/journal/2026-03-05-codex-acp-upstream-sync.md
+++ b/docs/journal/2026-03-05-codex-acp-upstream-sync.md
@@ -1,0 +1,35 @@
+# 2026-03-05 Codex ACP Upstream Sync
+
+## Context
+
+`agenthub-codex-acp` was behind recent `zed-industries/codex-acp` updates that improved
+runtime visibility in ACP clients and compatibility of client-provided MCP server names.
+
+## Upstream Changes Migrated
+
+1. `678a99ec` (`src/codex_agent.rs`)
+- sanitize MCP server names by replacing whitespace with `_` before inserting into config.
+- applied for both `McpServer::Http` and `McpServer::Stdio`.
+
+2. `a2784322` (`src/thread.rs`)
+- forward `EventMsg::Warning` messages to ACP client stream.
+- surface context compaction completion as an agent-visible status message.
+- emit compaction status for both `EventMsg::ContextCompacted` and
+  `EventMsg::ItemCompleted(TurnItem::ContextCompaction(..))`.
+
+3. `34dc10c9` (`src/thread.rs`)
+- handle `EventMsg::TokenCount` and send `SessionUpdate::UsageUpdate`.
+- usage values map from `last_token_usage.tokens_in_context_window()` and
+  `model_context_window`.
+
+## Local Test Coverage Added
+
+- `test_warning_forwarded_to_client`
+- `test_context_compacted_event_forwarded`
+- `test_token_count_emits_usage_update`
+- updated `test_compact` to assert `"Context compacted"` behavior.
+
+## Validation
+
+- `cargo fmt --manifest-path agenthub-codex-acp/Cargo.toml`
+- `cargo test --manifest-path agenthub-codex-acp/Cargo.toml`


### PR DESCRIPTION
## Summary

This PR syncs recent upstream updates from `zed-industries/codex-acp` into `agenthub-codex-acp`.

### Migrated upstream changes

- `678a99ec` (`src/codex_agent.rs`)
  - sanitize MCP server names by replacing whitespace with `_` for both HTTP and stdio MCP server definitions.
- `a2784322` (`src/thread.rs`)
  - forward `EventMsg::Warning` to the ACP client stream.
  - surface context-compaction completion as visible client message.
- `34dc10c9` (`src/thread.rs`)
  - handle `EventMsg::TokenCount` and emit `SessionUpdate::UsageUpdate`.

### Local follow-up

- Added/updated tests for migrated behavior:
  - `test_compact` (updated assertion)
  - `test_warning_forwarded_to_client`
  - `test_context_compacted_event_forwarded`
  - `test_token_count_emits_usage_update`
- Added journal note:
  - `docs/journal/2026-03-05-codex-acp-upstream-sync.md`

## Why

`agenthub-codex-acp` was missing recent upstream runtime visibility and compatibility fixes. This keeps the codex app behavior aligned with upstream and improves client feedback during warning/compact/token-usage flows.

## Validation

- `cargo fmt --manifest-path agenthub-codex-acp/Cargo.toml`
- `cargo test --manifest-path agenthub-codex-acp/Cargo.toml`
  - Result: `29 passed, 0 failed`

## Related

- Upstream commits:
  - https://github.com/zed-industries/codex-acp/commit/678a99ec
  - https://github.com/zed-industries/codex-acp/commit/a2784322
  - https://github.com/zed-industries/codex-acp/commit/34dc10c9
