### PR TITLE
docs: sync readme and workbench docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ for the operational side of agent workflows:
 - View ACP events such as messages, plans, tool calls, command output, and
   debug streams
 - Run multi-agent Team workflows with leader/worker coordination
+- Install AgentHub as an app-like PWA shell while still picking up fresh web
+  deploys on refresh
 - Register remote execution nodes and start agents on those nodes
 - Persist session history and operational records in SQLite
 - Receive completion notifications in the web UI
@@ -122,6 +124,9 @@ current contract and rollout model.
   - Rust backend serving the API, embedded web UI, and runtime control plane
 - **ACP runtime**
   - Structured event model for plans, tools, output, and history replay
+- **Web workbench**
+  - Mantine primitives plus Tailwind utilities, shared UI primitives, and
+    bounded recent-window conversation views for ACP and Team surfaces
 - **Teams runtime**
   - Leader/worker orchestration, Team tasks, mailbox coordination, and shared
     conversation flow
@@ -141,10 +146,12 @@ current contract and rollout model.
 - Internal docs guide: [docs/README.md](docs/README.md)
 - Project charter and engineering constraints: [AGENTS.md](AGENTS.md)
 - Agent and Team architecture: [docs/features/agents-teams.md](docs/features/agents-teams.md)
+- Frontend/UI architecture: [docs/features/frontend-design.md](docs/features/frontend-design.md)
 - Actor runtime and mailbox model: [docs/features/actor-foundation.md](docs/features/actor-foundation.md)
 - ACP runtime contract: [docs/features/acp-runtime.md](docs/features/acp-runtime.md)
 - Remote execution nodes: [docs/features/agent-nodes.md](docs/features/agent-nodes.md)
 - Distributed node architecture: [docs/features/distributed-node-architecture.md](docs/features/distributed-node-architecture.md)
+- Team workbench user guide: [userdocs/docs/advanced/team-workbench.md](userdocs/docs/advanced/team-workbench.md)
 - Active follow-up backlog: [docs/todo.md](docs/todo.md)
 - API payload naming rules: [docs/api_naming.md](docs/api_naming.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,12 +17,16 @@ Use this checklist for every non-trivial change:
 
 1. Update the canonical feature spec in `docs/features/` when contracts or
    behavior changed.
+   - For Agents / ACP / Team UI behavior, this usually means
+     `docs/features/frontend-design.md`.
 2. Add or append a dated journal in `docs/journal/` for the implementation
    checkpoint.
 3. Add a follow-up item in `docs/todo.md` only when open work remains.
 4. If API payloads changed, ensure naming still conforms to
    `docs/api_naming.md`.
 5. If behavior is user-visible, update `userdocs/docs/` accordingly.
+   - Team workbench changes should usually update
+     `userdocs/docs/advanced/team-workbench.md`.
 
 ## Journal Convention
 

--- a/docs/features/agents-teams.md
+++ b/docs/features/agents-teams.md
@@ -241,6 +241,9 @@ Constraint:
 - `Conversation` does not require an active run.
 - `Conversation` is not a task list; task creation is an internal Team planning/runtime decision.
 - Humans are not required to phrase requests in task form before the Team can act on them.
+- Human-facing `Conversation` is a bounded recent window, not an unbounded
+  archive; operators should use ACP / Runs / other debug lanes for deeper
+  history.
 - `Kanban` is task-first and should show task state plus linked run history/summary.
 - Leader owns canonical Team task creation and lifecycle management; workers advance assigned work
   and report progress/blockers promptly so task state remains current.

--- a/docs/features/frontend-design.md
+++ b/docs/features/frontend-design.md
@@ -25,7 +25,10 @@ state labels, and panel behaviors diverged.
 - UI component baseline: `@mantine/core` + Tailwind CSS utilities.
 - Styling strategy:
   - semantic tokens in Tailwind config;
+  - matching `@theme` token definitions in `web/src/tailwind.css`;
   - reusable class presets in `web/src/ui/tailwind_classes.ts`;
+  - thin shared UI primitives in `web/src/ui/primitives.tsx` and
+    `web/src/ui/floating_surfaces.ts`;
   - avoid new handcrafted global CSS blocks.
 
 ### 1.1) Workbench Shell Language
@@ -48,6 +51,9 @@ state labels, and panel behaviors diverged.
 - Team surface is conversation-first for human interaction.
 - `Conversation` remains available even when no active run exists.
 - Conversation uses one shared group stream (human + leader + workers); no per-recipient split view on the human surface.
+- Shared conversation and ACP views are intentionally bounded recent windows by
+  default (current product baseline: recent-10) instead of infinite in-memory
+  scrollback.
 - Default response routing is team-wide when no `@mention` is provided, with leader-first speaking priority.
 - `@member_id` marks people in the same shared stream and should be surfaced back to agents/UI as mention metadata, without changing group-chat fan-out.
 - `Runs` is the dedicated run-entry tab (run browser + `Start Team` + run selection).
@@ -82,6 +88,8 @@ state labels, and panel behaviors diverged.
 ### 1) Styling Contract
 
 - New reusable visual patterns should be extracted into shared Tailwind class presets.
+- Repeated shells/actions/badges should prefer shared UI primitives before
+  introducing new page-local Tailwind strings.
 - Feature code should prefer semantic tokens (`brand.*`, `ui.*`, `state.*`) over literal color strings.
 
 ### 2) Team Interaction Contract

--- a/docs/journal/2026-04-05-readme-and-doc-sync.md
+++ b/docs/journal/2026-04-05-readme-and-doc-sync.md
@@ -1,0 +1,19 @@
+# README And Docs Sync
+
+## Summary
+
+- Updated `README.md` to reflect the current web workbench direction:
+  installable PWA shell, Mantine + Tailwind UI baseline, shared UI primitives,
+  and bounded recent-window conversation behavior.
+- Updated `docs/README.md` so frontend/UI work explicitly points contributors to
+  `docs/features/frontend-design.md` and the Team workbench user docs.
+- Synced `docs/features/frontend-design.md` and
+  `docs/features/agents-teams.md` with the current frontend architecture and
+  Team conversation-window contract.
+- Updated the user-facing Team workbench guide to describe the current
+  recent-10 shared-channel behavior instead of the older “hydrate a larger tail”
+  wording.
+
+## Validation
+
+- `npm --prefix userdocs run build`

--- a/userdocs/docs/advanced/team-workbench.md
+++ b/userdocs/docs/advanced/team-workbench.md
@@ -32,7 +32,7 @@ debug artifacts. They are not the primary planning surface.
   - `# all` is a stable Team-level conversation target resolved by the backend, not whichever task
     happens to be visible first in the Kanban list
   - optimized for live coordination: the composer stays pinned to the bottom and the workbench
-    prioritizes a fast recent slice before hydrating a larger recent tail in the background
+    shows a bounded recent-10 message window by default
   - human goals, constraints, approvals, and `@member_id` coordination requests
 - **Kanban**:
   - task ownership and lifecycle
@@ -116,9 +116,10 @@ The Team header exposes the shared-thread connection state directly:
 - a manual channel refresh action is still available when you want to force a fresh pull
 
 The shared channel is intentionally tuned for live coordination, not infinite
-log browsing. If you need deeper execution history or raw event detail, drop
-into `Agent ACP`, `Runs`, or other debug surfaces instead of treating `# all`
-as the primary archive.
+log browsing. The default Team surface keeps only a small recent window in
+memory so the workbench stays responsive. If you need deeper execution history
+or raw event detail, drop into `Agent ACP`, `Runs`, or other debug surfaces
+instead of treating `# all` as the primary archive.
 
 ## What To Watch Operationally
 


### PR DESCRIPTION
# Summary

- sync `README.md` with the current web workbench direction
- update internal docs guidance to point frontend/UI changes at the canonical specs
- align Team workbench user docs with the current bounded recent-window conversation behavior

# Changes

- update `README.md` quick description and documentation map
- update `docs/README.md` contributor guidance for frontend/UI and Team workbench docs
- sync `docs/features/frontend-design.md` and `docs/features/agents-teams.md`
- update `userdocs/docs/advanced/team-workbench.md`
- add `docs/journal/2026-04-05-readme-and-doc-sync.md`

# Validation

- `npm --prefix userdocs run build`
