### PR TITLE
fix(web): remove ACP dock clearance spacer

### DIFF
--- a/docs/journal/2026-03-29-acp-input-dock-clearance.md
+++ b/docs/journal/2026-03-29-acp-input-dock-clearance.md
@@ -1,0 +1,22 @@
+## Why
+
+The Agents ACP conversation view was rendering an extra bottom spacer equal to the input dock
+clearance. Because the input dock already sits in normal document flow below the conversation
+panel, the spacer created a visible blank gap between the latest conversation item and the input
+composer.
+
+## What Changed
+
+- kept `scrollPaddingBottom` on the ACP conversation scroll container so jump-to-bottom and
+  auto-scroll logic still account for the dock height;
+- removed the rendered `dock-clearance` spacer element from the ACP conversation body so the
+  latest conversation item now sits directly above the input dock;
+- updated the ACP panel regression test to assert scroll padding remains while no dock spacer is
+  emitted.
+
+## Validation
+
+- `cd web && npx vitest run src/acp_panel.test.tsx src/acp_conversation_render.test.tsx`
+- `cd web && npm run lint`
+- `cd web && npm run build`
+- `git diff --check`

--- a/web/src/acp_panel.test.tsx
+++ b/web/src/acp_panel.test.tsx
@@ -248,8 +248,7 @@ describe("AcpPanel layout", () => {
       />
     );
     expect(html).toContain('scroll-padding-bottom:104px');
-    expect(html).toContain('class="acp-conversation-spacer dock-clearance"');
-    expect(html).toContain('height:104px');
+    expect(html).not.toContain('class="acp-conversation-spacer dock-clearance"');
   });
 
   it("hides conversation jump button when debug tab is active", () => {

--- a/web/src/components/acp_conversation.tsx
+++ b/web/src/components/acp_conversation.tsx
@@ -228,13 +228,6 @@ export function AcpConversation({
             style={{ height: virtualBottomSpacer }}
           />
         )}
-        {bottomClearance > 0 && (
-          <div
-            aria-hidden="true"
-            className="acp-conversation-spacer dock-clearance"
-            style={{ height: bottomClearance }}
-          />
-        )}
         {!stickToBottom && pendingCount > 0 && (
           <div
             className="acp-conversation-spacer"


### PR DESCRIPTION
## Summary

- remove the rendered ACP dock-clearance spacer from the Agents conversation panel
- keep conversation `scrollPaddingBottom` so jump/auto-scroll logic still respects dock height
- update ACP panel regression coverage for the new layout behavior

## Why

The Agents ACP conversation view was leaving a visible blank band between the latest conversation
item and the input composer. The input dock already sits below the conversation panel in normal
document flow, so rendering an additional dock-height spacer inside the scroll body doubled the
visual clearance.

## Testing

- `cd web && npx vitest run src/acp_panel.test.tsx src/acp_conversation_render.test.tsx`
- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`
