### PR TITLE
feat(team): add member agent controls and ACP header parity

### DIFF
--- a/docs/features/agents-teams.md
+++ b/docs/features/agents-teams.md
@@ -202,6 +202,16 @@ Constraint:
   agent review cannot complete.
 - `Runs` tab is the only primary entry for run selection/start.
 - Run-scoped tabs must use one shared active-run gate policy and one shared fallback guidance pattern.
+- `Agent ACP -> Debug` may expose a member-scoped `Force New Session` recovery action:
+  - it clears the selected member's persisted ACP session for the active provider
+  - restarts only that member runtime
+  - other team members keep their current sessions
+- The selected Team member workspace also exposes per-agent lifecycle controls:
+  - `Start Agent`
+  - `Stop Agent`
+  - `Delete Agent`
+  These act on the selected member's underlying agent record without requiring a Team-wide runtime
+  restart.
 - Human-facing conversation remains group-visible even when `@mention` is used.
 - `@mention` controls response priority and coordination scope, not message visibility.
 - Conversation input should allow omission of `run_id`/`from_actor_id`; backend should enrich sender identity and routing from session + mention context.

--- a/docs/journal/2026-03-24-team-member-agent-controls-and-acp-header.md
+++ b/docs/journal/2026-03-24-team-member-agent-controls-and-acp-header.md
@@ -1,0 +1,49 @@
+## Summary
+
+Added member-scoped agent lifecycle controls to the Team workspace and aligned the Team ACP panel
+with the standalone Agents ACP header so active thinking state is visible in both places.
+
+## Why
+
+Two Team workspace gaps were still slowing operators down:
+
+- selected Team members did not expose the same direct `Start Agent`, `Stop Agent`, and
+  `Delete Agent` controls that already existed on the main Agents page
+- Team `Agent ACP` rendered ACP conversation content, including `agent_thought`, but it did not
+  surface the same header-level status metadata and active `thinking Ns` affordance visible on the
+  standalone Agents ACP view
+
+## What Changed
+
+- added `resolveTeamMemberAgentControlState(...)` to keep Team member lifecycle button gating in
+  one place
+- added `Start Agent`, `Stop Agent`, and `Delete Agent` actions to the selected Team member
+  workspace menu
+- wired those actions to the existing agent lifecycle APIs and refreshed Team runtime / agent cache
+  after completion
+- kept Team member deletion scoped to the underlying agent record only; the Team spec still retains
+  the member until the profile is edited explicitly
+- added a Team ACP header that mirrors standalone ACP status rendering:
+  - member title
+  - model tag
+  - status badge
+  - active `thinking Ns`
+  - role pill
+  - session pill in developer mode
+- added focused tests for Team member lifecycle control derivation and Team ACP header rendering
+
+## Validation
+
+- `npm --prefix web run test -- --run src/pages/team_page.runs.test.ts src/pages/team_page.smoke.test.tsx src/pages/team_panels.test.tsx`
+- `npm --prefix web run build`
+- `git -c core.fsmonitor=false diff --check`
+
+## Chrome Notes
+
+- Remote baseline check against `https://agenthub.hawkingrei.com/teams/276a2682-9ce7-4af5-aa6c-f12575d13c37`
+  succeeded after login. The deployed Team workspace menu currently exposes `Overview`, `Events`,
+  `Steps`, and `Execution Mailbox`, but it does not yet include the new per-member `Start Agent`,
+  `Stop Agent`, or `Delete Agent` actions.
+- Local browser regression against `http://127.0.0.1:4174/` was not available at validation time
+  because the local Team frontend route returned `ERR_CONNECTION_REFUSED`, so the unmerged UI change
+  was validated via focused Vitest coverage plus production build output.

--- a/docs/journal/2026-03-24-team-member-agent-controls-and-acp-header.md
+++ b/docs/journal/2026-03-24-team-member-agent-controls-and-acp-header.md
@@ -31,10 +31,13 @@ Two Team workspace gaps were still slowing operators down:
   - role pill
   - session pill in developer mode
 - added focused tests for Team member lifecycle control derivation and Team ACP header rendering
+- extracted `removeTeamMemberLookupEntry(...)` so Team member discovery cache cleanup no longer
+  duplicates inline object mutation logic during agent deletion
 
 ## Validation
 
 - `npm --prefix web run test -- --run src/pages/team_page.runs.test.ts src/pages/team_page.smoke.test.tsx src/pages/team_panels.test.tsx`
+- `npm --prefix web run test -- --run src/pages/team_page.runs.test.ts`
 - `npm --prefix web run build`
 - `git -c core.fsmonitor=false diff --check`
 

--- a/web/src/components/acp_debug.tsx
+++ b/web/src/components/acp_debug.tsx
@@ -62,6 +62,7 @@ type AcpDebugProps = {
   onAcpSetConfig: () => void;
   onAcpCancel: () => void;
   onAcpClearSession: () => void;
+  acpClearSessionLabel?: string;
   onJumpToPermissionHistory: (permission: AcpPermissionRecord) => void;
   runtimeMetrics: AcpRuntimeMetrics;
   initialTab?: DebugTab;
@@ -93,6 +94,7 @@ export function AcpDebug({
   onAcpSetConfig,
   onAcpCancel,
   onAcpClearSession,
+  acpClearSessionLabel,
   onJumpToPermissionHistory,
   runtimeMetrics,
   initialTab,
@@ -321,7 +323,7 @@ export function AcpDebug({
               Cancel Run
             </button>
             <button className={debugSecondaryButtonClassName} onClick={onAcpClearSession}>
-              Clear Session
+              {acpClearSessionLabel ?? "Clear Session"}
             </button>
           </div>
         </div>

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -136,7 +136,8 @@ export function removeTeamMemberLookupEntry<T>(
   if (!Object.prototype.hasOwnProperty.call(lookup, memberId)) {
     return lookup;
   }
-  const { [memberId]: _removed, ...next } = lookup;
+  const next = { ...lookup };
+  delete next[memberId];
   return next;
 }
 

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -60,6 +60,12 @@ export type AgentWorkspaceStatusView = {
   currentWork: string;
 };
 
+export type TeamMemberAgentControlState = {
+  canStart: boolean;
+  canStop: boolean;
+  canDelete: boolean;
+};
+
 type TeamRuntimeStatusRecord = {
   status: TeamRuntimeRecord["status"];
   members: Array<Pick<TeamRuntimeRecord["members"][number], "member_id" | "session_id">>;
@@ -98,6 +104,26 @@ export function resolveAgentWorkspaceStatusView(
       member?.pending_inbox_count == null ? "-" : String(member.pending_inbox_count),
     currentWork:
       member?.current_work?.trim() || "No direct activity reported yet.",
+  };
+}
+
+export function resolveTeamMemberAgentControlState(
+  agent: Pick<AgentRecord, "id"> | null,
+  lifecycle: string,
+  busy: string | null
+): TeamMemberAgentControlState {
+  const normalizedLifecycle = lifecycle.trim().toLowerCase();
+  const hasAgent = Boolean(agent?.id?.trim());
+  return {
+    canStart:
+      hasAgent &&
+      busy !== "start-team-member-agent" &&
+      normalizedLifecycle !== "working",
+    canStop:
+      hasAgent &&
+      busy !== "stop-team-member-agent" &&
+      normalizedLifecycle === "working",
+    canDelete: hasAgent && busy !== "delete-team-member-agent",
   };
 }
 

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -127,6 +127,17 @@ export function resolveTeamMemberAgentControlState(
   };
 }
 
+export function removeTeamMemberLookupEntry<T>(
+  lookup: Record<string, T>,
+  memberId: string
+): Record<string, T> {
+  if (!Object.prototype.hasOwnProperty.call(lookup, memberId)) {
+    return lookup;
+  }
+  const { [memberId]: _removed, ...next } = lookup;
+  return next;
+}
+
 export function resolveTeamRuntimeStatus(
   summary: TeamMemberAgentStatusSummary | null,
   runtime?: TeamRuntimeStatusRecord | null

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -114,15 +114,17 @@ export function resolveTeamMemberAgentControlState(
 ): TeamMemberAgentControlState {
   const normalizedLifecycle = lifecycle.trim().toLowerCase();
   const hasAgent = Boolean(agent?.id?.trim());
+  const isRunning =
+    normalizedLifecycle === "working" || normalizedLifecycle === "idle";
   return {
     canStart:
       hasAgent &&
       busy !== "start-team-member-agent" &&
-      normalizedLifecycle !== "working",
+      !isRunning,
     canStop:
       hasAgent &&
       busy !== "stop-team-member-agent" &&
-      normalizedLifecycle === "working",
+      isRunning,
     canDelete: hasAgent && busy !== "delete-team-member-agent",
   };
 }

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -5,9 +5,18 @@ import { AcpPanel } from "../components/acp_panel";
 import { getAcpConversationCacheStats } from "../components/acp_conversation";
 import { resolveInputDockJumpMode } from "../components/acp_panel_helpers";
 import { InputDock } from "../components/input_dock";
+import { StatusBadge, resolveTeamRunStatusTone } from "../components/status_badge";
 import { useAcpConversation } from "../hooks/use_acp_conversation";
 import { pushInputHistory } from "../input_history";
 import {
+  OUTPUT_HEADER_META_CLASS,
+  OUTPUT_HEADER_PILL_CLASS,
+  OUTPUT_HEADER_ROOT_CLASS,
+  OUTPUT_HEADER_SESSION_CLASS,
+  OUTPUT_HEADER_TITLE_CLASS,
+  OUTPUT_HEADER_TITLE_HEADING_CLASS,
+  OUTPUT_HEADER_TITLE_MAIN_CLASS,
+  OUTPUT_HEADER_TITLE_TEXT_CLASS,
   TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_REFRESH_BUTTON_CLASS,
@@ -27,6 +36,7 @@ type TeamMemberAcpPanelProps = {
   eventsLoading: boolean;
   oldestMemberEventId: number | null;
   onSendInput?: (input: string, sessionId: string) => Promise<void> | void;
+  onForceNewSession?: () => Promise<void> | void;
   onRefresh: () => Promise<void> | void;
   onLoadOlder: () => Promise<void> | void;
 };
@@ -48,6 +58,7 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
     eventsLoading,
     oldestMemberEventId,
     onSendInput,
+    onForceNewSession,
     onRefresh,
     onLoadOlder,
   } = props;
@@ -67,8 +78,10 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
     [memberEvents]
   );
   const acpView = React.useMemo(() => buildAcpView(acpEventLines), [acpEventLines]);
+  const thinkingStartTs = acpView.thinkingStartTs;
   const [acpTab, setAcpTab] = React.useState<TeamMemberAcpTab>("conversation");
   const effectiveAcpTab = !developerMode && acpTab === "debug" ? "conversation" : acpTab;
+  const [thinkingTick, setThinkingTick] = React.useState(0);
   const conversationEventMeta = React.useMemo(() => {
     const memberId = selectedMemberId.trim();
     if (!memberId || !selectedSessionId) {
@@ -124,6 +137,16 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
     setAcpTab("conversation");
   }, [selectedMemberId, selectedSessionId]);
   React.useEffect(() => {
+    if (!thinkingStartTs) {
+      return;
+    }
+    setThinkingTick(0);
+    const timer = window.setInterval(() => {
+      setThinkingTick((prev) => prev + 1);
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [thinkingStartTs]);
+  React.useEffect(() => {
     setInput("");
     setInputHistory([]);
     setInputHistoryCursor(-1);
@@ -136,6 +159,25 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
     memberEventsHasMore &&
     oldestMemberEventId != null;
   const canSendInput = Boolean(selectedMemberId.trim() && selectedSessionId && onSendInput);
+  const memberTitle = selectedMemberId.trim() || "No team member selected";
+  const memberModelLabel = selectedMemberSnapshot?.model?.trim() || null;
+  const memberRoleLabel =
+    selectedMemberRole?.trim() || selectedMemberSnapshot?.role?.trim() || null;
+  const memberStatus = (
+    acpView.runStatus?.status?.trim() ||
+    selectedMemberSnapshot?.status?.trim() ||
+    selectedMemberSnapshot?.session_status?.trim() ||
+    memberRoleLabel ||
+    "unknown"
+  ).toLowerCase();
+  const thinkingLabel = thinkingStartTs
+    ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - thinkingStartTs))}s`
+    : null;
+  const memberStatusLabel = thinkingLabel
+    ? `${memberStatus} · ${thinkingLabel}`
+    : memberStatus;
+  const memberStatusClassToken = memberStatus.replace(/[^a-z0-9_-]+/g, "-");
+  void thinkingTick;
   const handleTerminalScroll = React.useCallback(() => {
     const element = terminalRef.current;
     if (!element) {
@@ -356,7 +398,10 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
         onAcpSetModel: NOOP,
         onAcpSetConfig: NOOP,
         onAcpCancel: NOOP,
-        onAcpClearSession: NOOP,
+        onAcpClearSession: () => {
+          void onForceNewSession?.();
+        },
+        acpClearSessionLabel: "Force New Session",
         onJumpToPermissionHistory: NOOP,
         runtimeMetrics: acpRuntimeMetrics,
       },
@@ -377,6 +422,7 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
       effectiveAcpTab,
       handleTerminalScroll,
       jumpToTerminalBottom,
+      onForceNewSession,
       panelSubtitle,
       terminalOutputs,
       terminalShowJump,
@@ -455,6 +501,36 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
 
       {shouldRenderPanel && (
         <div className="relative mt-2 min-h-0 flex-1">
+          <div className={OUTPUT_HEADER_ROOT_CLASS}>
+            <div className={OUTPUT_HEADER_TITLE_CLASS}>
+              <div className={OUTPUT_HEADER_TITLE_TEXT_CLASS}>
+                <div className={OUTPUT_HEADER_TITLE_MAIN_CLASS}>
+                  <h2 className={OUTPUT_HEADER_TITLE_HEADING_CLASS}>{memberTitle}</h2>
+                  {memberModelLabel ? (
+                    <span className="agent-tag hidden sm:inline-flex">{memberModelLabel}</span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+            <div className={OUTPUT_HEADER_META_CLASS}>
+              <StatusBadge
+                label={memberStatusLabel}
+                tone={resolveTeamRunStatusTone(memberStatus)}
+                className={`agent-status status-${memberStatusClassToken}`}
+                title={`status: ${memberStatusLabel}`}
+              />
+              {memberRoleLabel ? (
+                <span className={OUTPUT_HEADER_PILL_CLASS}>
+                  Role {memberRoleLabel}
+                </span>
+              ) : null}
+              {developerMode && selectedSessionId ? (
+                <span className={OUTPUT_HEADER_SESSION_CLASS}>
+                  Session {selectedSessionId.slice(0, 8)}
+                </span>
+              ) : null}
+            </div>
+          </div>
           <AcpPanel {...acpPanelProps} />
         </div>
       )}

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -81,7 +81,7 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
   const thinkingStartTs = acpView.thinkingStartTs;
   const [acpTab, setAcpTab] = React.useState<TeamMemberAcpTab>("conversation");
   const effectiveAcpTab = !developerMode && acpTab === "debug" ? "conversation" : acpTab;
-  const [thinkingTick, setThinkingTick] = React.useState(0);
+  const [, setThinkingTick] = React.useState(0);
   const conversationEventMeta = React.useMemo(() => {
     const memberId = selectedMemberId.trim();
     if (!memberId || !selectedSessionId) {
@@ -177,7 +177,6 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
     ? `${memberStatus} · ${thinkingLabel}`
     : memberStatus;
   const memberStatusClassToken = memberStatus.replace(/[^a-z0-9_-]+/g, "-");
-  void thinkingTick;
   const handleTerminalScroll = React.useCallback(() => {
     const element = terminalRef.current;
     if (!element) {

--- a/web/src/pages/team_page.runs.test.ts
+++ b/web/src/pages/team_page.runs.test.ts
@@ -20,6 +20,7 @@ import {
   parseTeamSpecMembers,
   resolveConversationMaxMessageId,
   resolveMailboxChatActors,
+  resolveTeamMemberAgentControlState,
   toggleSkillSelection,
   selectMailboxConversation,
   selectTeamForgeAgents,
@@ -470,6 +471,39 @@ describe("team run list helpers", () => {
       inactive: 1,
       missing: 1,
       total: 4,
+    });
+  });
+
+  it("derives selected Team member lifecycle controls from agent presence and busy state", () => {
+    const stoppedAgent = buildAgent("worker-agent", "stopped");
+    expect(
+      resolveTeamMemberAgentControlState(stoppedAgent, "stopped", null)
+    ).toEqual({
+      canStart: true,
+      canStop: false,
+      canDelete: true,
+    });
+
+    const runningAgent = buildAgent("worker-agent", "running");
+    expect(
+      resolveTeamMemberAgentControlState(runningAgent, "working", null)
+    ).toEqual({
+      canStart: false,
+      canStop: true,
+      canDelete: true,
+    });
+
+    expect(resolveTeamMemberAgentControlState(null, "missing", null)).toEqual({
+      canStart: false,
+      canStop: false,
+      canDelete: false,
+    });
+    expect(
+      resolveTeamMemberAgentControlState(runningAgent, "working", "stop-team-member-agent")
+    ).toEqual({
+      canStart: false,
+      canStop: false,
+      canDelete: true,
     });
   });
 

--- a/web/src/pages/team_page.runs.test.ts
+++ b/web/src/pages/team_page.runs.test.ts
@@ -20,6 +20,7 @@ import {
   parseTeamSpecMembers,
   resolveConversationMaxMessageId,
   resolveMailboxChatActors,
+  removeTeamMemberLookupEntry,
   resolveTeamMemberAgentControlState,
   toggleSkillSelection,
   selectMailboxConversation,
@@ -505,6 +506,17 @@ describe("team run list helpers", () => {
       canStop: false,
       canDelete: true,
     });
+  });
+
+  it("removes selected Team member discovery cache entries without cloning untouched maps", () => {
+    const existing = {
+      "worker-agent": { title: "Worker" },
+      "reviewer-agent": { title: "Reviewer" },
+    };
+    expect(removeTeamMemberLookupEntry(existing, "worker-agent")).toEqual({
+      "reviewer-agent": { title: "Reviewer" },
+    });
+    expect(removeTeamMemberLookupEntry(existing, "missing-agent")).toBe(existing);
   });
 
   it("maps lifecycle tone to active, inactive, and missing", () => {

--- a/web/src/pages/team_page.runs.test.ts
+++ b/web/src/pages/team_page.runs.test.ts
@@ -493,6 +493,13 @@ describe("team run list helpers", () => {
       canStop: true,
       canDelete: true,
     });
+    expect(
+      resolveTeamMemberAgentControlState(runningAgent, "idle", null)
+    ).toEqual({
+      canStart: false,
+      canStop: true,
+      canDelete: true,
+    });
 
     expect(resolveTeamMemberAgentControlState(null, "missing", null)).toEqual({
       canStart: false,

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -118,6 +118,7 @@ import {
   resolveSelectedAgentWorkspaceLabel,
   resolveSelectedTeamTask,
   resolveTaskConversationMemberIds,
+  removeTeamMemberLookupEntry,
   resolveTeamMemberAgentControlState,
   resolveTeamRuntimeControlTone,
   resolveTeamRuntimeStatus,
@@ -214,7 +215,10 @@ export {
   selectRunsForTask,
   selectTeamPreviewEvents,
 } from "./team/run_helpers";
-export { resolveTeamMemberAgentControlState } from "./team/page_helpers";
+export {
+  removeTeamMemberLookupEntry,
+  resolveTeamMemberAgentControlState,
+} from "./team/page_helpers";
 export type { MailboxTemplateKey, TeamMailboxChatActors } from "./team/mailbox_helpers";
 export type {
   TeamMemberAgentStatus,
@@ -2778,20 +2782,10 @@ export function TeamPage(props: TeamPageProps) {
         [selectedAgentWorkspaceMemberId]: null,
       }));
       setMemberDiscoveryCardsById((prev) => {
-        if (!(selectedAgentWorkspaceMemberId in prev)) {
-          return prev;
-        }
-        const next = { ...prev };
-        delete next[selectedAgentWorkspaceMemberId];
-        return next;
+        return removeTeamMemberLookupEntry(prev, selectedAgentWorkspaceMemberId);
       });
       setMemberDiscoveryCardLoadingById((prev) => {
-        if (!(selectedAgentWorkspaceMemberId in prev)) {
-          return prev;
-        }
-        const next = { ...prev };
-        delete next[selectedAgentWorkspaceMemberId];
-        return next;
+        return removeTeamMemberLookupEntry(prev, selectedAgentWorkspaceMemberId);
       });
       void Promise.all([
         refreshAgents(),

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -118,6 +118,7 @@ import {
   resolveSelectedAgentWorkspaceLabel,
   resolveSelectedTeamTask,
   resolveTaskConversationMemberIds,
+  resolveTeamMemberAgentControlState,
   resolveTeamRuntimeControlTone,
   resolveTeamRuntimeStatus,
   sortTasksByActivity,
@@ -213,6 +214,7 @@ export {
   selectRunsForTask,
   selectTeamPreviewEvents,
 } from "./team/run_helpers";
+export { resolveTeamMemberAgentControlState } from "./team/page_helpers";
 export type { MailboxTemplateKey, TeamMailboxChatActors } from "./team/mailbox_helpers";
 export type {
   TeamMemberAgentStatus,
@@ -2369,6 +2371,13 @@ export function TeamPage(props: TeamPageProps) {
       ),
     [focusedAgentMemberId, selectedAgentFallbackName, selectedAgentLiveState]
   );
+  const selectedAgentWorkspaceAgent = useMemo(() => {
+    const memberId = selectedAgentWorkspaceMemberId.trim();
+    if (!memberId) {
+      return null;
+    }
+    return teamMemberAgentsById[memberId] ?? agents.find((agent) => agent.id === memberId) ?? null;
+  }, [agents, selectedAgentWorkspaceMemberId, teamMemberAgentsById]);
   const selectedAgentSpecDraft = useMemo(() => {
     if (!selectedTeam) {
       return null;
@@ -2649,6 +2658,173 @@ export function TeamPage(props: TeamPageProps) {
       selectedTeamId,
       setError,
     ]
+  );
+  const onForceNewTeamMemberSession = useCallback(async () => {
+    if (!props.token || !selectedTeamId || !selectedAgentWorkspaceMemberId) {
+      return;
+    }
+    setError(null);
+    setWarning(null);
+    setBusy("force-new-session");
+    try {
+      const runtime = await api.forceTeamMemberNewSession(
+        props.token,
+        selectedTeamId,
+        selectedAgentWorkspaceMemberId
+      );
+      void Promise.all([
+        refreshTeamRuntime(selectedTeamId),
+        refreshAgents(),
+      ]).catch(() => undefined);
+      setWarning(formatTeamRuntimeActionSummary("force", runtime.members));
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    props.token,
+    refreshAgents,
+    refreshTeamRuntime,
+    selectedAgentWorkspaceMemberId,
+    selectedTeamId,
+    setBusy,
+    setError,
+    setWarning,
+  ]);
+  const onStartSelectedTeamAgent = useCallback(async () => {
+    if (!props.token || !selectedAgentWorkspaceAgent) {
+      return;
+    }
+    setError(null);
+    setWarning(null);
+    setBusy("start-team-member-agent");
+    try {
+      await api.startAgent(props.token, selectedAgentWorkspaceAgent.id);
+      void Promise.all([
+        refreshAgents(),
+        selectedTeamId ? refreshTeamRuntime(selectedTeamId) : Promise.resolve(null),
+      ]).catch(() => undefined);
+      setWarning(`Started ${selectedAgentLabel}.`);
+    } catch (err) {
+      const message = parseErrorMessage(err);
+      if (message.toLowerCase().includes("agent already running")) {
+        void Promise.all([
+          refreshAgents(),
+          selectedTeamId ? refreshTeamRuntime(selectedTeamId) : Promise.resolve(null),
+        ]).catch(() => undefined);
+        setWarning(`${selectedAgentLabel} is already running.`);
+        return;
+      }
+      setError(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    props.token,
+    refreshAgents,
+    refreshTeamRuntime,
+    selectedAgentLabel,
+    selectedAgentWorkspaceAgent,
+    selectedTeamId,
+    setBusy,
+    setError,
+    setWarning,
+  ]);
+  const onStopSelectedTeamAgent = useCallback(async () => {
+    if (!props.token || !selectedAgentWorkspaceAgent) {
+      return;
+    }
+    setError(null);
+    setWarning(null);
+    setBusy("stop-team-member-agent");
+    try {
+      await api.stopAgent(props.token, selectedAgentWorkspaceAgent.id);
+      void Promise.all([
+        refreshAgents(),
+        selectedTeamId ? refreshTeamRuntime(selectedTeamId) : Promise.resolve(null),
+      ]).catch(() => undefined);
+      setWarning(`Stopped ${selectedAgentLabel}.`);
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    props.token,
+    refreshAgents,
+    refreshTeamRuntime,
+    selectedAgentLabel,
+    selectedAgentWorkspaceAgent,
+    selectedTeamId,
+    setBusy,
+    setError,
+    setWarning,
+  ]);
+  const onDeleteSelectedTeamAgent = useCallback(async () => {
+    if (!props.token || !selectedAgentWorkspaceAgent || !selectedAgentWorkspaceMemberId) {
+      return;
+    }
+    setError(null);
+    setWarning(null);
+    setBusy("delete-team-member-agent");
+    try {
+      await api.deleteAgent(props.token, selectedAgentWorkspaceAgent.id);
+      setAgents((prev) =>
+        prev.filter((agent) => agent.id !== selectedAgentWorkspaceAgent.id)
+      );
+      setTeamMemberAgentsById((prev) => ({
+        ...prev,
+        [selectedAgentWorkspaceMemberId]: null,
+      }));
+      setMemberDiscoveryCardsById((prev) => {
+        if (!(selectedAgentWorkspaceMemberId in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[selectedAgentWorkspaceMemberId];
+        return next;
+      });
+      setMemberDiscoveryCardLoadingById((prev) => {
+        if (!(selectedAgentWorkspaceMemberId in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[selectedAgentWorkspaceMemberId];
+        return next;
+      });
+      void Promise.all([
+        refreshAgents(),
+        selectedTeamId ? refreshTeamRuntime(selectedTeamId) : Promise.resolve(null),
+      ]).catch(() => undefined);
+      setWarning(
+        `Deleted ${selectedAgentLabel}. The Team member remains in the spec until you edit the profile.`
+      );
+    } catch (err) {
+      setError(parseErrorMessage(err));
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    props.token,
+    refreshAgents,
+    refreshTeamRuntime,
+    selectedAgentLabel,
+    selectedAgentWorkspaceAgent,
+    selectedAgentWorkspaceMemberId,
+    selectedTeamId,
+    setBusy,
+    setError,
+    setWarning,
+  ]);
+  const selectedAgentControlState = useMemo(
+    () =>
+      resolveTeamMemberAgentControlState(
+        selectedAgentWorkspaceAgent,
+        selectedAgentStatusView.lifecycle,
+        busy
+      ),
+    [busy, selectedAgentStatusView.lifecycle, selectedAgentWorkspaceAgent]
   );
   useEffect(() => {
     if (!selectedTeamId) {
@@ -3400,6 +3576,28 @@ export function TeamPage(props: TeamPageProps) {
                           >
                             Edit profile
                           </Menu.Item>
+                          <Menu.Item
+                            leftSection={<i className="bi bi-play-circle" aria-hidden="true" />}
+                            onClick={onStartSelectedTeamAgent}
+                            disabled={!selectedAgentControlState.canStart}
+                          >
+                            Start Agent
+                          </Menu.Item>
+                          <Menu.Item
+                            leftSection={<i className="bi bi-stop-circle" aria-hidden="true" />}
+                            onClick={onStopSelectedTeamAgent}
+                            disabled={!selectedAgentControlState.canStop}
+                          >
+                            Stop Agent
+                          </Menu.Item>
+                          <Menu.Item
+                            color="red"
+                            leftSection={<i className="bi bi-trash" aria-hidden="true" />}
+                            onClick={onDeleteSelectedTeamAgent}
+                            disabled={!selectedAgentControlState.canDelete}
+                          >
+                            Delete Agent
+                          </Menu.Item>
                         </Menu.Dropdown>
                       </Menu>
                   ) : showWorkspaceRuntimeBadge ? (
@@ -3686,6 +3884,7 @@ export function TeamPage(props: TeamPageProps) {
                       eventsLoading={eventsLoading}
                       oldestMemberEventId={oldestMemberEventId}
                       onSendInput={onSendAgentAcpInput}
+                      onForceNewSession={onForceNewTeamMemberSession}
                       onRefresh={onRefreshMemberConsole}
                       onLoadOlder={onLoadOlderMemberConsole}
                     />

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2671,7 +2671,62 @@ describe("team panels interactions", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onLoadOlder).toHaveBeenCalledTimes(0);
   });
+  it("TeamMemberAcpPanel mirrors member header status and model metadata", () => {
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedMemberSnapshot={buildMemberSnapshot({
+          member_id: "worker-agent",
+          role: "worker",
+          model: "gpt-5",
+          status: "working",
+          latest_step: buildStep({ member_id: "worker-agent", remote_task_id: "task-77" }),
+        })}
+        memberEvents={[]}
+        memberEventsHasMore={false}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onRefresh={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
 
+    expect(container.textContent).toContain("worker-agent");
+    expect(container.textContent).toContain("gpt-5");
+    expect(container.textContent).toContain("working");
+    expect(container.textContent).toContain("Role worker");
+    expect(container.textContent).toContain("Session task-77");
+  });
+
+  it("TeamMemberAcpPanel exposes a force-new-session action in debug mode", () => {
+    const onForceNewSession = vi.fn();
+
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedMemberSnapshot={null}
+        selectedMemberRole="worker"
+        selectedSessionId="runtime-session-1"
+        memberEvents={[]}
+        memberEventsHasMore={false}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onForceNewSession={onForceNewSession}
+        onRefresh={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    clickElement(findButtonByText(container, "Debug"));
+    clickElement(findButtonByText(container, "Force New Session"));
+    expect(onForceNewSession).toHaveBeenCalledTimes(1);
+  });
   it("TeamMemberAcpPanel auto-loads older ACP history for short threads and renders agent thinking", async () => {
     const onLoadOlder = vi.fn();
 
@@ -2729,6 +2784,47 @@ describe("team panels interactions", () => {
       "Inspecting the previous failure before replying."
     );
     expect(container.textContent).toContain("I found the relevant stack trace.");
+  });
+
+  it("TeamMemberAcpPanel shows active thinking status in the header", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_208_000);
+
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedMemberSnapshot={buildMemberSnapshot({
+          member_id: "worker-agent",
+          role: "worker",
+          status: "working",
+          latest_step: buildStep({ member_id: "worker-agent", remote_task_id: "task-77" }),
+        })}
+        memberEvents={[
+          {
+            event_id: 23,
+            agent_id: "worker-agent",
+            session_id: "task-77",
+            seq: "23",
+            ts: 1_700_000_203,
+            stream: "acp",
+            message: JSON.stringify({
+              type: "agent_thought",
+              text: "Inspecting the previous failure before replying.",
+            }),
+          },
+        ]}
+        memberEventsHasMore={false}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onRefresh={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    expect(container.textContent).toContain("working · thinking 5s");
+    nowSpy.mockRestore();
   });
 
   it("TeamMemberAcpPanel hides technical metadata when developer mode is off", () => {


### PR DESCRIPTION
## Summary

- add `Start Agent`, `Stop Agent`, and `Delete Agent` actions to the selected Team member workspace menu
- add Team `Agent ACP` header parity with the standalone Agents page, including member/model/status metadata and active `thinking Ns`
- honor Team-specific debug wording by allowing the ACP debug button label to render `Force New Session`

## Why

The Team workbench already exposes the selected member's workspace, mailbox, and ACP thread, but it was still missing two pieces of basic operator control:

1. lifecycle actions for the concrete Team member agent
2. the same ACP header/status treatment that the standalone Agents surface already provides

Without those controls, Team debugging is awkward: you can inspect a member but cannot directly start/stop/delete it from the Team surface, and active thinking is harder to read because the Team ACP panel lacked the header/status treatment used elsewhere.

## What Changed

### Team member lifecycle controls

- derive a Team-member-specific control state from the selected agent lifecycle and the current busy action
- surface `Start Agent`, `Stop Agent`, and `Delete Agent` in the selected Team member workspace menu
- keep delete behavior scoped to the agent record only; the Team member still remains in the Team spec until the profile is edited

### Team ACP header parity

- add a Team ACP header that mirrors the standalone Agents surface:
  - member title
  - model tag
  - role pill
  - session pill in developer mode
  - status badge with active `thinking Ns`
- wire the Team ACP debug action to render `Force New Session`

### Tests and docs

- add focused Team page lifecycle-control coverage
- add focused Team ACP header/thinking coverage
- document the new Team surface behavior in `docs/features/agents-teams.md`
- record implementation/validation in `docs/journal/2026-03-24-team-member-agent-controls-and-acp-header.md`

## Validation

### Automated

- `npm --prefix web run test -- --run src/pages/team_page.runs.test.ts src/pages/team_page.smoke.test.tsx src/pages/team_panels.test.tsx`
- `npm --prefix web run build`

### Chrome MCP

- baseline checked against the live Team page:
  - `https://agenthub.hawkingrei.com/teams/276a2682-9ce7-4af5-aa6c-f12575d13c37`
  - confirmed the current deployed Team member workspace menu still only shows `Overview / Events / Steps / Execution Mailbox`
- local regression shell checked at:
  - `http://127.0.0.1:4174/`
  - the frontend shell loads, but full authenticated Team-flow verification is limited because the local frontend is not attached to a running local backend API in this session

