### PR TITLE
feat(actor): prefer text mailbox messages

### DIFF
--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -38,13 +38,13 @@ Team mailbox tools:
 2. Acknowledge a message after processing:
    `actor_ack` with `{{"run_id":"<run-id>","message_id": 123}}`
 3. Send a local message:
-   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","payload":{{"text":"..."}}}}`
+   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","text":"Please review this patch.\n\n- verify API shape\n- call out blockers"}}`
 4. Send a remote message:
-   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"remote-worker","transport":"remote","route":{{"endpoint":"https://..."}},"payload":{{"text":"..."}}}}`
+   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"remote-worker","transport":"remote","route":{{"endpoint":"https://..."}},"text":"Please review this patch.\n\n- verify API shape\n- call out blockers"}}`
 5. Force duplicate delivery when business logic requires repeated send:
-   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","allow_duplicate":true,"payload":{{"text":"..."}}}}`
+   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","allow_duplicate":true,"text":"Reminder:\n\n- update the test evidence\n- reply when done"}}`
 6. Use explicit idempotency key when coordinating retries across workers:
-   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","idempotency_key":"stable-key","payload":{{"text":"..."}}}}`
+   `actor_send` with `{{"run_id":"<run-id>","to_actor_id":"worker","idempotency_key":"stable-key","text":"Reminder:\n\n- update the test evidence\n- reply when done"}}`
 
 Team context tool:
 
@@ -58,15 +58,17 @@ Protocol rules:
 - Always pull inbox before starting a new coordination step.
 - In each turn, the first mailbox action must be `actor_inbox` before planning/coding.
 - Before routing work based on teammate assumptions, inspect `team_members`.
-- Treat `team_members` as the single Team context snapshot tool: it returns runtime summary, roster/card data, and optional run overlay.
+- Treat `team_members` as the single Team context snapshot tool: it returns runtime summary, roster/card data, per-member `pending_inbox_count`, and optional run overlay.
 - Treat `current_run_id` as a convenience default only; pass `run_id` explicitly whenever you are operating on a different run.
 - If inbox has pending items, process and `actor_ack` them before emitting final result.
 - Acknowledge each consumed message exactly once.
 - Keep payload JSON compact and deterministic.
+- Prefer `actor_send.text` for markdown-rich messages; it preserves formatting better than wrapping prose inside structured fields.
 - Use `channel` only when a non-default channel is required.
 - By default, `actor_send` auto-generates an idempotency key from message fields to prevent duplicate delivery on retries.
 - Reuse the same payload and routing fields when retrying; changing payload under the same idempotency key will be rejected.
 - Use `allow_duplicate=true` only when you intentionally need repeated delivery of equivalent payloads.
+- Use `payload` only when the receiver genuinely needs machine-readable fields such as `status`, `evidence`, or workflow metadata.
 "#,
         team_section = team_section,
         current_run_section = current_run_section,

--- a/docs/journal/2026-03-22-actor-send-text-first.md
+++ b/docs/journal/2026-03-22-actor-send-text-first.md
@@ -1,0 +1,28 @@
+# Actor Send Text-First Mailbox Contract
+
+## Summary
+
+- made `actor_send` prefer raw `text` for mailbox prose so markdown survives transport without being squeezed into structured fields
+- kept `payload` as the compatibility path for machine-readable coordination data
+- added explicit warnings when callers still use structured `payload` for `actor_send`
+- extended `team_members` so actor CLI/MCP sessions can see per-member `pending_inbox_count`
+
+## Details
+
+- MCP `actor_send` now accepts either `text` or `payload`
+- when `text` is used, the mailbox payload is stored as a raw JSON string value so markdown formatting stays intact
+- when `payload` is used, MCP returns a warning in `structuredContent.warning` recommending `text` for markdown-rich messages
+- CLI `agenthub actor send` now accepts `--text` in addition to `--payload-json`
+- CLI sends still preserve the existing structured payload path, but print a warning to `stderr` when `--payload-json` is used
+- `team_members` now includes `pending_inbox_count` for each member when a run-scoped context is available, so actors can see unread mailbox load without switching to a separate mailbox query
+- Team mailbox skill examples now recommend markdown text for task briefs and status updates, and keep structured payloads only for machine-readable coordination
+
+## Validation
+
+- `cargo test parse_send_accepts_text_and_preserves_markdown -- --nocapture`
+- `cargo test parse_send_payload_json_marks_payload_source_for_warning -- --nocapture`
+- `cargo test actor_runtime_skill_includes_context_and_native_tool_contract -- --nocapture`
+- `cargo test resolve_actor_send_payload_prefers_text_and_marks_payload_source -- --nocapture`
+- `cargo test actor_send_returns_warning_when_structured_payload_is_used -- --nocapture`
+- `cargo test describe_team_context_merges_runtime_summary_and_optional_run_overlay -- --nocapture`
+- `cargo test jsonrpc_team_members_returns_live_roster_view -- --nocapture`

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -7,7 +7,8 @@ name: team-actor-mailbox
 Use this skill for Team mailbox communication. It is the protocol reference for
 `actor inbox`, `actor send`, and `actor ack`.
 
-For Team runtime/roster context, use the single `team_members` tool. Do not
+For Team runtime/roster context, use the single `team_members` tool. It exposes
+runtime summary, roster/card data, and per-member `pending_inbox_count`. Do not
 invent a second Team context query path.
 Shared routing, mention, and human-visible reply policy remain canonical in
 `skills/team/AGENTS.md`; this skill only defines mailbox transport behavior.
@@ -50,12 +51,15 @@ Recommended fields:
 2. Parse message payload and validate required fields before acting.
 3. Acknowledge each consumed message exactly once:
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
-4. For internal execution coordination, send deterministic reply payloads with explicit status/evidence:
+4. For human-readable coordination, prefer markdown text and preserve it verbatim:
+   `MESSAGE="$(cat <<'EOF'\n## Status update\n\n- work finished\n- tests passed\n- next: wait for review\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$TARGET_ACTOR_ID" --text "$MESSAGE"`
+5. Use structured payloads only when the receiver truly needs machine-readable fields:
    `PAYLOAD_JSON="$(jq -cn --arg status "done|blocked" --arg result "..." --argjson evidence '["..."]' '{status:$status,result:$result,evidence:$evidence}')"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$TARGET_ACTOR_ID" --payload-json "$PAYLOAD_JSON"`
 
 ## Reply Modes
 
 - Internal execution coordination (`leader <-> worker`, worker status/evidence, blocker escalation):
+  - prefer plain markdown text for task briefs, review notes, and discussion so formatting survives mailbox transport
   - use structured payloads with `status`, `result`, `evidence`, and `next_action` when needed
   - include phase metadata only when it helps internal coordination
 - Human-facing team conversation replies:

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -191,7 +191,7 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 2. Acknowledge each consumed message once:
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
 3. Delegate with deterministic payload JSON:
-   `PAYLOAD_JSON="$(jq -cn --arg task "..." --arg acceptance "..." --arg deadline "..." '{task:$task,acceptance:$acceptance,deadline:$deadline}')"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$WORKER_ID" --payload-json "$PAYLOAD_JSON"`
+   `MESSAGE="$(cat <<'EOF'\n## Task brief\n\n- task: ...\n- acceptance: ...\n- deadline: ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$WORKER_ID" --text "$MESSAGE"`
 4. If a worker is blocked, ask for missing facts or re-scope the task.
 5. Keep a running decision log and conflict resolution summary.
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -129,7 +129,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
 3. Execute with minimal, auditable changes.
 4. Reply to leader with status and evidence:
-   `PAYLOAD_JSON="$(jq -cn --arg status "done|blocked" --arg result "..." --argjson evidence '["..."]' '{status:$status,result:$result,evidence:$evidence}')"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --payload-json "$PAYLOAD_JSON"`
+   `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: done|blocked\n- result: ...\n- evidence:\n  - ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
 5. Include phase metadata when reporting substantial progress:
    `{"phase":"communication_and_collaboration|consensus_formation|result_integration", ...}`
 6. Proactively advance the assigned task:

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -31,6 +31,12 @@ enum ActorOutputFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActorSendPayloadSource {
+    Text,
+    Payload,
+}
+
 enum ActorCommand {
     Help,
     TeamMembers {
@@ -57,13 +63,14 @@ enum ActorCommand {
         transport: TeamActorMessageTransport,
         route: Option<Value>,
         payload: Value,
+        payload_source: ActorSendPayloadSource,
         idempotency_key: Option<String>,
     },
 }
 
 fn actor_usage() -> String {
     format!(
-        "Usage:\n  agenthub actor [--json] team-members [--team-id <team_id>] [--run-id <run_id>]\n  agenthub actor [--json] inbox [--run-id <run_id>] [--actor-id <actor_id> | --agent-id <agent_id>] [--limit <n>] [--after-id <id>] [--include-delivered]\n  agenthub actor [--json] ack --message-id <id> [--run-id <run_id>] [--actor-id <actor_id> | --agent-id <agent_id>]\n  agenthub actor [--json] send --to-actor-id <actor_id> | --to-agent-id <agent_id> --payload-json <json> [--run-id <run_id>] [--from-actor-id <actor_id> | --from-agent-id <agent_id>] [--channel <name>] [--transport <local|remote>] [--route-json <json>] [--idempotency-key <key>] [--allow-duplicate]\n\nOutput:\n  Read-heavy results (`team-members`, `inbox`) default to TOON on stdout.\n  Confirmation results (`ack`, `send`) default to compact JSON for script compatibility.\n  `--json` forces JSON output for all structured success results.\n\nEnvironment fallback:\n  {}\n  {}\n  {}\n  {}\n  {}\n",
+        "Usage:\n  agenthub actor [--json] team-members [--team-id <team_id>] [--run-id <run_id>]\n  agenthub actor [--json] inbox [--run-id <run_id>] [--actor-id <actor_id> | --agent-id <agent_id>] [--limit <n>] [--after-id <id>] [--include-delivered]\n  agenthub actor [--json] ack --message-id <id> [--run-id <run_id>] [--actor-id <actor_id> | --agent-id <agent_id>]\n  agenthub actor [--json] send --to-actor-id <actor_id> | --to-agent-id <agent_id> (--text <markdown> | --payload-json <json>) [--run-id <run_id>] [--from-actor-id <actor_id> | --from-agent-id <agent_id>] [--channel <name>] [--transport <local|remote>] [--route-json <json>] [--idempotency-key <key>] [--allow-duplicate]\n\nOutput:\n  Read-heavy results (`team-members`, `inbox`) default to TOON on stdout.\n  Confirmation results (`ack`, `send`) default to compact JSON for script compatibility.\n  `--json` forces JSON output for all structured success results.\n\nEnvironment fallback:\n  {}\n  {}\n  {}\n  {}\n  {}\n",
         ACTOR_RUNTIME_TEAM_ID_ENV,
         ACTOR_RUNTIME_CURRENT_RUN_ID_ENV,
         ACTOR_RUNTIME_ACTOR_ID_ENV,
@@ -130,6 +137,25 @@ fn parse_i64(value: &str, field: &str) -> anyhow::Result<i64> {
 fn parse_json(value: &str, field: &str) -> anyhow::Result<Value> {
     serde_json::from_str::<Value>(value)
         .map_err(|err| anyhow::anyhow!("invalid {} JSON: {}", field, err))
+}
+
+fn resolve_actor_send_payload(
+    text: Option<String>,
+    payload: Option<Value>,
+) -> anyhow::Result<(Value, ActorSendPayloadSource)> {
+    match (text, payload) {
+        (Some(text), None) => {
+            if text.trim().is_empty() {
+                return Err(anyhow::anyhow!("text must be a non-empty string"));
+            }
+            Ok((Value::String(text), ActorSendPayloadSource::Text))
+        }
+        (None, Some(payload)) => Ok((payload, ActorSendPayloadSource::Payload)),
+        (Some(_), Some(_)) => Err(anyhow::anyhow!(
+            "--text and --payload-json cannot be used together"
+        )),
+        (None, None) => Err(anyhow::anyhow!("--text or --payload-json is required")),
+    }
 }
 
 fn take_required_with_env_keys(
@@ -363,6 +389,7 @@ fn parse_actor_command(
             let mut channel = None;
             let mut transport = None;
             let mut route = None;
+            let mut text = None;
             let mut payload = None;
             let mut idempotency_key = None;
             let mut allow_duplicate = false;
@@ -433,6 +460,14 @@ fn parse_actor_command(
                             .ok_or_else(|| anyhow::anyhow!("--route-json requires a value"))?;
                         route = Some(parse_json(raw, "route_json")?);
                     }
+                    "--text" => {
+                        idx += 1;
+                        text = Some(
+                            args.get(idx)
+                                .cloned()
+                                .ok_or_else(|| anyhow::anyhow!("--text requires a value"))?,
+                        );
+                    }
                     "--payload-json" => {
                         idx += 1;
                         let raw = args
@@ -476,7 +511,7 @@ fn parse_actor_command(
             )?;
             let to_actor_id = take_required_with_env_keys(to_actor_id, &[], "to_actor_id")?;
             let channel = take_optional(channel).unwrap_or(fallback_channel);
-            let payload = payload.ok_or_else(|| anyhow::anyhow!("payload_json is required"))?;
+            let (payload, payload_source) = resolve_actor_send_payload(text, payload)?;
             let explicit_idempotency_key = match idempotency_key {
                 Some(raw) => {
                     let trimmed = raw.trim();
@@ -530,6 +565,7 @@ fn parse_actor_command(
                 transport,
                 route,
                 payload,
+                payload_source,
                 idempotency_key: resolved_idempotency_key,
             })
         }
@@ -617,6 +653,7 @@ async fn run_actor_command(
             transport,
             route,
             payload,
+            payload_source,
             idempotency_key,
         } => {
             let db = agenthub_db::init_db().await?;
@@ -639,6 +676,11 @@ async fn run_actor_command(
                     idempotency_key: idempotency_key.as_deref(),
                 })
                 .await?;
+            if payload_source == ActorSendPayloadSource::Payload {
+                eprintln!(
+                    "warning: prefer --text for markdown-rich mailbox messages; --payload-json is best reserved for structured machine-readable coordination"
+                );
+            }
             write_actor_output(&message, output_mode, ActorOutputPreference::JsonPreferred)?;
         }
     }
@@ -870,8 +912,8 @@ mod tests {
             "remote-peer".to_string(),
             "--transport".to_string(),
             "remote".to_string(),
-            "--payload-json".to_string(),
-            r#"{"text":"hi"}"#.to_string(),
+            "--text".to_string(),
+            "hi".to_string(),
         ];
         assert!(
             parse_actor_command(&args, &mut ActorOutputMode::Default).is_err(),
@@ -897,8 +939,8 @@ mod tests {
             "send".to_string(),
             "--to-actor-id".to_string(),
             "reviewer".to_string(),
-            "--payload-json".to_string(),
-            r#"{"text":"hello"}"#.to_string(),
+            "--text".to_string(),
+            "hello".to_string(),
         ];
         let parsed = parse_actor_command(&args, &mut ActorOutputMode::Default).expect("parse send");
         match parsed {
@@ -930,8 +972,8 @@ mod tests {
             "send".to_string(),
             "--to-actor-id".to_string(),
             "reviewer".to_string(),
-            "--payload-json".to_string(),
-            r#"{"text":"hello"}"#.to_string(),
+            "--text".to_string(),
+            "hello".to_string(),
             "--allow-duplicate".to_string(),
         ];
         let parsed = parse_actor_command(&args, &mut ActorOutputMode::Default).expect("parse send");
@@ -966,8 +1008,8 @@ mod tests {
             "send".to_string(),
             "--to-actor-id".to_string(),
             "reviewer".to_string(),
-            "--payload-json".to_string(),
-            r#"{"text":"hello"}"#.to_string(),
+            "--text".to_string(),
+            "hello".to_string(),
             "--idempotency-key".to_string(),
             "k-1".to_string(),
             "--allow-duplicate".to_string(),
@@ -1052,18 +1094,116 @@ mod tests {
             "leader-agent".to_string(),
             "--to-agent-id".to_string(),
             "worker-agent".to_string(),
-            "--payload-json".to_string(),
-            r#"{"text":"hello"}"#.to_string(),
+            "--text".to_string(),
+            "hello".to_string(),
         ];
         let parsed = parse_actor_command(&args, &mut ActorOutputMode::Default).expect("parse send");
         match parsed {
             ActorCommand::Send {
                 from_actor_id,
                 to_actor_id,
+                payload_source,
                 ..
             } => {
                 assert_eq!(from_actor_id, "leader-agent");
                 assert_eq!(to_actor_id, "worker-agent");
+                assert_eq!(payload_source, ActorSendPayloadSource::Text);
+            }
+            _ => panic!("expected send command"),
+        }
+        restore_env(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, prev_current_run);
+        restore_env(ACTOR_RUNTIME_ACTOR_ID_ENV, prev_actor);
+        restore_env(ACTOR_RUNTIME_AGENT_ID_ENV, prev_agent);
+    }
+
+    #[test]
+    fn parse_send_accepts_text_and_preserves_markdown() {
+        let _guard = ENV_LOCK.lock().expect("lock env");
+        let prev_current_run = std::env::var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV).ok();
+        let prev_actor = std::env::var(ACTOR_RUNTIME_ACTOR_ID_ENV).ok();
+        let prev_agent = std::env::var(ACTOR_RUNTIME_AGENT_ID_ENV).ok();
+        unsafe {
+            std::env::set_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, "run-send-markdown");
+            std::env::set_var(ACTOR_RUNTIME_ACTOR_ID_ENV, "leader");
+            std::env::remove_var(ACTOR_RUNTIME_AGENT_ID_ENV);
+        }
+        let markdown = "## Review\n\n- keep markdown\n- keep spacing\n";
+        let args = vec![
+            "send".to_string(),
+            "--to-actor-id".to_string(),
+            "worker".to_string(),
+            "--text".to_string(),
+            markdown.to_string(),
+        ];
+        let parsed = parse_actor_command(&args, &mut ActorOutputMode::Default).expect("parse send");
+        match parsed {
+            ActorCommand::Send {
+                payload,
+                payload_source,
+                ..
+            } => {
+                assert_eq!(payload, Value::String(markdown.to_string()));
+                assert_eq!(payload_source, ActorSendPayloadSource::Text);
+            }
+            _ => panic!("expected send command"),
+        }
+        restore_env(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, prev_current_run);
+        restore_env(ACTOR_RUNTIME_ACTOR_ID_ENV, prev_actor);
+        restore_env(ACTOR_RUNTIME_AGENT_ID_ENV, prev_agent);
+    }
+
+    #[test]
+    fn parse_send_rejects_text_and_payload_json_together() {
+        let _guard = ENV_LOCK.lock().expect("lock env");
+        let prev_current_run = std::env::var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV).ok();
+        let prev_actor = std::env::var(ACTOR_RUNTIME_ACTOR_ID_ENV).ok();
+        let prev_agent = std::env::var(ACTOR_RUNTIME_AGENT_ID_ENV).ok();
+        unsafe {
+            std::env::set_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, "run-send-conflict");
+            std::env::set_var(ACTOR_RUNTIME_ACTOR_ID_ENV, "leader");
+            std::env::remove_var(ACTOR_RUNTIME_AGENT_ID_ENV);
+        }
+        let args = vec![
+            "send".to_string(),
+            "--to-actor-id".to_string(),
+            "worker".to_string(),
+            "--text".to_string(),
+            "hello".to_string(),
+            "--payload-json".to_string(),
+            r#"{"text":"hello"}"#.to_string(),
+        ];
+        let err = match parse_actor_command(&args, &mut ActorOutputMode::Default) {
+            Ok(_) => panic!("text and payload should conflict"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("--text and --payload-json"));
+        restore_env(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, prev_current_run);
+        restore_env(ACTOR_RUNTIME_ACTOR_ID_ENV, prev_actor);
+        restore_env(ACTOR_RUNTIME_AGENT_ID_ENV, prev_agent);
+    }
+
+    #[test]
+    fn parse_send_payload_json_marks_payload_source_for_warning() {
+        let _guard = ENV_LOCK.lock().expect("lock env");
+        let prev_current_run = std::env::var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV).ok();
+        let prev_actor = std::env::var(ACTOR_RUNTIME_ACTOR_ID_ENV).ok();
+        let prev_agent = std::env::var(ACTOR_RUNTIME_AGENT_ID_ENV).ok();
+        unsafe {
+            std::env::set_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, "run-send-payload");
+            std::env::set_var(ACTOR_RUNTIME_ACTOR_ID_ENV, "leader");
+            std::env::remove_var(ACTOR_RUNTIME_AGENT_ID_ENV);
+        }
+        let args = vec![
+            "send".to_string(),
+            "--to-actor-id".to_string(),
+            "worker".to_string(),
+            "--payload-json".to_string(),
+            r#"{"status":"done","result":"ok"}"#.to_string(),
+        ];
+        let parsed = parse_actor_command(&args, &mut ActorOutputMode::Default).expect("parse send");
+        match parsed {
+            ActorCommand::Send { payload_source, .. } => {
+                assert_eq!(payload_source, ActorSendPayloadSource::Payload);
             }
             _ => panic!("expected send command"),
         }

--- a/src/actor_mcp.rs
+++ b/src/actor_mcp.rs
@@ -66,6 +66,7 @@ struct ActorAckToolArgs {
 struct ActorSendToolArgs {
     run_id: Option<String>,
     to_actor_id: Option<String>,
+    text: Option<String>,
     payload: Option<Value>,
     channel: Option<String>,
     transport: Option<String>,
@@ -295,14 +296,22 @@ fn actor_tools() -> Vec<Value> {
         }),
         json!({
             "name": "actor_send",
-            "description": "Send a mailbox message from current actor to another actor.",
+            "description": "Send a mailbox message from current actor to another actor. Prefer text for markdown-rich replies; use payload only for structured machine-readable coordination.",
             "inputSchema": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["to_actor_id", "payload"],
+                "oneOf": [
+                    { "required": ["to_actor_id", "text"] },
+                    { "required": ["to_actor_id", "payload"] }
+                ],
                 "properties": {
                     "run_id": { "type": "string", "minLength": 1 },
                     "to_actor_id": { "type": "string", "minLength": 1 },
+                    "text": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Preferred raw mailbox text. Markdown is preserved as-is."
+                    },
                     "payload": {},
                     "channel": { "type": "string" },
                     "transport": { "type": "string", "enum": ["local", "remote"], "default": "local" },
@@ -515,6 +524,29 @@ fn resolve_tool_run_id(explicit: Option<String>, current: Option<&str>) -> Resul
     Err("run_id is required for this tool call".to_string())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActorSendPayloadSource {
+    Text,
+    Payload,
+}
+
+fn resolve_actor_send_payload(
+    text: Option<String>,
+    payload: Option<Value>,
+) -> Result<(Value, ActorSendPayloadSource), String> {
+    match (text, payload) {
+        (Some(text), None) => {
+            if text.trim().is_empty() {
+                return Err("text must be a non-empty string".to_string());
+            }
+            Ok((Value::String(text), ActorSendPayloadSource::Text))
+        }
+        (None, Some(payload)) => Ok((payload, ActorSendPayloadSource::Payload)),
+        (Some(_), Some(_)) => Err("text and payload cannot be used together".to_string()),
+        (None, None) => Err("text or payload is required".to_string()),
+    }
+}
+
 struct ResolveIdempotencyKeyInput<'a> {
     run_id: &'a str,
     from_actor_id: &'a str,
@@ -682,9 +714,9 @@ async fn tool_actor_send<S: ActorMailboxService + ?Sized>(
         Ok(value) => value,
         Err(err) => return tool_result_error(err.to_string(), None),
     };
-    let mut payload = match args.payload {
-        Some(payload) => payload,
-        None => return tool_result_error("payload is required", None),
+    let (mut payload, payload_source) = match resolve_actor_send_payload(args.text, args.payload) {
+        Ok(payload) => payload,
+        Err(err) => return tool_result_error(err, None),
     };
     let transport = match parse_actor_transport(args.transport.as_deref()) {
         Ok(transport) => transport,
@@ -753,6 +785,19 @@ async fn tool_actor_send<S: ActorMailboxService + ?Sized>(
         .await;
     match response {
         Ok(response) => {
+            let mut structured = json!({
+                "message_id": response.message_id,
+                "state": response.state,
+                "deduped": response.deduped,
+                "created_at": response.created_at,
+                "message": response.message,
+            });
+            if payload_source == ActorSendPayloadSource::Payload {
+                structured["warning"] = Value::String(
+                    "Prefer actor_send.text for markdown-rich mailbox messages; payload is best reserved for structured machine-readable coordination."
+                        .to_string(),
+                );
+            }
             if let Some(permission_id) = permission_review_request_id.as_deref()
                 && let Err(err) = permissions
                     .record_review_dispatch(
@@ -772,13 +817,7 @@ async fn tool_actor_send<S: ActorMailboxService + ?Sized>(
                     })),
                 );
             }
-            tool_result_success(json!({
-                "message_id": response.message_id,
-                "state": response.state,
-                "deduped": response.deduped,
-                "created_at": response.created_at,
-                "message": response.message,
-            }))
+            tool_result_success(structured)
         }
         Err(err) => tool_result_actor_service_error(err),
     }
@@ -1583,7 +1622,7 @@ pub async fn maybe_run_from_args() -> Option<anyhow::Result<()>> {
 mod tests {
     use super::*;
     use crate::api::team_tests::build_test_state;
-    use crate::team::TeamDefinitionConfig;
+    use crate::team::{SendActorMessageInput, TeamActorMessageTransport, TeamDefinitionConfig};
     use sqlx::Row;
     use uuid::Uuid;
 
@@ -2344,6 +2383,29 @@ mod tests {
     }
 
     #[test]
+    fn resolve_actor_send_payload_prefers_text_and_marks_payload_source() {
+        let markdown = "## Review\n\n- preserve markdown\n";
+        let (payload, source) = resolve_actor_send_payload(Some(markdown.to_string()), None)
+            .expect("resolve text payload");
+        assert_eq!(payload, Value::String(markdown.to_string()));
+        assert_eq!(source, ActorSendPayloadSource::Text);
+
+        let (payload, source) =
+            resolve_actor_send_payload(None, Some(json!({"status":"done","result":"ok"})))
+                .expect("resolve structured payload");
+        assert_eq!(payload, json!({"status":"done","result":"ok"}));
+        assert_eq!(source, ActorSendPayloadSource::Payload);
+    }
+
+    #[test]
+    fn resolve_actor_send_payload_rejects_conflicting_inputs() {
+        let err =
+            resolve_actor_send_payload(Some("hello".to_string()), Some(json!({"text":"hello"})))
+                .expect_err("text and payload should conflict");
+        assert!(err.contains("cannot be used together"));
+    }
+
+    #[test]
     fn resolve_tool_run_id_prefers_explicit_then_current_context() {
         assert_eq!(
             resolve_tool_run_id(Some("run-explicit".to_string()), Some("run-current"))
@@ -2615,7 +2677,7 @@ mod tests {
                 "name":"actor_send",
                 "arguments":{
                     "to_actor_id":"reviewer",
-                    "payload":{"task":"review patch"}
+                    "text":"## Review request\n\n- check the patch\n- report blockers"
                 }
             })),
         )
@@ -2666,6 +2728,10 @@ mod tests {
         assert_eq!(inbox_messages.len(), 1);
         assert_eq!(inbox_messages[0]["message_id"].as_i64(), Some(message_id));
         assert_eq!(inbox_messages[0]["status"], "delivered");
+        assert_eq!(
+            inbox_messages[0]["payload"],
+            Value::String("## Review request\n\n- check the patch\n- report blockers".to_string())
+        );
 
         let ack_resp = handle_jsonrpc_request(
             &tool_context,
@@ -2703,6 +2769,63 @@ mod tests {
             .expect("delivered messages");
         assert_eq!(delivered_messages.len(), 1);
         assert_eq!(delivered_messages[0]["status"], "delivered");
+    }
+
+    #[tokio::test]
+    async fn actor_send_returns_warning_when_structured_payload_is_used() {
+        let state = build_test_state().await;
+        let team = state
+            .teams
+            .create_team(TeamDefinitionConfig {
+                name: format!("actor-mcp-send-payload-warning-{}", Uuid::new_v4()),
+                description: Some("actor mcp payload warning".to_string()),
+                spec: json!({
+                    "entrypoint":"planner",
+                    "members":[{"member_id":"planner"},{"member_id":"reviewer"}]
+                }),
+            })
+            .await
+            .expect("create team");
+        let run = state
+            .teams
+            .create_run(
+                &team.id,
+                Some("ctx-actor-mcp-payload-warning"),
+                json!({"prompt":"go"}),
+            )
+            .await
+            .expect("create run");
+        let service = state.teams.actor_mailbox_service();
+        let permissions = AcpPermissionService::new(state.db.clone());
+        let context = ActorMcpContext {
+            team_id: Some(team.id),
+            current_run_id: Some(run.id),
+            actor_id: "planner".to_string(),
+            default_channel: "coordination".to_string(),
+        };
+
+        let response = tool_actor_send(
+            &service,
+            &state.teams,
+            &permissions,
+            &context,
+            Some(
+                json!({
+                    "to_actor_id":"reviewer",
+                    "payload":{"status":"done","result":"ok"}
+                })
+                .as_object()
+                .expect("payload args"),
+            ),
+        )
+        .await;
+        assert_eq!(response["isError"], Value::Bool(false), "{response}");
+        assert!(
+            response["structuredContent"]["warning"]
+                .as_str()
+                .is_some_and(|warning| warning.contains("Prefer actor_send.text")),
+            "missing payload warning: {response}"
+        );
     }
 
     #[tokio::test]
@@ -2824,6 +2947,22 @@ mod tests {
             .start_step(&leader_step.id, Some("session-leader"))
             .await
             .expect("start leader step");
+        state
+            .teams
+            .send_actor_message(SendActorMessageInput {
+                run_id: &run.id,
+                from_actor_id: "leader",
+                from_peer_id: ACTOR_MAIN_PEER_ID,
+                to_actor_id: "worker",
+                to_peer_id: ACTOR_MAIN_PEER_ID,
+                channel: "coordination",
+                transport: TeamActorMessageTransport::Local,
+                route: None,
+                payload: json!("## Review request\n\nPlease inspect the patch."),
+                idempotency_key: Some("team-members-unread-worker"),
+            })
+            .await
+            .expect("send unread worker mailbox message");
 
         let team_id = team.id.clone();
         let run_id = run.id.clone();
@@ -2889,12 +3028,14 @@ mod tests {
             .expect("members array");
         assert_eq!(members.len(), 2);
         assert_eq!(members[0]["display_name"], "Leader Agent");
+        assert_eq!(members[0]["pending_inbox_count"], 0);
         assert_eq!(members[0]["session_id"], "session-leader");
         assert_eq!(members[0]["session_status"], "running");
         assert_eq!(members[0]["steps"][0]["session_id"], "session-leader");
         assert_eq!(members[0]["steps"][0]["session_status"], "running");
         assert_eq!(members[1]["display_name"], "Worker Agent");
         assert_eq!(members[1]["description"], "Implements patches");
+        assert_eq!(members[1]["pending_inbox_count"], 1);
         assert_eq!(members[1]["session_id"], "session-worker");
         assert_eq!(members[1]["session_status"], "running");
         assert_eq!(members[1]["steps"][0]["status"], "submitted");
@@ -3184,6 +3325,8 @@ mod tests {
             .as_array()
             .expect("members array");
         assert_eq!(members.len(), 2);
+        assert_eq!(members[0]["pending_inbox_count"], 0);
+        assert_eq!(members[1]["pending_inbox_count"], 0);
         assert!(
             members[0]["steps"]
                 .as_array()

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -145,6 +145,7 @@ pub struct TeamRuntimeMemberRecord {
     pub display_name: String,
     pub role: String,
     pub description: Option<String>,
+    pub pending_inbox_count: i64,
     pub agent_status: Option<String>,
     pub session_id: Option<String>,
     pub session_status: Option<String>,
@@ -157,6 +158,7 @@ pub struct TeamRunMemberRecord {
     pub display_name: String,
     pub role: String,
     pub description: Option<String>,
+    pub pending_inbox_count: i64,
     pub agent_status: Option<String>,
     pub session_id: Option<String>,
     pub session_status: Option<String>,
@@ -899,6 +901,7 @@ impl TeamManager {
         let team = self.get_team(&run.team_id).await?;
         let members = parse_team_member_specs(&team.spec)?;
         let steps = self.list_steps(run_id).await?;
+        let pending_inbox_counts = self.list_actor_pending_counts_by_actor(run_id).await?;
 
         let mut steps_by_member = HashMap::<String, Vec<TeamStepRecord>>::new();
         let mut session_ids = Vec::new();
@@ -924,6 +927,10 @@ impl TeamManager {
 
         let mut out = Vec::with_capacity(members.len());
         for member in members {
+            let pending_inbox_count = pending_inbox_counts
+                .get(member.member_id.as_str())
+                .copied()
+                .unwrap_or(0);
             let display_name = agent_runtime_by_id
                 .get(member.member_id.as_str())
                 .map(|agent| agent.name.clone())
@@ -961,6 +968,7 @@ impl TeamManager {
                 display_name,
                 role: member.role,
                 description: member.description,
+                pending_inbox_count,
                 agent_status,
                 session_id,
                 session_status,
@@ -1010,6 +1018,7 @@ impl TeamManager {
                 display_name,
                 role: member.role,
                 description: member.description,
+                pending_inbox_count: 0,
                 agent_status,
                 session_id,
                 session_status,
@@ -3955,6 +3964,7 @@ fn team_run_member_from_runtime_member(member: TeamRuntimeMemberRecord) -> TeamR
         display_name: member.display_name,
         role: member.role,
         description: member.description,
+        pending_inbox_count: member.pending_inbox_count,
         agent_status: member.agent_status,
         session_id: member.session_id,
         session_status: member.session_status,

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -3923,6 +3923,22 @@ async fn describe_team_context_merges_runtime_summary_and_optional_run_overlay()
         .await
         .expect("start leader step");
 
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "leader",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!("## Review request\n\nPlease inspect the patch."),
+            idempotency_key: Some("ctx-unread-worker"),
+        })
+        .await
+        .expect("send unread worker message");
+
     let team_context = manager
         .describe_team_context(Some(&team.id), Some(&run.id))
         .await
@@ -3944,7 +3960,9 @@ async fn describe_team_context_merges_runtime_summary_and_optional_run_overlay()
     );
     assert_eq!(team_context.members.len(), 2);
     assert_eq!(team_context.members[0].display_name, "Leader Agent");
+    assert_eq!(team_context.members[0].pending_inbox_count, 0);
     assert_eq!(team_context.members[0].steps.len(), 1);
+    assert_eq!(team_context.members[1].pending_inbox_count, 1);
 
     let runtime_only_context = manager
         .describe_team_context(Some(&team.id), None)
@@ -3957,5 +3975,7 @@ async fn describe_team_context_merges_runtime_summary_and_optional_run_overlay()
     );
     assert!(runtime_only_context.run.is_none());
     assert_eq!(runtime_only_context.members.len(), 2);
+    assert_eq!(runtime_only_context.members[0].pending_inbox_count, 0);
+    assert_eq!(runtime_only_context.members[1].pending_inbox_count, 0);
     assert!(runtime_only_context.members[0].steps.is_empty());
 }


### PR DESCRIPTION
## Summary

- make `actor_send` prefer raw `text` so markdown-rich mailbox messages preserve formatting
- keep `payload` as the compatibility path for structured machine-readable coordination and emit warnings when it is used for prose
- expose per-member `pending_inbox_count` in `team_members` so actor CLI/MCP sessions can see unread mailbox load

## Changes

- add `actor_send.text` support to actor MCP and make `text`/`payload` mutually exclusive
- return an MCP warning in `structuredContent.warning` when `payload` is used
- add CLI `agenthub actor send --text` and print a stderr warning for `--payload-json`
- update actor runtime skill and Team mailbox skills to recommend text-first mailbox replies
- extend Team context records so `team_members` includes `pending_inbox_count`
- add/adjust focused tests for CLI parsing, MCP behavior, and Team context snapshots

## Validation

- `cargo test parse_send_accepts_text_and_preserves_markdown -- --nocapture`
- `cargo test parse_send_payload_json_marks_payload_source_for_warning -- --nocapture`
- `cargo test resolve_actor_send_payload_prefers_text_and_marks_payload_source -- --nocapture`
- `cargo test resolve_actor_send_payload_rejects_conflicting_inputs -- --nocapture`
- `cargo test actor_send_returns_warning_when_structured_payload_is_used -- --nocapture`
- `cargo test describe_team_context_merges_runtime_summary_and_optional_run_overlay -- --nocapture`
- `cargo test jsonrpc_team_members_returns_live_roster_view -- --nocapture`
- `cargo test -p agenthub-acp actor_runtime_skill_includes_context_and_native_tool_contract -- --nocapture`
