### PR TITLE
fix(web): forward refs in shared action primitives

### DIFF
--- a/docs/journal/2026-04-04-ui-primitives-bootstrap.md
+++ b/docs/journal/2026-04-04-ui-primitives-bootstrap.md
@@ -86,8 +86,9 @@ surface/header/button patterns stop drifting independently across Agents and Tea
     - removed duplicated base bubble class composition now that variant constants already include the shared bubble shell
   - `web/src/ui/primitives.tsx`
     - `ActionButton` and `SelectableListItem` now forward refs so Mantine `Menu.Target` can anchor shared button primitives safely
+    - `SelectableListItem` now exposes an explicit `layout` prop so row/column direction does not rely on conflicting Tailwind utilities
   - `web/src/pages/team/team_selector_panel.tsx`
-    - selector rows now opt into an explicit horizontal list-item layout instead of inheriting the default column stack
+    - selector rows now use `layout="row"` instead of overriding the primitive's default column stack with conflicting flex classes
 
 ## Validation
 

--- a/docs/journal/2026-04-04-ui-primitives-bootstrap.md
+++ b/docs/journal/2026-04-04-ui-primitives-bootstrap.md
@@ -84,6 +84,10 @@ surface/header/button patterns stop drifting independently across Agents and Tea
     - cleaned up lingering type imports after the hook extraction so dispatcher/output-cache signatures match actual exports
   - `web/src/components/bubbles/markdown_bubble.tsx`, `web/src/pages/team_task_panel.tsx`, `web/src/pages/team_mailbox_panel.tsx`
     - removed duplicated base bubble class composition now that variant constants already include the shared bubble shell
+  - `web/src/ui/primitives.tsx`
+    - `ActionButton` and `SelectableListItem` now forward refs so Mantine `Menu.Target` can anchor shared button primitives safely
+  - `web/src/pages/team/team_selector_panel.tsx`
+    - selector rows now opt into an explicit horizontal list-item layout instead of inheriting the default column stack
 
 ## Validation
 

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -94,8 +94,9 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
             {items.map((team) => (
               <SelectableListItem
                 key={team.id}
+                layout="row"
                 type="button"
-                className="min-w-0 flex-row items-start justify-between gap-3 rounded-[10px] border-transparent bg-transparent px-2 py-2 shadow-none hover:bg-[rgba(55,53,47,0.05)]"
+                className="min-w-0 justify-between gap-3 rounded-[10px] border-transparent bg-transparent px-2 py-2 shadow-none hover:bg-[rgba(55,53,47,0.05)]"
                 data-team-selector-entry="true"
                 data-team-id={team.id}
                 data-team-name={team.name}

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -95,7 +95,7 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
               <SelectableListItem
                 key={team.id}
                 type="button"
-                className="rounded-[10px] border-transparent bg-transparent px-2 py-2 shadow-none hover:bg-[rgba(55,53,47,0.05)]"
+                className="min-w-0 flex-row items-start justify-between gap-3 rounded-[10px] border-transparent bg-transparent px-2 py-2 shadow-none hover:bg-[rgba(55,53,47,0.05)]"
                 data-team-selector-entry="true"
                 data-team-id={team.id}
                 data-team-name={team.name}

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -121,11 +121,12 @@ export function PanelHeader({
 
 type SelectableListItemProps = React.ComponentPropsWithoutRef<"button"> & {
   active?: boolean;
+  layout?: "column" | "row";
 };
 
 export const SelectableListItem = React.forwardRef<HTMLButtonElement, SelectableListItemProps>(
   function SelectableListItem(
-    { active = false, className, type = "button", ...props },
+    { active = false, className, layout = "column", type = "button", ...props },
     ref
   ) {
     return (
@@ -135,6 +136,7 @@ export const SelectableListItem = React.forwardRef<HTMLButtonElement, Selectable
         type={type}
         className={cx(
           SELECTABLE_LIST_ITEM_BASE_CLASS,
+          layout === "row" ? "flex-row items-start" : "flex-col",
           active && SELECTABLE_LIST_ITEM_ACTIVE_CLASS,
           className
         )}

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -123,52 +123,55 @@ type SelectableListItemProps = React.ComponentPropsWithoutRef<"button"> & {
   active?: boolean;
 };
 
-export function SelectableListItem({
-  active = false,
-  className,
-  type = "button",
-  ...props
-}: SelectableListItemProps) {
-  return (
-    <Box
-      component="button"
-      type={type}
-      className={cx(
-        SELECTABLE_LIST_ITEM_BASE_CLASS,
-        active && SELECTABLE_LIST_ITEM_ACTIVE_CLASS,
-        className
-      )}
-      {...props}
-    />
-  );
-}
+export const SelectableListItem = React.forwardRef<HTMLButtonElement, SelectableListItemProps>(
+  function SelectableListItem(
+    { active = false, className, type = "button", ...props },
+    ref
+  ) {
+    return (
+      <Box
+        ref={ref}
+        component="button"
+        type={type}
+        className={cx(
+          SELECTABLE_LIST_ITEM_BASE_CLASS,
+          active && SELECTABLE_LIST_ITEM_ACTIVE_CLASS,
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+SelectableListItem.displayName = "SelectableListItem";
 
 type ActionButtonProps = React.ComponentPropsWithoutRef<"button"> & {
   tone?: keyof typeof ACTION_BUTTON_TONE_CLASS;
   size?: keyof typeof ACTION_BUTTON_SIZE_CLASS;
 };
 
-export function ActionButton({
-  tone = "secondary",
-  size = "md",
-  className,
-  type = "button",
-  ...props
-}: ActionButtonProps) {
-  return (
-    <Box
-      component="button"
-      type={type}
-      className={cx(
-        ACTION_BUTTON_BASE_CLASS,
-        ACTION_BUTTON_SIZE_CLASS[size],
-        ACTION_BUTTON_TONE_CLASS[tone],
-        className
-      )}
-      {...props}
-    />
-  );
-}
+export const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProps>(
+  function ActionButton(
+    { tone = "secondary", size = "md", className, type = "button", ...props },
+    ref
+  ) {
+    return (
+      <Box
+        ref={ref}
+        component="button"
+        type={type}
+        className={cx(
+          ACTION_BUTTON_BASE_CLASS,
+          ACTION_BUTTON_SIZE_CLASS[size],
+          ACTION_BUTTON_TONE_CLASS[tone],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+ActionButton.displayName = "ActionButton";
 
 type IconButtonProps = React.ComponentPropsWithoutRef<typeof ActionIcon> & {
   tone?: keyof typeof ICON_BUTTON_TONE_CLASS;


### PR DESCRIPTION
## Summary

- forward `ref` through shared `ActionButton` and `SelectableListItem`
- fix `TeamSelectorPanel` rows to opt into an explicit horizontal list-item layout
- record the follow-up in the UI primitives journal

## Why

This follows up on the frontend primitive-adoption work after the previous branch was merged.

- Mantine `Menu.Target` expects a ref-forwarding child for positioning and focus management
- `ActionButton` was already used as a menu trigger in Team workspace header flows
- `SelectableListItem` defaults to a column layout, but selector rows need an explicit row layout to keep runtime labels aligned

## Testing

- `cd web && npm run lint`
- `cd web && npm run test -- src/pages/team/team_workspace_header.test.tsx src/pages/team/team_selector_panel.test.tsx src/pages/team_page.smoke.test.tsx`

## Notes

- scope is intentionally small and limited to shared primitive behavior plus the selector row layout
- no Team data flow or runtime logic changed
