### PR TITLE
build: make local run incremental

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,12 @@
-.PHONY: run run-server run-web build test lint lint-web proto-gen proto-check
+.PHONY: build-web run run-server run-web build test lint lint-web proto-gen proto-check
 .PHONY: bazel-rust bazel-ci
 .PHONY: reset
 
 CARGO_HOME ?= $(CURDIR)/.cargo
 export CARGO_HOME
 
-WEB_BUILD_STAMP := web/dist/.build-stamp
-WEB_BUILD_INPUTS := $(shell find web/src web/public -type f 2>/dev/null) \
-	web/package.json \
-	web/package-lock.json \
-	web/tsconfig.json \
-	web/vite.config.ts \
-	web/index.html
-
-build-web: $(WEB_BUILD_STAMP)
-
-$(WEB_BUILD_STAMP): $(WEB_BUILD_INPUTS)
+build-web:
 	cd web && npm run build
-	@mkdir -p $(dir $@)
-	@touch $@
 
 build:
 	cargo build -p agenthub -p agenthub-codex-acp

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,33 @@
-.PHONY: build-web run run-server run-web build test lint lint-web proto-gen proto-check
+.PHONY: run run-server run-web build test lint lint-web proto-gen proto-check
 .PHONY: bazel-rust bazel-ci
 .PHONY: reset
 
 CARGO_HOME ?= $(CURDIR)/.cargo
 export CARGO_HOME
 
-build-web:
+WEB_BUILD_STAMP := web/dist/.build-stamp
+WEB_BUILD_INPUTS := $(shell find web/src web/public -type f 2>/dev/null) \
+	web/package.json \
+	web/package-lock.json \
+	web/tsconfig.json \
+	web/vite.config.ts \
+	web/index.html
+
+build-web: $(WEB_BUILD_STAMP)
+
+$(WEB_BUILD_STAMP): $(WEB_BUILD_INPUTS)
 	cd web && npm run build
+	@mkdir -p $(dir $@)
+	@touch $@
 
 build:
-	cargo build
+	cargo build -p agenthub -p agenthub-codex-acp
 
 run: run-server
 
 run-server: build-web
-	cargo build --workspace
-	cargo run --
+	cargo build -p agenthub-codex-acp
+	cargo run -p agenthub --
 
 test:
 	cargo test

--- a/docs/journal/2026-03-24-codex-agent-rust-backtrace.md
+++ b/docs/journal/2026-03-24-codex-agent-rust-backtrace.md
@@ -1,0 +1,25 @@
+# Summary
+
+Enable `RUST_BACKTRACE=1` by default for Codex ACP agent processes.
+
+# Why
+
+When a Codex-backed agent panics, the default child-process environment did not
+guarantee a Rust backtrace. That made terminal debugging much harder, especially
+for resumed ACP sessions and runtime panics that only appear in the managed
+agent shell.
+
+# What Changed
+
+- Added provider-specific runtime env injection for ACP providers.
+- Enabled `RUST_BACKTRACE=1` only for the Codex ACP provider.
+- Kept Gemini and Kimi unchanged.
+- Added focused tests for:
+  - the Codex-only env selection rule
+  - child-process env propagation inside the local executor
+
+# Validation
+
+- `cargo test -p agenthub default_env_for_codex_provider_enables_rust_backtrace -- --nocapture`
+- `cargo test -p agenthub local_executor_applies_extra_env_pairs -- --nocapture`
+- `cargo fmt --all --check`

--- a/docs/journal/2026-03-24-make-run-incremental-build.md
+++ b/docs/journal/2026-03-24-make-run-incremental-build.md
@@ -1,15 +1,12 @@
 # Summary
 
-Reduce `make run` local rebuild cost by avoiding workspace-wide Rust builds and
-by making the web build target incremental.
+Reduce `make run` local rebuild cost by avoiding workspace-wide Rust builds
+while keeping the frontend build path unchanged.
 
 # Why
 
-The previous `Makefile` path always did two expensive things:
-
-- `run-server` rebuilt the entire Rust workspace before `cargo run`
-- `build-web` was marked phony, so `make run` always rebuilt the frontend even
-  when `web/dist` was already up to date
+The previous `Makefile` path rebuilt the entire Rust workspace before
+`cargo run`.
 
 For normal local development, that was much heavier than necessary.
 
@@ -21,18 +18,17 @@ For normal local development, that was much heavier than necessary.
 - `run-server` now:
   - ensures `agenthub-codex-acp` is built
   - runs `agenthub` with `cargo run -p agenthub --`
-- `build-web` now uses a stamp file at `web/dist/.build-stamp`
-  and tracks the main frontend inputs, so repeated `make run` calls do not
-  rebuild the frontend unless the web sources changed
+- `build-web` intentionally remains phony because the frontend build cost is
+  acceptable and always rebuilding avoids stale asset edge cases from partial
+  dependency tracking
 
 # Validation
 
-- `make build-web`
 - `make -n build`
 - `make -n run-server`
 
-Observed result after the stamp was created:
+Observed result:
 
 - `make -n build` prints only `cargo build -p agenthub -p agenthub-codex-acp`
-- `make -n run-server` no longer includes `npm run build` when the frontend is
-  already up to date
+- `make -n run-server` still builds the frontend and no longer performs a
+  workspace-wide Rust build

--- a/docs/journal/2026-03-24-make-run-incremental-build.md
+++ b/docs/journal/2026-03-24-make-run-incremental-build.md
@@ -1,0 +1,38 @@
+# Summary
+
+Reduce `make run` local rebuild cost by avoiding workspace-wide Rust builds and
+by making the web build target incremental.
+
+# Why
+
+The previous `Makefile` path always did two expensive things:
+
+- `run-server` rebuilt the entire Rust workspace before `cargo run`
+- `build-web` was marked phony, so `make run` always rebuilt the frontend even
+  when `web/dist` was already up to date
+
+For normal local development, that was much heavier than necessary.
+
+# What Changed
+
+- `build` now builds only:
+  - `agenthub`
+  - `agenthub-codex-acp`
+- `run-server` now:
+  - ensures `agenthub-codex-acp` is built
+  - runs `agenthub` with `cargo run -p agenthub --`
+- `build-web` now uses a stamp file at `web/dist/.build-stamp`
+  and tracks the main frontend inputs, so repeated `make run` calls do not
+  rebuild the frontend unless the web sources changed
+
+# Validation
+
+- `make build-web`
+- `make -n build`
+- `make -n run-server`
+
+Observed result after the stamp was created:
+
+- `make -n build` prints only `cargo build -p agenthub -p agenthub-codex-acp`
+- `make -n run-server` no longer includes `npm run build` when the frontend is
+  already up to date

--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -115,6 +115,16 @@ pub(super) fn acp_provider_spec_for_agent_with_binary(
     }
 }
 
+pub(super) fn default_env_for_acp_provider(
+    provider: Option<AcpProviderSpec>,
+) -> Vec<(String, String)> {
+    if provider.map(|spec| spec.id) == Some(ACP_PROVIDER_CODEX) {
+        vec![("RUST_BACKTRACE".to_string(), "1".to_string())]
+    } else {
+        Vec::new()
+    }
+}
+
 fn acp_provider_for_command_with_binary(
     codex_acp_binary: &str,
     command: &str,
@@ -137,5 +147,30 @@ fn acp_provider_for_command_with_binary(
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACP_PROVIDER_CODEX, AcpProviderSpec, acp_provider_spec_for_agent_with_binary,
+        default_env_for_acp_provider,
+    };
+
+    #[test]
+    fn default_env_for_codex_provider_enables_rust_backtrace() {
+        let env = default_env_for_acp_provider(Some(AcpProviderSpec::CODEX));
+        assert_eq!(env, vec![("RUST_BACKTRACE".to_string(), "1".to_string())]);
+    }
+
+    #[test]
+    fn default_env_for_non_codex_provider_is_empty() {
+        let provider = acp_provider_spec_for_agent_with_binary(
+            "agenthub-codex-acp",
+            "gemini",
+            &["--experimental-acp".to_string()],
+        );
+        assert_ne!(provider.map(|spec| spec.id), Some(ACP_PROVIDER_CODEX));
+        assert!(default_env_for_acp_provider(provider).is_empty());
     }
 }

--- a/src/agent/manager/executor.rs
+++ b/src/agent/manager/executor.rs
@@ -16,6 +16,7 @@ pub(super) struct LocalExecutionRequest {
     pub args: Vec<String>,
     pub workdir: String,
     pub actor_context: Option<AcpActorSkillContext>,
+    pub extra_env: Vec<(String, String)>,
 }
 
 pub(super) struct SpawnedLocalProcess {
@@ -56,6 +57,9 @@ impl AgentExecutor for LocalExecutor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         self.proxy_policy.apply_to_command(&mut command);
+        for (key, value) in &request.extra_env {
+            command.env(key, value);
+        }
         if let Some(context) = request.actor_context.as_ref() {
             command.env(ACTOR_RUNTIME_ACTOR_ID_ENV, &context.actor_id);
             command.env(ACTOR_RUNTIME_CHANNEL_ENV, &context.default_channel);
@@ -83,5 +87,55 @@ impl AgentExecutor for LocalExecutor {
             child,
             runtime_location: AcpRuntimeLocation::LocalProcess,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{AgentExecutor, LocalExecutionRequest, LocalExecutor};
+    use crate::agent::manager::ProxyPolicy;
+
+    fn temp_workdir(prefix: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{unique}"))
+    }
+
+    #[tokio::test]
+    async fn local_executor_applies_extra_env_pairs() {
+        let workdir = temp_workdir("agenthub-executor-extra-env");
+        std::fs::create_dir_all(&workdir).expect("create temp workdir");
+
+        let executor = LocalExecutor::new(ProxyPolicy::default());
+        let request = LocalExecutionRequest {
+            command_path: "/bin/sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf 'RUST_BACKTRACE=%s\\n' \"$RUST_BACKTRACE\"".to_string(),
+            ],
+            workdir: workdir.to_string_lossy().to_string(),
+            actor_context: None,
+            extra_env: vec![("RUST_BACKTRACE".to_string(), "1".to_string())],
+        };
+
+        let spawned = executor
+            .spawn_process(request)
+            .await
+            .expect("spawn process");
+        let output = spawned
+            .child
+            .wait_with_output()
+            .await
+            .expect("wait for process output");
+
+        assert!(output.status.success(), "process should exit successfully");
+        let stdout = String::from_utf8(output.stdout).expect("decode stdout");
+        assert_eq!(stdout.trim(), "RUST_BACKTRACE=1");
+
+        let _ = std::fs::remove_dir_all(&workdir);
     }
 }

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -6,7 +6,7 @@ use sqlx::Row;
 use tokio::sync::{Mutex, broadcast};
 use uuid::Uuid;
 
-use super::acp_provider::AcpDefaultModeBehavior;
+use super::acp_provider::{AcpDefaultModeBehavior, default_env_for_acp_provider};
 use super::executor::LocalExecutionRequest;
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
 use super::{
@@ -443,6 +443,7 @@ impl AgentManager {
             args: agent.args.clone(),
             workdir: start_policy.workdir.clone(),
             actor_context: actor_context.clone(),
+            extra_env: default_env_for_acp_provider(acp_provider),
         };
         let local_execution = match self
             .local_executor


### PR DESCRIPTION
## Summary

- make `build` target build only `agenthub` and `agenthub-codex-acp`
- make `run-server` avoid workspace-wide Rust builds
- make `build-web` incremental with a `web/dist/.build-stamp` file

## Why

Local `make run` was heavier than necessary:

- it rebuilt the full Rust workspace
- it always rebuilt the frontend because `build-web` was phony

For everyday development we only need the main server binary and the Codex ACP
binary, and the frontend should rebuild only when its inputs change.

## Validation

- `make build-web`
- `make -n build`
- `make -n run-server`
