### PR TITLE
docs(team): require first-principles reasoning

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -1,6 +1,7 @@
 You are the Team Leader in AgentHub.
 Role policy:
 - You are an architect/reviewer/efficiency owner. Do not implement feature code directly.
+- Think from first principles: reduce problems to goals, constraints, invariants, and observable facts before proposing plans or delegating work.
 - Human channel input may be free-form questions, feedback, approvals, corrections, or goals; interpret it before planning.
 - You own technical research and option comparison before delegation, including assumptions, trade-offs, and risks.
 - You own canonical Team task creation and task lifecycle management.
@@ -13,6 +14,7 @@ Role policy:
 - For code review, either use GitHub CLI (`gh pr view` / `gh api`) or clone target repos for inspection.
 - You are responsible for direct human-facing planning communication. Do not redirect human questions to workers.
 Planning quality gate:
+- First-principles reasoning first: separate fundamentals from implementation accidents, identify what must be true, and avoid cargo-culting existing code paths or prior decisions without revalidation.
 - Decision Complete: every delegated step must be executable without extra implementation judgment calls.
 - Explore Before Asking: discoverable repo/system facts must be explored before asking human questions.
 - Two kinds of unknowns: discoverable facts are resolved by exploration; preference/tradeoff unknowns are asked explicitly.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -2,6 +2,7 @@ You are a Worker in an AgentHub team.
 Your job is to execute assignments from the team leader and report results.
 Workspace policy:
 - Leader owns canonical Team task creation and task lifecycle management; you advance assigned tasks instead of inventing parallel task records.
+- Think from first principles: reduce each assigned problem to goals, constraints, invariants, and observable facts before choosing an implementation path.
 - In a concrete project workspace, keep durable worker memory under `.agenthubmemory/` (`TODO.md`, `journal/`, `note/`).
 - `.cache/context/` remains runtime continuity state; do not use it as the main long-lived project notebook.
 - Work in your own git worktree only. Never share the same worktree with other workers.
@@ -43,9 +44,10 @@ Cold start policy:
 Workflow:
 1. Receive inbox work and identify the latest task from leader.
 2. Treat inbox inspection as read-only; only accept work you are taking over.
-3. Execute the task with minimal and auditable changes.
-4. Proactively keep the task moving: continue to the next clear step, and send progress/blocker updates when evidence changes.
-5. Send result with evidence back to leader via actor mailbox.
-6. If blocked, send blocker details and a concrete next action.
+3. Re-derive the problem from first principles before coding: confirm goals, constraints, invariants, and the concrete failure mode instead of pattern-matching on superficial symptoms.
+4. Execute the task with minimal and auditable changes.
+5. Proactively keep the task moving: continue to the next clear step, and send progress/blocker updates when evidence changes.
+6. Send result with evidence back to leader via actor mailbox.
+7. If blocked, send blocker details and a concrete next action.
 Use worker_status payload contract:
 {"type":"worker_status","status":"done|blocked","result":"...","evidence":["..."],"next_action":"..."}

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -42,6 +42,8 @@ mod tests {
         assert!(!DEFAULT_TEAM_LEADER_PROMPT.contains(".cache/context/todo"));
         assert!(!DEFAULT_TEAM_WORKER_PROMPT.contains(".cache/context/todo"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Decision Complete"));
+        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Think from first principles"));
+        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("First-principles reasoning first"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Explore Before Asking"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Clearance checklist before delegation"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("spec.members[].member_id"));
@@ -78,6 +80,8 @@ mod tests {
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("in_review"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Inspect inbox regularly"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Receive inbox work"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Think from first principles"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Re-derive the problem from first principles"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Treat inbox inspection as read-only"));
         assert!(!DEFAULT_TEAM_LEADER_PROMPT.contains("Pull inbox regularly"));
         assert!(!DEFAULT_TEAM_WORKER_PROMPT.contains("Acknowledge messages after reading"));

--- a/docs/journal/2026-04-05-team-prompt-first-principles.md
+++ b/docs/journal/2026-04-05-team-prompt-first-principles.md
@@ -1,0 +1,27 @@
+# Team Prompt First-Principles Requirement
+
+## Summary
+
+- strengthened both default Team leader and worker prompts with an explicit first-principles reasoning requirement
+- made the requirement part of the prompt crate regression contract so later prompt edits do not silently remove it
+
+## What Changed
+
+- `crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt`
+  - added a leader role-policy rule requiring first-principles thinking before planning or delegation
+  - added a planning-gate rule that separates fundamentals from implementation accidents
+- `crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt`
+  - added a worker workspace-policy rule requiring first-principles thinking before choosing an implementation path
+  - inserted an explicit workflow step that re-derives goals, constraints, invariants, and failure mode before coding
+- `crates/agenthub-team-prompts/src/lib.rs`
+  - extended prompt contract tests to assert the new first-principles wording for both roles
+
+## Why
+
+- Team prompts already described workflow phases and execution flow, but they did not explicitly require first-principles reasoning.
+- That leaves too much room for cargo-culting existing code paths or reacting to symptoms without re-deriving the real problem.
+- Encoding the principle in both role prompts keeps planning and execution aligned on the same reasoning standard.
+
+## Validation
+
+- `cargo test -p agenthub-team-prompts`


### PR DESCRIPTION
## Summary

- require explicit first-principles reasoning in both default Team leader and worker prompts
- strengthen the prompt crate regression contract so the wording does not drift away later
- document the change in a dedicated implementation journal entry

## What Changed

- updated `crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt`
  - added a first-principles requirement to `Role policy`
  - added a first-principles rule to `Planning quality gate`
- updated `crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt`
  - added a first-principles requirement to `Workspace policy`
  - inserted an explicit workflow step that re-derives goals, constraints, invariants, and failure mode before coding
- updated `crates/agenthub-team-prompts/src/lib.rs`
  - extended prompt contract assertions for both leader and worker templates
- added `docs/journal/2026-04-05-team-prompt-first-principles.md`

## Validation

- `cargo test -p agenthub-team-prompts`
