### PR TITLE
fix: fix flaky test teams_api_delete_team_cascades_related_run_data

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use sqlx::{
     Row, SqlitePool,
@@ -182,26 +188,57 @@ impl AgentEventDbRouter {
             let mut pools = self.pools.lock().await;
             pools.remove(agent_id)
         };
+        let db_path = self.db_path_for_agent(agent_id);
         if let Some(pool) = cell.and_then(|c| c.get().cloned()) {
+            if let Err(err) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+                .execute(&pool)
+                .await
+            {
+                tracing::warn!(
+                    agent_id = agent_id,
+                    db_path = %db_path.display(),
+                    error = %err,
+                    "WAL checkpoint before deleting agent event db failed"
+                );
+            }
             pool.close().await;
         }
-        let db_path = self.db_path_for_agent(agent_id);
-        if db_path.exists() {
-            std::fs::remove_file(&db_path)?;
-        }
-        let wal_path = PathBuf::from(format!("{}-wal", db_path.display()));
-        if wal_path.exists() {
-            std::fs::remove_file(wal_path)?;
-        }
-        let shm_path = PathBuf::from(format!("{}-shm", db_path.display()));
-        if shm_path.exists() {
-            std::fs::remove_file(shm_path)?;
-        }
+        Self::remove_file_with_retry(&db_path).await?;
+        Self::remove_file_with_retry(&Self::suffixed_path(&db_path, "-wal")).await?;
+        Self::remove_file_with_retry(&Self::suffixed_path(&db_path, "-shm")).await?;
         Ok(())
     }
 
     pub fn db_path_for_agent(&self, agent_id: &str) -> PathBuf {
         self.base_dir.join(format!("{agent_id}.db"))
+    }
+
+    fn suffixed_path(path: &Path, suffix: &str) -> PathBuf {
+        let mut raw = path.as_os_str().to_os_string();
+        raw.push(suffix);
+        PathBuf::from(raw)
+    }
+
+    async fn remove_file_with_retry(path: &Path) -> std::io::Result<()> {
+        if !tokio::fs::try_exists(path).await? {
+            return Ok(());
+        }
+
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::fs::remove_file(path).await {
+                Ok(()) => return Ok(()),
+                Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+                Err(err) => {
+                    last_err = Some(err);
+                    if attempt < 4 {
+                        tokio::time::sleep(Duration::from_millis(20 * (attempt as u64 + 1))).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_err.expect("remove_file_with_retry should record the final deletion error"))
     }
 }
 
@@ -2750,6 +2787,76 @@ mod tests {
 
         pool.close().await;
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn remove_agent_db_retries_cleanup_and_reopens_empty_history() {
+        let dir = unique_temp_dir("db-remove-agent");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let event_dbs = AgentEventDbRouter::new(dir.clone());
+        let agent_id = "agent-remove";
+        let db_path = event_dbs.db_path_for_agent(agent_id);
+        let wal_path = AgentEventDbRouter::suffixed_path(&db_path, "-wal");
+        let shm_path = AgentEventDbRouter::suffixed_path(&db_path, "-shm");
+
+        let pool = event_dbs
+            .pool_for_agent(agent_id)
+            .await
+            .expect("open per-agent db");
+        sqlx::query(
+            r#"
+            INSERT INTO agent_events (session_id, seq, ts, stream, message)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )
+        .bind("session-remove")
+        .bind("seq-1")
+        .bind(chrono::Utc::now().timestamp())
+        .bind("stdout")
+        .bind("cleanup-test")
+        .execute(&pool)
+        .await
+        .expect("insert event");
+
+        assert!(
+            tokio::fs::try_exists(&db_path)
+                .await
+                .expect("check db path")
+        );
+
+        event_dbs
+            .remove_agent_db(agent_id)
+            .await
+            .expect("remove agent db");
+
+        assert!(
+            !tokio::fs::try_exists(&db_path)
+                .await
+                .expect("check db removal")
+        );
+        assert!(
+            !tokio::fs::try_exists(&wal_path)
+                .await
+                .expect("check wal removal")
+        );
+        assert!(
+            !tokio::fs::try_exists(&shm_path)
+                .await
+                .expect("check shm removal")
+        );
+
+        let reopened = event_dbs
+            .pool_for_agent(agent_id)
+            .await
+            .expect("reopen per-agent db");
+        let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_events")
+            .fetch_one(&reopened)
+            .await
+            .expect("count reopened events");
+        assert_eq!(event_count, 0);
+
+        reopened.close().await;
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]

--- a/docs/journal/2026-03-24-agent-event-db-cleanup-hardening.md
+++ b/docs/journal/2026-03-24-agent-event-db-cleanup-hardening.md
@@ -18,8 +18,9 @@ The previous flaky cleanup change still had three structural problems:
 - built SQLite sidecar paths with `OsString` so non-UTF8 paths stay lossless
 - logged WAL checkpoint failures before deleting the event DB files
 - added a router-level regression test that removes an agent DB and verifies the reopened history is empty
-- updated the team delete regression test to poll for per-agent event DB removal instead of reopening the DB or sleeping
+- updated the team delete regression test to poll for per-agent event DB removal, including WAL/SHM sidecars, instead of reopening the DB or sleeping
 - stopped `finalize_process_exit(...)` from recreating a deleted event DB when `agent_sessions` has already been removed by higher-level cleanup
+- released the process-handle write lock before awaiting idle-gc cleanup in `finalize_process_exit(...)`
 
 ## Validation
 

--- a/docs/journal/2026-03-24-agent-event-db-cleanup-hardening.md
+++ b/docs/journal/2026-03-24-agent-event-db-cleanup-hardening.md
@@ -1,0 +1,32 @@
+## Summary
+
+Hardened per-agent event DB cleanup so team deletion no longer relies on fixed sleeps or lossy path handling.
+
+## Why
+
+The previous flaky cleanup change still had three structural problems:
+
+- file deletion failures could be swallowed while `remove_agent_db` reported success
+- async cleanup used blocking filesystem calls
+- the delete-team regression test relied on timing instead of the final cleanup condition
+
+## What Changed
+
+- kept `remove_agent_db` error propagation intact after bounded retries
+- switched cleanup to `tokio::fs::try_exists` and `tokio::fs::remove_file`
+- treated `NotFound` as successful cleanup instead of a retryable failure
+- built SQLite sidecar paths with `OsString` so non-UTF8 paths stay lossless
+- logged WAL checkpoint failures before deleting the event DB files
+- added a router-level regression test that removes an agent DB and verifies the reopened history is empty
+- updated the team delete regression test to poll for per-agent event DB removal instead of reopening the DB or sleeping
+- stopped `finalize_process_exit(...)` from recreating a deleted event DB when `agent_sessions` has already been removed by higher-level cleanup
+
+## Validation
+
+- `cargo test -p agenthub-db remove_agent_db_retries_cleanup_and_reopens_empty_history -- --nocapture`
+- `cargo test -p agenthub teams_api_delete_team_cascades_related_run_data -- --nocapture`
+- `cargo test -p agenthub finalize_process_exit_skips_event_persist_when_session_row_is_missing -- --nocapture`
+- `cargo clippy --locked -p agenthub-db --all-targets -- -D warnings`
+- `cargo clippy --locked -p agenthub --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git -c core.fsmonitor=false diff --check`

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1264,6 +1264,11 @@ impl AgentManager {
         self.event_dbs.pool_for_agent(agent_id).await
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_event_db_path_for_agent(&self, agent_id: &str) -> std::path::PathBuf {
+        self.event_dbs.db_path_for_agent(agent_id)
+    }
+
     async fn record_agent_activity(&self, agent_id: &str) {
         if let Some(idle_gc) = &self.idle_gc {
             idle_gc.record_activity(agent_id).await;

--- a/src/agent/manager/process.rs
+++ b/src/agent/manager/process.rs
@@ -220,6 +220,24 @@ impl AgentManager {
                 None
             }
         };
+        if row.is_none() {
+            tracing::debug!(
+                agent_id = %agent_id,
+                session_id = %session_id,
+                "finalize_process_exit skipped because agent session row no longer exists"
+            );
+            let mut guard = inner.write().await;
+            let removed = if Self::handle_matches_session(guard.get(agent_id), session_id) {
+                guard.remove(agent_id);
+                true
+            } else {
+                false
+            };
+            if removed && let Some(idle_gc) = &idle_gc {
+                idle_gc.remove_agent(agent_id).await;
+            }
+            return;
+        }
         let ended_at: Option<i64> = row.map(|r| r.get("ended_at"));
         if ended_at.is_some() {
             let mut guard = inner.write().await;
@@ -517,6 +535,46 @@ mod tests {
             false,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn finalize_process_exit_skips_event_persist_when_session_row_is_missing() {
+        let state = crate::api::team_tests::build_test_state().await;
+        let (agent_id, session_id) =
+            insert_agent_and_session(&state.db, "finalize-missing-session").await;
+        let event_db_path = state.agents.event_dbs.db_path_for_agent(&agent_id);
+
+        sqlx::query("DELETE FROM agent_sessions WHERE id = ?1")
+            .bind(&session_id)
+            .execute(&state.db)
+            .await
+            .expect("delete session row");
+
+        assert!(
+            !tokio::fs::try_exists(&event_db_path)
+                .await
+                .expect("check event db path before finalize"),
+            "per-agent event db should not exist before finalize"
+        );
+
+        super::AgentManager::finalize_process_exit(
+            &state.db,
+            &state.agents.event_dbs,
+            state.agents.idle_gc.clone(),
+            &state.agents.inner,
+            &state.push,
+            &agent_id,
+            &session_id,
+            false,
+        )
+        .await;
+
+        assert!(
+            !tokio::fs::try_exists(&event_db_path)
+                .await
+                .expect("check event db path after finalize"),
+            "finalize_process_exit must not recreate a deleted per-agent event db when the session row is already gone"
+        );
     }
 
     #[cfg(unix)]

--- a/src/agent/manager/process.rs
+++ b/src/agent/manager/process.rs
@@ -226,12 +226,14 @@ impl AgentManager {
                 session_id = %session_id,
                 "finalize_process_exit skipped because agent session row no longer exists"
             );
-            let mut guard = inner.write().await;
-            let removed = if Self::handle_matches_session(guard.get(agent_id), session_id) {
-                guard.remove(agent_id);
-                true
-            } else {
-                false
+            let removed = {
+                let mut guard = inner.write().await;
+                if Self::handle_matches_session(guard.get(agent_id), session_id) {
+                    guard.remove(agent_id);
+                    true
+                } else {
+                    false
+                }
             };
             if removed && let Some(idle_gc) = &idle_gc {
                 idle_gc.remove_agent(agent_id).await;
@@ -240,12 +242,14 @@ impl AgentManager {
         }
         let ended_at: Option<i64> = row.map(|r| r.get("ended_at"));
         if ended_at.is_some() {
-            let mut guard = inner.write().await;
-            let removed = if Self::handle_matches_session(guard.get(agent_id), session_id) {
-                guard.remove(agent_id);
-                true
-            } else {
-                false
+            let removed = {
+                let mut guard = inner.write().await;
+                if Self::handle_matches_session(guard.get(agent_id), session_id) {
+                    guard.remove(agent_id);
+                    true
+                } else {
+                    false
+                }
             };
             if removed && let Some(idle_gc) = &idle_gc {
                 idle_gc.remove_agent(agent_id).await;

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5,17 +5,35 @@ async fn wait_for_agent_event_history_cleanup(
 ) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
     let event_db_path = state.agents.test_event_db_path_for_agent(agent_id);
+    let event_db_wal_path = {
+        let mut raw = event_db_path.as_os_str().to_os_string();
+        raw.push("-wal");
+        std::path::PathBuf::from(raw)
+    };
+    let event_db_shm_path = {
+        let mut raw = event_db_path.as_os_str().to_os_string();
+        raw.push("-shm");
+        std::path::PathBuf::from(raw)
+    };
     loop {
-        if !tokio::fs::try_exists(&event_db_path)
+        let main_exists = tokio::fs::try_exists(&event_db_path)
             .await
-            .expect("check member event db path")
-        {
+            .expect("check member event db path");
+        let wal_exists = tokio::fs::try_exists(&event_db_wal_path)
+            .await
+            .expect("check member event db wal path");
+        let shm_exists = tokio::fs::try_exists(&event_db_shm_path)
+            .await
+            .expect("check member event db shm path");
+        if !main_exists && !wal_exists && !shm_exists {
             return;
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "member event db was not deleted after delete_team: agent_id={agent_id}, session_id={session_id}, path={}",
-            event_db_path.display()
+            "member event db and sidecars were not deleted after delete_team: agent_id={agent_id}, session_id={session_id}, path={}, wal_path={}, shm_path={}",
+            event_db_path.display(),
+            event_db_wal_path.display(),
+            event_db_shm_path.display()
         );
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
@@ -357,17 +375,18 @@ async fn teams_api_delete_team_cascades_related_run_data() {
     .await
     .expect("insert acp permission request");
 
-    let Json(team) = create_team(
-        State(state.clone()),
-        headers.clone(),
-        Json(CreateTeamRequest {
-            name: "delete-team".to_string(),
-            description: Some("delete target".to_string()),
-            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"leader"}]}),
-        }),
-    )
-    .await
-    .expect("create team");
+    let team = state
+        .teams
+        .create_team_with_owner(
+            TeamDefinitionConfig {
+                name: "delete-team".to_string(),
+                description: Some("delete target".to_string()),
+                spec: json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"leader"}]}),
+            },
+            None,
+        )
+        .await
+        .expect("create team");
 
     let Json(run) = create_team_run(
         State(state.clone()),

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -1,3 +1,26 @@
+async fn wait_for_agent_event_history_cleanup(
+    state: &AppState,
+    agent_id: &str,
+    session_id: &str,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let event_db_path = state.agents.test_event_db_path_for_agent(agent_id);
+    loop {
+        if !tokio::fs::try_exists(&event_db_path)
+            .await
+            .expect("check member event db path")
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "member event db was not deleted after delete_team: agent_id={agent_id}, session_id={session_id}, path={}",
+            event_db_path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
 #[tokio::test]
 async fn teams_api_requires_authorization() {
     let state = build_test_state().await;
@@ -522,18 +545,7 @@ async fn teams_api_delete_team_cascades_related_run_data() {
             .expect("count member sessions");
     assert_eq!(session_count, 0);
 
-    let member_event_db = state
-        .agents
-        .test_event_pool_for_agent(member_agent_id)
-        .await
-        .expect("reopen member event db");
-    let event_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM agent_events WHERE session_id = ?1")
-            .bind(&session_id)
-            .fetch_one(&member_event_db)
-            .await
-            .expect("count member events");
-    assert_eq!(event_count, 0);
+    wait_for_agent_event_history_cleanup(&state, member_agent_id, &session_id).await;
 
     let permission_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM acp_permission_requests WHERE agent_id = ?1")


### PR DESCRIPTION
## Summary

This hardens agent event DB cleanup during `delete_team` and removes the remaining race that could recreate per-agent event history after cleanup.

## Why

`teams_api_delete_team_cascades_related_run_data` was still flaky because cleanup involved multiple layers:

- SQLite WAL/SHM sidecars had to be removed alongside the main DB file
- `finalize_process_exit(...)` could still race with higher-level cleanup and recreate the event DB after `agent_sessions` rows were deleted
- the API regression test was broader than necessary because it created the team through the runtime-starting API path

## What Changed

- hardened `remove_agent_db(...)` to keep real deletion errors visible, use async filesystem cleanup, and log WAL checkpoint failures
- treated `NotFound` as successful cleanup and preserved path fidelity for `-wal` / `-shm` sidecars via `OsString`
- stopped `finalize_process_exit(...)` from recreating event DB state when the backing `agent_sessions` row is already gone
- released the process-handle write lock before awaiting idle GC cleanup in `finalize_process_exit(...)`
- narrowed the API regression test to create the team through `TeamManager::create_team_with_owner(...)` so the assertion focuses on `delete_team` cleanup instead of runtime auto-start side effects
- updated the API regression to poll until the main DB and its WAL/SHM sidecars are all gone
- kept the DB-layer regression that reopens a cleaned event DB and verifies the history is empty

## Testing

- `cargo test -p agenthub-db remove_agent_db_retries_cleanup_and_reopens_empty_history -- --nocapture`
- `cargo test -p agenthub teams_api_delete_team_cascades_related_run_data -- --nocapture`
- `cargo test -p agenthub finalize_process_exit_skips_event_persist_when_session_row_is_missing -- --nocapture`
- `cargo clippy --locked -p agenthub-db --all-targets -- -D warnings`
- `cargo clippy --locked -p agenthub --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git -c core.fsmonitor=false diff --check`