### PR TITLE
fix(web): reduce live output retention

### DIFF
--- a/docs/journal/2026-04-09-web-live-output-retention.md
+++ b/docs/journal/2026-04-09-web-live-output-retention.md
@@ -1,0 +1,20 @@
+# Web Live Output Retention
+
+## Summary
+
+- reduced the in-memory live output retention window from `1200` to `600`
+- reduced the in-memory live ACP output retention window from `1200` to `600`
+
+## Why
+
+The browser-facing live output window is only a convenience tail for the active page state. It does not need to retain the same depth as persisted history or explicit older-event pagination.
+
+Cutting the live window in half lowers steady-state browser memory and render pressure for long-lived Agent and ACP sessions while preserving:
+
+- explicit older-event loading
+- persisted output cache slices
+- session-scoped history switching
+
+## Validation
+
+- `cd web && npm run lint`

--- a/web/src/use_app_output_cache.ts
+++ b/web/src/use_app_output_cache.ts
@@ -36,8 +36,8 @@ import {
 } from "./event_polling";
 import { resolveOutputHistoryKey, resolveSessionScopedEvents } from "./app_agents_helpers";
 
-const LIVE_OUTPUT_RETENTION_LIMIT = 1200;
-const LIVE_ACP_OUTPUT_RETENTION_LIMIT = 1200;
+const LIVE_OUTPUT_RETENTION_LIMIT = 600;
+const LIVE_ACP_OUTPUT_RETENTION_LIMIT = 600;
 
 export function useAppOutputCache(
   auth: AuthState | null,


### PR DESCRIPTION
## Summary

- reduce the live output retention window from `1200` to `600`
- reduce the live ACP output retention window from `1200` to `600`
- document the browser-memory tradeoff in the journal

## Why

The active page state only needs a bounded recent tail. Persisted cache slices and explicit older-event loading already cover deeper history, so keeping `1200` live rows in memory was larger than necessary for long-lived browser tabs.

This halves the steady-state in-memory live output footprint and reduces render pressure for long-running sessions without changing history-loading behavior.

## Testing

- cd web && npm run lint

## MCP

- Baseline: loaded `https://agenthub.hawkingrei.com/` and verified the page rendered normally before the edit.
- Regression: reloaded the same page in Chrome DevTools MCP after the edit and verified it still rendered normally (anonymous login page).
