### PR TITLE
fix(team): stabilize member ACP panel layout

### DIFF
--- a/docs/journal/2026-03-29-team-member-acp-layout.md
+++ b/docs/journal/2026-03-29-team-member-acp-layout.md
@@ -1,0 +1,21 @@
+## Why
+
+The Team member ACP panel was still using a mixed container layout where the member header and ACP
+body shared a plain block wrapper. In constrained layouts this let the ACP body compete with the
+input dock for height, which could visually collapse or overlap the member info/header area with
+the composer region.
+
+## What Changed
+
+- changed the Team member ACP shell to a dedicated `flex-col` layout;
+- kept the member header as a shrink-fixed row;
+- wrapped the ACP body in its own `min-h-0 flex-1 overflow-hidden` container so the conversation
+  scroll region owns the remaining height cleanly above the input dock;
+- added a focused regression test for the Team member ACP shell structure.
+
+## Validation
+
+- `cd web && npx vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm run lint`
+- `cd web && npm run build`
+- `git diff --check`

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -501,7 +501,7 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
       )}
 
       {shouldRenderPanel && (
-        <div className="relative mt-2 flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden">
+        <div className="relative mt-2 flex min-h-0 flex-1 flex-col gap-0 sm:gap-1.5">
           <div className={`${OUTPUT_HEADER_ROOT_CLASS} shrink-0`}>
             <div className={OUTPUT_HEADER_TITLE_CLASS}>
               <div className={OUTPUT_HEADER_TITLE_TEXT_CLASS}>

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -501,8 +501,8 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
       )}
 
       {shouldRenderPanel && (
-        <div className="relative mt-2 min-h-0 flex-1">
-          <div className={OUTPUT_HEADER_ROOT_CLASS}>
+        <div className="relative mt-2 flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden">
+          <div className={`${OUTPUT_HEADER_ROOT_CLASS} shrink-0`}>
             <div className={OUTPUT_HEADER_TITLE_CLASS}>
               <div className={OUTPUT_HEADER_TITLE_TEXT_CLASS}>
                 <div className={OUTPUT_HEADER_TITLE_MAIN_CLASS}>
@@ -539,7 +539,9 @@ export function TeamMemberAcpPanel(props: TeamMemberAcpPanelProps) {
               </div>
             )}
           </div>
-          <AcpPanel {...acpPanelProps} />
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <AcpPanel {...acpPanelProps} />
+          </div>
         </div>
       )}
 

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2920,6 +2920,61 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("session=task-77");
   });
 
+  it("TeamMemberAcpPanel keeps the ACP body in a dedicated flex shell above the input dock", () => {
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedMemberSnapshot={buildMemberSnapshot({
+          member_id: "worker-agent",
+          role: "worker",
+          latest_step: buildStep({ member_id: "worker-agent", remote_task_id: "task-77" }),
+        })}
+        memberEvents={[
+          {
+            event_id: 25,
+            agent_id: "worker-agent",
+            session_id: "task-77",
+            seq: "25",
+            ts: 1_700_000_205,
+            stream: "acp",
+            message: JSON.stringify({
+              type: "agent_message",
+              text: "Panel layout should keep the ACP body above the input dock.",
+            }),
+          },
+        ]}
+        memberEventsHasMore={false}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onSendInput={vi.fn()}
+        onRefresh={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    const acpRoot = required(
+      container.querySelector(".acp") as HTMLDivElement | null,
+      "team member acp root missing"
+    );
+    const acpShell = required(
+      acpRoot.parentElement as HTMLDivElement | null,
+      "team member acp shell missing"
+    );
+    expect(acpShell.className).toContain("min-h-0");
+    expect(acpShell.className).toContain("flex-1");
+    expect(acpShell.className).toContain("overflow-hidden");
+
+    const header = required(
+      acpShell.previousElementSibling as HTMLDivElement | null,
+      "team member header missing"
+    );
+    expect(header.className).toContain("output-header");
+    expect(container.querySelector("textarea")).not.toBeNull();
+  });
+
   it("TeamMemberAcpPanel exposes a force-new-session action in debug mode", () => {
     const onForceNewSession = vi.fn();
 

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2963,9 +2963,9 @@ describe("team panels interactions", () => {
       acpRoot.parentElement as HTMLDivElement | null,
       "team member acp shell missing"
     );
-    expect(acpShell.className).toContain("min-h-0");
-    expect(acpShell.className).toContain("flex-1");
-    expect(acpShell.className).toContain("overflow-hidden");
+    expect(acpShell.classList.contains("min-h-0")).toBe(true);
+    expect(acpShell.classList.contains("flex-1")).toBe(true);
+    expect(acpShell.classList.contains("overflow-hidden")).toBe(true);
 
     const header = required(
       acpShell.previousElementSibling as HTMLDivElement | null,


### PR DESCRIPTION
## Summary

- fix the Team member ACP shell so the member header, ACP body, and input dock no longer compete for height
- wrap the ACP body in its own `min-h-0 flex-1 overflow-hidden` container
- add a focused regression test for the Team member ACP shell layout

## Why

The previous Agents-page ACP spacer fix addressed the standalone Agents workbench, but the Team
member ACP panel still used a mixed block wrapper for the member header plus ACP body. In
constrained layouts this allowed the ACP body to push into the composer region and visually
collapse/overlap the member info block with the input area.

## Testing

- `cd web && npx vitest run src/pages/team_panels.test.tsx`
- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`
