### PR TITLE
Strengthen team reporting and supervision skills

### DIFF
--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -19,7 +19,7 @@ timely way, and leaders actively supervise worker output and publish integrated 
   before a task is complete.
 - Leaders are expected to supervise reporting cadence and publish integrated progress updates to
   human-visible channels when team state materially changes.
-- Developer/code tasks now use `merge-ready against latest main` as the default completion bar.
+- Developer/code tasks now use merge-ready against latest `main` as the default completion bar.
 - Task delegation is now tied explicitly to worker identity cards so leader assignment and
   collaboration planning stay capability-aware.
 - Channel status updates now assume the underlying state has already been recorded in docs/tasks, so

--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -1,0 +1,22 @@
+## Summary
+
+Strengthened Team skill guidance so workers report progress, findings, and reusable experience in a
+timely way, and leaders actively supervise worker output and publish integrated progress updates.
+
+## Scope
+
+- update the shared Team reporting contract in `skills/team/AGENTS.md`
+- extend the runtime template progress log fields in `skills/team/TEAM_AGENTS.md`
+- strengthen leader supervision and progress-update expectations in
+  `skills/team/team-leader-orchestrator.SKILL.md`
+- strengthen worker progress/finding reporting expectations in
+  `skills/team/team-worker-executor.SKILL.md`
+
+## Notes
+
+- Reporting is now an explicit first-class contract, not an optional courtesy.
+- Findings, debugging experience, and reusable heuristics are treated as valuable outputs even
+  before a task is complete.
+- Leaders are expected to supervise reporting cadence and publish integrated progress updates to
+  human-visible channels when team state materially changes.
+- Developer/code tasks now use `merge-ready against latest main` as the default completion bar.

--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -28,3 +28,9 @@ timely way, and leaders actively supervise worker output and publish integrated 
   follow-up responsibility stay explicit.
 - Routine internal coordination can still happen directly through mailbox; the doc/task-first rule
   only applies when the discussion produces durable state that should be tracked.
+
+## Validation
+
+- No code or automated tests were run as part of this journal update.
+- Reviewed and updated Team skill guidance for reporting, card-aligned assignment, and mailbox
+  coordination.

--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -20,3 +20,5 @@ timely way, and leaders actively supervise worker output and publish integrated 
 - Leaders are expected to supervise reporting cadence and publish integrated progress updates to
   human-visible channels when team state materially changes.
 - Developer/code tasks now use `merge-ready against latest main` as the default completion bar.
+- Task delegation is now tied explicitly to worker identity cards so leader assignment and
+  collaboration planning stay capability-aware.

--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -26,3 +26,5 @@ timely way, and leaders actively supervise worker output and publish integrated 
   chat stays a summary layer instead of becoming the only durable execution record.
 - Channel status updates are also expected to `@` the relevant agents/people so ownership and
   follow-up responsibility stay explicit.
+- Routine internal coordination can still happen directly through mailbox; the doc/task-first rule
+  only applies when the discussion produces durable state that should be tracked.

--- a/docs/journal/2026-03-22-team-skill-reporting-guidance.md
+++ b/docs/journal/2026-03-22-team-skill-reporting-guidance.md
@@ -22,3 +22,7 @@ timely way, and leaders actively supervise worker output and publish integrated 
 - Developer/code tasks now use `merge-ready against latest main` as the default completion bar.
 - Task delegation is now tied explicitly to worker identity cards so leader assignment and
   collaboration planning stay capability-aware.
+- Channel status updates now assume the underlying state has already been recorded in docs/tasks, so
+  chat stays a summary layer instead of becoming the only durable execution record.
+- Channel status updates are also expected to `@` the relevant agents/people so ownership and
+  follow-up responsibility stay explicit.

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -78,12 +78,20 @@ restating the same rules.
   when blockers appear, and when work completes.
 - Default route: report to `@leader`; additionally report to the relevant channel or impacted peers
   when the update changes shared plans, dependencies, or human-visible progress.
+- When an update needs durable traceability, record it in the relevant document, TODO, journal, or
+  canonical Team task first; then use channel messages as the lightweight status broadcast.
+- Channel status messages should actively `@` the relevant agents/people instead of broadcasting
+  without ownership context.
 - Findings, debugging experience, reusable heuristics, and newly discovered risks are first-class
   outputs; report them even before implementation completes when they can change team decisions.
 - Silent execution is unacceptable for long-running or uncertain work; send a progress or blocker
   update instead of waiting for the final result.
 - Leader owns integrated progress updates to the human/channel and must ensure each active
   assignment has a next checkpoint and fresh evidence.
+- Documents and tasks are the source of truth for execution state; channel updates should summarize
+  that recorded state instead of becoming the only copy.
+- In channel updates, mention the owner, current reviewer, blocked dependency owner, or other
+  directly affected members so the right people are pulled into the thread immediately.
 - Task assignment should align with the assignee's identity card and current specialization; do not
   dispatch work that is unrelated to the worker's card unless the reassignment is explicit and justified.
 - For developer/code tasks, `completed` means the change is merge-ready against the latest `main`,

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -78,6 +78,8 @@ restating the same rules.
   when blockers appear, and when work completes.
 - Default route: report to `@leader`; additionally report to the relevant channel or impacted peers
   when the update changes shared plans, dependencies, or human-visible progress.
+- Internal discussion, clarification, dependency negotiation, and other routine coordination may go
+  directly through mailbox without first updating channel.
 - When an update needs durable traceability, record it in the relevant document, TODO, journal, or
   canonical Team task first; then use channel messages as the lightweight status broadcast.
 - Channel status messages should actively `@` the relevant agents/people instead of broadcasting
@@ -90,6 +92,7 @@ restating the same rules.
   assignment has a next checkpoint and fresh evidence.
 - Documents and tasks are the source of truth for execution state; channel updates should summarize
   that recorded state instead of becoming the only copy.
+- This durability rule applies to state/progress updates, not to every internal mailbox exchange.
 - In channel updates, mention the owner, current reviewer, blocked dependency owner, or other
   directly affected members so the right people are pulled into the thread immediately.
 - Task assignment should align with the assignee's identity card and current specialization; do not

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -76,12 +76,16 @@ restating the same rules.
 
 - Non-trivial assignments must be reported when work starts, when meaningful progress happens,
   when blockers appear, and when work completes.
-- Default route: report to `@leader`; additionally report to the relevant channel or impacted peers
-  when the update changes shared plans, dependencies, or human-visible progress.
+- Default route: report to the leader using their stable `@member_id` from runtime `AGENTS.md`;
+  additionally report to the relevant channel or impacted peers when the update changes shared
+  plans, dependencies, or human-visible progress.
 - Internal discussion, clarification, dependency negotiation, and other routine coordination may go
   directly through mailbox without first updating channel.
-- When an update needs durable traceability, record it in the relevant document, TODO, journal, or
-  canonical Team task first; then use channel messages as the lightweight status broadcast.
+- When an update needs durable traceability:
+  - workers: persist it in the relevant document, TODO, journal, note, or local evidence artifact,
+    then report that evidence to leader;
+  - leader: ensure the canonical Team task or coordination document reflects the latest recorded
+    state before using channel messages as the lightweight status broadcast.
 - Channel status messages should actively `@` the relevant agents/people instead of broadcasting
   without ownership context.
 - Findings, debugging experience, reusable heuristics, and newly discovered risks are first-class

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -11,6 +11,7 @@ restating the same rules.
 - Operate as one coordinated team for human goals.
 - Keep routing deterministic through `Mailbox -> ACP upstream -> MCP`.
 - Enforce role boundary: leader plans/synthesizes, workers execute/report evidence.
+- Keep execution visible with timely progress updates, findings, and reusable experience sharing.
 
 ## Core Contract
 
@@ -70,6 +71,21 @@ restating the same rules.
 4. communication and collaboration
 5. consensus formation
 6. result integration
+
+## Reporting Contract
+
+- Non-trivial assignments must be reported when work starts, when meaningful progress happens,
+  when blockers appear, and when work completes.
+- Default route: report to `@leader`; additionally report to the relevant channel or impacted peers
+  when the update changes shared plans, dependencies, or human-visible progress.
+- Findings, debugging experience, reusable heuristics, and newly discovered risks are first-class
+  outputs; report them even before implementation completes when they can change team decisions.
+- Silent execution is unacceptable for long-running or uncertain work; send a progress or blocker
+  update instead of waiting for the final result.
+- Leader owns integrated progress updates to the human/channel and must ensure each active
+  assignment has a next checkpoint and fresh evidence.
+- For developer/code tasks, `completed` means the change is merge-ready against the latest `main`,
+  not merely that a local patch exists.
 
 ## Routing To Skills
 

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -84,6 +84,8 @@ restating the same rules.
   update instead of waiting for the final result.
 - Leader owns integrated progress updates to the human/channel and must ensure each active
   assignment has a next checkpoint and fresh evidence.
+- Task assignment should align with the assignee's identity card and current specialization; do not
+  dispatch work that is unrelated to the worker's card unless the reassignment is explicit and justified.
 - For developer/code tasks, `completed` means the change is merge-ready against the latest `main`,
   not merely that a local patch exists.
 

--- a/skills/team/TEAM_AGENTS.md
+++ b/skills/team/TEAM_AGENTS.md
@@ -58,4 +58,7 @@ Keep runtime `AGENTS.md` minimal and role-scoped to control context size.
 
 - status: `pending|in_progress|completed|blocked`
 - latest update:
+- latest finding:
+- report target: `leader|channel|both`
 - next checkpoint:
+- overdue action:

--- a/skills/team/TEAM_AGENTS.md
+++ b/skills/team/TEAM_AGENTS.md
@@ -59,6 +59,6 @@ Keep runtime `AGENTS.md` minimal and role-scoped to control context size.
 - status: `pending|in_progress|completed|blocked`
 - latest update:
 - latest finding:
-- report target: `leader|channel|both`
+- report target: e.g. `leader`, `peers`, `channel`, `leader+peers`, `leader+channel`, or `both` (`leader+channel`)
 - next checkpoint:
 - overdue action:

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -60,6 +60,8 @@ Recommended fields:
 
 - Internal execution coordination (`leader <-> worker`, worker status/evidence, blocker escalation):
   - prefer plain markdown text for task briefs, review notes, and discussion so formatting survives mailbox transport
+  - routine clarification, dependency negotiation, and internal discussion can be resolved directly in mailbox
+    without first writing a channel update
   - use structured payloads with `status`, `result`, `evidence`, and `next_action` when needed
   - include phase metadata only when it helps internal coordination
 - Human-facing team conversation replies:
@@ -74,6 +76,8 @@ Recommended fields:
 - Keep messages idempotent-friendly; include stable identifiers in payloads.
 - If the same assignment is retried, return deterministic status updates.
 - If blocked, always include a concrete `next_action`.
+- When mailbox discussion changes durable execution state, follow up by recording that state in the
+  relevant doc/task artifact before or alongside any channel broadcast.
 
 ## Escalation Rules
 

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -54,7 +54,7 @@ Recommended fields:
 4. For human-readable coordination, prefer markdown text and preserve it verbatim:
    `MESSAGE="$(cat <<'EOF'\n## Status update\n\n- work finished\n- tests passed\n- next: wait for review\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$TARGET_ACTOR_ID" --text "$MESSAGE"`
 5. Use structured payloads only when the receiver truly needs machine-readable fields:
-   `PAYLOAD_JSON="$(jq -cn --arg status "done|blocked" --arg result "..." --argjson evidence '["..."]' '{status:$status,result:$result,evidence:$evidence}')"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$TARGET_ACTOR_ID" --payload-json "$PAYLOAD_JSON"`
+   `PAYLOAD_JSON="$(jq -cn --arg status "completed|blocked" --arg result "..." --argjson evidence '["..."]' '{status:$status,result:$result,evidence:$evidence}')"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$TARGET_ACTOR_ID" --payload-json "$PAYLOAD_JSON"`
 
 ## Reply Modes
 
@@ -93,11 +93,11 @@ Recommended fields:
 
 ## Output Contract Examples
 
-Done:
+Completed:
 
 ```json
 {
-  "status": "done",
+  "status": "completed",
   "result": "Implemented API validation and updated tests",
   "evidence": [
     "src/api/teams/router.rs",

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -214,6 +214,10 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
   log or project memory when they can help later tasks.
 - Send integrated progress updates to the human or shared channel whenever plan shape changes,
   major findings emerge, blockers threaten delivery, or milestones complete.
+- Before posting channel-level progress, make sure the underlying state is already reflected in the
+  relevant task/doc artifact so the channel message is a summary, not the only durable record.
+- In shared-channel progress updates, explicitly `@` the responsible workers, reviewers, and
+  affected stakeholders instead of posting anonymous team-wide status text.
 
 ## Collaboration Planning Contract
 
@@ -232,6 +236,8 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 - Assignment, ownership transfer, dependency requests, and review requests must mention the exact target members.
 - For cross-worker dependencies, mention both sides in the same message to reduce relay delay.
 - Use broadcast (no `@`) only for team-wide checkpoints or final integrated updates.
+- Even for team-wide checkpoints, include direct `@member_id` mentions for owners or blockers when
+  a follow-up action is expected from specific people.
 
 ## Task Status Discipline
 

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -16,6 +16,9 @@ You are the coordinator for a multi-agent team run.
 - Aggregate worker outputs and produce one final answer.
 - Communicate directly with the human actor for planning, decisions, and final delivery.
 - Operate as team architect and code reviewer for feature work.
+- Supervise worker execution quality, reporting cadence, and evidence freshness.
+- Publish integrated progress updates when team state, risks, or findings materially change.
+- Surface reusable findings and team lessons to the human/channel when they affect future work.
 
 ## AGENTS Index Contract
 
@@ -195,6 +198,19 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 4. If a worker is blocked, ask for missing facts or re-scope the task.
 5. Keep a running decision log and conflict resolution summary.
 
+## Reporting And Supervision Contract
+
+- Every active worker assignment must have an owner, latest status, latest evidence, and next
+  checkpoint recorded in leader coordination artifacts.
+- Require worker updates at assignment start, meaningful progress, blocker discovery, and
+  completion; do not wait for final delivery to learn state.
+- If a worker misses a checkpoint or sends low-evidence updates, follow up, re-scope, or reassign
+  the work instead of passively waiting.
+- Fold important worker findings, debugging experience, and reusable heuristics into the decision
+  log or project memory when they can help later tasks.
+- Send integrated progress updates to the human or shared channel whenever plan shape changes,
+  major findings emerge, blockers threaten delivery, or milestones complete.
+
 ## Mention Discipline
 
 - Leader should proactively route collaboration with explicit `@member_id` mentions.
@@ -216,6 +232,10 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 - Successful worker execution should normally land in `in_review`, not directly `completed`.
 - Move `in_review -> completed` only after review/acceptance is explicit.
 - Move `in_review -> in_progress` when changes are requested.
+- For developer/code tasks, treat `completed` as "merge-ready to latest `main`":
+  - required code and docs are in place
+  - conflicts against current `main` are resolved
+  - known review/CI blockers are addressed or explicitly accepted
 - Keep Kanban-aligned Team task state synchronized with worker evidence and mailbox checkpoints.
 - Before each coordination round, reconcile leader TODO status with actual team progress:
   - move active task to `in_progress`

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -113,9 +113,9 @@ Use this shared phase model for every team run:
 Phase execution contract:
 - `Team formation`: confirm available members, capability gaps, and operating assumptions.
 - `Task analysis`: decompose objective, risks, constraints, and acceptance criteria.
-- `Role assignment`: bind tasks to owners with deterministic payloads and deadlines.
-- `Role assignment`: match each task to the worker card that best fits the needed specialization,
-  then design collaboration edges only where combined cards increase throughput or reduce risk.
+- `Role assignment`: bind tasks to owners with deterministic payloads and deadlines; match each
+  task to the worker card that best fits the needed specialization, then design collaboration
+  edges only where combined cards increase throughput or reduce risk.
 - `Communication and collaboration`: drive checkpoint cadence and unblock workers.
 - `Consensus formation`: compare evidence, settle conflicts, and lock decisions.
 - `Result integration`: merge outputs into a single human-facing answer.

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -41,6 +41,7 @@ You are the coordinator for a multi-agent team run.
 - Routing keys, mention discipline, and human-facing reply rules are shared in `skills/team/AGENTS.md`.
 - In planning artifacts and payload examples, always reference teammates by stable `member_id`.
 - Treat `spec.members[].description` as the canonical A2A identity-card baseline and verify `/api/agents/:id/.well-known/agent-card` when role ownership is ambiguous.
+- Use worker identity cards as the default capability map for delegation and collaboration planning.
 - Record any required identity-card update checkpoints in leader coordination artifacts instead of duplicating policy here.
 - If your own leader description/prompt/skill profile needs correction, send `profile_patch_proposal`
   for your own member record; use `target="team"` for durable identity changes and `target="run"`
@@ -113,6 +114,8 @@ Phase execution contract:
 - `Team formation`: confirm available members, capability gaps, and operating assumptions.
 - `Task analysis`: decompose objective, risks, constraints, and acceptance criteria.
 - `Role assignment`: bind tasks to owners with deterministic payloads and deadlines.
+- `Role assignment`: match each task to the worker card that best fits the needed specialization,
+  then design collaboration edges only where combined cards increase throughput or reduce risk.
 - `Communication and collaboration`: drive checkpoint cadence and unblock workers.
 - `Consensus formation`: compare evidence, settle conflicts, and lock decisions.
 - `Result integration`: merge outputs into a single human-facing answer.
@@ -133,6 +136,7 @@ Apply this gate before assigning worker implementation steps.
 4. Clearance Checklist (all must be explicit before delegation):
    - objective and success criteria
    - in-scope and out-of-scope boundaries
+   - why the selected worker card is the right fit
    - technical approach and affected modules/interfaces
    - per-step acceptance criteria and evidence expectations
    - test/verification strategy
@@ -210,6 +214,17 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
   log or project memory when they can help later tasks.
 - Send integrated progress updates to the human or shared channel whenever plan shape changes,
   major findings emerge, blockers threaten delivery, or milestones complete.
+
+## Collaboration Planning Contract
+
+- Read worker cards before delegation and treat them as the primary source for capability matching.
+- Prefer assignments that fit one worker's card cleanly before creating cross-worker coordination.
+- Use worker collaboration intentionally:
+  - when one card covers implementation and another covers review, validation, or domain context
+  - when parallel slices are independent and the card split reduces cycle time
+  - when dependency handoff is explicit and cheaper than asking one mismatched worker to learn a new area
+- Do not assign work unrelated to a worker's card just because the worker is idle; either re-plan,
+  split the task differently, or make the reassignment explicit with rationale.
 
 ## Mention Discipline
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -134,6 +134,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Send blocker updates immediately with a concrete `next_action`.
 - Send completion updates with evidence plus any findings or reusable lessons discovered along the
   way.
+- Use mailbox directly for internal discussion, clarifications, and dependency coordination; do not
+  force those conversations through channel first.
 - If the update should persist beyond chat, write it into the relevant TODO, journal, note, or
   Team task evidence first; then send the channel/leader status message.
 - Report to `@leader` by default; additionally notify impacted peers or the shared channel when the
@@ -146,6 +148,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
   inefficient ownership split.
 - Do not let a channel update become the only record of execution state; durable state belongs in
   docs/tasks first.
+- Routine mailbox discussion does not need a prior doc/task write unless it changes durable state.
 - Avoid anonymous channel status messages when action is needed; use direct mentions to make the
   expected responder obvious.
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -30,6 +30,8 @@ findings.
   advance assigned tasks instead of inventing parallel task records.
 - Use stable `spec.members[].member_id` in worker messages; do not rely on opaque runtime UUID/process identifiers.
 - Keep worker identity in `spec.members[].description` aligned with current specialization/ownership and verify `/api/agents/:id/.well-known/agent-card` when status reports become ambiguous.
+- Treat your own identity card as the default boundary for accepted work; escalate to leader when the
+  assigned task is materially outside your card or would be better owned by another worker card.
 - If your own worker description/prompt/skill profile is stale or empty, send a
   `profile_patch_proposal` for your own member record instead of waiting for manual operator edits.
 - Use `target="team"` for durable identity-card changes and `target="run"` for temporary
@@ -136,6 +138,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
   discovery affects shared plans, dependencies, or future debugging work.
 - Persist reusable findings, debugging heuristics, and lessons in `.agenthubmemory/note/` and
   summarize them back to leader so the rest of the team can use them.
+- If the task-to-card fit is poor, report that mismatch early instead of silently continuing with an
+  inefficient ownership split.
 
 ## Worker Loop
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -4,7 +4,8 @@ name: team-worker-executor
 
 # Team Worker Executor
 
-You execute tasks assigned by the team leader and report verifiable outputs.
+You execute tasks assigned by the team leader, report verifiable outputs, and surface reusable
+findings.
 
 ## AGENTS Index Contract
 
@@ -86,6 +87,8 @@ Completion guardrails:
 - never mark task `completed` when acceptance is unmet
 - never mark task `completed` while unresolved errors/blockers remain
 - add follow-up TODO items when new required work is discovered
+- for developer/code tasks, do not report `done` until the branch is merge-ready against the latest
+  `main` or leader explicitly narrows the acceptance criteria
 
 ## Team Workflow Phases
 
@@ -121,6 +124,19 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 6. Persist durable project notes in `.agenthubmemory/journal/` and `.agenthubmemory/note/`; use
    `.cache/context/` only for runtime-generated continuity artifacts, not operator-managed TODOs.
 
+## Reporting Expectations
+
+- Send a start update when beginning a non-trivial assignment.
+- Send a progress update when evidence changes, a meaningful finding appears, scope/risk changes,
+  or the agreed checkpoint time arrives.
+- Send blocker updates immediately with a concrete `next_action`.
+- Send completion updates with evidence plus any findings or reusable lessons discovered along the
+  way.
+- Report to `@leader` by default; additionally notify impacted peers or the shared channel when the
+  discovery affects shared plans, dependencies, or future debugging work.
+- Persist reusable findings, debugging heuristics, and lessons in `.agenthubmemory/note/` and
+  summarize them back to leader so the rest of the team can use them.
+
 ## Worker Loop
 
 1. Pull inbox and find the latest unhandled assignment:
@@ -128,7 +144,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 2. Acknowledge after parsing the task:
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
 3. Execute with minimal, auditable changes.
-4. Reply to leader with status and evidence:
+4. Reply to leader with status, evidence, and findings:
    `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: done|blocked\n- result: ...\n- evidence:\n  - ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
 5. Include phase metadata when reporting substantial progress:
    `{"phase":"communication_and_collaboration|consensus_formation|result_integration", ...}`
@@ -154,6 +170,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Do not call `team_task_create` or `team_task_update`; raise the lifecycle change to leader.
 - When implementation evidence is ready, push the task toward `in_review`; do not treat worker
   completion as canonical Team task `completed`.
+- For developer/code tasks, "ready for review" should normally mean merge-ready or very close to
+  merge-ready against latest `main`, not just "local code compiles".
 - If review requests changes, resume execution from `in_progress` with updated acceptance notes.
 - Keep worker TODO state aligned with execution evidence; never skip status transitions.
 - If task tracking becomes stale (duplicate/resolved entries), compact TODO list and keep one authoritative active item.
@@ -172,6 +190,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - `status`: `done` or `blocked`
 - `result`: concise summary of what changed or what failed
 - `evidence`: command output snippets, file paths, test names
+- `finding`: optional concise discovery, lesson, or reusable heuristic
 - `next_action`: required when blocked
 - `phase`: recommended for non-trivial updates
 
@@ -184,3 +203,5 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Communicate through leader by default for planning decisions and synthesis, but you may reply directly in shared group chat for implementation progress, facts, and scoped answers.
 - Include current workflow phase in status updates when possible.
 - Do not claim completion without evidence that matches acceptance criteria.
+- Do not stay silent on non-trivial work past the agreed checkpoint; send an update even if the
+  result is only a new finding or an informed blocker.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -157,7 +157,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
 3. Execute with minimal, auditable changes.
 4. Reply to leader with status, evidence, and findings:
-   `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: done|blocked\n- result: ...\n- evidence:\n  - ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
+   `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: in_progress|done|blocked\n- result: ...\n- evidence:\n  - ...\n- finding: ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
 5. Include phase metadata when reporting substantial progress:
    `{"phase":"communication_and_collaboration|consensus_formation|result_integration", ...}`
 6. Proactively advance the assigned task:
@@ -186,7 +186,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
   merge-ready against latest `main`, not just "local code compiles".
 - If review requests changes, resume execution from `in_progress` with updated acceptance notes.
 - Keep worker TODO state aligned with execution evidence; never skip status transitions.
-- If task tracking becomes stale (duplicate/resolved entries), compact TODO list and keep one authoritative active item.
+- If task tracking becomes stale (duplicate/resolved entries), compact TODO list and keep
+  one authoritative active item.
 - Before reporting `done`, ensure acceptance evidence is attached and TODO state is `completed`.
 
 ## Shutdown Handling
@@ -199,7 +200,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 
 ## Response Contract
 
-- `status`: `done` or `blocked`
+- `status`: `in_progress`, `done`, or `blocked`
 - `result`: concise summary of what changed or what failed
 - `evidence`: command output snippets, file paths, test names
 - `finding`: optional concise discovery, lesson, or reusable heuristic

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -89,8 +89,8 @@ Completion guardrails:
 - never mark task `completed` when acceptance is unmet
 - never mark task `completed` while unresolved errors/blockers remain
 - add follow-up TODO items when new required work is discovered
-- for developer/code tasks, do not report `done` until the branch is merge-ready against the latest
-  `main` or leader explicitly narrows the acceptance criteria
+- for developer/code tasks, do not report `completed` until the branch is merge-ready against the
+  latest `main` or leader explicitly narrows the acceptance criteria
 
 ## Team Workflow Phases
 
@@ -136,10 +136,12 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
   way.
 - Use mailbox directly for internal discussion, clarifications, and dependency coordination; do not
   force those conversations through channel first.
-- If the update should persist beyond chat, write it into the relevant TODO, journal, note, or
-  Team task evidence first; then send the channel/leader status message.
-- Report to `@leader` by default; additionally notify impacted peers or the shared channel when the
-  discovery affects shared plans, dependencies, or future debugging work.
+- If the update should persist beyond chat, record it in the relevant TODO, journal, note, or
+  local evidence artifact first; then send the channel/leader status message and let leader update
+  the canonical Team task if needed.
+- By default, report to the leader using their stable `@member_id` from runtime `AGENTS.md`;
+  additionally notify impacted peers or the shared channel when the discovery affects shared plans,
+  dependencies, or future debugging work.
 - When posting to a shared channel, explicitly `@` the relevant owner, reviewer, dependency peer,
   or human stakeholder so the update has clear recipients.
 - Persist reusable findings, debugging heuristics, and lessons in `.agenthubmemory/note/` and
@@ -160,7 +162,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
    `MESSAGE_ID="<from inbox>"; "$AGENTHUB_ACTOR_CLI" actor ack --message-id "$MESSAGE_ID"`
 3. Execute with minimal, auditable changes.
 4. Reply to leader with status, evidence, and findings:
-   `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: in_progress|done|blocked\n- result: ...\n- evidence:\n  - ...\n- finding: ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
+   `MESSAGE="$(cat <<'EOF'\n## Execution update\n\n- status: in_progress|completed|blocked\n- result: ...\n- evidence:\n  - ...\n- finding: ...\nEOF\n)"; "$AGENTHUB_ACTOR_CLI" actor send --to-actor-id "$LEADER_ID" --text "$MESSAGE"`
 5. Include phase metadata when reporting substantial progress:
    `{"phase":"communication_and_collaboration|consensus_formation|result_integration", ...}`
 6. Proactively advance the assigned task:
@@ -170,7 +172,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 
 ## Mention Discipline
 
-- Proactively mention `@leader` in all non-trivial status/evidence updates.
+- Proactively mention the leader by stable `@member_id` in all non-trivial status/evidence updates.
 - Mention impacted peers directly for dependency handoff, interface changes, or blocker ownership.
 - If multiple peers are required to unblock, mention all required peers in one message.
 - Avoid broad broadcasts for actionable work items; use directed mentions to keep ownership explicit.
@@ -191,7 +193,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Keep worker TODO state aligned with execution evidence; never skip status transitions.
 - If task tracking becomes stale (duplicate/resolved entries), compact TODO list and keep
   one authoritative active item.
-- Before reporting `done`, ensure acceptance evidence is attached and TODO state is `completed`.
+- Before reporting `completed`, ensure acceptance evidence is attached and TODO state is
+  `completed`.
 
 ## Shutdown Handling
 
@@ -203,7 +206,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 
 ## Response Contract
 
-- `status`: `in_progress`, `done`, or `blocked`
+- `status`: `in_progress`, `completed`, or `blocked`
 - `result`: concise summary of what changed or what failed
 - `evidence`: command output snippets, file paths, test names
 - `finding`: optional concise discovery, lesson, or reusable heuristic

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -134,12 +134,20 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Send blocker updates immediately with a concrete `next_action`.
 - Send completion updates with evidence plus any findings or reusable lessons discovered along the
   way.
+- If the update should persist beyond chat, write it into the relevant TODO, journal, note, or
+  Team task evidence first; then send the channel/leader status message.
 - Report to `@leader` by default; additionally notify impacted peers or the shared channel when the
   discovery affects shared plans, dependencies, or future debugging work.
+- When posting to a shared channel, explicitly `@` the relevant owner, reviewer, dependency peer,
+  or human stakeholder so the update has clear recipients.
 - Persist reusable findings, debugging heuristics, and lessons in `.agenthubmemory/note/` and
   summarize them back to leader so the rest of the team can use them.
 - If the task-to-card fit is poor, report that mismatch early instead of silently continuing with an
   inefficient ownership split.
+- Do not let a channel update become the only record of execution state; durable state belongs in
+  docs/tasks first.
+- Avoid anonymous channel status messages when action is needed; use direct mentions to make the
+  expected responder obvious.
 
 ## Worker Loop
 


### PR DESCRIPTION
## Summary

- require timely worker progress reporting instead of silent long-running execution
- treat findings, debugging experience, and reusable heuristics as first-class worker outputs
- strengthen leader supervision, checkpoint tracking, and integrated progress reporting
- raise the default completion bar for developer tasks to merge-ready against latest `main`

## Scope

- update shared Team reporting rules in `skills/team/AGENTS.md`
- extend runtime progress-log fields in `skills/team/TEAM_AGENTS.md`
- strengthen leader supervision guidance in `skills/team/team-leader-orchestrator.SKILL.md`
- strengthen worker reporting/finding guidance in `skills/team/team-worker-executor.SKILL.md`
- document the policy update in `docs/journal/2026-03-22-team-skill-reporting-guidance.md`

## Validation

- no code/test run; this is a Team skill and documentation change only