### PR TITLE
refactor: share Rust test binary and path helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol 0.9.5",
  "agenthub-acp-core",
+ "agenthub-config",
  "agenthub-text",
  "anyhow",
  "async-trait",

--- a/crates/agenthub-acp/BUILD.bazel
+++ b/crates/agenthub-acp/BUILD.bazel
@@ -21,6 +21,7 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(normal = True) + [
         "//crates/agenthub-acp-core:agenthub_acp_core",
+        "//crates/agenthub-config:agenthub_config",
         "//crates/agenthub-text:agenthub_text",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 agenthub-acp-core = { path = "../agenthub-acp-core" }
+agenthub-config = { path = "../agenthub-config" }
 agenthub-text = { path = "../agenthub-text" }
 agent-client-protocol = { version = "0.9.4", features = ["unstable"] }
 anyhow = "1"

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -32,6 +32,7 @@ use agenthub_acp_core::{
     AcpSkill, build_skill, build_skill_blocks, build_skills_meta, expand_tilde, extract_skill_name,
     filter_mcp_servers, parse_mcp_config, parse_skills_config,
 };
+use agenthub_config::path_utils::{is_path_allowed, normalize_path};
 use team_role_skills::{
     build_team_role_skills, is_reserved_team_role_skill, should_attach_team_role_skills,
 };
@@ -192,36 +193,6 @@ fn mcp_config_path() -> PathBuf {
 fn skills_config_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     Path::new(&home).join(SKILLS_CONFIG_FILE)
-}
-
-fn normalize_path(path: &str) -> String {
-    let mut parts = Vec::new();
-    for comp in std::path::Path::new(path).components() {
-        match comp {
-            std::path::Component::RootDir => parts.clear(),
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                parts.pop();
-            }
-            std::path::Component::Normal(seg) => {
-                parts.push(seg.to_string_lossy().to_string());
-            }
-            _ => {}
-        }
-    }
-    format!("/{}", parts.join("/"))
-}
-
-fn is_path_allowed(target: &str, allowed: &str) -> bool {
-    let target = normalize_path(target);
-    let allowed = normalize_path(allowed);
-    if target == allowed {
-        return true;
-    }
-    if !target.starts_with(&allowed) {
-        return false;
-    }
-    target.chars().nth(allowed.len()) == Some('/')
 }
 
 pub async fn load_safe_paths(db: &SqlitePool) -> anyhow::Result<Vec<String>> {

--- a/crates/agenthub-config/src/path_utils.rs
+++ b/crates/agenthub-config/src/path_utils.rs
@@ -19,9 +19,29 @@ pub fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+pub fn normalize_path(path: &str) -> String {
+    let mut normalized = std::path::PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized.to_string_lossy().to_string()
+}
+
+pub fn is_path_allowed(target: &str, allowed: &str) -> bool {
+    let target = normalize_path(target);
+    let allowed = normalize_path(allowed);
+    target == allowed || target.starts_with(&(allowed + std::path::MAIN_SEPARATOR_STR))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::expand_tilde;
+    use super::{expand_tilde, is_path_allowed, normalize_path};
 
     #[test]
     fn expand_tilde_uses_home_join_for_relative_paths() {
@@ -33,5 +53,21 @@ mod tests {
                 .to_string_lossy()
                 .to_string()
         );
+    }
+
+    #[test]
+    fn normalize_path_resolves_dot_and_parent() {
+        assert_eq!(normalize_path("/a/b/./c"), "/a/b/c");
+        assert_eq!(normalize_path("/a/b/../c"), "/a/c");
+        assert_eq!(normalize_path("/a/./b/../c/."), "/a/c");
+    }
+
+    #[test]
+    fn is_path_allowed_matches_exact_or_child() {
+        assert!(is_path_allowed("/home/foo", "/home/foo"));
+        assert!(is_path_allowed("/home/foo/bar", "/home/foo"));
+        assert!(is_path_allowed("/home/foo/bar/baz", "/home/foo/bar"));
+        assert!(!is_path_allowed("/home/foobar", "/home/foo"));
+        assert!(!is_path_allowed("/home/foo/../bar", "/home/foo"));
     }
 }

--- a/src/acp/runtime.rs
+++ b/src/acp/runtime.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use anyhow::{Context, ensure};
 
 use agenthub_acp::AcpActorSkillContext;
+#[cfg(test)]
+use crate::agenthub_binary::resolve_agenthub_binary_path;
 
 pub(crate) const DEFAULT_ACTOR_CHANNEL: &str = "default";
 
@@ -30,24 +32,9 @@ fn canonicalize_actor_cli_path(path: &str) -> anyhow::Result<PathBuf> {
         .with_context(|| format!("actor_runtime.actor_cli_path is invalid: {}", trimmed))
 }
 
-#[cfg(test)]
-fn resolve_test_binary_path() -> Option<PathBuf> {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_agenthub")
-        && let Ok(canonical) = std::fs::canonicalize(&path)
-    {
-        return Some(canonical);
-    }
-    let current = std::env::current_exe().ok()?;
-    let sibling = current
-        .parent()
-        .and_then(|parent| parent.parent())
-        .map(|dir| dir.join(format!("agenthub{}", std::env::consts::EXE_SUFFIX)))?;
-    std::fs::canonicalize(sibling).ok()
-}
-
 pub(crate) fn default_actor_cli_path() -> anyhow::Result<String> {
     #[cfg(test)]
-    let exe = resolve_test_binary_path()
+    let exe = resolve_agenthub_binary_path()
         .unwrap_or(std::env::current_exe().context("resolve current executable for actor cli")?);
     #[cfg(not(test))]
     let exe = std::env::current_exe().context("resolve current executable for actor cli")?;

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -21,10 +21,7 @@ use uuid::Uuid;
 use self::codec::acp_provider_for_agent_with_binary;
 #[cfg(test)]
 use self::codec::stream_to_str;
-use self::codec::{
-    expand_tilde, is_path_allowed, normalize_path, status_from_str, status_to_str, stream_from_str,
-    worktree_mode_from_opt, worktree_mode_to_str,
-};
+use self::codec::{status_from_str, status_to_str, stream_from_str, worktree_mode_from_opt, worktree_mode_to_str};
 use super::event_message_codec::{decode_message_from_storage, persist_agent_event};
 use super::{
     AgentConfig, AgentEvent, AgentOutput, AgentRecord, AgentStatus, OutputStream, WorktreeMode,
@@ -35,6 +32,7 @@ use crate::acp::{
     normalize_actor_context, spawn_acp_session,
 };
 use crate::auth::AuthService;
+use crate::path_utils::{expand_tilde, is_path_allowed, normalize_path};
 use crate::push::PushService;
 use agent_client_protocol::Implementation;
 use agenthub_db::{AgentEventDbRouter, AgentEventIdleGc};

--- a/src/agent/manager/codec.rs
+++ b/src/agent/manager/codec.rs
@@ -158,33 +158,3 @@ fn acp_provider_for_command_with_binary(
         }
     }
 }
-
-pub(super) fn normalize_path(path: &str) -> String {
-    let mut parts = Vec::new();
-    for comp in std::path::Path::new(path).components() {
-        match comp {
-            std::path::Component::RootDir => parts.clear(),
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                parts.pop();
-            }
-            std::path::Component::Normal(seg) => {
-                parts.push(seg.to_string_lossy().to_string());
-            }
-            _ => {}
-        }
-    }
-    format!("/{}", parts.join("/"))
-}
-
-pub(super) fn is_path_allowed(target: &str, allowed: &str) -> bool {
-    let target = normalize_path(target);
-    let allowed = normalize_path(allowed);
-    if target == allowed {
-        return true;
-    }
-    if !target.starts_with(&allowed) {
-        return false;
-    }
-    target.chars().nth(allowed.len()) == Some('/')
-}

--- a/src/agent/manager/codec.rs
+++ b/src/agent/manager/codec.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use crate::agent::{AgentStatus, OutputStream, WorktreeMode};
-pub(super) use crate::path_utils::expand_tilde;
 
 use super::{ACP_PROVIDER_CODEX, ACP_PROVIDER_GEMINI, ACP_PROVIDER_KIMI, AgentManager};
 

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -2,31 +2,16 @@ use super::codec::is_acp_message;
 use super::{
     ACP_PROVIDER_CODEX, ACP_PROVIDER_GEMINI, ACP_PROVIDER_KIMI, AgentRecord, AgentStatus,
     OutputStream, WorktreeMode, acp_provider_for_agent_with_binary, build_runtime_start_policy,
-    ensure_team_leader_workdir_exists, expand_tilde, is_path_allowed, normalize_path,
-    status_from_str, status_to_str, stream_from_str, stream_to_str,
+    ensure_team_leader_workdir_exists, status_from_str, status_to_str, stream_from_str,
+    stream_to_str,
 };
 use crate::acp::AcpActorSkillContext;
 use crate::acp::default_actor_cli_path;
+use crate::path_utils::expand_tilde;
 use std::sync::Mutex;
 use uuid::Uuid;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-#[test]
-fn normalize_path_resolves_dot_and_parent() {
-    assert_eq!(normalize_path("/a/b/./c"), "/a/b/c");
-    assert_eq!(normalize_path("/a/b/../c"), "/a/c");
-    assert_eq!(normalize_path("/a/./b/../c/."), "/a/c");
-}
-
-#[test]
-fn is_path_allowed_matches_exact_or_child() {
-    assert!(is_path_allowed("/home/foo", "/home/foo"));
-    assert!(is_path_allowed("/home/foo/bar", "/home/foo"));
-    assert!(is_path_allowed("/home/foo/bar/baz", "/home/foo/bar"));
-    assert!(!is_path_allowed("/home/foobar", "/home/foo"));
-    assert!(!is_path_allowed("/home/foo/../bar", "/home/foo"));
-}
 
 #[test]
 fn expand_tilde_uses_home() {

--- a/src/agenthub_binary.rs
+++ b/src/agenthub_binary.rs
@@ -1,0 +1,135 @@
+use std::path::{Path, PathBuf};
+
+const AGENTHUB_BINARY_NAME: &str = "agenthub";
+// Cargo exposes this as CARGO_BIN_EXE_<name>, where <name> is the binary target name as-is.
+const AGENTHUB_BINARY_ENV: &str = "CARGO_BIN_EXE_agenthub";
+
+pub(crate) fn resolve_agenthub_binary_path() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    resolve_agenthub_binary_path_from(current_exe.as_deref())
+}
+
+fn resolve_agenthub_binary_path_from(current_exe: Option<&Path>) -> Option<PathBuf> {
+    resolve_cargo_provided_agenthub_binary_path()
+        .or_else(|| resolve_sibling_agenthub_binary_path(current_exe))
+}
+
+fn resolve_cargo_provided_agenthub_binary_path() -> Option<PathBuf> {
+    let path = std::env::var(AGENTHUB_BINARY_ENV).ok()?;
+    std::fs::canonicalize(path).ok()
+}
+
+fn resolve_sibling_agenthub_binary_path(current_exe: Option<&Path>) -> Option<PathBuf> {
+    let current = current_exe?;
+    let sibling = current
+        .parent()
+        .and_then(|parent| parent.parent())
+        .map(|dir| {
+            dir.join(format!(
+                "{AGENTHUB_BINARY_NAME}{}",
+                std::env::consts::EXE_SUFFIX
+            ))
+        })?;
+    std::fs::canonicalize(sibling).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    use uuid::Uuid;
+
+    use super::*;
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct TempBinaryLayout {
+        root: PathBuf,
+        current_exe: PathBuf,
+        sibling_binary: PathBuf,
+        env_binary: PathBuf,
+    }
+
+    struct EnvVarGuard;
+
+    impl Drop for TempBinaryLayout {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var(AGENTHUB_BINARY_ENV);
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_agenthub_binary_path_prefers_cargo_env() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("lock env mutex");
+        let layout = create_temp_binary_layout();
+        let _env_guard = EnvVarGuard;
+        unsafe {
+            std::env::set_var(AGENTHUB_BINARY_ENV, &layout.env_binary);
+        }
+
+        let resolved = resolve_agenthub_binary_path_from(Some(&layout.current_exe))
+            .expect("resolve path from cargo env");
+
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&layout.env_binary).expect("canonical env binary")
+        );
+    }
+
+    #[test]
+    fn resolve_agenthub_binary_path_falls_back_to_sibling_binary() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("lock env mutex");
+        let layout = create_temp_binary_layout();
+        unsafe {
+            std::env::remove_var(AGENTHUB_BINARY_ENV);
+        }
+
+        let resolved = resolve_agenthub_binary_path_from(Some(&layout.current_exe))
+            .expect("resolve sibling binary");
+
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&layout.sibling_binary).expect("canonical sibling binary")
+        );
+    }
+
+    fn create_temp_binary_layout() -> TempBinaryLayout {
+        let root = std::env::temp_dir().join(format!("agenthub-binary-{}", Uuid::new_v4()));
+        let debug_dir = root.join("target").join("debug");
+        let deps_dir = debug_dir.join("deps");
+        let env_dir = root.join("env-bin");
+        std::fs::create_dir_all(&deps_dir).expect("create deps dir");
+        std::fs::create_dir_all(&env_dir).expect("create env dir");
+
+        let current_exe = deps_dir.join(format!("agenthub-tests{}", std::env::consts::EXE_SUFFIX));
+        let sibling_binary =
+            debug_dir.join(format!("{AGENTHUB_BINARY_NAME}{}", std::env::consts::EXE_SUFFIX));
+        let env_binary =
+            env_dir.join(format!("{AGENTHUB_BINARY_NAME}{}", std::env::consts::EXE_SUFFIX));
+
+        std::fs::write(&current_exe, b"test").expect("write current exe marker");
+        std::fs::write(&sibling_binary, b"test").expect("write sibling binary marker");
+        std::fs::write(&env_binary, b"test").expect("write env binary marker");
+
+        TempBinaryLayout {
+            root,
+            current_exe,
+            sibling_binary,
+            env_binary,
+        }
+    }
+}

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -17,6 +17,7 @@ use sqlx::{Row, SqlitePool};
 use tower::util::ServiceExt;
 use uuid::Uuid;
 
+use crate::agenthub_binary::resolve_agenthub_binary_path;
 use crate::acp::AcpActorSkillContext;
 use crate::acp::AcpPermissionService;
 use crate::acp::DEFAULT_ACTOR_CHANNEL;
@@ -87,31 +88,11 @@ fn team_member_actor_context_matches(
 fn resolve_test_agenthub_binary_path() -> String {
     TEST_AGENTHUB_BIN
         .get_or_init(|| {
-            if let Ok(path) = std::env::var("CARGO_BIN_EXE_agenthub") {
-                return std::fs::canonicalize(path)
-                    .expect("canonicalize cargo-provided agenthub binary path")
-                    .to_string_lossy()
-                    .to_string();
+            if let Some(path) = resolve_agenthub_binary_path() {
+                return path.to_string_lossy().to_string();
             }
 
             let current = std::env::current_exe().expect("resolve current test executable path");
-            let sibling = current
-                .parent()
-                .and_then(|parent| parent.parent())
-                .map(|dir| dir.join(format!("agenthub{}", std::env::consts::EXE_SUFFIX)))
-                .expect("resolve target dir for agenthub binary");
-            if sibling.exists() {
-                return std::fs::canonicalize(&sibling)
-                    .unwrap_or_else(|err| {
-                        panic!(
-                            "canonicalize derived agenthub binary path {}: {err}",
-                            sibling.display()
-                        )
-                    })
-                    .to_string_lossy()
-                    .to_string();
-            }
-
             panic!(
                 "resolve real agenthub binary path for tests from {}",
                 current.display()

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -2072,9 +2072,7 @@ async fn team_runs_api_paginates_high_volume_without_duplicates_and_honors_statu
             );
         }
 
-        for pair in page.windows(2) {
-            let current = &pair[0];
-            let next = &pair[1];
+        for [current, next] in page.array_windows::<2>() {
             assert!(
                 current.created_at > next.created_at
                     || (current.created_at == next.created_at && current.id > next.id),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "512"]
 
+#[cfg(test)]
+mod agenthub_binary;
 mod acp;
 mod actor_cli;
 mod actor_mcp;

--- a/src/team/runtime.rs
+++ b/src/team/runtime.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use crate::acp::{AcpActorSkillContext, DEFAULT_ACTOR_CHANNEL, default_actor_cli_path};
 use crate::agent::{AgentManager, AgentRecord, WorktreeMode};
-use crate::path_utils::expand_tilde;
+use crate::path_utils::{expand_tilde, is_path_allowed, normalize_path};
 use crate::team::{TeamDefinitionRecord, TeamRuntimeStatus};
 
 #[derive(Debug, thiserror::Error)]
@@ -235,31 +235,11 @@ fn collect_repo_candidates(safe_paths: &[String]) -> Vec<String> {
     candidates
 }
 
-fn normalize_path_for_compare(path: &str) -> String {
-    let mut normalized = std::path::PathBuf::new();
-    for component in Path::new(path).components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized.to_string_lossy().to_string()
-}
-
-fn path_is_allowed(target: &str, allowed: &str) -> bool {
-    let target = normalize_path_for_compare(target);
-    let allowed = normalize_path_for_compare(allowed);
-    target == allowed || target.starts_with(&(allowed + std::path::MAIN_SEPARATOR_STR))
-}
-
 fn safe_paths_allow(safe_paths: &[String], target: &str) -> bool {
     let expanded_target = expand_tilde(target);
     safe_paths.iter().any(|allowed| {
         let expanded_allowed = expand_tilde(allowed);
-        path_is_allowed(&expanded_target, &expanded_allowed)
+        is_path_allowed(&expanded_target, &expanded_allowed)
     })
 }
 
@@ -277,9 +257,9 @@ fn adjust_worker_runtime_workdir_for_safe_paths(
     }
 
     if safe_paths_allow(safe_paths, &config.workdir) {
-        let normalized_repo = normalize_path_for_compare(&expand_tilde(&config.worktree_repo));
-        let normalized_workdir = normalize_path_for_compare(&expand_tilde(&config.workdir));
-        if path_is_allowed(&normalized_workdir, &normalized_repo) {
+        let normalized_repo = normalize_path(&expand_tilde(&config.worktree_repo));
+        let normalized_workdir = normalize_path(&expand_tilde(&config.workdir));
+        if is_path_allowed(&normalized_workdir, &normalized_repo) {
             return Err(TeamRuntimeStartError::InvalidConfig(format!(
                 "legacy worker runtime workdir '{}' is inside repo '{}' and cannot derive a safe worktree root",
                 config.workdir, config.worktree_repo


### PR DESCRIPTION
## Summary

- add a test-only helper to resolve the `agenthub` binary path and centralize the Cargo env plus sibling-binary fallback
- replace the pagination ordering assertion with `array_windows::<2>()` for clearer adjacent-pair checks
- move path normalization and safe-path prefix checks into `agenthub-config::path_utils` and reuse them from the main service and `agenthub-acp`
- align `agenthub-acp` Cargo and Bazel deps with the new shared path helper location

## Purpose

- reduce duplicated path-comparison logic so safe-path behavior does not drift across runtime codepaths
- hide Cargo-specific binary-resolution details behind a project-specific helper
- simplify test/runtime helper code around the Rust 1.94 cleanup

## Related Issues

- N/A

## Testing

- Not run locally. The exact `1.94.0-x86_64-unknown-linux-gnu` rustup toolchain on this machine is currently inconsistent and needs reinstall before `cargo check` / `cargo test` can run against the repo-pinned toolchain.
