### PR TITLE
ci(bazel): disable cached test results in coverage job

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -136,7 +136,7 @@ jobs:
         run: bazel build $BAZEL_ROOT_RUNTIME_PREREQ_TARGETS
       - name: Bazel coverage
         run: |
-          bazel coverage --combined_report=lcov --test_output=errors \
+          bazel coverage --combined_report=lcov --test_output=errors --nocache_test_results \
             $BAZEL_COVERAGE_TARGETS
           cp "$(bazel info output_path)/_coverage/_coverage_report.dat" bazel.lcov
           test -s bazel.lcov

--- a/docs/journal/2026-03-31-bazel-coverage-no-test-cache.md
+++ b/docs/journal/2026-03-31-bazel-coverage-no-test-cache.md
@@ -8,7 +8,7 @@ Coverage runs should execute tests fresh instead of reusing cached test results.
 
 ## Change
 
-- Updated [`.github/workflows/bazel.yml`](/Users/weizhenwang/devel/opensource/agenthub/.github/workflows/bazel.yml) so `bazel coverage` runs with:
+- Updated [`.github/workflows/bazel.yml`](../../.github/workflows/bazel.yml) so `bazel coverage` runs with:
   - `--combined_report=lcov`
   - `--test_output=errors`
   - `--nocache_test_results`

--- a/docs/journal/2026-03-31-bazel-coverage-no-test-cache.md
+++ b/docs/journal/2026-03-31-bazel-coverage-no-test-cache.md
@@ -1,0 +1,21 @@
+## Summary
+
+Adjusted the `Bazel Coverage` GitHub Actions job to disable Bazel test result caching while keeping normal build/action cache behavior.
+
+## Why
+
+Coverage runs should execute tests fresh instead of reusing cached test results. Reusing cached test results can hide coverage-specific runtime behavior and make the coverage job less trustworthy as a verification signal.
+
+## Change
+
+- Updated [`.github/workflows/bazel.yml`](/Users/weizhenwang/devel/opensource/agenthub/.github/workflows/bazel.yml) so `bazel coverage` runs with:
+  - `--combined_report=lcov`
+  - `--test_output=errors`
+  - `--nocache_test_results`
+
+This keeps Bazel build/action caches available for compilation and analysis work, while forcing test execution during the coverage job.
+
+## Validation
+
+- Reviewed the workflow diff to confirm only the coverage invocation changed.
+- Ran `git diff --check`.


### PR DESCRIPTION
## Summary

- disable cached test results in the `Bazel Coverage` workflow job
- keep normal Bazel build caching for compile and analysis work
- document the change and validation rationale

## Why

`bazel coverage` should execute tests fresh. Reusing cached test results weakens the coverage job as a verification signal and can hide coverage-specific runtime behavior.

## Testing

- `git diff --check`
