### PR TITLE
refactor(cli): add staged clap root parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "clap",
  "futures",
  "hmac 0.13.0",
  "jwt-simple",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ path = "cmd/agenthub/src/main.rs"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 chrono = { version = "0.4", features = ["clock"] }
+clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/journal/2026-03-30-clap-root-cli-refactor.md
+++ b/docs/journal/2026-03-30-clap-root-cli-refactor.md
@@ -1,0 +1,47 @@
+# Clap Root CLI Refactor
+
+## Summary
+
+- introduced a clap-based root parser for `agenthub`
+- migrated `doctor` parsing/help onto clap
+- routed `actor` through the new root parser while intentionally preserving the existing actor execution/parser layer
+
+## Scope
+
+This change is a staged CLI refactor, not a full actor subcommand rewrite.
+
+### Included
+
+- `agenthub --help` / `--version` now come from clap
+- `agenthub doctor` now uses clap for parsing and help rendering
+- `agenthub actor ...` now enters through the same clap root parser and then delegates to the existing actor parser/execution layer
+- unknown top-level subcommands now fail fast instead of silently booting the HTTP server
+
+### Deferred
+
+- full clap migration of every `agenthub actor ...` subcommand and flag
+- removal of the legacy hand-written actor help/parser layer
+
+## Rationale
+
+The previous root command flow used two independent `std::env::args()` probes (`doctor` and `actor`) before falling through to server startup. That had three maintainability problems:
+
+1. top-level help/version behavior was effectively undefined
+2. root command dispatch and subcommand help formatting were split across multiple ad-hoc entry points
+3. unknown top-level argv could accidentally boot the server instead of failing as CLI input
+
+This staged refactor narrows the problem first:
+
+- one root parser owns the command boundary
+- `doctor` becomes a complete clap command
+- `actor` keeps its existing business parser until a dedicated follow-up change migrates it safely
+
+## Validation
+
+- focused unit coverage should exercise:
+  - root parser `serve` / `doctor` / `actor` / legacy `actor-mcp`
+  - clap help handling
+  - doctor clap help / unknown-flag behavior
+- CI evidence should be recorded here after merge:
+  - push run id:
+  - pr run id:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,7 @@
 # TODO
 
 Active backlog only. Keep this file small and current.
+- [ ] Verify the staged clap root CLI refactor after merge: `agenthub --help` should render root help and exit cleanly, `agenthub doctor` should route through clap-based parsing/help, `agenthub actor ...` should continue to preserve existing execution semantics through the new root parser, and unknown top-level subcommands should now fail fast instead of silently booting the server. Record focused notes and push/PR CI run IDs in `docs/journal/2026-03-30-clap-root-cli-refactor.md`.
 - [ ] Verify the codex-acp apply-patch deadlock fix after merge: when `agenthub-codex-acp` uses ACP-backed filesystem reads, `apply_patch` verification against an existing file should complete instead of hanging forever at the ACP tool boundary. Record focused notes and push/PR CI run IDs in `docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md`.
 - [ ] Verify `actor ack` status-change diagnostics after merge: repeated `agenthub actor ack` on the same message should keep succeeding, but the returned JSON must set `status_changed=false` after the first successful `pending -> delivered` transition. Record focused notes and push/PR CI run IDs in `docs/journal/2026-03-30-actor-ack-status-changed.md`.
 - [ ] Verify Bazel Codecov upload records `AGENTHUB_CODECOV_UPLOAD_TAG=bazel` on both `push` and `pull_request`, alongside the existing `flags: bazel` metadata. Record workflow run IDs in `docs/journal/2026-03-30-bazel-codecov-env-tag.md`.

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -258,19 +258,12 @@ fn maybe_reject_legacy_actor_mcp_args(args: &[String]) -> Option<anyhow::Result<
     None
 }
 
-pub async fn maybe_run_from_args() -> Option<anyhow::Result<()>> {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if let Some(result) = maybe_reject_legacy_actor_mcp_args(&args) {
-        return Some(result);
+pub async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
+    if let Some(result) = maybe_reject_legacy_actor_mcp_args(args) {
+        return result;
     }
-    if args.first().map(String::as_str) != Some("actor") {
-        return None;
-    }
-    let parsed = parse_actor_args(&args[1..]);
-    Some(match parsed {
-        Ok(parsed) => run_actor_command(parsed.command, parsed.output_mode).await,
-        Err(err) => Err(err),
-    })
+    let parsed = parse_actor_args(args)?;
+    run_actor_command(parsed.command, parsed.output_mode).await
 }
 
 #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,11 +179,26 @@ where
 }
 
 pub async fn run() -> anyhow::Result<()> {
-    if let Some(result) = crate::doctor_cli::maybe_run_from_args().await {
-        return result;
-    }
-    if let Some(result) = crate::actor_cli::maybe_run_from_args().await {
-        return result;
+    match crate::cli::parse_root_cli_from_env() {
+        Ok(crate::cli::RootCliCommand::Serve) => {}
+        Ok(crate::cli::RootCliCommand::Doctor { args }) => {
+            return crate::doctor_cli::run_from_args(&args).await;
+        }
+        Ok(crate::cli::RootCliCommand::Actor { args }) => {
+            return crate::actor_cli::run_from_args(&args).await;
+        }
+        Ok(crate::cli::RootCliCommand::LegacyActorMcp) => {
+            return Err(anyhow::anyhow!(
+                "`agenthub actor-mcp` has been removed. Use `agenthub actor ...` instead."
+            ));
+        }
+        Err(err) if crate::cli::is_non_error_clap_exit(&err) => {
+            err.print()?;
+            return Ok(());
+        }
+        Err(err) => {
+            return Err(err.into());
+        }
     }
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ enum AgentHubSubcommand {
     Doctor(PassthroughArgs),
     Actor(PassthroughArgs),
     #[command(name = "actor-mcp", hide = true)]
-    ActorMcp,
+    ActorMcp(PassthroughArgs),
 }
 
 #[derive(Debug, Default, Args)]
@@ -46,7 +46,7 @@ where
         None => RootCliCommand::Serve,
         Some(AgentHubSubcommand::Doctor(args)) => RootCliCommand::Doctor { args: args.args },
         Some(AgentHubSubcommand::Actor(args)) => RootCliCommand::Actor { args: args.args },
-        Some(AgentHubSubcommand::ActorMcp) => RootCliCommand::LegacyActorMcp,
+        Some(AgentHubSubcommand::ActorMcp(_)) => RootCliCommand::LegacyActorMcp,
     })
 }
 
@@ -103,6 +103,13 @@ mod tests {
     #[test]
     fn parse_root_maps_legacy_actor_mcp_command() {
         let parsed = parse_root_cli_from(["agenthub", "actor-mcp"]).expect("parse actor-mcp");
+        assert_eq!(parsed, RootCliCommand::LegacyActorMcp);
+    }
+
+    #[test]
+    fn parse_root_keeps_legacy_actor_mcp_help_on_removed_path() {
+        let parsed =
+            parse_root_cli_from(["agenthub", "actor-mcp", "--help"]).expect("parse actor-mcp");
         assert_eq!(parsed, RootCliCommand::LegacyActorMcp);
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,122 @@
+use std::ffi::OsString;
+
+use clap::{Args, Parser, Subcommand, error::ErrorKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RootCliCommand {
+    Serve,
+    Doctor { args: Vec<String> },
+    Actor { args: Vec<String> },
+    LegacyActorMcp,
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "agenthub", version, disable_help_subcommand = true)]
+struct AgentHubCli {
+    #[command(subcommand)]
+    command: Option<AgentHubSubcommand>,
+}
+
+#[derive(Debug, Subcommand)]
+enum AgentHubSubcommand {
+    Doctor(PassthroughArgs),
+    Actor(PassthroughArgs),
+    #[command(name = "actor-mcp", hide = true)]
+    ActorMcp,
+}
+
+#[derive(Debug, Default, Args)]
+#[command(
+    disable_help_flag = true,
+    disable_help_subcommand = true,
+    trailing_var_arg = true
+)]
+struct PassthroughArgs {
+    #[arg(num_args = 0.., allow_hyphen_values = true, value_name = "ARGS")]
+    args: Vec<String>,
+}
+
+pub(crate) fn parse_root_cli_from<I, T>(iter: I) -> Result<RootCliCommand, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let cli = AgentHubCli::try_parse_from(iter)?;
+    Ok(match cli.command {
+        None => RootCliCommand::Serve,
+        Some(AgentHubSubcommand::Doctor(args)) => RootCliCommand::Doctor { args: args.args },
+        Some(AgentHubSubcommand::Actor(args)) => RootCliCommand::Actor { args: args.args },
+        Some(AgentHubSubcommand::ActorMcp) => RootCliCommand::LegacyActorMcp,
+    })
+}
+
+pub(crate) fn parse_root_cli_from_env() -> Result<RootCliCommand, clap::Error> {
+    parse_root_cli_from(std::env::args_os())
+}
+
+pub(crate) fn is_non_error_clap_exit(err: &clap::Error) -> bool {
+    matches!(
+        err.kind(),
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::{RootCliCommand, is_non_error_clap_exit, parse_root_cli_from};
+
+    #[test]
+    fn parse_root_defaults_to_serve_without_subcommand() {
+        let parsed = parse_root_cli_from(["agenthub"]).expect("parse root");
+        assert_eq!(parsed, RootCliCommand::Serve);
+    }
+
+    #[test]
+    fn parse_root_preserves_doctor_passthrough_args() {
+        let parsed = parse_root_cli_from(["agenthub", "doctor", "--help"]).expect("parse doctor");
+        assert_eq!(
+            parsed,
+            RootCliCommand::Doctor {
+                args: vec!["--help".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_root_preserves_actor_passthrough_args() {
+        let parsed = parse_root_cli_from(["agenthub", "actor", "--json", "inbox", "--help"])
+            .expect("parse actor");
+        assert_eq!(
+            parsed,
+            RootCliCommand::Actor {
+                args: vec![
+                    "--json".to_string(),
+                    "inbox".to_string(),
+                    "--help".to_string()
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_root_maps_legacy_actor_mcp_command() {
+        let parsed = parse_root_cli_from(["agenthub", "actor-mcp"]).expect("parse actor-mcp");
+        assert_eq!(parsed, RootCliCommand::LegacyActorMcp);
+    }
+
+    #[test]
+    fn parse_root_reports_help_without_treating_it_as_failure() {
+        let err = parse_root_cli_from(["agenthub", "--help"]).expect_err("display help");
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+        assert!(is_non_error_clap_exit(&err));
+    }
+
+    #[test]
+    fn parse_root_rejects_unknown_top_level_subcommands() {
+        let err = parse_root_cli_from(["agenthub", "unknown"]).expect_err("reject unknown");
+        assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
+        assert!(err.to_string().contains("unknown"));
+    }
+}

--- a/src/cli_error.rs
+++ b/src/cli_error.rs
@@ -16,6 +16,10 @@ pub fn write_cli_error<W: Write>(mut writer: W, err: &anyhow::Error) -> io::Resu
 }
 
 pub fn report_cli_error(err: &anyhow::Error) {
+    if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
+        let _ = clap_err.print();
+        return;
+    }
     let stderr = io::stderr();
     let mut handle = stderr.lock();
     let _ = write_cli_error(&mut handle, err);

--- a/src/doctor_cli.rs
+++ b/src/doctor_cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use agenthub_managed_skills::install_managed_skills;
+use clap::{CommandFactory, Parser, error::ErrorKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DoctorCommand {
@@ -8,27 +9,34 @@ enum DoctorCommand {
     Help,
 }
 
-fn is_help_flag(arg: &str) -> bool {
-    matches!(arg.trim(), "--help" | "-h")
-}
+#[derive(Debug, Parser)]
+#[command(
+    name = "doctor",
+    bin_name = "agenthub doctor",
+    about = "Materialize managed AgentHub runtime skills under ~/.agents/skills/agenthub-runtime and exit.",
+    disable_help_subcommand = true
+)]
+struct DoctorCli;
 
-fn doctor_usage() -> &'static str {
-    "Usage:\n  agenthub doctor\n  agenthub doctor --help\n\nBehavior:\n  Materialize managed AgentHub runtime skills under ~/.agents/skills/agenthub-runtime and exit.\n"
+fn render_doctor_help() -> String {
+    let mut command = DoctorCli::command();
+    let mut buffer = Vec::new();
+    command
+        .write_long_help(&mut buffer)
+        .expect("render doctor help");
+    String::from_utf8(buffer).expect("doctor help should be utf8")
 }
 
 fn parse_doctor_args(args: &[String]) -> anyhow::Result<DoctorCommand> {
-    match args {
-        [] => Ok(DoctorCommand::Run),
-        [arg] if is_help_flag(arg) || arg.trim() == "help" => Ok(DoctorCommand::Help),
-        [arg] => Err(anyhow::anyhow!(
-            "unknown flag for doctor: {}\n{}",
-            arg,
-            doctor_usage()
-        )),
-        _ => Err(anyhow::anyhow!(
-            "doctor does not accept positional arguments\n{}",
-            doctor_usage()
-        )),
+    if matches!(args, [arg] if arg.trim() == "help") {
+        return Ok(DoctorCommand::Help);
+    }
+
+    let argv = std::iter::once("doctor".to_string()).chain(args.iter().cloned());
+    match DoctorCli::try_parse_from(argv) {
+        Ok(_) => Ok(DoctorCommand::Run),
+        Err(err) if err.kind() == ErrorKind::DisplayHelp => Ok(DoctorCommand::Help),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -48,7 +56,7 @@ fn render_install_report(installed: &[PathBuf]) -> String {
 fn run_doctor_command(command: DoctorCommand) -> anyhow::Result<()> {
     match command {
         DoctorCommand::Help => {
-            println!("{}", doctor_usage());
+            print!("{}", render_doctor_help());
         }
         DoctorCommand::Run => {
             let installed = install_managed_skills(None)?;
@@ -58,21 +66,14 @@ fn run_doctor_command(command: DoctorCommand) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn maybe_run_from_args() -> Option<anyhow::Result<()>> {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if args.first().map(String::as_str) != Some("doctor") {
-        return None;
-    }
-
-    Some(match parse_doctor_args(&args[1..]) {
-        Ok(command) => run_doctor_command(command),
-        Err(err) => Err(err),
-    })
+pub async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
+    let command = parse_doctor_args(args)?;
+    run_doctor_command(command)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DoctorCommand, doctor_usage, parse_doctor_args, render_install_report};
+    use super::{DoctorCommand, parse_doctor_args, render_doctor_help, render_install_report};
     use std::path::PathBuf;
 
     #[test]
@@ -90,7 +91,7 @@ mod tests {
     #[test]
     fn parse_doctor_rejects_unknown_flag() {
         let err = parse_doctor_args(&["--verbose".to_string()]).expect_err("reject unknown flag");
-        assert!(err.to_string().contains("unknown flag for doctor"));
+        assert!(err.to_string().contains("unexpected argument '--verbose'"));
         assert!(err.to_string().contains("agenthub doctor"));
     }
 
@@ -112,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn doctor_usage_mentions_managed_skills() {
-        assert!(doctor_usage().contains("managed AgentHub runtime skills"));
+    fn doctor_help_mentions_managed_skills() {
+        assert!(render_doctor_help().contains("managed AgentHub runtime skills"));
     }
 }

--- a/src/doctor_cli.rs
+++ b/src/doctor_cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use agenthub_managed_skills::install_managed_skills;
+use anyhow::Context;
 use clap::{CommandFactory, Parser, error::ErrorKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,13 +19,13 @@ enum DoctorCommand {
 )]
 struct DoctorCli;
 
-fn render_doctor_help() -> String {
+fn render_doctor_help_result() -> anyhow::Result<String> {
     let mut command = DoctorCli::command();
     let mut buffer = Vec::new();
     command
         .write_long_help(&mut buffer)
-        .expect("render doctor help");
-    String::from_utf8(buffer).expect("doctor help should be utf8")
+        .context("render doctor help")?;
+    String::from_utf8(buffer).context("doctor help output should be valid utf8")
 }
 
 fn parse_doctor_args(args: &[String]) -> anyhow::Result<DoctorCommand> {
@@ -56,7 +57,7 @@ fn render_install_report(installed: &[PathBuf]) -> String {
 fn run_doctor_command(command: DoctorCommand) -> anyhow::Result<()> {
     match command {
         DoctorCommand::Help => {
-            print!("{}", render_doctor_help());
+            print!("{}", render_doctor_help_result()?);
         }
         DoctorCommand::Run => {
             let installed = install_managed_skills(None)?;
@@ -73,7 +74,9 @@ pub async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DoctorCommand, parse_doctor_args, render_doctor_help, render_install_report};
+    use super::{
+        DoctorCommand, parse_doctor_args, render_doctor_help_result, render_install_report,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -114,6 +117,7 @@ mod tests {
 
     #[test]
     fn doctor_help_mentions_managed_skills() {
-        assert!(render_doctor_help().contains("managed AgentHub runtime skills"));
+        let help = render_doctor_help_result().expect("render doctor help");
+        assert!(help.contains("managed AgentHub runtime skills"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod agenthub_binary;
 mod api;
 mod app;
 mod auth;
+mod cli;
 mod cli_error;
 mod doctor_cli;
 pub use agenthub_config as config;


### PR DESCRIPTION
## Summary

- add a clap-based root parser for `agenthub`
- migrate `agenthub doctor` parsing/help to clap
- route `agenthub actor ...` through the new root parser while preserving the existing actor parser/execution layer

## Why

The previous root command flow used two independent `std::env::args()` probes and silently fell through to server startup for unknown top-level argv. That left root help/version behavior undefined and duplicated CLI dispatch logic.

This change narrows the problem first:

- one root parser owns top-level command dispatch
- `doctor` becomes a complete clap command
- `actor` keeps its current behavior, but now enters through the same root boundary

## Scope

Included in this PR:

- `agenthub --help` / `--version` now come from clap
- `agenthub doctor` now uses clap parsing and clap-rendered help
- `agenthub actor ...` now goes through the root clap parser before delegating to the existing actor parser
- unknown top-level subcommands now fail fast instead of booting the server

Deferred to follow-up:

- full clap migration for every `agenthub actor ...` subcommand and flag
- removal of the legacy hand-written actor help/parser layer

## Validation

- `cargo test -p agenthub cli::tests:: -- --nocapture`
- `cargo clippy -p agenthub --all-targets -- -D warnings`
- `git diff --check`
