### PR TITLE
test(team): extend channel mailbox coverage

### DIFF
--- a/crates/agenthub-team-actor/src/idempotency.rs
+++ b/crates/agenthub-team-actor/src/idempotency.rs
@@ -249,4 +249,43 @@ mod tests {
         assert_eq!(key_a, key_b);
         assert!(key_a.starts_with("auto:channel:v1:"));
     }
+
+    #[test]
+    fn channel_fanout_idempotency_key_is_stable_per_recipient() {
+        let base = "auto:channel:v1:abc";
+        let reviewer_a = build_actor_channel_fanout_idempotency_key(base, "reviewer-a");
+        let reviewer_a_retry = build_actor_channel_fanout_idempotency_key(base, "reviewer-a");
+        let reviewer_b = build_actor_channel_fanout_idempotency_key(base, "reviewer-b");
+
+        assert_eq!(reviewer_a, reviewer_a_retry);
+        assert_ne!(reviewer_a, reviewer_b);
+        assert!(reviewer_a.starts_with("fanout:v1:"));
+    }
+
+    #[test]
+    fn default_channel_idempotency_key_changes_when_channel_target_changes() {
+        let payload = json!({"text":"hello"});
+        let all_key = build_default_actor_channel_idempotency_key(
+            "run-1",
+            "planner",
+            ACTOR_MAIN_PEER_ID,
+            "all",
+            "coordination",
+            "local",
+            None,
+            &payload,
+        );
+        let reviewers_key = build_default_actor_channel_idempotency_key(
+            "run-1",
+            "planner",
+            ACTOR_MAIN_PEER_ID,
+            "reviewers",
+            "coordination",
+            "local",
+            None,
+            &payload,
+        );
+
+        assert_ne!(all_key, reviewers_key);
+    }
 }

--- a/docs/journal/2026-03-22-team-channel-coverage-followup.md
+++ b/docs/journal/2026-03-22-team-channel-coverage-followup.md
@@ -1,0 +1,22 @@
+## Summary
+
+Added focused test coverage for the Team channel mailbox helpers and actor channel idempotency helpers on `main`.
+
+## What changed
+
+- Added mailbox helper unit tests in `src/team/manager/mailbox.rs` covering:
+  - channel payload normalization for string/non-object inputs
+  - deterministic correlation-id fallback behavior
+  - channel mailbox forward payload metadata + mention propagation
+  - human-visible chat reply persistence guardrails
+  - canonical chat reply extraction from stringified JSON payloads
+- Added idempotency helper unit tests in `crates/agenthub-team-actor/src/idempotency.rs` covering:
+  - per-recipient fanout idempotency determinism
+  - channel target changes producing distinct default idempotency keys
+
+## Validation
+
+- `cargo test -p agenthub-team-actor --lib idempotency::tests -- --nocapture`
+- `cargo test team::manager::mailbox::tests -- --nocapture`
+- `cargo fmt -- crates/agenthub-team-actor/src/idempotency.rs src/team/manager/mailbox.rs`
+- `git -c core.fsmonitor=false diff --check`

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -1797,3 +1797,160 @@ fn map_actor_mailbox_store_error(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn normalize_channel_message_payload_wraps_non_object_inputs() {
+        let text = normalize_channel_message_payload(Value::String("hello".to_string()));
+        let number = normalize_channel_message_payload(json!(42));
+
+        assert_eq!(
+            text,
+            json!({
+                "type": "chat_message",
+                "text": "hello"
+            })
+        );
+        assert_eq!(
+            number,
+            json!({
+                "type": "chat_message",
+                "text": "42"
+            })
+        );
+    }
+
+    #[test]
+    fn ensure_channel_message_correlation_id_preserves_existing_or_uses_fallback() {
+        let existing = ensure_channel_message_correlation_id(
+            json!({
+                "type": "chat_message",
+                "text": "hello",
+                "correlation_id": "corr-existing"
+            }),
+            Some("corr-fallback"),
+        );
+        let fallback = ensure_channel_message_correlation_id(
+            json!({
+                "type": "chat_message",
+                "text": "hello"
+            }),
+            Some("corr-fallback"),
+        );
+
+        assert_eq!(
+            channel_payload_correlation_id(&existing),
+            Some("corr-existing")
+        );
+        assert_eq!(
+            channel_payload_correlation_id(&fallback),
+            Some("corr-fallback")
+        );
+    }
+
+    #[test]
+    fn build_channel_mailbox_forward_payload_carries_metadata_and_mentions() {
+        let payload = build_channel_mailbox_forward_payload(
+            &json!({
+                "type": "chat_message",
+                "text": "@reviewer please inspect this",
+                "correlation_id": "corr-1"
+            }),
+            &ResolvedChannelMailboxTarget {
+                team_id: "team-1".to_string(),
+                task_id: "task-1".to_string(),
+                conversation_id: "conversation-1".to_string(),
+                recipient_actor_ids: vec!["reviewer".to_string()],
+            },
+            "all",
+            42,
+            &["reviewer".to_string(), "worker-b".to_string()],
+        );
+
+        assert_eq!(
+            payload.get("delivery_scope"),
+            Some(&Value::String("channel_broadcast".to_string()))
+        );
+        assert_eq!(
+            payload.get("team_id"),
+            Some(&Value::String("team-1".to_string()))
+        );
+        assert_eq!(
+            payload.get("channel_conversation_id"),
+            Some(&Value::String("conversation-1".to_string()))
+        );
+        assert_eq!(
+            payload.get("task_id"),
+            Some(&Value::String("task-1".to_string()))
+        );
+        assert_eq!(payload.get("authority_message_id"), Some(&json!(42)));
+        assert_eq!(
+            payload.get("mentioned_actor_ids"),
+            Some(&json!(["reviewer", "worker-b"]))
+        );
+        assert_eq!(channel_payload_correlation_id(&payload), Some("corr-1"));
+    }
+
+    #[test]
+    fn human_visible_chat_reply_requires_local_non_human_to_human_chat_message() {
+        let payload = json!({
+            "type": "chat_message",
+            "text": "final answer"
+        });
+
+        assert!(should_persist_human_visible_chat_reply_for_payload(
+            &agenthub_team_actor::ActorMessageTransport::Local,
+            "user",
+            ACTOR_MAIN_PEER_ID,
+            "worker",
+            &payload,
+        ));
+        assert!(!should_persist_human_visible_chat_reply_for_payload(
+            &agenthub_team_actor::ActorMessageTransport::Remote,
+            "user",
+            ACTOR_MAIN_PEER_ID,
+            "worker",
+            &payload,
+        ));
+        assert!(!should_persist_human_visible_chat_reply_for_payload(
+            &agenthub_team_actor::ActorMessageTransport::Local,
+            "reviewer",
+            ACTOR_MAIN_PEER_ID,
+            "worker",
+            &payload,
+        ));
+        assert!(!should_persist_human_visible_chat_reply_for_payload(
+            &agenthub_team_actor::ActorMessageTransport::Local,
+            "user:123",
+            ACTOR_MAIN_PEER_ID,
+            "user",
+            &payload,
+        ));
+        assert!(!should_persist_human_visible_chat_reply_for_payload(
+            &agenthub_team_actor::ActorMessageTransport::Local,
+            "user",
+            ACTOR_MAIN_PEER_ID,
+            "worker",
+            &json!({
+                "type": "tool_result",
+                "text": "not a chat"
+            }),
+        ));
+    }
+
+    #[test]
+    fn resolve_canonical_chat_reply_accepts_stringified_json_chat_message() {
+        let reply = resolve_canonical_chat_reply(&Value::String(
+            r#"{"type":"chat_message","text":"hello","correlation_id":"corr-9"}"#.to_string(),
+        ))
+        .expect("resolve chat reply");
+
+        assert_eq!(reply.text, "hello");
+        assert_eq!(reply.correlation_id.as_deref(), Some("corr-9"));
+    }
+}


### PR DESCRIPTION
## Summary

- add focused unit coverage for team channel mailbox helpers
- add focused unit coverage for actor channel idempotency helpers
- document the coverage follow-up in the journal

## Why

The recent team/channel/p2p mailbox work added a fair amount of branching logic in helper layers that was still under-covered:

- channel payload normalization
- deterministic correlation id fallback
- channel forward payload metadata propagation
- human-visible chat reply persistence guardrails
- channel fanout idempotency derivation

These tests are cheap to run and increase confidence without adding another heavy integration path.

## Testing

- `cargo test -p agenthub-team-actor --lib idempotency::tests -- --nocapture`
- `cargo test team::manager::mailbox::tests -- --nocapture`
- `cargo fmt -- crates/agenthub-team-actor/src/idempotency.rs src/team/manager/mailbox.rs`
- `git -c core.fsmonitor=false diff --check`
