### PR TITLE
fix(codex): normalize managed global skill paths

### DIFF
--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -3595,12 +3595,15 @@ fn build_prompt_items_with_trusted_root(
     prompt: Vec<ContentBlock>,
     trusted_root: Option<&Path>,
 ) -> Vec<UserInput> {
+    let canonical_trusted_root = trusted_root.and_then(|root| std::fs::canonicalize(root).ok());
     prompt
         .into_iter()
         .filter_map(|block| match block {
-            ContentBlock::Text(text_block) => {
-                Some(build_text_or_skill_input(text_block.text, trusted_root))
-            }
+            ContentBlock::Text(text_block) => Some(build_text_or_skill_input(
+                text_block.text,
+                trusted_root,
+                canonical_trusted_root.as_deref(),
+            )),
             ContentBlock::Image(image_block) => Some(UserInput::Image {
                 image_url: format!("data:{};base64,{}", image_block.mime_type, image_block.data),
             }),
@@ -3629,14 +3632,24 @@ fn build_prompt_items_with_trusted_root(
         .collect()
 }
 
-fn build_text_or_skill_input(text: String, trusted_root: Option<&Path>) -> UserInput {
-    parse_agenthub_skill_input(&text, trusted_root).unwrap_or(UserInput::Text {
-        text,
-        text_elements: vec![],
-    })
+fn build_text_or_skill_input(
+    text: String,
+    trusted_root: Option<&Path>,
+    canonical_trusted_root: Option<&Path>,
+) -> UserInput {
+    parse_agenthub_skill_input(&text, trusted_root, canonical_trusted_root).unwrap_or(
+        UserInput::Text {
+            text,
+            text_elements: vec![],
+        },
+    )
 }
 
-fn parse_agenthub_skill_input(text: &str, trusted_root: Option<&Path>) -> Option<UserInput> {
+fn parse_agenthub_skill_input(
+    text: &str,
+    trusted_root: Option<&Path>,
+    canonical_trusted_root: Option<&Path>,
+) -> Option<UserInput> {
     let body = text
         .strip_prefix("<skill>\n")
         .or_else(|| text.strip_prefix("<skill>\r\n"))?;
@@ -3648,7 +3661,7 @@ fn parse_agenthub_skill_input(text: &str, trusted_root: Option<&Path>) -> Option
     let (path_line, _) = split_first_line(rest)?;
     let path =
         normalize_agenthub_skill_path(&parse_skill_meta_line(path_line, "path")?, trusted_root)?;
-    if !is_trusted_agenthub_skill_path(&path, trusted_root) {
+    if !is_trusted_agenthub_skill_path(&path, canonical_trusted_root) {
         return None;
     }
     Some(UserInput::Skill { name, path })
@@ -3694,13 +3707,10 @@ fn is_trusted_agenthub_skill_path(path: &Path, trusted_root: Option<&Path>) -> b
     let Some(trusted_root) = trusted_root else {
         return false;
     };
-    let Ok(canonical_root) = std::fs::canonicalize(trusted_root) else {
-        return false;
-    };
     let Ok(canonical_path) = std::fs::canonicalize(path) else {
         return false;
     };
-    canonical_path.starts_with(canonical_root)
+    canonical_path.starts_with(trusted_root)
 }
 
 fn split_first_line(input: &str) -> Option<(&str, &str)> {

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -3646,11 +3646,45 @@ fn parse_agenthub_skill_input(text: &str, trusted_root: Option<&Path>) -> Option
     let (name_line, rest) = split_first_line(body)?;
     let name = parse_skill_meta_line(name_line, "name")?;
     let (path_line, _) = split_first_line(rest)?;
-    let path = PathBuf::from(parse_skill_meta_line(path_line, "path")?);
+    let path =
+        normalize_agenthub_skill_path(&parse_skill_meta_line(path_line, "path")?, trusted_root)?;
     if !is_trusted_agenthub_skill_path(&path, trusted_root) {
         return None;
     }
     Some(UserInput::Skill { name, path })
+}
+
+fn normalize_agenthub_skill_path(raw_path: &str, trusted_root: Option<&Path>) -> Option<PathBuf> {
+    let path = PathBuf::from(raw_path);
+    if path.is_absolute() {
+        return Some(path);
+    }
+
+    let trusted_root = trusted_root?;
+    let home_dir = infer_home_dir_from_managed_skills_root(trusted_root)?;
+
+    if let Some(relative_path) = raw_path.strip_prefix("~/") {
+        return Some(home_dir.join(relative_path));
+    }
+
+    let legacy_managed_relative = Path::new(".agents").join("skills").join("agenthub-runtime");
+    if path.starts_with(&legacy_managed_relative) {
+        return Some(home_dir.join(path));
+    }
+
+    None
+}
+
+fn infer_home_dir_from_managed_skills_root(trusted_root: &Path) -> Option<PathBuf> {
+    let skills_dir = trusted_root.parent()?;
+    let agents_dir = skills_dir.parent()?;
+    let home_dir = agents_dir.parent()?;
+    if skills_dir.file_name() != Some(OsStr::new("skills"))
+        || agents_dir.file_name() != Some(OsStr::new(".agents"))
+    {
+        return None;
+    }
+    Some(home_dir.to_path_buf())
 }
 
 fn is_trusted_agenthub_skill_path(path: &Path, trusted_root: Option<&Path>) -> bool {
@@ -3660,10 +3694,13 @@ fn is_trusted_agenthub_skill_path(path: &Path, trusted_root: Option<&Path>) -> b
     let Some(trusted_root) = trusted_root else {
         return false;
     };
+    let Ok(canonical_root) = std::fs::canonicalize(trusted_root) else {
+        return false;
+    };
     let Ok(canonical_path) = std::fs::canonicalize(path) else {
         return false;
     };
-    canonical_path.starts_with(trusted_root)
+    canonical_path.starts_with(canonical_root)
 }
 
 fn split_first_line(input: &str) -> Option<(&str, &str)> {
@@ -3812,13 +3849,10 @@ mod tests {
 
     impl TempManagedSkillsHome {
         fn new() -> Self {
-            let nonce = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos();
             let home = std::env::temp_dir().join(format!(
-                "agenthub-codex-acp-managed-skills-{}-{nonce}",
-                std::process::id()
+                "agenthub-codex-acp-managed-skills-{}-{}",
+                std::process::id(),
+                Uuid::new_v4()
             ));
             std::fs::create_dir_all(&home).expect("create temp managed skills home");
             install_managed_skills(Some(home.as_path())).expect("install managed skills");
@@ -5494,6 +5528,79 @@ mod tests {
                     text_elements: vec![],
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_items_converts_tilde_managed_skill_block_to_native_skill_input() {
+        let managed_home = TempManagedSkillsHome::new();
+        let trusted_root = managed_home.trusted_root();
+        let skill_path = managed_home.skill_path(ManagedSkillKind::TeamTaskLifecycle);
+        let relative_to_home = skill_path
+            .strip_prefix(managed_home.home.as_path())
+            .expect("skill path should live under temp home");
+        let skill_block = format!(
+            "<skill>\n<name>team-task-lifecycle</name>\n<path>~/{}\
+</path>\nUse tilde path.\n</skill>",
+            relative_to_home.display()
+        );
+        let items = build_prompt_items_with_trusted_root(
+            vec![ContentBlock::Text(TextContent::new(skill_block.as_str()))],
+            Some(trusted_root.as_path()),
+        );
+
+        assert_eq!(
+            items,
+            vec![UserInput::Skill {
+                name: "team-task-lifecycle".to_string(),
+                path: skill_path,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_items_converts_legacy_relative_managed_skill_block_to_native_skill_input()
+    {
+        let managed_home = TempManagedSkillsHome::new();
+        let trusted_root = managed_home.trusted_root();
+        let skill_path = managed_home.skill_path(ManagedSkillKind::TeamLeaderOrchestrator);
+        let relative_to_home = skill_path
+            .strip_prefix(managed_home.home.as_path())
+            .expect("skill path should live under temp home");
+        let skill_block = format!(
+            "<skill>\n<name>team-leader-orchestrator</name>\n<path>{}</path>\nLegacy relative managed path.\n</skill>",
+            relative_to_home.display()
+        );
+        let items = build_prompt_items_with_trusted_root(
+            vec![ContentBlock::Text(TextContent::new(skill_block.as_str()))],
+            Some(trusted_root.as_path()),
+        );
+
+        assert_eq!(
+            items,
+            vec![UserInput::Skill {
+                name: "team-leader-orchestrator".to_string(),
+                path: skill_path,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_items_keeps_repo_local_relative_skill_block_as_text() {
+        let managed_home = TempManagedSkillsHome::new();
+        let trusted_root = managed_home.trusted_root();
+        let text = "<skill>\n<name>tidb-optimizer-bugfix</name>\n<path>.agents/skills/tidb-optimizer-bugfix/SKILL.md</path>\nRepo-local skill.\n</skill>";
+        let items = build_prompt_items_with_trusted_root(
+            vec![ContentBlock::Text(TextContent::new(text))],
+            Some(trusted_root.as_path()),
+        );
+
+        assert_eq!(
+            items,
+            vec![UserInput::Text {
+                text: text.to_string(),
+                text_elements: vec![],
+            }]
         );
     }
 

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -149,6 +149,10 @@ ACP permission requests are first-class runtime records:
   `~/.agents/skills/agenthub-runtime/.../SKILL.md` during ACP session bootstrap, then inject those
   file-backed skills through ACP `<skill>` wrappers so `agenthub-codex-acp` can translate them into
   native Codex `UserInput::Skill` items.
+- Global managed-skill paths should stay on the home-rooted forms only: canonical absolute paths,
+  with `~/...` accepted as a compatibility spelling before translation. Repo-local
+  `<workdir>/.agents/skills/**/SKILL.md` remains an independent discovery path and should not be
+  rewritten into the managed global namespace.
 - Dynamic actor runtime fields such as `team_id`, `current_run_id`, and continuity summaries should
   stay in a separate text prefix block injected before each prompt instead of being rewritten into
   the managed `SKILL.md` files.

--- a/docs/journal/2026-03-29-codex-global-skill-path-normalization.md
+++ b/docs/journal/2026-03-29-codex-global-skill-path-normalization.md
@@ -1,0 +1,40 @@
+# Summary
+
+Harden Codex skill-path handling so AgentHub-managed global skills continue to
+resolve from the user home skill root, while repo-local `.agents/skills`
+remains untouched.
+
+# Why
+
+We observed sessions attempting to open managed global skills via a current-workdir
+relative path such as `.agents/skills/...`, which is only valid for repo-local
+skills. AgentHub-managed global skills are materialized under the user home root
+(`~/.agents/skills/agenthub-runtime/...`) and should not depend on the current
+repository path.
+
+# What Changed
+
+- Taught `agenthub-codex-acp` to normalize two compatibility spellings for
+  AgentHub-managed global skill wrappers before trust validation:
+  - `~/...`
+  - `.agents/skills/agenthub-runtime/...`
+- Kept trust enforcement narrow: only paths that still resolve under the
+  managed global root are converted into native Codex `UserInput::Skill` items.
+- Left repo-local `.agents/skills/**/SKILL.md` untouched so workspace-owned
+  skills continue to follow local discovery rules.
+- Added focused tests covering:
+  - `~/...` managed skill wrappers
+  - legacy relative managed-global wrappers
+  - repo-local relative skill paths staying as plain text
+
+# Validation
+
+Suggested validation:
+
+- `cargo test -p agenthub-codex-acp build_prompt_items`
+
+# Follow-up
+
+- Continue treating the canonical outbound form for managed global skills as an
+  absolute home-rooted path even though the Codex bridge now accepts the
+  compatibility spellings above.

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -69,6 +69,8 @@ For Codex-backed ACP sessions, AgentHub also materializes its managed Team and
 runtime skills under `~/.agents/skills/agenthub-runtime/...`.
 
 - No manual `~/.codex/config.toml` skill configuration is required.
+- Global managed skills should be referenced through an absolute path or
+  `~/...`; do not treat them as current-workdir-relative `.agents/...` paths.
 - Repo-local `.agents/skills` continue to work independently alongside the
   managed AgentHub skill set.
 


### PR DESCRIPTION
## Summary

- normalize AgentHub-managed global Codex skill paths from `~/...` and legacy `.agents/skills/agenthub-runtime/...`
- keep repo-local `.agents/skills/**/SKILL.md` untouched
- document the global-vs-local skill path boundary

## Testing

- `cargo test -p agenthub-codex-acp build_prompt_items -- --nocapture`
- `cargo fmt --all`
- `git diff --check`
