### PR TITLE
test(db): stabilize idle gc idle-window timing

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1822,6 +1822,7 @@ mod tests {
         init_db_at_path, try_connect,
     };
     use agenthub_config::path_utils::expand_tilde;
+    use sqlx::SqlitePool;
     use sqlx::Row;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::time::Duration;
@@ -2738,14 +2739,9 @@ mod tests {
         .expect("insert first old event");
 
         idle_gc.record_activity("agent-idle-gc").await;
-        tokio::time::sleep(Duration::from_millis(180)).await;
 
-        let remaining_after_first_check: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM agent_events WHERE ts < ?1")
-                .bind(old_ts + 1)
-                .fetch_one(&pool)
-                .await
-                .expect("count after first idle gc");
+        let remaining_after_first_check =
+            wait_for_old_event_count(&pool, old_ts + 1, 0, Duration::from_millis(500)).await;
         assert_eq!(remaining_after_first_check, 0);
 
         sqlx::query(
@@ -2776,17 +2772,36 @@ mod tests {
         );
 
         idle_gc.record_activity("agent-idle-gc").await;
-        tokio::time::sleep(Duration::from_millis(180)).await;
-        let remaining_after_second_idle_window: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM agent_events WHERE ts < ?1")
-                .bind(old_ts + 1)
-                .fetch_one(&pool)
-                .await
-                .expect("count after second idle window");
+        let remaining_after_second_idle_window =
+            wait_for_old_event_count(&pool, old_ts + 1, 0, Duration::from_millis(500)).await;
         assert_eq!(remaining_after_second_idle_window, 0);
 
         pool.close().await;
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    async fn wait_for_old_event_count(
+        pool: &SqlitePool,
+        cutoff_ts: i64,
+        expected: i64,
+        timeout: Duration,
+    ) -> i64 {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining: i64 =
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agent_events WHERE ts < ?1")
+                .bind(cutoff_ts)
+                .fetch_one(pool)
+                .await
+                .expect("count old events");
+            if remaining == expected {
+                return remaining;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return remaining;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
     }
 
     #[tokio::test]

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -2786,19 +2786,23 @@ mod tests {
         expected: i64,
         timeout: Duration,
     ) -> i64 {
-        let deadline = tokio::time::Instant::now() + timeout;
+        let started_at = tokio::time::Instant::now();
+        let deadline = started_at + timeout;
         loop {
             let remaining: i64 =
                 sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM agent_events WHERE ts < ?1")
-                .bind(cutoff_ts)
-                .fetch_one(pool)
-                .await
-                .expect("count old events");
+                    .bind(cutoff_ts)
+                    .fetch_one(pool)
+                    .await
+                    .expect("count old events");
             if remaining == expected {
                 return remaining;
             }
             if tokio::time::Instant::now() >= deadline {
-                return remaining;
+                panic!(
+                    "timed out waiting for old event count: cutoff_ts={cutoff_ts}, expected={expected}, last_remaining={remaining}, timeout_ms={}",
+                    timeout.as_millis()
+                );
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }

--- a/docs/journal/2026-03-31-db-idle-gc-test-flake.md
+++ b/docs/journal/2026-03-31-db-idle-gc-test-flake.md
@@ -9,6 +9,7 @@ The test previously assumed that a fixed `sleep(180ms)` was always long enough f
 ## Change
 
 - Replaced the fixed post-activity sleep used for the cleanup assertions with a small polling helper that waits until the expected old-event count is observed or a bounded timeout expires.
+- Made timeout failures explicit so CI surfaces a clear cutoff/expected/last-observed mismatch instead of silently returning the final count.
 - Kept the "should not re-run without new activity" assertion on the existing short idle window so the test still validates the generation-gating behavior rather than masking it behind long unconditional waits.
 
 ## Validation

--- a/docs/journal/2026-03-31-db-idle-gc-test-flake.md
+++ b/docs/journal/2026-03-31-db-idle-gc-test-flake.md
@@ -1,0 +1,16 @@
+## Summary
+
+Stabilized the `idle_gc_checks_only_once_per_idle_window` test in `agenthub-db`.
+
+## Why
+
+The test previously assumed that a fixed `sleep(180ms)` was always long enough for the background idle-GC task to wake up, acquire state, open the per-agent SQLite pool, and finish cleanup. That assumption was too brittle under slower CI environments such as Bazel coverage runs.
+
+## Change
+
+- Replaced the fixed post-activity sleep used for the cleanup assertions with a small polling helper that waits until the expected old-event count is observed or a bounded timeout expires.
+- Kept the "should not re-run without new activity" assertion on the existing short idle window so the test still validates the generation-gating behavior rather than masking it behind long unconditional waits.
+
+## Validation
+
+- `cargo test -p agenthub-db idle_gc_checks_only_once_per_idle_window -- --nocapture`


### PR DESCRIPTION
## Summary

- stabilize `idle_gc_checks_only_once_per_idle_window` in `agenthub-db`
- replace fixed cleanup sleeps with bounded condition waits for the positive cleanup assertions
- document the flaky timing root cause and validation

## Why

The test relied on a fixed `sleep(180ms)` after `record_activity()`, but idle GC runs in a spawned background task. Under slower CI environments, especially Bazel coverage, the cleanup can complete after that fixed sleep and cause a false failure.

## Testing

- `cargo test -p agenthub-db idle_gc_checks_only_once_per_idle_window -- --nocapture`
- `git diff --check`
