### PR TITLE
fix: require materialized Team and actor managed skills

### DIFF
--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -13,9 +13,9 @@ pub(super) fn build_required_managed_skill(
     home_dir: Option<&Path>,
 ) -> Result<AcpSkill> {
     let doc = managed_skill_doc(kind, home_dir)?;
-    if !doc.path.exists() {
+    if !doc.path.is_file() {
         bail!(
-            "managed skill '{}' is not materialized at {}; run `agenthub doctor` or fix managed skill installation before starting the actor runtime",
+            "managed skill '{}' is not materialized as a regular file at {}; run `agenthub doctor` or fix managed skill installation before starting the ACP session",
             doc.name,
             doc.path.display()
         );
@@ -105,44 +105,17 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
 mod tests {
     use std::fs;
 
-    use agenthub_managed_skills::{ManagedSkillKind, install_managed_skills};
+    use agenthub_managed_skills::{ManagedSkillKind, install_managed_skills, managed_skill_doc};
 
     use super::{
         AcpActorSkillContext, build_actor_runtime_context_block, build_required_managed_skill,
     };
+    use crate::test_utils::TempManagedSkillsHome;
     use agent_client_protocol::ContentBlock;
-    use uuid::Uuid;
-
-    struct TempManagedSkillsHome {
-        root: std::path::PathBuf,
-    }
-
-    impl TempManagedSkillsHome {
-        fn new() -> Self {
-            let root = std::env::temp_dir().join(format!(
-                "agenthub-acp-managed-skill-home-{}",
-                Uuid::new_v4()
-            ));
-            fs::create_dir_all(&root).expect("create temp managed skills home");
-            Self { root }
-        }
-
-        fn path(&self) -> &std::path::Path {
-            &self.root
-        }
-    }
-
-    impl Drop for TempManagedSkillsHome {
-        fn drop(&mut self) {
-            if self.root.exists() {
-                let _ = fs::remove_dir_all(&self.root);
-            }
-        }
-    }
 
     #[test]
     fn actor_runtime_skill_uses_static_name() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-managed-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let skill = build_required_managed_skill(ManagedSkillKind::ActorRuntime, Some(home.path()))
             .expect("build actor runtime skill");
@@ -152,11 +125,29 @@ mod tests {
 
     #[test]
     fn required_managed_skill_errors_when_not_materialized() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-managed-skill-home");
         let err = build_required_managed_skill(ManagedSkillKind::ActorRuntime, Some(home.path()))
             .expect_err("missing managed skill should hard fail");
         assert!(
             err.to_string().contains("is not materialized"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("ACP session"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn required_managed_skill_errors_when_path_is_directory() {
+        let home = TempManagedSkillsHome::new("agenthub-acp-managed-skill-home");
+        let doc = managed_skill_doc(ManagedSkillKind::ActorRuntime, Some(home.path()))
+            .expect("load managed skill doc");
+        fs::create_dir_all(&doc.path).expect("create directory at skill path");
+        let err = build_required_managed_skill(ManagedSkillKind::ActorRuntime, Some(home.path()))
+            .expect_err("directory should not satisfy materialized skill contract");
+        assert!(
+            err.to_string().contains("regular file"),
             "unexpected error: {err}"
         );
     }

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -1,32 +1,34 @@
+use std::path::Path;
+
 use agent_client_protocol::{ContentBlock, TextContent};
 use agenthub_acp_core::{AcpSkill, build_skill};
-use agenthub_managed_skills::{
-    ManagedSkillKind, managed_skill_contents, managed_skill_doc, managed_skill_name,
-};
+use agenthub_managed_skills::{ManagedSkillKind, managed_skill_doc};
 use agenthub_text::truncate_chars;
+use anyhow::{Result, bail};
 
 use crate::AcpActorSkillContext;
 
-const FALLBACK_ACTOR_RUNTIME_SKILL_PATH: &str = "builtin://agenthub/actor-runtime";
-
-pub(super) fn build_actor_runtime_skill() -> AcpSkill {
-    match managed_skill_doc(ManagedSkillKind::ActorRuntime, None) {
-        Ok(doc) if doc.path.exists() => build_skill(
-            doc.name.to_string(),
-            doc.path.to_string_lossy().to_string(),
-            &doc.contents,
-        ),
-        Ok(doc) => build_skill(
-            doc.name.to_string(),
-            FALLBACK_ACTOR_RUNTIME_SKILL_PATH.to_string(),
-            &doc.contents,
-        ),
-        Err(_) => build_skill(
-            managed_skill_name(ManagedSkillKind::ActorRuntime).to_string(),
-            FALLBACK_ACTOR_RUNTIME_SKILL_PATH.to_string(),
-            managed_skill_contents(ManagedSkillKind::ActorRuntime).as_str(),
-        ),
+pub(super) fn build_required_managed_skill(
+    kind: ManagedSkillKind,
+    home_dir: Option<&Path>,
+) -> Result<AcpSkill> {
+    let doc = managed_skill_doc(kind, home_dir)?;
+    if !doc.path.exists() {
+        bail!(
+            "managed skill '{}' is not materialized at {}; run `agenthub doctor` or fix managed skill installation before starting the actor runtime",
+            doc.name,
+            doc.path.display()
+        );
     }
+    Ok(build_skill(
+        doc.name.to_string(),
+        doc.path.to_string_lossy().to_string(),
+        &doc.contents,
+    ))
+}
+
+pub(super) fn build_actor_runtime_skill() -> Result<AcpSkill> {
+    build_required_managed_skill(ManagedSkillKind::ActorRuntime, None)
 }
 
 pub(super) fn build_actor_runtime_context_block(context: &AcpActorSkillContext) -> ContentBlock {
@@ -101,16 +103,62 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use agenthub_managed_skills::{ManagedSkillKind, install_managed_skills};
+
     use super::{
-        AcpActorSkillContext, build_actor_runtime_context_block, build_actor_runtime_skill,
+        AcpActorSkillContext, build_actor_runtime_context_block, build_required_managed_skill,
     };
     use agent_client_protocol::ContentBlock;
+    use uuid::Uuid;
+
+    struct TempManagedSkillsHome {
+        root: std::path::PathBuf,
+    }
+
+    impl TempManagedSkillsHome {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "agenthub-acp-managed-skill-home-{}",
+                Uuid::new_v4()
+            ));
+            fs::create_dir_all(&root).expect("create temp managed skills home");
+            Self { root }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.root
+        }
+    }
+
+    impl Drop for TempManagedSkillsHome {
+        fn drop(&mut self) {
+            if self.root.exists() {
+                let _ = fs::remove_dir_all(&self.root);
+            }
+        }
+    }
 
     #[test]
     fn actor_runtime_skill_uses_static_name() {
-        let skill = build_actor_runtime_skill();
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
+        let skill = build_required_managed_skill(ManagedSkillKind::ActorRuntime, Some(home.path()))
+            .expect("build actor runtime skill");
         assert_eq!(skill.name, "agenthub-actor-runtime");
         assert!(skill.instructions.contains("AgentHub Actor Runtime Skill"));
+    }
+
+    #[test]
+    fn required_managed_skill_errors_when_not_materialized() {
+        let home = TempManagedSkillsHome::new();
+        let err = build_required_managed_skill(ManagedSkillKind::ActorRuntime, Some(home.path()))
+            .expect_err("missing managed skill should hard fail");
+        assert!(
+            err.to_string().contains("is not materialized"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -1,7 +1,9 @@
 mod actor_runtime_skill;
 mod team_role_skills;
+#[cfg(test)]
+mod test_utils;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -465,6 +467,25 @@ fn dedupe_skills(skills: Vec<AcpSkill>) -> Vec<AcpSkill> {
     out
 }
 
+fn remove_skills_conflicting_with_reserved(existing: &mut Vec<AcpSkill>, reserved: &[AcpSkill]) {
+    if reserved.is_empty() {
+        return;
+    }
+
+    let reserved_names = reserved
+        .iter()
+        .map(|skill| skill.name.to_ascii_lowercase())
+        .collect::<HashSet<_>>();
+    let reserved_paths = reserved
+        .iter()
+        .map(|skill| skill.path.to_ascii_lowercase())
+        .collect::<HashSet<_>>();
+    existing.retain(|skill| {
+        !reserved_names.contains(&skill.name.to_ascii_lowercase())
+            && !reserved_paths.contains(&skill.path.to_ascii_lowercase())
+    });
+}
+
 fn build_prompt_prefix_blocks(
     skills: &[AcpSkill],
     actor_context: Option<&AcpActorSkillContext>,
@@ -882,6 +903,7 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                             return;
                         }
                     };
+                    remove_skills_conflicting_with_reserved(&mut skills, &team_role_skills);
                     skills.extend(team_role_skills);
                     attached_team_role_skills = true;
                 }
@@ -893,6 +915,10 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                         return;
                     }
                 };
+                remove_skills_conflicting_with_reserved(
+                    &mut skills,
+                    std::slice::from_ref(&actor_runtime_skill),
+                );
                 skills.push(actor_runtime_skill);
             }
             let skills = dedupe_skills(skills);
@@ -1746,7 +1772,7 @@ mod tests {
         AcpPermissionRespondResult, AcpPermissionService, AcpPromptDeliveryPolicy,
         AcpRuntimeLocation, AcpSendError, build_prompt_prefix_blocks, dedupe_skills,
         load_mcp_servers_from_path, load_skills_from_config, load_workdir_skills,
-        should_queue_while_prompts_active,
+        remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
     };
     use agent_client_protocol::McpServer;
     use agent_client_protocol::{
@@ -2168,6 +2194,41 @@ Fallback to the user-level review contract.
         assert_eq!(deduped.len(), 1);
         assert_eq!(deduped[0].name, "shared-review");
         assert_eq!(deduped[0].path, local_skill.to_string_lossy());
+    }
+
+    #[test]
+    fn reserved_skills_take_precedence_over_preloaded_name_and_path_aliases() {
+        let reserved = build_skill(
+            "agenthub-actor-runtime".to_string(),
+            "/tmp/runtime/actor/SKILL.md".to_string(),
+            "---\nname: agenthub-actor-runtime\n---\nCanonical runtime skill.\n",
+        );
+        let mut skills = vec![
+            build_skill(
+                "agenthub-actor-runtime".to_string(),
+                "/tmp/custom/runtime-alias/SKILL.md".to_string(),
+                "---\nname: agenthub-actor-runtime\n---\nAlias by name.\n",
+            ),
+            build_skill(
+                "custom-runtime-alias".to_string(),
+                reserved.path.clone(),
+                "---\nname: custom-runtime-alias\n---\nAlias by path.\n",
+            ),
+            build_skill(
+                "shared-review".to_string(),
+                "/tmp/review/SKILL.md".to_string(),
+                "---\nname: shared-review\n---\nUnrelated skill.\n",
+            ),
+        ];
+
+        remove_skills_conflicting_with_reserved(&mut skills, std::slice::from_ref(&reserved));
+        skills.push(reserved.clone());
+        let deduped = dedupe_skills(skills);
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].name, "shared-review");
+        assert_eq!(deduped[1].name, reserved.name);
+        assert_eq!(deduped[1].path, reserved.path);
     }
 
     fn sample_actor_context() -> AcpActorSkillContext {

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -865,10 +865,8 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
             if actor_context.is_some()
                 && let Err(err) = install_managed_skills(None)
             {
-                tracing::warn!(
-                    error = %err,
-                    "failed to materialize managed skills under ~/.agents/skills; falling back to inline skill paths"
-                );
+                let _ = ready_tx.send(Err(format!("acp managed skill install failed: {err}")));
+                return;
             }
             let mcp_servers = load_mcp_servers();
             let mut skills = load_skills(Path::new(&workdir), &safe_paths);
@@ -876,10 +874,26 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
             let mut attached_team_role_skills = false;
             if let Some(ctx) = actor_context.as_ref() {
                 if should_attach_team_role_skills(Some(ctx)) {
-                    skills.extend(build_team_role_skills(ctx));
+                    let team_role_skills = match build_team_role_skills(ctx) {
+                        Ok(team_role_skills) => team_role_skills,
+                        Err(err) => {
+                            let _ = ready_tx
+                                .send(Err(format!("acp managed team skill load failed: {err}")));
+                            return;
+                        }
+                    };
+                    skills.extend(team_role_skills);
                     attached_team_role_skills = true;
                 }
-                skills.push(build_actor_runtime_skill());
+                let actor_runtime_skill = match build_actor_runtime_skill() {
+                    Ok(actor_runtime_skill) => actor_runtime_skill,
+                    Err(err) => {
+                        let _ = ready_tx
+                            .send(Err(format!("acp actor runtime skill load failed: {err}")));
+                        return;
+                    }
+                };
+                skills.push(actor_runtime_skill);
             }
             let skills = dedupe_skills(skills);
             if let Some(ctx) = actor_context.as_ref() {

--- a/crates/agenthub-acp/src/team_role_skills.rs
+++ b/crates/agenthub-acp/src/team_role_skills.rs
@@ -1,9 +1,11 @@
-use agenthub_acp_core::{AcpSkill, build_skill};
-use agenthub_managed_skills::{
-    ManagedSkillKind, managed_skill_contents, managed_skill_doc, managed_skill_name,
-};
+use std::path::Path;
+
+use agenthub_acp_core::AcpSkill;
+use agenthub_managed_skills::ManagedSkillKind;
+use anyhow::Result;
 
 use crate::AcpActorSkillContext;
+use crate::actor_runtime_skill::build_required_managed_skill;
 
 const TEAM_AGENTS_INDEX_SKILL_NAME: &str = "team-agents-index";
 const TEAM_LEADER_AGENTS_INDEX_SKILL_NAME: &str = "team-leader-agents-index";
@@ -27,37 +29,17 @@ impl TeamRoleIndexKind {
             Self::Worker => ManagedSkillKind::TeamWorkerAgentsIndex,
         }
     }
-
-    fn fallback_path(self) -> &'static str {
-        match self {
-            Self::Leader => "builtin://agenthub/team/team-leader-agents-index",
-            Self::Worker => "builtin://agenthub/team/team-worker-agents-index",
-        }
-    }
 }
 
-fn build_managed_skill(kind: ManagedSkillKind, fallback_path: &str) -> AcpSkill {
-    match managed_skill_doc(kind, None) {
-        Ok(doc) if doc.path.exists() => build_skill(
-            doc.name.to_string(),
-            doc.path.to_string_lossy().to_string(),
-            &doc.contents,
-        ),
-        Ok(doc) => build_skill(
-            doc.name.to_string(),
-            fallback_path.to_string(),
-            &doc.contents,
-        ),
-        Err(_) => build_skill(
-            managed_skill_name(kind).to_string(),
-            fallback_path.to_string(),
-            managed_skill_contents(kind).as_str(),
-        ),
-    }
+fn build_managed_skill(kind: ManagedSkillKind, home_dir: Option<&Path>) -> Result<AcpSkill> {
+    build_required_managed_skill(kind, home_dir)
 }
 
-fn build_role_agents_index_skill(kind: TeamRoleIndexKind) -> AcpSkill {
-    build_managed_skill(kind.managed_kind(), kind.fallback_path())
+fn build_role_agents_index_skill(
+    kind: TeamRoleIndexKind,
+    home_dir: Option<&Path>,
+) -> Result<AcpSkill> {
+    build_managed_skill(kind.managed_kind(), home_dir)
 }
 
 fn normalize_member_role(role: Option<&str>) -> Option<&str> {
@@ -89,7 +71,14 @@ pub(super) fn is_reserved_team_role_skill(name: &str) -> bool {
         || name.eq_ignore_ascii_case(TEAM_ACTOR_MAILBOX_SKILL_NAME)
 }
 
-pub(super) fn build_team_role_skills(context: &AcpActorSkillContext) -> Vec<AcpSkill> {
+pub(super) fn build_team_role_skills(context: &AcpActorSkillContext) -> Result<Vec<AcpSkill>> {
+    build_team_role_skills_with_home(context, None)
+}
+
+fn build_team_role_skills_with_home(
+    context: &AcpActorSkillContext,
+    home_dir: Option<&Path>,
+) -> Result<Vec<AcpSkill>> {
     let role = normalize_member_role(context.member_role.as_deref());
     let enable_deliberation = has_member_skill(context, TEAM_DELIBERATION_SKILL_NAME);
     let enable_task_lifecycle = has_member_skill(context, TEAM_TASK_LIFECYCLE_SKILL_NAME);
@@ -98,69 +87,108 @@ pub(super) fn build_team_role_skills(context: &AcpActorSkillContext) -> Vec<AcpS
         Some("leader") => {
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamAgentsIndex,
-                "builtin://agenthub/team/team-agents-index",
-            ));
-            out.push(build_role_agents_index_skill(TeamRoleIndexKind::Leader));
+                home_dir,
+            )?);
+            out.push(build_role_agents_index_skill(
+                TeamRoleIndexKind::Leader,
+                home_dir,
+            )?);
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamLeaderOrchestrator,
-                "builtin://agenthub/team/team-leader-orchestrator",
-            ));
+                home_dir,
+            )?);
             if enable_task_lifecycle {
                 out.push(build_managed_skill(
                     ManagedSkillKind::TeamTaskLifecycle,
-                    "builtin://agenthub/team/team-task-lifecycle",
-                ));
+                    home_dir,
+                )?);
             }
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamActorMailbox,
-                "builtin://agenthub/team/team-actor-mailbox",
-            ));
+                home_dir,
+            )?);
             if enable_deliberation {
                 out.push(build_managed_skill(
                     ManagedSkillKind::TeamDeliberationRules,
-                    "builtin://agenthub/team/team-deliberation-rules",
-                ));
+                    home_dir,
+                )?);
             }
         }
         Some("worker") => {
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamAgentsIndex,
-                "builtin://agenthub/team/team-agents-index",
-            ));
-            out.push(build_role_agents_index_skill(TeamRoleIndexKind::Worker));
+                home_dir,
+            )?);
+            out.push(build_role_agents_index_skill(
+                TeamRoleIndexKind::Worker,
+                home_dir,
+            )?);
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamWorkerExecutor,
-                "builtin://agenthub/team/team-worker-executor",
-            ));
+                home_dir,
+            )?);
             if enable_task_lifecycle {
                 out.push(build_managed_skill(
                     ManagedSkillKind::TeamTaskLifecycle,
-                    "builtin://agenthub/team/team-task-lifecycle",
-                ));
+                    home_dir,
+                )?);
             }
             out.push(build_managed_skill(
                 ManagedSkillKind::TeamActorMailbox,
-                "builtin://agenthub/team/team-actor-mailbox",
-            ));
+                home_dir,
+            )?);
             if enable_deliberation {
                 out.push(build_managed_skill(
                     ManagedSkillKind::TeamDeliberationRules,
-                    "builtin://agenthub/team/team-deliberation-rules",
-                ));
+                    home_dir,
+                )?);
             }
         }
         _ => {}
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use agenthub_managed_skills::install_managed_skills;
+    use uuid::Uuid;
+
     use super::{
         TeamRoleIndexKind, build_role_agents_index_skill, build_team_role_skills,
-        is_reserved_team_role_skill, should_attach_team_role_skills,
+        build_team_role_skills_with_home, is_reserved_team_role_skill,
+        should_attach_team_role_skills,
     };
     use crate::AcpActorSkillContext;
+
+    struct TempManagedSkillsHome {
+        root: std::path::PathBuf,
+    }
+
+    impl TempManagedSkillsHome {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "agenthub-acp-team-role-skill-home-{}",
+                Uuid::new_v4()
+            ));
+            fs::create_dir_all(&root).expect("create temp managed skills home");
+            Self { root }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.root
+        }
+    }
+
+    impl Drop for TempManagedSkillsHome {
+        fn drop(&mut self) {
+            if self.root.exists() {
+                let _ = fs::remove_dir_all(&self.root);
+            }
+        }
+    }
 
     fn context_with_role(role: Option<&str>) -> AcpActorSkillContext {
         AcpActorSkillContext {
@@ -178,7 +206,11 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_for_leader() {
-        let skills = build_team_role_skills(&context_with_role(Some("leader")));
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
+        let skills =
+            build_team_role_skills_with_home(&context_with_role(Some("leader")), Some(home.path()))
+                .expect("build leader team role skills");
         let names = skills
             .iter()
             .map(|item| item.name.as_str())
@@ -196,7 +228,11 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_for_worker() {
-        let skills = build_team_role_skills(&context_with_role(Some("worker")));
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
+        let skills =
+            build_team_role_skills_with_home(&context_with_role(Some("worker")), Some(home.path()))
+                .expect("build worker team role skills");
         let names = skills
             .iter()
             .map(|item| item.name.as_str())
@@ -214,11 +250,14 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_includes_task_lifecycle_when_requested() {
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
         let mut context = context_with_role(Some("leader"));
         context
             .member_skills
             .push("team-task-lifecycle".to_string());
-        let skills = build_team_role_skills(&context);
+        let skills = build_team_role_skills_with_home(&context, Some(home.path()))
+            .expect("build team role skills");
         let names = skills
             .iter()
             .map(|item| item.name.as_str())
@@ -228,11 +267,14 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_enables_deliberation_when_requested() {
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
         let mut context = context_with_role(Some("worker"));
         context
             .member_skills
             .push("team-deliberation-rules".to_string());
-        let skills = build_team_role_skills(&context);
+        let skills = build_team_role_skills_with_home(&context, Some(home.path()))
+            .expect("build team role skills");
         let names = skills
             .iter()
             .map(|item| item.name.as_str())
@@ -242,8 +284,16 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_skips_unknown_role() {
-        assert!(build_team_role_skills(&context_with_role(Some("observer"))).is_empty());
-        assert!(build_team_role_skills(&context_with_role(None)).is_empty());
+        assert!(
+            build_team_role_skills(&context_with_role(Some("observer")))
+                .expect("build observer team role skills")
+                .is_empty()
+        );
+        assert!(
+            build_team_role_skills(&context_with_role(None))
+                .expect("build empty team role skills")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -279,10 +329,26 @@ mod tests {
 
     #[test]
     fn role_agents_index_skill_uses_expected_names() {
-        let leader = build_role_agents_index_skill(TeamRoleIndexKind::Leader);
+        let home = TempManagedSkillsHome::new();
+        install_managed_skills(Some(home.path())).expect("install managed skills");
+        let leader = build_role_agents_index_skill(TeamRoleIndexKind::Leader, Some(home.path()))
+            .expect("build leader role agents index skill");
         assert_eq!(leader.name, "team-leader-agents-index");
 
-        let worker = build_role_agents_index_skill(TeamRoleIndexKind::Worker);
+        let worker = build_role_agents_index_skill(TeamRoleIndexKind::Worker, Some(home.path()))
+            .expect("build worker role agents index skill");
         assert_eq!(worker.name, "team-worker-agents-index");
+    }
+
+    #[test]
+    fn build_team_role_skills_error_when_managed_skill_not_materialized() {
+        let home = TempManagedSkillsHome::new();
+        let err =
+            build_team_role_skills_with_home(&context_with_role(Some("leader")), Some(home.path()))
+                .expect_err("missing managed team skills should hard fail");
+        assert!(
+            err.to_string().contains("is not materialized"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/agenthub-acp/src/team_role_skills.rs
+++ b/crates/agenthub-acp/src/team_role_skills.rs
@@ -31,15 +31,11 @@ impl TeamRoleIndexKind {
     }
 }
 
-fn build_managed_skill(kind: ManagedSkillKind, home_dir: Option<&Path>) -> Result<AcpSkill> {
-    build_required_managed_skill(kind, home_dir)
-}
-
 fn build_role_agents_index_skill(
     kind: TeamRoleIndexKind,
     home_dir: Option<&Path>,
 ) -> Result<AcpSkill> {
-    build_managed_skill(kind.managed_kind(), home_dir)
+    build_required_managed_skill(kind.managed_kind(), home_dir)
 }
 
 fn normalize_member_role(role: Option<&str>) -> Option<&str> {
@@ -85,7 +81,7 @@ fn build_team_role_skills_with_home(
     let mut out = Vec::new();
     match role {
         Some("leader") => {
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamAgentsIndex,
                 home_dir,
             )?);
@@ -93,29 +89,29 @@ fn build_team_role_skills_with_home(
                 TeamRoleIndexKind::Leader,
                 home_dir,
             )?);
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamLeaderOrchestrator,
                 home_dir,
             )?);
             if enable_task_lifecycle {
-                out.push(build_managed_skill(
+                out.push(build_required_managed_skill(
                     ManagedSkillKind::TeamTaskLifecycle,
                     home_dir,
                 )?);
             }
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamActorMailbox,
                 home_dir,
             )?);
             if enable_deliberation {
-                out.push(build_managed_skill(
+                out.push(build_required_managed_skill(
                     ManagedSkillKind::TeamDeliberationRules,
                     home_dir,
                 )?);
             }
         }
         Some("worker") => {
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamAgentsIndex,
                 home_dir,
             )?);
@@ -123,22 +119,22 @@ fn build_team_role_skills_with_home(
                 TeamRoleIndexKind::Worker,
                 home_dir,
             )?);
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamWorkerExecutor,
                 home_dir,
             )?);
             if enable_task_lifecycle {
-                out.push(build_managed_skill(
+                out.push(build_required_managed_skill(
                     ManagedSkillKind::TeamTaskLifecycle,
                     home_dir,
                 )?);
             }
-            out.push(build_managed_skill(
+            out.push(build_required_managed_skill(
                 ManagedSkillKind::TeamActorMailbox,
                 home_dir,
             )?);
             if enable_deliberation {
-                out.push(build_managed_skill(
+                out.push(build_required_managed_skill(
                     ManagedSkillKind::TeamDeliberationRules,
                     home_dir,
                 )?);
@@ -151,10 +147,7 @@ fn build_team_role_skills_with_home(
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use agenthub_managed_skills::install_managed_skills;
-    use uuid::Uuid;
 
     use super::{
         TeamRoleIndexKind, build_role_agents_index_skill, build_team_role_skills,
@@ -162,33 +155,7 @@ mod tests {
         should_attach_team_role_skills,
     };
     use crate::AcpActorSkillContext;
-
-    struct TempManagedSkillsHome {
-        root: std::path::PathBuf,
-    }
-
-    impl TempManagedSkillsHome {
-        fn new() -> Self {
-            let root = std::env::temp_dir().join(format!(
-                "agenthub-acp-team-role-skill-home-{}",
-                Uuid::new_v4()
-            ));
-            fs::create_dir_all(&root).expect("create temp managed skills home");
-            Self { root }
-        }
-
-        fn path(&self) -> &std::path::Path {
-            &self.root
-        }
-    }
-
-    impl Drop for TempManagedSkillsHome {
-        fn drop(&mut self) {
-            if self.root.exists() {
-                let _ = fs::remove_dir_all(&self.root);
-            }
-        }
-    }
+    use crate::test_utils::TempManagedSkillsHome;
 
     fn context_with_role(role: Option<&str>) -> AcpActorSkillContext {
         AcpActorSkillContext {
@@ -206,7 +173,7 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_for_leader() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let skills =
             build_team_role_skills_with_home(&context_with_role(Some("leader")), Some(home.path()))
@@ -228,7 +195,7 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_for_worker() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let skills =
             build_team_role_skills_with_home(&context_with_role(Some("worker")), Some(home.path()))
@@ -250,7 +217,7 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_includes_task_lifecycle_when_requested() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let mut context = context_with_role(Some("leader"));
         context
@@ -267,7 +234,7 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_enables_deliberation_when_requested() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let mut context = context_with_role(Some("worker"));
         context
@@ -329,7 +296,7 @@ mod tests {
 
     #[test]
     fn role_agents_index_skill_uses_expected_names() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         install_managed_skills(Some(home.path())).expect("install managed skills");
         let leader = build_role_agents_index_skill(TeamRoleIndexKind::Leader, Some(home.path()))
             .expect("build leader role agents index skill");
@@ -342,12 +309,16 @@ mod tests {
 
     #[test]
     fn build_team_role_skills_error_when_managed_skill_not_materialized() {
-        let home = TempManagedSkillsHome::new();
+        let home = TempManagedSkillsHome::new("agenthub-acp-team-role-skill-home");
         let err =
             build_team_role_skills_with_home(&context_with_role(Some("leader")), Some(home.path()))
                 .expect_err("missing managed team skills should hard fail");
         assert!(
             err.to_string().contains("is not materialized"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("ACP session"),
             "unexpected error: {err}"
         );
     }

--- a/crates/agenthub-acp/src/test_utils.rs
+++ b/crates/agenthub-acp/src/test_utils.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+pub(crate) struct TempManagedSkillsHome {
+    root: PathBuf,
+}
+
+impl TempManagedSkillsHome {
+    pub(crate) fn new(prefix: &str) -> Self {
+        let root = std::env::temp_dir().join(format!("{prefix}-{}", Uuid::new_v4()));
+        fs::create_dir_all(&root).expect("create temp managed skills home");
+        Self { root }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TempManagedSkillsHome {
+    fn drop(&mut self) {
+        if self.root.exists() {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+}

--- a/docs/journal/2026-03-25-managed-skills-no-builtin-fallback.md
+++ b/docs/journal/2026-03-25-managed-skills-no-builtin-fallback.md
@@ -1,0 +1,40 @@
+# 2026-03-25 Managed Skills No Builtin Fallback
+
+## Summary
+
+- removed `builtin://...` fallback for Team role managed skills and the actor runtime skill
+- require managed Team/actor skills to exist as materialized `SKILL.md` files under `~/.agents/skills/agenthub-runtime/...`
+- changed ACP actor session startup to fail fast when managed skill installation or loading fails
+
+## Why
+
+Team actor sessions were still able to degrade into inline `builtin://...` skill paths when
+managed skill materialization failed. That kept the session alive, but it also:
+
+- hid managed skill installation problems
+- prevented `agenthub-codex-acp` from upgrading trusted skill blocks into native skill inputs
+- increased prompt/context overhead because the fallback path stayed text-like
+
+For Team runtime correctness and prompt efficiency, managed Team/actor skills need to resolve to
+real `SKILL.md` paths consistently.
+
+## Implementation
+
+- `crates/agenthub-acp/src/actor_runtime_skill.rs`
+  - introduced a strict `build_required_managed_skill(...)` helper
+  - `build_actor_runtime_skill()` now returns an error if the managed skill is not materialized
+- `crates/agenthub-acp/src/team_role_skills.rs`
+  - Team role skill builders now return `Result<_>` and require materialized managed skill files
+  - tests now install managed skills into a temp home instead of relying on ambient `~/.agents`
+- `crates/agenthub-acp/src/lib.rs`
+  - `spawn_acp_session(...)` now fails session startup if:
+    - managed skill installation fails
+    - Team role skill loading fails
+    - actor runtime skill loading fails
+
+## Validation
+
+- `cargo test -p agenthub-acp build_team_role_skills -- --nocapture`
+- `cargo test -p agenthub-acp actor_runtime_skill -- --nocapture`
+- `cargo test -p agenthub-acp prompt_prefix_blocks -- --nocapture`
+- `git diff --check`

--- a/docs/journal/2026-03-25-managed-skills-no-builtin-fallback.md
+++ b/docs/journal/2026-03-25-managed-skills-no-builtin-fallback.md
@@ -23,6 +23,8 @@ real `SKILL.md` paths consistently.
 - `crates/agenthub-acp/src/actor_runtime_skill.rs`
   - introduced a strict `build_required_managed_skill(...)` helper
   - `build_actor_runtime_skill()` now returns an error if the managed skill is not materialized
+  - materialization validation now requires a regular file, not only path existence
+  - startup error text is generic to ACP session startup, so Team role skill failures report accurately
 - `crates/agenthub-acp/src/team_role_skills.rs`
   - Team role skill builders now return `Result<_>` and require materialized managed skill files
   - tests now install managed skills into a temp home instead of relying on ambient `~/.agents`
@@ -31,6 +33,7 @@ real `SKILL.md` paths consistently.
     - managed skill installation fails
     - Team role skill loading fails
     - actor runtime skill loading fails
+  - reserved Team/actor managed skills now evict conflicting preloaded skills by canonical name/path before dedupe, so the materialized runtime skills always win over workspace/config aliases
 
 ## Validation
 

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -344,7 +344,8 @@ fn generate_pin() -> String {
 }
 
 fn hash_pin(pin: &str) -> anyhow::Result<String> {
-    let salt = argon2::password_hash::SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    let salt =
+        argon2::password_hash::SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
     let argon2 = Argon2::default();
     let hash = argon2
         .hash_password(pin.as_bytes(), &salt)

--- a/src/push.rs
+++ b/src/push.rs
@@ -124,8 +124,7 @@ impl PushService {
                     .private_key
                     .clone()
             };
-            let mut sig_builder =
-                VapidSignatureBuilder::from_base64(&private_key, &subscription)?;
+            let mut sig_builder = VapidSignatureBuilder::from_base64(&private_key, &subscription)?;
             sig_builder.add_claim("sub", self.subject.as_str());
             let sig = sig_builder.build()?;
 


### PR DESCRIPTION
## Summary

- remove `builtin://...` fallback for Team role managed skills and the actor runtime skill
- require Team/actor managed skills to resolve to real materialized `SKILL.md` paths
- fail ACP session startup fast when managed skill installation or loading fails
- add focused `agenthub-acp` regression tests around strict managed skill loading

## Why

Team actor sessions could silently degrade into inline `builtin://...` skill paths when managed skill materialization failed. That hid installation problems and prevented Codex ACP from treating managed Team/actor skills as trusted native skill inputs.

This change makes the failure mode explicit and keeps the runtime on the canonical materialized skill path only.

## Testing

- `cargo test -p agenthub-acp build_team_role_skills -- --nocapture`
- `cargo test -p agenthub-acp actor_runtime_skill -- --nocapture`
- `cargo test -p agenthub-acp prompt_prefix_blocks -- --nocapture`
- `git diff --check`
