### PR TITLE
ci: install lld for bazel rust builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.94.0
         with:

--- a/docs/journal/2026-03-24-bazel-ci-lld-linker.md
+++ b/docs/journal/2026-03-24-bazel-ci-lld-linker.md
@@ -1,0 +1,53 @@
+# Summary
+
+Switch Bazel CI away from the deprecated GNU gold linker by making `lld`
+available on the GitHub Actions runner before Bazel configures the local C/C++
+toolchain.
+
+# Why
+
+Rust 1.94 warns when the final link step uses `-fuse-ld=gold`:
+
+```text
+warning: the gold linker is deprecated and has known bugs with Rust
+```
+
+In this repository, Bazel Rust targets inherit linker selection from the Bazel
+C/C++ toolchain. The related `rules_rust` issue
+[`bazelbuild/rules_rust#1114`](https://github.com/bazelbuild/rules_rust/issues/1114)
+shows the same forwarding path from `cc_toolchain` into `rustc`.
+
+For GitHub-hosted Linux runners, Bazel's local C/C++ toolchain prefers `lld`
+when it is available and otherwise falls back to `gold`. Our Bazel workflow
+installed the Rust and native library prerequisites, but not `lld`, so the CI
+baseline was still selecting `gold`.
+
+# What Changed
+
+- Added `lld` to `.github/workflows/bazel.yml` system dependencies.
+- Kept the fix scoped to CI runner provisioning instead of forcing a repository
+  wide Rust linker override.
+- Added a CI verification backlog item to `docs/todo.md` so the warning
+  disappearance can be confirmed on both `push` and `pull_request`.
+
+# Why This Approach
+
+- It matches Bazel's native linker selection path instead of layering a custom
+  linker policy on top of `rules_rust`.
+- It avoids introducing a repo-wide `.bazelrc` override that could diverge from
+  local developer environments or interact poorly with mixed Rust/C linking.
+- It addresses the actual CI symptom source: `gold` is only chosen because
+  `lld` is absent on the runner image.
+
+# Validation
+
+- `rustc /tmp/min.rs -o /tmp/min-gold -Clinker=gcc -Clink-arg=-fuse-ld=gold`
+  reproduces the exact Rust gold-linker deprecation warning locally.
+- Expected CI validation:
+  - `bazel build //...`
+  - `bazel test --test_output=errors //...`
+
+Expected result:
+
+- Bazel CI no longer emits the Rust gold-linker deprecation warning once the
+  runner has `lld` available during local C/C++ toolchain detection.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,6 +44,7 @@ Active backlog only. Keep this file small and current.
 
 ## CI, Docs, And Maintainability
 
+- [ ] Verify the Bazel CI linker baseline after installing `lld`: `bazel build //...` and `bazel test //...` on both `push` and `pull_request` should stop emitting the Rust gold-linker deprecation warning, and the workflow run IDs should be recorded before closing this item (see `docs/journal/2026-03-24-bazel-ci-lld-linker.md`).
 - [ ] Verify Codecov strict-mode uploads and core CI matrices (`Rust`, `Web`, `Web E2E`, distributed node tests, Linux sandbox hardening) on both `push` and `pull_request`, and record run IDs before closing the remaining rollout items (see `docs/journal/2026-02-19-ci-libcap-linux-sandbox.md`, `docs/journal/2026-02-20-ci-codecov-fail-fast-upload.md`, `docs/journal/2026-03-19-distributed-node-architecture.md`).
 - [ ] Continue `docs/features` compaction wave 2: move stable conclusions out of residual Team and UI micro-journals into canonical feature specs and replace merged records with explicit supersession pointers where useful (see `docs/features/README.md`).
 - [ ] Strengthen documentation governance: every user-visible workflow change should update `userdocs/`, stable engineering contracts should live in `docs/features/`, and `docs/todo.md` should remain an active backlog rather than a historical ledger (see `docs/README.md`, `docs/journal/2026-03-24-documentation-surface-compaction.md`).


### PR DESCRIPTION
# Summary

- install `lld` in the Bazel GitHub Actions workflow so Bazel's local C/C++
  toolchain can prefer it over GNU gold
- document the linker-selection reasoning and add a follow-up verification item
  for the Bazel CI matrix

# Purpose

Rust 1.94 emits a warning when Bazel ends up linking Rust targets with GNU
gold. In our CI setup this comes from the Bazel-generated local C/C++ toolchain
falling back to `gold` when `lld` is not present on the runner.

This change keeps the fix at the CI provisioning layer instead of forcing a
repository-wide Rust linker override.

# Testing

- `rustc /tmp/min.rs -o /tmp/min-gold -Clinker=gcc -Clink-arg=-fuse-ld=gold`
  reproduces the exact gold-linker deprecation warning locally
- `bazel test --test_output=errors //...`
  - blocked locally by an existing wildcard package-loading issue under
    `.cargo/git/checkouts/...`
- `bazel test --test_output=errors //:all //crates/... //agenthub-codex-acp:all //third_party/...`
  - blocked locally by an existing `third_party/codex_linux_sandbox` Bazel
    package-loading failure for `@@rules_cc+//cc:defs.bzl`

# Related

- rules_rust issue: bazelbuild/rules_rust#1114