### PR TITLE
fix(codex-acp): avoid ACP apply_patch deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "codex-utils-cli",
  "heck",
  "itertools 0.14.0",
+ "piper",
  "regex-lite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -45,6 +45,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 unicode-segmentation = "1.13.2"
 uuid = { version = "1", features = ["v4"] }
 
+[dev-dependencies]
+piper = "0.2"
+
 [lints.rust]
 let-underscore = "warn"
 rust-2018-idioms = "warn"

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -47,6 +47,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 piper = "0.2"
+tempfile = "3"
 
 [lints.rust]
 let-underscore = "warn"

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -48,8 +48,9 @@ where
                 .build()
                 .map_err(std::io::Error::other)
                 .and_then(|runtime| {
+                    let local_set = LocalSet::new();
                     runtime
-                        .block_on(io_task)
+                        .block_on(local_set.run_until(io_task))
                         .map_err(|err| std::io::Error::other(format!("ACP I/O error: {err}")))
                 });
             drop(tx.send(result));

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -7,6 +7,7 @@ use codex_core::config::{Config, ConfigOverrides};
 use codex_core::features::{Feature, Features};
 use codex_utils_cli::CliConfigOverrides;
 use std::fmt;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::{io::Result as IoResult, rc::Rc};
@@ -28,6 +29,35 @@ mod prompt_args;
 mod thread;
 
 pub static ACP_CLIENT: OnceLock<Arc<AgentSideConnection>> = OnceLock::new();
+
+pub(crate) fn spawn_acp_io_task<F>(
+    thread_name: &str,
+    io_task: F,
+) -> IoResult<tokio::sync::oneshot::Receiver<IoResult<()>>>
+where
+    F: Future<Output = agent_client_protocol::Result<()>> + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let thread_name = thread_name.to_string();
+
+    std::thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            let result = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(std::io::Error::other)
+                .and_then(|runtime| {
+                    runtime
+                        .block_on(io_task)
+                        .map_err(|err| std::io::Error::other(format!("ACP I/O error: {err}")))
+                });
+            drop(tx.send(result));
+        })
+        .map_err(std::io::Error::other)?;
+
+    Ok(rx)
+}
 
 const MISLEADING_MODELS_REFRESH_TIMEOUT_MESSAGE: &str =
     "failed to refresh available models: timeout waiting for child process to exit";
@@ -250,9 +280,10 @@ pub async fn run_main(
                 return Err(std::io::Error::other("ACP client already set"));
             }
 
-            io_task
-                .await
-                .map_err(|e| std::io::Error::other(format!("ACP I/O error: {e}")))
+            let io_task = spawn_acp_io_task("agenthub-codex-acp-io", io_task)?;
+            io_task.await.map_err(|_| {
+                std::io::Error::other("ACP I/O thread shut down before reporting a result")
+            })?
         })
         .await?;
 

--- a/agenthub-codex-acp/src/local_spawner.rs
+++ b/agenthub-codex-acp/src/local_spawner.rs
@@ -309,13 +309,33 @@ impl LocalSpawner {
 
 #[cfg(test)]
 mod tests {
-    use super::ensure_path_within_root;
+    use super::{AcpFs, LocalSpawner, ensure_path_within_root};
+    use crate::{ACP_CLIENT, spawn_acp_io_task};
+    use agent_client_protocol::{
+        Agent, AgentSideConnection, AuthenticateRequest, AuthenticateResponse, Client,
+        ClientCapabilities, FileSystemCapabilities, Implementation, InitializeRequest,
+        InitializeResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+        NewSessionResponse, PromptRequest, PromptResponse, ReadTextFileRequest,
+        ReadTextFileResponse, SessionId, SetSessionConfigOptionRequest,
+        SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, StopReason,
+        WriteTextFileRequest,
+    };
     use std::{
+        collections::HashMap,
         fs,
         path::{Path, PathBuf},
-        sync::atomic::{AtomicU64, Ordering},
+        process::Command,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU64, Ordering},
+        },
+        thread,
+        time::Duration,
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    const DEADLOCK_CHILD_ENV: &str = "AGENTHUB_CODEX_ACP_APPLY_PATCH_DEADLOCK_CHILD";
+    const DEADLOCK_CHILD_TEST: &str = "local_spawner::tests::apply_patch_verification_child";
 
     fn temp_root() -> PathBuf {
         static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -402,5 +422,288 @@ mod tests {
 
         drop(fs::remove_dir_all(root));
         drop(fs::remove_dir_all(outside));
+    }
+
+    #[test]
+    fn apply_patch_verification_does_not_deadlock_over_acp_fs() {
+        if std::env::var_os(DEADLOCK_CHILD_ENV).is_some() {
+            return;
+        }
+
+        let current_exe = std::env::current_exe().expect("resolve current test binary");
+        let mut child = Command::new(current_exe)
+            .arg("--exact")
+            .arg(DEADLOCK_CHILD_TEST)
+            .arg("--nocapture")
+            .env(DEADLOCK_CHILD_ENV, "1")
+            .spawn()
+            .expect("spawn deadlock child");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().expect("poll deadlock child") {
+                assert!(status.success(), "child exited with {status}");
+                return;
+            }
+
+            if std::time::Instant::now() >= deadline {
+                drop(child.kill());
+                drop(child.wait());
+                panic!("child timed out; apply_patch ACP fs roundtrip deadlocked");
+            }
+
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    #[test]
+    fn apply_patch_verification_child() {
+        if std::env::var_os(DEADLOCK_CHILD_ENV).is_none() {
+            return;
+        }
+
+        reproduce_apply_patch_roundtrip();
+    }
+
+    fn reproduce_apply_patch_roundtrip() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        let local_set = tokio::task::LocalSet::new();
+
+        runtime.block_on(local_set.run_until(async move {
+            let client = TestClient::new();
+            let agent = TestAgent;
+            let root = std::env::temp_dir()
+                .join(format!("agenthub-codex-acp-deadlock-{}", std::process::id()));
+            let session_id = SessionId::new("test-session");
+            let (client_to_agent_rx, client_to_agent_tx) = piper::pipe(1024);
+            let (agent_to_client_rx, agent_to_client_tx) = piper::pipe(1024);
+            let (client_ready_tx, client_ready_rx) = std::sync::mpsc::channel();
+
+            let source_dir = root.join("src");
+            fs::create_dir_all(&source_dir).expect("create test dirs");
+            let file_path = fs::canonicalize(&source_dir)
+                .expect("canonicalize source dir")
+                .join("client.rs");
+            client.add_file_content(file_path.clone(), "fn old() {}\n".to_string());
+
+            let _client_thread = thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build remote client runtime");
+                let local_set = tokio::task::LocalSet::new();
+
+                runtime.block_on(local_set.run_until(async move {
+                    let (_client_side, client_io_task) = agent_client_protocol::ClientSideConnection::new(
+                        client,
+                        client_to_agent_tx,
+                        agent_to_client_rx,
+                        |fut| {
+                            tokio::task::spawn_local(fut);
+                        },
+                    );
+                    client_ready_tx.send(()).expect("signal remote client ready");
+                    client_io_task.await.expect("run remote client io task");
+                }));
+            });
+
+            client_ready_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("wait for remote client bootstrap");
+
+            let (agent_side, agent_io_task) = AgentSideConnection::new(
+                agent,
+                agent_to_client_tx,
+                client_to_agent_rx,
+                |fut| {
+                    tokio::task::spawn_local(fut);
+                },
+            );
+
+            ACP_CLIENT
+                .set(Arc::new(agent_side))
+                .expect("install ACP client for child");
+
+            let _agent_io =
+                spawn_acp_io_task("agenthub-codex-acp-test-agent-io", agent_io_task)
+                    .expect("spawn agent io thread");
+
+            tokio::task::yield_now().await;
+
+            let capabilities = Arc::new(Mutex::new(
+                ClientCapabilities::new().fs(FileSystemCapabilities::new().read_text_file(true)),
+            ));
+            let session_roots = Arc::new(Mutex::new(HashMap::from([(
+                session_id.clone(),
+                root.clone(),
+            )])));
+            let fs = AcpFs::new(session_id, capabilities, LocalSpawner::new(), session_roots);
+
+            let patch = "*** Begin Patch\n*** Update File: src/client.rs\n@@\n-fn old() {}\n+fn new() {}\n*** End Patch";
+            let argv = vec!["apply_patch".to_string(), patch.to_string()];
+            let result =
+                codex_apply_patch::maybe_parse_apply_patch_verified(&argv, &root, &fs);
+
+            assert!(
+                matches!(result, codex_apply_patch::MaybeApplyPatchVerified::Body(_)),
+                "expected verified patch body, got {result:?}"
+            );
+        }));
+    }
+
+    #[derive(Clone)]
+    struct TestClient {
+        file_contents: Arc<Mutex<HashMap<PathBuf, String>>>,
+    }
+
+    impl TestClient {
+        fn new() -> Self {
+            Self {
+                file_contents: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn add_file_content(&self, path: PathBuf, content: String) {
+            self.file_contents.lock().unwrap().insert(path, content);
+        }
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl Client for TestClient {
+        async fn request_permission(
+            &self,
+            _arguments: agent_client_protocol::RequestPermissionRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::RequestPermissionResponse>
+        {
+            unimplemented!()
+        }
+
+        async fn write_text_file(
+            &self,
+            _arguments: WriteTextFileRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::WriteTextFileResponse> {
+            unimplemented!()
+        }
+
+        async fn read_text_file(
+            &self,
+            arguments: ReadTextFileRequest,
+        ) -> agent_client_protocol::Result<ReadTextFileResponse> {
+            let contents = self.file_contents.lock().unwrap();
+            let content = contents
+                .get(&arguments.path)
+                .cloned()
+                .unwrap_or_else(|| "default content".to_string());
+            Ok(ReadTextFileResponse::new(content))
+        }
+
+        async fn session_notification(
+            &self,
+            _args: agent_client_protocol::SessionNotification,
+        ) -> agent_client_protocol::Result<()> {
+            Ok(())
+        }
+
+        async fn create_terminal(
+            &self,
+            _args: agent_client_protocol::CreateTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::CreateTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn terminal_output(
+            &self,
+            _args: agent_client_protocol::TerminalOutputRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::TerminalOutputResponse> {
+            unimplemented!()
+        }
+
+        async fn kill_terminal(
+            &self,
+            _args: agent_client_protocol::KillTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::KillTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn release_terminal(
+            &self,
+            _args: agent_client_protocol::ReleaseTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::ReleaseTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn wait_for_terminal_exit(
+            &self,
+            _args: agent_client_protocol::WaitForTerminalExitRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::WaitForTerminalExitResponse>
+        {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestAgent;
+
+    #[async_trait::async_trait(?Send)]
+    impl Agent for TestAgent {
+        async fn initialize(
+            &self,
+            arguments: InitializeRequest,
+        ) -> agent_client_protocol::Result<InitializeResponse> {
+            Ok(InitializeResponse::new(arguments.protocol_version)
+                .agent_info(Implementation::new("test-agent", "0.0.0").title("Test Agent")))
+        }
+
+        async fn authenticate(
+            &self,
+            _arguments: AuthenticateRequest,
+        ) -> agent_client_protocol::Result<AuthenticateResponse> {
+            Ok(AuthenticateResponse::default())
+        }
+
+        async fn new_session(
+            &self,
+            _arguments: NewSessionRequest,
+        ) -> agent_client_protocol::Result<NewSessionResponse> {
+            Ok(NewSessionResponse::new(SessionId::new("unused")))
+        }
+
+        async fn load_session(
+            &self,
+            _arguments: LoadSessionRequest,
+        ) -> agent_client_protocol::Result<LoadSessionResponse> {
+            Ok(LoadSessionResponse::new())
+        }
+
+        async fn set_session_mode(
+            &self,
+            _arguments: SetSessionModeRequest,
+        ) -> agent_client_protocol::Result<SetSessionModeResponse> {
+            Ok(SetSessionModeResponse::new())
+        }
+
+        async fn prompt(
+            &self,
+            _arguments: PromptRequest,
+        ) -> agent_client_protocol::Result<PromptResponse> {
+            Ok(PromptResponse::new(StopReason::EndTurn))
+        }
+
+        async fn cancel(
+            &self,
+            _arguments: agent_client_protocol::CancelNotification,
+        ) -> agent_client_protocol::Result<()> {
+            Ok(())
+        }
+
+        async fn set_session_config_option(
+            &self,
+            _args: SetSessionConfigOptionRequest,
+        ) -> agent_client_protocol::Result<SetSessionConfigOptionResponse> {
+            Ok(SetSessionConfigOptionResponse::new(vec![]))
+        }
     }
 }

--- a/agenthub-codex-acp/src/local_spawner.rs
+++ b/agenthub-codex-acp/src/local_spawner.rs
@@ -475,8 +475,11 @@ mod tests {
         runtime.block_on(local_set.run_until(async move {
             let client = TestClient::new();
             let agent = TestAgent;
-            let root = std::env::temp_dir()
-                .join(format!("agenthub-codex-acp-deadlock-{}", std::process::id()));
+            let temp_dir = tempfile::Builder::new()
+                .prefix("agenthub-codex-acp-deadlock-")
+                .tempdir()
+                .expect("create temp dir");
+            let root = temp_dir.path().to_path_buf();
             let session_id = SessionId::new("test-session");
             let (client_to_agent_rx, client_to_agent_tx) = piper::pipe(1024);
             let (agent_to_client_rx, agent_to_client_tx) = piper::pipe(1024);
@@ -551,6 +554,7 @@ mod tests {
                 matches!(result, codex_apply_patch::MaybeApplyPatchVerified::Body(_)),
                 "expected verified patch body, got {result:?}"
             );
+            drop(temp_dir);
         }));
     }
 

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -153,6 +153,9 @@ ACP permission requests are first-class runtime records:
   with `~/...` accepted as a compatibility spelling before translation. Repo-local
   `<workdir>/.agents/skills/**/SKILL.md` remains an independent discovery path and should not be
   rewritten into the managed global namespace.
+- `agenthub-codex-acp` must keep ACP request/response I/O alive on a dedicated runtime thread so
+  ACP-backed filesystem reads can safely round-trip while tool handlers synchronously verify or
+  patch existing files.
 - Dynamic actor runtime fields such as `team_id`, `current_run_id`, and continuity summaries should
   stay in a separate text prefix block injected before each prompt instead of being rewritten into
   the managed `SKILL.md` files.
@@ -180,3 +183,4 @@ ACP permission requests are first-class runtime records:
 - `docs/journal/2026-03-08-sse-stale-running-agent-reconciliation.md`
 - `docs/journal/2026-03-22-acp-provider-runtime-abstraction.md`
 - `docs/journal/2026-03-24-codex-acp-native-skill-injection.md`
+- `docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md`

--- a/docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md
+++ b/docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md
@@ -1,0 +1,71 @@
+# 2026-03-30 Codex ACP Apply Patch Deadlock
+
+## Context
+
+`agenthub-codex-acp` still ran the ACP agent-side I/O loop on the same local Tokio
+execution lane as tool handling. That is normally fine for lightweight ACP request
+handling, but it breaks when a tool synchronously calls back into ACP-backed
+filesystem reads.
+
+The concrete risk showed up on the `apply_patch` path:
+
+1. `codex_apply_patch::maybe_parse_apply_patch_verified(...)` verifies a patch
+   against the current file contents.
+2. Under `agenthub-codex-acp`, existing file contents may come from `AcpFs`
+   rather than the local filesystem.
+3. `AcpFs::read_to_string()` issues an ACP `read_text_file` round-trip and waits
+   synchronously for the reply.
+4. If the ACP I/O loop shares the same execution lane as the tool call, the tool
+   can end up waiting on work that the runtime is no longer driving.
+
+That leaves the ACP session stuck at the tool boundary with no patch applied.
+
+## Upstream Reference
+
+- `zed-industries/codex-acp#214`
+- title: `fix: avoid ACP apply_patch deadlock`
+
+AgentHub vendors `codex-acp` under `agenthub-codex-acp/`, so the correct move is
+to backport the narrow runtime/threading fix into the vendored adapter instead of
+waiting for a future dependency refresh.
+
+## Changes
+
+1. Added `spawn_acp_io_task(...)` in `agenthub-codex-acp/src/lib.rs`.
+   - runs ACP agent-side I/O on a dedicated OS thread
+   - builds a dedicated current-thread Tokio runtime for that thread
+   - returns a `oneshot` receiver so the main task can still await terminal I/O
+     completion and surface a clean failure if the ACP I/O thread dies early
+
+2. Updated `run_main(...)` in `agenthub-codex-acp/src/lib.rs`.
+   - keep the main `LocalSet` for agent/tool execution
+   - move `AgentSideConnection::new(...).io_task` onto the dedicated ACP I/O
+     thread instead of awaiting it directly on the same `LocalSet`
+
+3. Added a deterministic regression test in
+   `agenthub-codex-acp/src/local_spawner.rs`.
+   - creates a fake ACP client/server pair over pipes
+   - serves file contents through `AcpFs`
+   - calls `codex_apply_patch::maybe_parse_apply_patch_verified(...)` on an
+     update patch against an existing file
+   - fails the parent test if the child process does not finish within 5 seconds
+
+4. Added `piper` as a test-only dependency for the ACP pipe harness.
+
+## Validation
+
+- `cargo fmt --manifest-path agenthub-codex-acp/Cargo.toml`
+- `cargo test -p agenthub-codex-acp apply_patch_verification_does_not_deadlock_over_acp_fs -- --nocapture`
+- `cargo test -p agenthub-codex-acp --lib`
+- `cargo clippy --locked -p agenthub-codex-acp --all-targets -- -D warnings`
+- `git diff --check`
+
+## Result
+
+`agenthub-codex-acp` no longer relies on a single local execution lane for both:
+
+- tool execution
+- ACP request/response progress
+
+That removes the deadlock class where ACP-backed filesystem verification waits on
+an ACP reply that the runtime is no longer able to drive.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,7 @@
 # TODO
 
 Active backlog only. Keep this file small and current.
+- [ ] Verify the codex-acp apply-patch deadlock fix after merge: when `agenthub-codex-acp` uses ACP-backed filesystem reads, `apply_patch` verification against an existing file should complete instead of hanging forever at the ACP tool boundary. Record focused notes and push/PR CI run IDs in `docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md`.
 - [ ] Verify `actor ack` status-change diagnostics after merge: repeated `agenthub actor ack` on the same message should keep succeeding, but the returned JSON must set `status_changed=false` after the first successful `pending -> delivered` transition. Record focused notes and push/PR CI run IDs in `docs/journal/2026-03-30-actor-ack-status-changed.md`.
 - [ ] Verify Bazel Codecov upload records `AGENTHUB_CODECOV_UPLOAD_TAG=bazel` on both `push` and `pull_request`, alongside the existing `flags: bazel` metadata. Record workflow run IDs in `docs/journal/2026-03-30-bazel-codecov-env-tag.md`.
 - [ ] Verify internal gRPC fail-fast startup after merge: when the configured `internal_grpc.listen` address cannot be bound, AgentHub should fail startup immediately instead of logging a misleading "internal gRPC listening" line and continuing into a partially broken runtime. Record focused notes plus push/PR CI run IDs in `docs/journal/2026-03-30-internal-grpc-fail-fast-startup.md`.


### PR DESCRIPTION
## Summary

- backport the narrow runtime fix from `zed-industries/codex-acp#214` into vendored `agenthub-codex-acp`
- move ACP agent-side I/O onto a dedicated OS thread/runtime instead of sharing the main `LocalSet`
- add a deterministic regression test for `apply_patch` verification over ACP-backed filesystem reads
- document the ACP runtime contract and add a verification backlog item

## Why

`agenthub-codex-acp` still ran ACP request/response progress on the same local execution lane as
tool handling. That makes `apply_patch` verification vulnerable to a deadlock when an ACP-backed
filesystem read is needed while verifying an existing file.

The fix stays narrow:

- keep the main `LocalSet` for agent/tool execution
- move `AgentSideConnection::new(...).io_task` onto a dedicated current-thread Tokio runtime
- preserve the rest of AgentHub's Codex ACP adapter behavior

## Validation

```bash
cargo fmt --manifest-path agenthub-codex-acp/Cargo.toml
cargo test -p agenthub-codex-acp apply_patch_verification_does_not_deadlock_over_acp_fs -- --nocapture
cargo test -p agenthub-codex-acp --lib
cargo clippy --locked -p agenthub-codex-acp --all-targets -- -D warnings
git diff --check
```

## Upstream

- reference: `https://github.com/zed-industries/codex-acp/pull/214`
- adapted locally instead of direct cherry-pick because AgentHub carries adapter-specific changes in `agenthub-codex-acp/src/lib.rs`
