### PR TITLE
chore(acp): align prompt delivery with official turn semantics

### DIFF
--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -302,8 +302,10 @@ impl AppServerCodexThread {
         match response {
             Ok(_) => {
                 let mut state = self.state.lock().await;
-                if let Some(active_turn) = state.active_turn.as_mut() {
-                    active_turn.submission_id = submission_id.clone();
+                if let Some(current_active_turn) = state.active_turn.as_mut() {
+                    if current_active_turn.submission_id == active_turn.submission_id {
+                        current_active_turn.submission_id = submission_id.clone();
+                    }
                 }
                 Ok(SteerFollowUpAction::ReuseActiveSubmission(submission_id))
             }
@@ -573,57 +575,64 @@ impl AppServerCodexThread {
         &self,
         args: OverrideTurnContextArgs,
     ) -> Result<String, CodexErr> {
-        let mut state = self.state.lock().await;
-        let mut updated_config = state.config.clone();
+        let (updated_config, request_id, thread_id) = {
+            let mut state = self.state.lock().await;
+            let mut updated_config = state.config.clone();
 
-        if let Some(cwd) = args.cwd {
-            updated_config.cwd = cwd.try_into()?;
-        }
-        if let Some(approval_policy) = args.approval_policy {
-            updated_config
-                .permissions
-                .approval_policy
-                .set(approval_policy)
-                .map_err(|err| CodexErr::Fatal(err.to_string()))?;
-        }
-        if let Some(approvals_reviewer) = args.approvals_reviewer {
-            updated_config.approvals_reviewer = approvals_reviewer;
-        }
-        if let Some(sandbox_policy) = args.sandbox_policy {
-            updated_config
-                .permissions
-                .sandbox_policy
-                .set(sandbox_policy)
-                .map_err(|err| CodexErr::Fatal(err.to_string()))?;
-        }
-        if let Some(model) = args.model {
-            updated_config.model = Some(model);
-        }
-        if let Some(effort) = args.effort {
-            updated_config.model_reasoning_effort = effort;
-        }
-        if let Some(summary) = args.summary {
-            updated_config.model_reasoning_summary = Some(summary);
-        }
-        if let Some(personality) = args.personality {
-            updated_config.personality = Some(personality);
-        }
-        if let Some(service_tier) = args.service_tier {
-            updated_config.service_tier = service_tier;
-        }
+            if let Some(cwd) = args.cwd {
+                updated_config.cwd = cwd.try_into()?;
+            }
+            if let Some(approval_policy) = args.approval_policy {
+                updated_config
+                    .permissions
+                    .approval_policy
+                    .set(approval_policy)
+                    .map_err(|err| CodexErr::Fatal(err.to_string()))?;
+            }
+            if let Some(approvals_reviewer) = args.approvals_reviewer {
+                updated_config.approvals_reviewer = approvals_reviewer;
+            }
+            if let Some(sandbox_policy) = args.sandbox_policy {
+                updated_config
+                    .permissions
+                    .sandbox_policy
+                    .set(sandbox_policy)
+                    .map_err(|err| CodexErr::Fatal(err.to_string()))?;
+            }
+            if let Some(model) = args.model {
+                updated_config.model = Some(model);
+            }
+            if let Some(effort) = args.effort {
+                updated_config.model_reasoning_effort = effort;
+            }
+            if let Some(summary) = args.summary {
+                updated_config.model_reasoning_summary = Some(summary);
+            }
+            if let Some(personality) = args.personality {
+                updated_config.personality = Some(personality);
+            }
+            if let Some(service_tier) = args.service_tier {
+                updated_config.service_tier = service_tier;
+            }
+
+            let request_id = next_request_id(&mut state);
+            let thread_id = state.thread_id.clone();
+            (updated_config, request_id, thread_id)
+        };
 
         let _response: ThreadResumeResponse = self
             .request_handle
             .request_typed(ClientRequest::ThreadResume {
-                request_id: next_request_id(&mut state),
+                request_id,
                 params: thread_resume_params_from_config(
                     &updated_config,
-                    &SessionId::new(state.thread_id.clone()),
+                    &SessionId::new(thread_id),
                 ),
             })
             .await
             .map_err(typed_request_error_to_codex)?;
 
+        let mut state = self.state.lock().await;
         state.config = updated_config;
         Ok(noop_submission_id())
     }

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -230,10 +230,7 @@ impl AppServerCodexThread {
             state.active_turn.clone()
         };
         if let Some(active_turn) = active_turn {
-            match self
-                .try_steer_submission(submission_id.clone(), active_turn, &op)
-                .await?
-            {
+            match self.try_steer_submission(active_turn, &op).await? {
                 SteerFollowUpAction::ReuseActiveSubmission(steered_submission_id) => {
                     return Ok(steered_submission_id);
                 }
@@ -260,7 +257,6 @@ impl AppServerCodexThread {
 
     async fn try_steer_submission(
         &self,
-        submission_id: String,
         active_turn: ActiveTurn,
         op: &Op,
     ) -> Result<SteerFollowUpAction, CodexErr> {
@@ -282,7 +278,7 @@ impl AppServerCodexThread {
             let Some(current_active_turn) = state.active_turn.as_ref() else {
                 return Ok(SteerFollowUpAction::StartFreshTurn);
             };
-            if current_active_turn.submission_id != active_turn.submission_id {
+            if !active_turn_matches(current_active_turn, &active_turn) {
                 return Ok(SteerFollowUpAction::StartFreshTurn);
             }
             (next_request_id(&mut state), state.thread_id.clone())
@@ -301,13 +297,16 @@ impl AppServerCodexThread {
 
         match response {
             Ok(_) => {
-                let mut state = self.state.lock().await;
-                if let Some(current_active_turn) = state.active_turn.as_mut() {
-                    if current_active_turn.submission_id == active_turn.submission_id {
-                        current_active_turn.submission_id = submission_id.clone();
-                    }
+                let state = self.state.lock().await;
+                if let Some(submission_id) =
+                    reused_submission_id_after_successful_turn_steer(&state, &active_turn)
+                {
+                    return Ok(SteerFollowUpAction::ReuseActiveSubmission(submission_id));
                 }
-                Ok(SteerFollowUpAction::ReuseActiveSubmission(submission_id))
+                warn!(
+                    "turn/steer succeeded but local active-turn state changed, starting a fresh turn instead"
+                );
+                Ok(SteerFollowUpAction::StartFreshTurn)
             }
             Err(err) => match classify_turn_steer_failure(&err) {
                 TurnSteerFailure::StaleActiveTurn => {
@@ -318,7 +317,7 @@ impl AppServerCodexThread {
                     if state
                         .active_turn
                         .as_ref()
-                        .is_some_and(|turn| turn.submission_id == active_turn.submission_id)
+                        .is_some_and(|turn| active_turn_matches(turn, &active_turn))
                     {
                         clear_active_turn_state(&mut state);
                     }
@@ -332,7 +331,7 @@ impl AppServerCodexThread {
                     if let Some(current_active_turn) = state
                         .active_turn
                         .as_mut()
-                        .filter(|turn| turn.submission_id == active_turn.submission_id)
+                        .filter(|turn| active_turn_matches(turn, &active_turn))
                     {
                         current_active_turn.steerable = false;
                     } else {
@@ -346,7 +345,7 @@ impl AppServerCodexThread {
                     if state
                         .active_turn
                         .as_ref()
-                        .is_none_or(|turn| turn.submission_id != active_turn.submission_id)
+                        .is_none_or(|turn| !active_turn_matches(turn, &active_turn))
                     {
                         return Ok(SteerFollowUpAction::StartFreshTurn);
                     }
@@ -1993,6 +1992,21 @@ fn submission_id_for_turn_or_fallback(state: &AppServerState, turn_id: &str) -> 
         .or_else(|| active_submission_id(state))
 }
 
+fn active_turn_matches(current: &ActiveTurn, expected: &ActiveTurn) -> bool {
+    current.submission_id == expected.submission_id && current.turn_id == expected.turn_id
+}
+
+fn reused_submission_id_after_successful_turn_steer(
+    state: &AppServerState,
+    active_turn: &ActiveTurn,
+) -> Option<String> {
+    state
+        .active_turn
+        .as_ref()
+        .filter(|current| active_turn_matches(current, active_turn))
+        .map(|current| current.submission_id.clone())
+}
+
 fn pending_patch_changes_for_request(
     state: &AppServerState,
     item_id: &str,
@@ -2636,6 +2650,34 @@ mod tests {
     use std::fs;
     use uuid::Uuid;
 
+    async fn test_state_with_active_turn(active_turn: Option<ActiveTurn>) -> AppServerState {
+        let codex_home =
+            std::env::temp_dir().join(format!("agenthub-codex-home-{}", Uuid::new_v4()));
+        fs::create_dir_all(&codex_home).expect("create codex home");
+        let config = ConfigBuilder::default()
+            .codex_home(codex_home.clone())
+            .fallback_cwd(Some(codex_home))
+            .build()
+            .await
+            .expect("build config");
+        AppServerState {
+            config,
+            next_request_id: 1,
+            thread_id: "thread-1".to_string(),
+            active_turn,
+            queued_submissions: VecDeque::new(),
+            local_events: VecDeque::new(),
+            pending_exec_requests: HashMap::new(),
+            pending_patch_requests: HashMap::new(),
+            pending_patch_changes: HashMap::new(),
+            pending_permissions_requests: HashMap::new(),
+            pending_user_input_requests: HashMap::new(),
+            pending_elicitation_requests: HashMap::new(),
+            pending_turn_diffs: HashMap::new(),
+            interrupt_after_turn_starts: false,
+        }
+    }
+
     #[test]
     fn resumed_regular_turn_is_steerable() {
         let turn = Turn {
@@ -2884,35 +2926,49 @@ mod tests {
 
     #[tokio::test]
     async fn submission_id_for_turn_falls_back_to_turn_id_when_local_state_is_missing() {
-        let codex_home =
-            std::env::temp_dir().join(format!("agenthub-codex-home-{}", Uuid::new_v4()));
-        fs::create_dir_all(&codex_home).expect("create codex home");
-        let config = ConfigBuilder::default()
-            .codex_home(codex_home.clone())
-            .fallback_cwd(Some(codex_home.clone()))
-            .build()
-            .await
-            .expect("build config");
-        let state = AppServerState {
-            config,
-            next_request_id: 1,
-            thread_id: "thread-1".to_string(),
-            active_turn: None,
-            queued_submissions: VecDeque::new(),
-            local_events: VecDeque::new(),
-            pending_exec_requests: HashMap::new(),
-            pending_patch_requests: HashMap::new(),
-            pending_patch_changes: HashMap::new(),
-            pending_permissions_requests: HashMap::new(),
-            pending_user_input_requests: HashMap::new(),
-            pending_elicitation_requests: HashMap::new(),
-            pending_turn_diffs: HashMap::new(),
-            interrupt_after_turn_starts: false,
-        };
+        let state = test_state_with_active_turn(None).await;
 
         assert_eq!(
             submission_id_for_turn_or_fallback(&state, "resumed-turn").as_deref(),
             Some("resumed-turn")
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_turn_steer_reuses_existing_submission_when_local_active_turn_matches() {
+        let active_turn = ActiveTurn {
+            submission_id: "shared-submission".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            steerable: true,
+            last_agent_message: None,
+        };
+        let state = test_state_with_active_turn(Some(active_turn.clone())).await;
+
+        assert_eq!(
+            reused_submission_id_after_successful_turn_steer(&state, &active_turn).as_deref(),
+            Some("shared-submission")
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_turn_steer_starts_fresh_turn_when_local_active_turn_changed() {
+        let state = test_state_with_active_turn(Some(ActiveTurn {
+            submission_id: "new-submission".to_string(),
+            turn_id: Some("turn-2".to_string()),
+            steerable: true,
+            last_agent_message: None,
+        }))
+        .await;
+        let old_active_turn = ActiveTurn {
+            submission_id: "shared-submission".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            steerable: true,
+            last_agent_message: None,
+        };
+
+        assert_eq!(
+            reused_submission_id_after_successful_turn_steer(&state, &old_active_turn),
+            None
         );
     }
 

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -57,7 +57,6 @@ use codex_protocol::request_user_input::{
 use codex_shell_command::parse_command::parse_command;
 use tokio::sync::Mutex;
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::thread::CodexThreadImpl;
 
@@ -225,18 +224,20 @@ impl AppServerCodexThread {
         }
     }
 
-    async fn submit_prompt_like(&self, op: Op) -> Result<String, CodexErr> {
+    async fn submit_prompt_like(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
         let active_turn = {
             let state = self.state.lock().await;
             state.active_turn.clone()
         };
         if let Some(active_turn) = active_turn {
-            match self.try_steer_submission(active_turn, &op).await? {
+            match self
+                .try_steer_submission(submission_id.clone(), active_turn, &op)
+                .await?
+            {
                 SteerFollowUpAction::ReuseActiveSubmission(steered_submission_id) => {
                     return Ok(steered_submission_id);
                 }
                 SteerFollowUpAction::QueueFollowUp => {
-                    let submission_id = new_submission_id();
                     let mut state = self.state.lock().await;
                     if state.active_turn.is_some() {
                         state.queued_submissions.push_back(QueuedSubmission {
@@ -253,13 +254,13 @@ impl AppServerCodexThread {
             }
         }
 
-        let submission_id = new_submission_id();
         self.start_submission(submission_id.clone(), op).await?;
         Ok(submission_id)
     }
 
     async fn try_steer_submission(
         &self,
+        submission_id: String,
         active_turn: ActiveTurn,
         op: &Op,
     ) -> Result<SteerFollowUpAction, CodexErr> {
@@ -299,9 +300,13 @@ impl AppServerCodexThread {
             .await;
 
         match response {
-            Ok(_) => Ok(SteerFollowUpAction::ReuseActiveSubmission(
-                active_turn.submission_id,
-            )),
+            Ok(_) => {
+                let mut state = self.state.lock().await;
+                if let Some(active_turn) = state.active_turn.as_mut() {
+                    active_turn.submission_id = submission_id.clone();
+                }
+                Ok(SteerFollowUpAction::ReuseActiveSubmission(submission_id))
+            }
             Err(err) => match classify_turn_steer_failure(&err) {
                 TurnSteerFailure::StaleActiveTurn => {
                     let mut state = self.state.lock().await;
@@ -1666,10 +1671,10 @@ impl AppServerCodexThread {
 
 #[async_trait::async_trait]
 impl CodexThreadImpl for AppServerCodexThread {
-    async fn submit(&self, op: Op) -> Result<String, CodexErr> {
+    async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
         match op {
             op @ (Op::UserInput { .. } | Op::Review { .. } | Op::Compact | Op::Undo) => {
-                self.submit_prompt_like(op).await
+                self.submit_prompt_like(submission_id, op).await
             }
             Op::Interrupt => self.interrupt_active_turn().await,
             Op::Shutdown => self.shutdown_thread().await,
@@ -1940,10 +1945,6 @@ fn next_request_id(state: &mut AppServerState) -> RequestId {
     let request_id = state.next_request_id;
     state.next_request_id += 1;
     RequestId::Integer(request_id)
-}
-
-fn new_submission_id() -> String {
-    Uuid::new_v4().to_string()
 }
 
 fn noop_submission_id() -> String {
@@ -2624,6 +2625,7 @@ mod tests {
     use super::*;
     use codex_core::config::ConfigBuilder;
     use std::fs;
+    use uuid::Uuid;
 
     #[test]
     fn resumed_regular_turn_is_steerable() {

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -80,13 +80,13 @@ const ACTOR_RUNTIME_CLI_ENV: &str = "AGENTHUB_ACTOR_CLI";
 /// Trait for abstracting over the `CodexThread` to make testing easier.
 #[async_trait::async_trait]
 pub trait CodexThreadImpl {
-    async fn submit(&self, op: Op) -> Result<String, CodexErr>;
+    async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr>;
     async fn next_event(&self) -> Result<Event, CodexErr>;
 }
 
 #[async_trait::async_trait]
 impl CodexThreadImpl for CodexThread {
-    async fn submit(&self, op: Op) -> Result<String, CodexErr> {
+    async fn submit(&self, _submission_id: String, op: Op) -> Result<String, CodexErr> {
         self.submit(op).await
     }
 
@@ -316,7 +316,7 @@ impl Thread {
 
         if self.message_tx.send(message).is_err() {
             self.thread
-                .submit(Op::Shutdown)
+                .submit("shutdown".to_string(), Op::Shutdown)
                 .await
                 .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         } else {
@@ -658,11 +658,14 @@ impl PromptState {
                 };
 
                 self.thread
-                    .submit(Op::ExecApproval {
-                        id: approval_id,
-                        turn_id: Some(turn_id),
-                        decision,
-                    })
+                    .submit(
+                        self.submission_id.clone(),
+                        Op::ExecApproval {
+                            id: approval_id,
+                            turn_id: Some(turn_id),
+                            decision,
+                        },
+                    )
                     .await
                     .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
             }
@@ -682,10 +685,13 @@ impl PromptState {
                 };
 
                 self.thread
-                    .submit(Op::PatchApproval {
-                        id: call_id,
-                        decision,
-                    })
+                    .submit(
+                        self.submission_id.clone(),
+                        Op::PatchApproval {
+                            id: call_id,
+                            decision,
+                        },
+                    )
                     .await
                     .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
             }
@@ -718,10 +724,13 @@ impl PromptState {
                 };
 
                 self.thread
-                    .submit(Op::RequestPermissionsResponse {
-                        id: call_id,
-                        response,
-                    })
+                    .submit(
+                        self.submission_id.clone(),
+                        Op::RequestPermissionsResponse {
+                            id: call_id,
+                            response,
+                        },
+                    )
                     .await
                     .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
             }
@@ -1183,13 +1192,16 @@ impl PromptState {
         );
 
         self.thread
-            .submit(Op::ResolveElicitation {
-                server_name,
-                request_id: id,
-                decision: ElicitationAction::Decline,
-                content: None,
-                meta: None,
-            })
+            .submit(
+                self.submission_id.clone(),
+                Op::ResolveElicitation {
+                    server_name,
+                    request_id: id,
+                    decision: ElicitationAction::Decline,
+                    content: None,
+                    meta: None,
+                },
+            )
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
@@ -1515,11 +1527,14 @@ impl PromptState {
                 call_id, command
             );
             self.thread
-                .submit(Op::ExecApproval {
-                    id: resolved_approval_id,
-                    turn_id: Some(turn_id),
-                    decision,
-                })
+                .submit(
+                    self.submission_id.clone(),
+                    Op::ExecApproval {
+                        id: resolved_approval_id,
+                        turn_id: Some(turn_id),
+                        decision,
+                    },
+                )
                 .await
                 .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
             return Ok(());
@@ -3099,19 +3114,22 @@ impl<A: Auth> ThreadActor<A> {
         };
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                model: Some(model_to_use.clone()),
-                effort: Some(effort_to_use),
-                summary: None,
-                collaboration_mode: None,
-                personality: None,
-                windows_sandbox_level: None,
-                service_tier: None,
-            })
+            .submit(
+                "config".to_string(),
+                Op::OverrideTurnContext {
+                    cwd: None,
+                    approval_policy: None,
+                    approvals_reviewer: None,
+                    sandbox_policy: None,
+                    model: Some(model_to_use.clone()),
+                    effort: Some(effort_to_use),
+                    summary: None,
+                    collaboration_mode: None,
+                    personality: None,
+                    windows_sandbox_level: None,
+                    service_tier: None,
+                },
+            )
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
@@ -3146,19 +3164,22 @@ impl<A: Auth> ThreadActor<A> {
         }
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                model: None,
-                effort: Some(Some(effort)),
-                summary: None,
-                collaboration_mode: None,
-                personality: None,
-                windows_sandbox_level: None,
-                service_tier: None,
-            })
+            .submit(
+                "config".to_string(),
+                Op::OverrideTurnContext {
+                    cwd: None,
+                    approval_policy: None,
+                    approvals_reviewer: None,
+                    sandbox_policy: None,
+                    model: None,
+                    effort: Some(Some(effort)),
+                    summary: None,
+                    collaboration_mode: None,
+                    personality: None,
+                    windows_sandbox_level: None,
+                    service_tier: None,
+                },
+            )
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
@@ -3217,10 +3238,13 @@ impl<A: Auth> ThreadActor<A> {
             self.find_pending_user_input_answer(request.prompt.as_slice())?
         {
             self.thread
-                .submit(Op::UserInputAnswer {
-                    id: prepared.response_id.clone(),
-                    response: prepared.response.clone(),
-                })
+                .submit(
+                    submission_id.clone(),
+                    Op::UserInputAnswer {
+                        id: prepared.response_id.clone(),
+                        response: prepared.response.clone(),
+                    },
+                )
                 .await
                 .map_err(|e| {
                     let err = Error::internal_error().data(e.to_string());
@@ -3315,7 +3339,7 @@ impl<A: Auth> ThreadActor<A> {
 
         let submission_id = self
             .thread
-            .submit(op.clone())
+            .submit(Uuid::new_v4().to_string(), op.clone())
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
 
@@ -3359,19 +3383,22 @@ impl<A: Auth> ThreadActor<A> {
             .ok_or_else(Error::invalid_params)?;
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: Some(preset.approval),
-                approvals_reviewer: None,
-                sandbox_policy: Some(preset.sandbox.clone()),
-                model: None,
-                effort: None,
-                summary: None,
-                collaboration_mode: None,
-                personality: None,
-                windows_sandbox_level: None,
-                service_tier: None,
-            })
+            .submit(
+                "config".to_string(),
+                Op::OverrideTurnContext {
+                    cwd: None,
+                    approval_policy: Some(preset.approval),
+                    approvals_reviewer: None,
+                    sandbox_policy: Some(preset.sandbox.clone()),
+                    model: None,
+                    effort: None,
+                    summary: None,
+                    collaboration_mode: None,
+                    personality: None,
+                    windows_sandbox_level: None,
+                    service_tier: None,
+                },
+            )
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
@@ -3426,19 +3453,22 @@ impl<A: Auth> ThreadActor<A> {
         }
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                model: Some(model_to_use.clone()),
-                effort: Some(effort_to_use),
-                summary: None,
-                collaboration_mode: None,
-                personality: None,
-                windows_sandbox_level: None,
-                service_tier: None,
-            })
+            .submit(
+                "config".to_string(),
+                Op::OverrideTurnContext {
+                    cwd: None,
+                    approval_policy: None,
+                    approvals_reviewer: None,
+                    sandbox_policy: None,
+                    model: Some(model_to_use.clone()),
+                    effort: Some(effort_to_use),
+                    summary: None,
+                    collaboration_mode: None,
+                    personality: None,
+                    windows_sandbox_level: None,
+                    service_tier: None,
+                },
+            )
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
@@ -3451,7 +3481,7 @@ impl<A: Auth> ThreadActor<A> {
     async fn handle_cancel(&mut self) -> Result<(), Error> {
         self.abort_pending_interactions();
         self.thread
-            .submit(Op::Interrupt)
+            .submit("interrupt".to_string(), Op::Interrupt)
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         Ok(())
@@ -3460,7 +3490,7 @@ impl<A: Auth> ThreadActor<A> {
     async fn handle_shutdown(&mut self) -> Result<(), Error> {
         self.abort_pending_interactions();
         self.thread
-            .submit(Op::Shutdown)
+            .submit("shutdown".to_string(), Op::Shutdown)
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         Ok(())
@@ -5354,7 +5384,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl CodexThreadImpl for StubCodexThread {
-        async fn submit(&self, op: Op) -> Result<String, CodexErr> {
+        async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
             let id = self
                 .current_id
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -5363,7 +5393,7 @@ mod tests {
 
             match op {
                 Op::UserInput { items, .. } => {
-                    *self.active_prompt_id.lock().unwrap() = Some(id.to_string());
+                    *self.active_prompt_id.lock().unwrap() = Some(submission_id.clone());
                     let prompt = items
                         .into_iter()
                         .map(|i| match i {
@@ -5379,7 +5409,7 @@ mod tests {
                         let send = |msg| {
                             self.op_tx
                                 .send(Event {
-                                    id: id.to_string(),
+                                    id: submission_id.clone(),
                                     msg,
                                 })
                                 .unwrap();
@@ -5449,7 +5479,7 @@ mod tests {
                     } else if prompt == "approval-block" {
                         self.op_tx
                             .send(Event {
-                                id: id.to_string(),
+                                id: submission_id.clone(),
                                 msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
                                     call_id: "call-id".to_string(),
                                     approval_id: Some("approval-id".to_string()),
@@ -5474,7 +5504,7 @@ mod tests {
                     } else {
                         self.op_tx
                             .send(Event {
-                                id: id.to_string(),
+                                id: submission_id.clone(),
                                 msg: EventMsg::AgentMessageContentDelta(
                                     AgentMessageContentDeltaEvent {
                                         thread_id: id.to_string(),
@@ -5488,7 +5518,7 @@ mod tests {
                         // Send non-delta event (should be deduplicated, but handled by deduplication)
                         self.op_tx
                             .send(Event {
-                                id: id.to_string(),
+                                id: submission_id.clone(),
                                 msg: EventMsg::AgentMessage(AgentMessageEvent {
                                     message: prompt,
                                     phase: None,
@@ -5498,7 +5528,7 @@ mod tests {
                             .unwrap();
                         self.op_tx
                             .send(Event {
-                                id: id.to_string(),
+                                id: submission_id.clone(),
                                 msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                     last_agent_message: None,
                                     turn_id: id.to_string(),
@@ -5510,7 +5540,8 @@ mod tests {
                 Op::Compact => {
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::TurnStarted(TurnStartedEvent {
                                 model_context_window: None,
                                 collaboration_mode_kind: ModeKind::default(),
@@ -5520,7 +5551,8 @@ mod tests {
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::AgentMessage(AgentMessageEvent {
                                 message: "Compact task completed".to_string(),
                                 phase: None,
@@ -5530,7 +5562,8 @@ mod tests {
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
@@ -5541,7 +5574,8 @@ mod tests {
                 Op::Undo => {
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::UndoStarted(
                                 codex_protocol::protocol::UndoStartedEvent {
                                     message: Some("Undo in progress...".to_string()),
@@ -5551,7 +5585,8 @@ mod tests {
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::UndoCompleted(
                                 codex_protocol::protocol::UndoCompletedEvent {
                                     success: true,
@@ -5562,7 +5597,8 @@ mod tests {
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
@@ -5573,13 +5609,15 @@ mod tests {
                 Op::Review { review_request } => {
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::EnteredReviewMode(review_request.clone()),
                         })
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::ExitedReviewMode(ExitedReviewModeEvent {
                                 review_output: Some(ReviewOutputEvent {
                                     findings: vec![],
@@ -5595,7 +5633,8 @@ mod tests {
                         .unwrap();
                     self.op_tx
                         .send(Event {
-                            id: id.to_string(),
+                            id: submission_id.clone(),
+
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
@@ -5625,7 +5664,7 @@ mod tests {
                     unimplemented!()
                 }
             }
-            Ok(id.to_string())
+            Ok(submission_id)
         }
 
         async fn next_event(&self) -> Result<Event, CodexErr> {
@@ -5666,7 +5705,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl CodexThreadImpl for SharedSubmissionThread {
-        async fn submit(&self, op: Op) -> Result<String, CodexErr> {
+        async fn submit(&self, _submission_id: String, op: Op) -> Result<String, CodexErr> {
             self.ops.lock().unwrap().push(op);
             Ok(self.submission_id.clone())
         }

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -5365,6 +5365,7 @@ mod tests {
         current_id: AtomicUsize,
         active_prompt_id: std::sync::Mutex<Option<String>>,
         ops: std::sync::Mutex<Vec<Op>>,
+        submission_ids: std::sync::Mutex<Vec<String>>,
         op_tx: mpsc::UnboundedSender<Event>,
         op_rx: Mutex<mpsc::UnboundedReceiver<Event>>,
     }
@@ -5376,6 +5377,7 @@ mod tests {
                 current_id: AtomicUsize::new(0),
                 active_prompt_id: std::sync::Mutex::default(),
                 ops: std::sync::Mutex::default(),
+                submission_ids: std::sync::Mutex::default(),
                 op_tx,
                 op_rx: Mutex::new(op_rx),
             }
@@ -5389,6 +5391,10 @@ mod tests {
                 .current_id
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
+            self.submission_ids
+                .lock()
+                .unwrap()
+                .push(submission_id.clone());
             self.ops.lock().unwrap().push(op.clone());
 
             match op {
@@ -5646,7 +5652,8 @@ mod tests {
                 | Op::ResolveElicitation { .. }
                 | Op::RequestPermissionsResponse { .. }
                 | Op::PatchApproval { .. }
-                | Op::Interrupt => {}
+                | Op::Interrupt
+                | Op::OverrideTurnContext { .. } => {}
                 Op::Shutdown => {
                     if let Some(active_prompt_id) = self.active_prompt_id.lock().unwrap().take() {
                         self.op_tx
@@ -6760,6 +6767,150 @@ mod tests {
 
         let ops = conversation.ops.lock().unwrap();
         assert!(matches!(ops.last(), Some(Op::Shutdown)));
+        drop(ops);
+
+        let submission_ids = conversation.submission_ids.lock().unwrap();
+        assert_eq!(submission_ids.last().map(String::as_str), Some("shutdown"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_set_mode_uses_config_submission_id() -> anyhow::Result<()> {
+        let (_session_id, _client, thread, message_tx, local_set) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::SetMode {
+            mode: SessionModeId::new("read-only"),
+            response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                response_rx.await??;
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let submission_ids = thread.submission_ids.lock().unwrap();
+        assert_eq!(submission_ids.as_slice(), &["config".to_string()]);
+        drop(submission_ids);
+
+        let ops = thread.ops.lock().unwrap();
+        assert!(matches!(ops.as_slice(), [Op::OverrideTurnContext { .. }]));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_set_model_uses_config_submission_id() -> anyhow::Result<()> {
+        let (_session_id, _client, thread, message_tx, local_set) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::SetModel {
+            model: ModelId::new("test-model"),
+            response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                response_rx.await??;
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let submission_ids = thread.submission_ids.lock().unwrap();
+        assert_eq!(submission_ids.as_slice(), &["config".to_string()]);
+        drop(submission_ids);
+
+        let ops = thread.ops.lock().unwrap();
+        assert!(matches!(
+            ops.as_slice(),
+            [Op::OverrideTurnContext {
+                model: Some(model),
+                ..
+            }] if model == "test-model"
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_set_model_config_option_uses_config_submission_id() -> anyhow::Result<()> {
+        let (_session_id, _client, thread, message_tx, local_set) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::SetConfigOption {
+            config_id: SessionConfigId::new("model"),
+            value: SessionConfigOptionValue::ValueId {
+                value: SessionConfigValueId::new("test-model"),
+            },
+            response_tx,
+        })?;
+
+        tokio::try_join!(
+            async {
+                response_rx.await??;
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let submission_ids = thread.submission_ids.lock().unwrap();
+        assert_eq!(submission_ids.as_slice(), &["config".to_string()]);
+        drop(submission_ids);
+
+        let ops = thread.ops.lock().unwrap();
+        assert!(matches!(
+            ops.as_slice(),
+            [Op::OverrideTurnContext {
+                model: Some(model),
+                ..
+            }] if model == "test-model"
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cancel_uses_interrupt_submission_id() -> anyhow::Result<()> {
+        let (_session_id, _client, thread, message_tx, local_set) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Cancel { response_tx })?;
+
+        tokio::try_join!(
+            async {
+                response_rx.await??;
+                drop(message_tx);
+                anyhow::Ok(())
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?;
+
+        let submission_ids = thread.submission_ids.lock().unwrap();
+        assert_eq!(submission_ids.as_slice(), &["interrupt".to_string()]);
+        drop(submission_ids);
+
+        let ops = thread.ops.lock().unwrap();
+        assert!(matches!(ops.as_slice(), [Op::Interrupt]));
 
         Ok(())
     }

--- a/docs/journal/2026-04-02-openai-codex-baseline.md
+++ b/docs/journal/2026-04-02-openai-codex-baseline.md
@@ -57,6 +57,16 @@ To avoid splitting one live app-server turn into multiple ACP completion channel
 - when `thread.submit(op)` returns an already-tracked `submission_id`, ACP attaches a new waiter instead of replacing the existing prompt state;
 - one `TurnComplete` or `TurnAborted` event now resolves every waiter attached to that submission.
 
+## Compatibility-Safe Turn Steer Routing
+
+The adapter now preserves that shared-submission contract more explicitly while the ACP prompt state machine is still `submission_id`-centric.
+
+- a successful app-server `turn/steer` no longer swaps the local active turn onto a new caller-generated `submission_id`;
+- instead, ACP keeps reusing the original active submission id until the broader turn-centric refactor lands;
+- if `turn/steer` succeeds after local active-turn state already changed, ACP now starts a fresh turn instead of pretending the new submission was attached to the old turn.
+
+This keeps the intermediate app-server bridge slice compatible with the existing `PromptState` waiter model and avoids orphaning earlier ACP prompt waiters when multiple follow-up prompts share one live app-server turn.
+
 ## Resumed Active Turn Recovery
 
 The next gap was `load_session` against a thread that already had an in-progress turn.


### PR DESCRIPTION
Refactor agenthub-codex-acp prompt delivery to use official OpenAI Codex app-server turn semantics.

Key changes:
- Move submission_id generation from AppServerCodexThread to ThreadActor (UUID).
- Align with turn/start and turn/steer routing in the app-server bridge.
- Update active_turn tracking to correctly map steered turns back to the originating ACP submission.
- Update test mocks (StubCodexThread, SharedSubmissionThread) for the new 3-parameter submit signature.
- Verify that events are correctly routed via the provided submission_id.

Verified with 79 tests passing in agenthub-codex-acp.
Ref: docs/journal/2026-04-02-openai-codex-baseline.md