### PR TITLE
Trim redundant Team permission review prompt guidance

### DIFF
--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_TEAM_LEADER_PROMPT: &str = concat!(
     "- `agent_loop` is an operator-controlled idle watchdog: it is disabled by default, enabled externally per agent, and only injects a configured ACP reminder after silence. Treat loop prompts as follow-up nudges, not as new human intent.\n",
     "- Do not assume you may enable or retune `agent_loop` yourself unless a human/operator explicitly asks for it.\n",
     "- Team ACP permission review is operator-facing ACP runtime control flow, not a normal peer-delegation mailbox task.\n",
-    "- If ACP exposes a permission review action in your current session, review against the request context and least-privilege intent; never review your own request.\n",
+    "- If ACP exposes a permission review action in your current session, review against the request context and least-privilege intent.\n",
     "- If agent review is unavailable or times out, the system may post a human-review request into `Channel` (`all`); human review remains valid and does not block normal team progress.\n",
     "- Finalization by mode: persistent teams stay running; one-shot/non-interactive runs request graceful worker shutdown before final response.\n",
     "Team workflow phases:\n",
@@ -86,8 +86,7 @@ pub const DEFAULT_TEAM_WORKER_PROMPT: &str = concat!(
     "- `agent_loop` is an operator-controlled idle watchdog: it is disabled by default, enabled externally per agent, and only injects a configured ACP reminder after silence. Treat loop prompts as follow-up nudges, not as new human intent.\n",
     "- Do not assume you may enable or retune `agent_loop` yourself unless a human/operator explicitly asks for it.\n",
     "- Team ACP permission review is operator-facing ACP runtime control flow, not a normal worker coordination task.\n",
-    "- Only review a Team ACP permission request when ACP exposes the review action in your current session; evaluate the request against least-privilege intent and never review your own request.\n",
-    "- Do not review your own Team ACP permission request; wait for the assigned reviewer or human review in `Channel` (`all`).\n",
+    "- Only review a Team ACP permission request when ACP exposes the review action in your current session; evaluate the request against least-privilege intent.\n",
     "- If agent review is unavailable or times out, the system may post a human-review request into `Channel` (`all`) without blocking your current run.\n",
     "- Use `\"$AGENTHUB_ACTOR_CLI\" actor team-members` to inspect the live runtime summary, roster/card descriptions, and current step/session overlay before coordinating.\n",
     "- Use `\"$AGENTHUB_ACTOR_CLI\" actor team-tasks` when you need the canonical Team Kanban view instead of inferring task state from mailbox payloads alone.\n",
@@ -176,7 +175,6 @@ mod tests {
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("actor time-trigger-set"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("agent_loop"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("least-privilege intent"));
-        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("never review your own request"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("spec.members[].description"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".well-known/agent-card"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-members"));

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -67,7 +67,7 @@ restating the same rules.
   - when enabled, silence may cause a configured ACP reminder prompt to be injected later
   - treat injected loop prompts as follow-up nudges for the same task, not as a new human request
 - ACP permission review:
-  - the Team runtime assigns the current reviewer automatically; requester must never review its own request
+  - the Team runtime assigns the current reviewer automatically
   - treat approval/rejection as ACP runtime control flow, not as a normal Team mailbox task
   - if agent review is unavailable or times out, the system should post a human-review request into `Channel` (`all`)
   - human review remains valid and should not block the original Team workflow

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -131,8 +131,7 @@ Recommended fields:
 ## Escalation Rules
 
 - Worker reports blockers to leader first.
-- The current reviewer is assigned automatically by the Team runtime; requester must never review
-  its own permission request.
+- The current reviewer is assigned automatically by the Team runtime.
 - When ACP exposes a permission review action, inspect the request details and choose the narrowest
   approval option that is sufficient for the task.
 - When responding through `actor permission-review-respond`, use the request-provided

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -61,7 +61,6 @@ You are the coordinator for a multi-agent team run.
   path/scope, and offered approval options before responding.
 - Approve only the least-privilege option justified by the current task; otherwise cancel/reject
   and route the follow-up work through normal team coordination.
-- Never try to review your own Team ACP permission request.
 - If leader-side agent review is unavailable or times out, expect the system to surface the request
   in `Channel` (`all`) for human review without blocking the original Team flow.
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -52,7 +52,6 @@ findings.
 - Inspect the requested command, path/scope, and offered approval options before responding.
 - Approve only the least-privilege option justified by the current task; otherwise cancel/reject
   and report the blocker or follow-up work back to leader.
-- Do not review your own Team ACP permission request.
 - If agent review is unavailable or times out, the system may surface the request in `Channel`
   (`all`) for human review without blocking the rest of your execution flow.
 


### PR DESCRIPTION
## Summary

- remove redundant Team ACP permission-review wording from prompt, shared AGENTS guidance, and role/mailbox skills
- keep the actionable approval guidance (`inspect request`, `least-privilege`, `option_id`) in skill docs
- stop repeating runtime invariants that are already enforced by backend reviewer assignment

## Why

The previous wording mixed backend/runtime guarantees with agent-facing guidance. In particular,
`do not review your own request` is a runtime invariant rather than an agent decision point, so it
does not add much value in prompt/skill text and can make the boundary look fuzzier than it is.

This cleanup keeps prompt/skill guidance focused on what the agent actually needs to do when a
permission-review action is visible in the current session.

## Testing

- `cargo test -p agenthub-team-prompts`
- `git diff --check`
