### PR TITLE
fix(acp): demote handled reconnect logs

### DIFF
--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1024,7 +1024,7 @@ impl PromptState {
                 codex_error_info,
                 additional_details,
             }) => {
-                error!(
+                warn!(
                     "Handled error during turn: {message} {codex_error_info:?} {additional_details:?}"
                 );
             }

--- a/docs/journal/2026-04-09-acp-reconnect-log-level.md
+++ b/docs/journal/2026-04-09-acp-reconnect-log-level.md
@@ -1,0 +1,14 @@
+# ACP Reconnect Log Level
+
+## Summary
+
+- demoted handled `StreamError` turn logs in `agenthub-codex-acp` from `error!` to `warn!`
+- kept `EventMsg::Error` as `error!` because it still terminates the active turn
+
+## Why
+
+`EventMsg::StreamError` is emitted for recoverable upstream stream interruptions such as websocket reconnect attempts. AgentHub logs these events as handled and Codex retries the turn automatically, so `error!` overstated the severity and made normal reconnect behavior look like a hard failure in production logs.
+
+## Validation
+
+- `cargo check -p agenthub-codex-acp`


### PR DESCRIPTION
## Summary

- demote handled `StreamError` reconnect logs in `agenthub-codex-acp` from `error!` to `warn!`
- keep `EventMsg::Error` as `error!` so turn-terminating failures still stand out
- document the log-level change in the journal

## Why

Recoverable websocket/SSE disconnects already trigger Codex retry behavior. Logging these handled reconnect events at error level made normal retry flow look like a hard production failure.

## Testing

- cargo check -p agenthub-codex-acp
