### PR TITLE
Fix Team shared-thread discovery across refresh

### DIFF
--- a/docs/features/agents-teams.md
+++ b/docs/features/agents-teams.md
@@ -231,6 +231,8 @@ Constraint:
 - Channels are free-form communication/review lanes; agents should use timed triggers only for
   deferred follow-up and reminders, not as a substitute for canonical Team task tracking in
   `Kanban`.
+- The canonical `# all` shared-thread task must remain discoverable across refreshes; hiding it is
+  a workspace-task presentation choice, not a storage/query invariant.
 - Team ACP permission review requests should auto-route to a non-requester reviewer (`worker -> leader`,
   `leader -> subordinate worker`) and fall back to human review in `Conversation` (`all`) when
   agent review cannot complete.

--- a/docs/journal/2026-03-28-team-shared-thread-listing.md
+++ b/docs/journal/2026-03-28-team-shared-thread-listing.md
@@ -1,0 +1,26 @@
+## Summary
+
+Kept the canonical Team `# all` shared-thread discoverable across refreshes by adding an explicit
+public task-list query flag and using it from the Team conversation loader.
+
+## Why
+
+The Team page resolves the current `# all` conversation from the fetched task list. The public
+`GET /api/teams/:id/tasks` path reused the workspace-task default, which excludes
+`bootstrap_kind=shared_thread`. After a refresh, the page could no longer see the existing shared
+thread and the next send path created a new `all` task, making older conversation history appear to
+vanish.
+
+## Changes
+
+- Added `include_shared_thread` to the public Team task list query.
+- Updated Team page task refresh and shared conversation bootstrap to request shared-thread tasks.
+- Added regression coverage to ensure the client reuses an existing shared thread instead of
+  creating a duplicate.
+- Removed the obsolete `TeamManager::list_tasks` wrapper so call sites must spell out
+  `TeamTaskListQuery` semantics, including whether shared-thread tasks are included.
+
+## Validation
+
+- `cargo test -p agenthub team_task_list_api_can_include_shared_thread_when_requested -- --nocapture`
+- `cd web && npx vitest run src/pages/team/use_team_conversation_actions.test.tsx`

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -159,6 +159,8 @@ pub struct CreateTeamTaskRequest {
 #[derive(Debug, Deserialize)]
 pub struct ListTeamTasksQuery {
     pub limit: Option<i64>,
+    #[serde(default)]
+    pub include_shared_thread: bool,
 }
 
 // Keep deserialization compatibility for existing human clients even though
@@ -712,7 +714,12 @@ async fn list_team_tasks(
     load_team_for_user(&state, &team_id, &user).await?;
     let tasks = state
         .teams
-        .list_tasks(&team_id, query.limit.unwrap_or(100).clamp(1, 500))
+        .list_tasks_with_query(crate::team::TeamTaskListQuery {
+            team_id: Some(team_id),
+            limit: query.limit.unwrap_or(100).clamp(1, 500),
+            include_shared_thread: query.include_shared_thread,
+            ..crate::team::TeamTaskListQuery::default()
+        })
         .await
         .map_err(map_team_internal_error)?;
     Ok(Json(tasks))

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -4256,7 +4256,10 @@ async fn team_task_api_creates_lists_and_redacts_context() {
         State(state.clone()),
         headers.clone(),
         Path(team.id.clone()),
-        Query(ListTeamTasksQuery { limit: Some(20) }),
+        Query(ListTeamTasksQuery {
+            limit: Some(20),
+            include_shared_thread: false,
+        }),
     )
     .await
     .expect("list tasks");
@@ -4314,6 +4317,103 @@ async fn team_task_api_keeps_shared_thread_tasks_without_auto_run() {
 
     assert_eq!(created.task.status, crate::team::TeamTaskStatus::Open);
     assert!(created.latest_run.is_none());
+}
+
+#[tokio::test]
+async fn team_task_list_api_can_include_shared_thread_when_requested() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "shared-thread-listing-team".to_string(),
+            description: Some("shared thread listing coverage".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[
+                    {"member_id":"planner","role":"leader"},
+                    {"member_id":"worker-1","role":"worker"}
+                ]
+            }),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    let Json(shared_created) = create_team_task(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamTaskRequest {
+            title: "All".to_string(),
+            created_by_actor_id: Some("user".to_string()),
+            context: Some(json!({
+                "bootstrap_kind":"shared_thread",
+                "bootstrap_source":"teams_all"
+            })),
+            conversation_mode: Some("group_chat".to_string()),
+            topic: Some("all".to_string()),
+        }),
+    )
+    .await
+    .expect("create shared thread task");
+
+    let Json(workspace_created) = create_team_task(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamTaskRequest {
+            title: "Investigate regression".to_string(),
+            created_by_actor_id: Some("user".to_string()),
+            context: Some(json!({
+                "bootstrap_kind":"task_workspace"
+            })),
+            conversation_mode: Some("to_leader".to_string()),
+            topic: Some("Investigate regression".to_string()),
+        }),
+    )
+    .await
+    .expect("create workspace task");
+
+    let Json(default_list) = list_team_tasks(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Query(ListTeamTasksQuery {
+            limit: Some(100),
+            include_shared_thread: false,
+        }),
+    )
+    .await
+    .expect("list tasks without shared thread");
+    assert_eq!(default_list.len(), 1);
+    assert_eq!(default_list[0].id, workspace_created.task.id);
+
+    let Json(with_shared_thread) = list_team_tasks(
+        State(state),
+        headers,
+        Path(team.id),
+        Query(ListTeamTasksQuery {
+            limit: Some(100),
+            include_shared_thread: true,
+        }),
+    )
+    .await
+    .expect("list tasks with shared thread");
+    assert_eq!(with_shared_thread.len(), 2);
+    let listed_ids = with_shared_thread
+        .iter()
+        .map(|task| task.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        listed_ids,
+        std::collections::HashSet::from([
+            workspace_created.task.id.as_str(),
+            shared_created.task.id.as_str(),
+        ])
+    );
 }
 
 #[tokio::test]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -572,21 +572,6 @@ impl TeamManager {
         Ok((task, conversation))
     }
 
-    pub async fn list_tasks(
-        &self,
-        team_id: &str,
-        limit: i64,
-    ) -> anyhow::Result<Vec<TeamTaskRecord>> {
-        let rows = self
-            .list_tasks_with_query(TeamTaskListQuery {
-                team_id: Some(team_id.to_string()),
-                limit,
-                ..TeamTaskListQuery::default()
-            })
-            .await?;
-        Ok(rows)
-    }
-
     pub async fn list_tasks_with_query(
         &self,
         query: TeamTaskListQuery,

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -552,7 +552,14 @@ async fn task_and_conversation_messages_are_persisted_with_redaction() {
     assert_eq!(message.payload["authorization"], json!("[redacted]"));
     assert_eq!(message.payload["nested"]["secret"], json!("[redacted]"));
 
-    let listed = manager.list_tasks(&team.id, 20).await.expect("list tasks");
+    let listed = manager
+        .list_tasks_with_query(TeamTaskListQuery {
+            team_id: Some(team.id.clone()),
+            limit: 20,
+            ..TeamTaskListQuery::default()
+        })
+        .await
+        .expect("list tasks");
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, task.id);
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -644,9 +644,19 @@ export const api = {
         body: JSON.stringify(payload),
       }
     ),
-  listTeamTasks: (token: string, teamId: string, limit?: number) => {
+  listTeamTasks: (
+    token: string,
+    teamId: string,
+    limit?: number,
+    payload?: {
+      include_shared_thread?: boolean;
+    }
+  ) => {
     const params = new URLSearchParams();
     if (limit != null) params.set("limit", String(limit));
+    if (payload?.include_shared_thread) {
+      params.set("include_shared_thread", "true");
+    }
     const suffix = params.size > 0 ? `?${params.toString()}` : "";
     return apiFetch<TeamTaskRecord[]>(
       `/api/teams/${encodePathSegment(teamId)}/tasks${suffix}`,

--- a/web/src/pages/team/use_team_conversation_actions.test.tsx
+++ b/web/src/pages/team/use_team_conversation_actions.test.tsx
@@ -348,4 +348,60 @@ describe("useTeamConversationActions", () => {
       cleanupHarness(root, container);
     }
   });
+
+  it("reuses the existing shared thread instead of creating a duplicate", async () => {
+    mockedApi.listTeamTasks.mockResolvedValue([buildSharedThreadTask()]);
+    mockedApi.listTeamTaskMessages.mockResolvedValue([]);
+    mockedApi.sendTeamTaskMessage.mockResolvedValue({
+      message_id: 77,
+      conversation_id: "conv-all",
+      task_id: "task-all",
+      from_actor_id: "user:test",
+      to_actor_id: null,
+      route: "group_chat",
+      payload: {
+        type: "chat_message",
+        text: "hello shared thread",
+      },
+      created_at: 1_700_000_077,
+    });
+
+    let captured: TeamConversationActions | null = null;
+    const options = createOptions({
+      selectedConversation: null,
+      taskList: [],
+      activeRunIdForSelectedTeam: null,
+    });
+    const { root, container } = await mountHarness(options, (actions) => {
+      captured = actions;
+    });
+
+    try {
+      await act(async () => {
+        await captured?.sendTaskMessage({
+          text: "hello shared thread",
+          mentionActorIds: [],
+        });
+      });
+
+      expect(mockedApi.listTeamTasks).toHaveBeenCalledWith("token-1", "team-1", 100, {
+        include_shared_thread: true,
+      });
+      expect(mockedApi.createTeamTask).not.toHaveBeenCalled();
+      expect(mockedApi.sendTeamTaskMessage).toHaveBeenCalledWith(
+        "token-1",
+        "team-1",
+        "task-all",
+        {
+          payload: {
+            type: "chat_message",
+            text: "hello shared thread",
+            source: "team_workbench",
+          },
+        }
+      );
+    } finally {
+      cleanupHarness(root, container);
+    }
+  });
 });

--- a/web/src/pages/team/use_team_conversation_actions.ts
+++ b/web/src/pages/team/use_team_conversation_actions.ts
@@ -211,7 +211,11 @@ export function useTeamConversationActions({
     if (existing) {
       return existing;
     }
-    const remoteTasks = sortTasksByActivity(await api.listTeamTasks(token, selectedTeamId, 100));
+    const remoteTasks = sortTasksByActivity(
+      await api.listTeamTasks(token, selectedTeamId, 100, {
+        include_shared_thread: true,
+      })
+    );
     const remoteConversation = resolveTeamConversationTask(remoteTasks, selectedTeamId);
     if (remoteConversation) {
       setTaskList(remoteTasks);

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -2066,7 +2066,9 @@ export function TeamPage(props: TeamPageProps) {
     async (teamId: string) => {
       setTasksLoading(true);
       try {
-        const list = await api.listTeamTasks(props.token, teamId, 100);
+        const list = await api.listTeamTasks(props.token, teamId, 100, {
+          include_shared_thread: true,
+        });
         const sorted = sortTasksByActivity(list);
         setTaskList(sorted);
         setSelectedTaskId((prev) => {


### PR DESCRIPTION
## Summary

- keep the canonical Team `# all` shared-thread task discoverable across refreshes
- add an explicit public Team task-list query flag for including shared-thread tasks
- remove the obsolete `TeamManager::list_tasks` wrapper and make callers spell out query semantics

## Why

The Team page resolves the visible `# all` conversation from the fetched task list.
The public `GET /api/teams/:id/tasks` path previously reused the workspace-task default,
which excludes `bootstrap_kind=shared_thread`.

After a refresh, the page could no longer see the existing shared thread and the next send path
could create a new `all` task, making older `# all` history appear to disappear.

## Changes

- add `include_shared_thread` to `ListTeamTasksQuery`
- route the public Team task list endpoint through `list_tasks_with_query(...)`
- request `include_shared_thread=true` from Team page refresh and shared-thread bootstrap
- add backend and frontend regression coverage for reusing an existing shared thread
- document the shared-thread discoverability contract

## Validation

- `git diff --check`
- `cd web && npx vitest run src/pages/team/use_team_conversation_actions.test.tsx`

## Limits

- Rust-targeted regression tests were not completed in this environment because local disk space is exhausted (`No space left on device` while compiling test artifacts).
- This PR fixes shared-thread discoverability through the existing task-list path.
  A follow-up should still address the deeper model issue: shared-thread selection still depends on task-list ordering/limits and does not recover historical duplicate `all` threads.
