### PR TITLE
fix(acp): slim runtime context tail

### DIFF
--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -91,7 +91,6 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
         format!("- continuity_mode: {}", continuity.mode),
         format!("- continuity_source_run_id: {}", continuity.source_run_id),
         format!("- continuity_summary: {summary}"),
-        "- continuity_detail_policy: inspect persisted artifacts or replay state for deeper history.".to_string(),
     ]
 }
 
@@ -213,8 +212,8 @@ mod tests {
             panic!("expected text content block");
         };
         assert!(text.text.contains("continuity_summary: Continue implementation with the same branch."));
-        assert!(text.text.contains("continuity_detail_policy: inspect persisted artifacts"));
         assert!(!text.text.contains("continuity_history_window_json"));
+        assert!(!text.text.contains("continuity_detail_policy"));
         assert!(!text.text.contains("continuity_source_session_id"));
         assert!(!text.text.contains("artifact-0001-continuity-output.json"));
     }

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -57,8 +57,6 @@ fn build_actor_runtime_context_text(context: &AcpActorSkillContext) -> String {
         .filter(|value| !value.is_empty())
     {
         lines.push(format!("- current_run_id: {run_id}"));
-    } else {
-        lines.push("- current_run_id: n/a".to_string());
     }
     if let Some(member_role) = context
         .member_role
@@ -89,11 +87,9 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
         return Vec::new();
     };
     let summary = truncate_chars(continuity.summary_text.as_str(), 400);
-    let source_session = continuity.source_session_id.as_deref().unwrap_or("n/a");
     vec![
         format!("- continuity_mode: {}", continuity.mode),
         format!("- continuity_source_run_id: {}", continuity.source_run_id),
-        format!("- continuity_source_session_id: {source_session}"),
         format!("- continuity_summary: {summary}"),
         "- continuity_detail_policy: inspect persisted artifacts or replay state for deeper history.".to_string(),
     ]
@@ -174,6 +170,24 @@ mod tests {
     }
 
     #[test]
+    fn actor_runtime_context_block_omits_missing_run_id_placeholder() {
+        let block = build_actor_runtime_context_block(&AcpActorSkillContext {
+            team_id: Some("team-7".to_string()),
+            current_run_id: None,
+            actor_id: "planner".to_string(),
+            default_channel: "coordination".to_string(),
+            member_role: Some("leader".to_string()),
+            member_skills: Vec::new(),
+            contract_version: Some("v1".to_string()),
+            continuity: None,
+        });
+        let ContentBlock::Text(text) = block else {
+            panic!("expected text content block");
+        };
+        assert!(!text.text.contains("current_run_id: n/a"));
+    }
+
+    #[test]
     fn actor_runtime_context_block_keeps_continuity_pointer_first() {
         let block = build_actor_runtime_context_block(&AcpActorSkillContext {
             team_id: Some("team-7".to_string()),
@@ -201,6 +215,7 @@ mod tests {
         assert!(text.text.contains("continuity_summary: Continue implementation with the same branch."));
         assert!(text.text.contains("continuity_detail_policy: inspect persisted artifacts"));
         assert!(!text.text.contains("continuity_history_window_json"));
+        assert!(!text.text.contains("continuity_source_session_id"));
         assert!(!text.text.contains("artifact-0001-continuity-output.json"));
     }
 }

--- a/crates/agenthub-managed-skills/src/lib.rs
+++ b/crates/agenthub-managed-skills/src/lib.rs
@@ -345,7 +345,10 @@ You are running inside an AgentHub actor session.
 Use this skill together with the runtime context block that AgentHub injects
 before each prompt. The context block carries the current `team_id`,
 `current_run_id`, `actor_id`, `default_channel`, and
-optional continuity summary for this specific session.
+compact continuity summary for this specific session.
+Treat deeper continuity detail as pointer-backed runtime state: inspect
+persisted artifacts or replay state when you need more history, instead of
+expecting large inline continuity payloads in the prompt itself.
 
 Team mailbox commands:
 
@@ -441,6 +444,8 @@ mod tests {
                 assert!(doc.contents.contains("Runtime coordination contract"));
                 assert!(!doc.contents.contains("`actor_cli_path`"));
                 assert!(doc.contents.contains("`agenthub actor receive"));
+                assert!(doc.contents.contains("compact continuity summary"));
+                assert!(doc.contents.contains("persisted artifacts or replay state"));
             }
         }
     }

--- a/crates/agenthub-managed-skills/src/lib.rs
+++ b/crates/agenthub-managed-skills/src/lib.rs
@@ -345,7 +345,7 @@ You are running inside an AgentHub actor session.
 Use this skill together with the runtime context block that AgentHub injects
 before each prompt. The context block carries the current `team_id`,
 `current_run_id`, `actor_id`, `default_channel`, and
-compact continuity summary for this specific session.
+optional compact continuity summary for this specific session.
 Treat deeper continuity detail as pointer-backed runtime state: inspect
 persisted artifacts or replay state when you need more history, instead of
 expecting large inline continuity payloads in the prompt itself.

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -172,6 +172,9 @@ ACP permission requests are first-class runtime records:
 - Dynamic actor runtime fields such as `team_id`, `current_run_id`, and continuity summaries should
   stay in a separate text prefix block injected before each prompt instead of being rewritten into
   the managed `SKILL.md` files.
+- That runtime continuity block should stay pointer-first: keep a compact continuity summary in
+  prompt text, and route deeper history through persisted artifacts or replay state instead of
+  embedding raw continuity windows inline.
 - Keep debug capabilities available without exposing internal-only controls in primary user path.
 - Treat in-memory runtime ownership as authoritative for live SSE; use persisted status as a recoverable cache that may require reconciliation after abrupt exits.
 - Keep provider metadata, runtime placement, and proxy policy explicit in code so future P2P work extends stable seams instead of forking provider-specific paths.

--- a/docs/journal/2026-04-10-runtime-context-identity-compaction.md
+++ b/docs/journal/2026-04-10-runtime-context-identity-compaction.md
@@ -1,0 +1,24 @@
+# Runtime Context Identity Compaction
+
+## Summary
+
+- further slimmed the ACP runtime context block by dropping fields that do not help the current actor choose the next action
+- removed the `current_run_id: n/a` placeholder when no active run scope exists
+- removed `continuity_source_session_id` from prompt text so provider continuity internals stay outside the actor-facing working set
+
+## What Changed
+
+- `crates/agenthub-acp/src/actor_runtime_skill.rs`
+  - stopped emitting a synthetic `current_run_id: n/a` line when the runtime has no current run id
+  - stopped emitting `continuity_source_session_id` in the continuity block
+  - added focused regression coverage for both behaviors
+
+## Why
+
+- The runtime context block should bias toward fields that affect the actor's immediate execution decision.
+- A missing run id does not need an explicit placeholder in prompt text; omission is cheaper and clearer.
+- Provider session ids are useful for backend continuity bookkeeping, but they are not actionable for leader/worker behavior inside a prompt turn.
+
+## Validation
+
+- `cargo test -p agenthub-acp actor_runtime_context_block`

--- a/src/state.rs
+++ b/src/state.rs
@@ -458,7 +458,12 @@ mod tests {
 
     #[tokio::test]
     async fn seed_safe_paths_inserts_default_when_not_configured() {
+        let _guard = ENV_LOCK.lock().await;
         let db = test_db().await;
+        let temp_home = std::env::temp_dir().join(format!("agenthub-home-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_home).expect("create temp home");
+        let _home_guard = set_env_var("HOME", &temp_home);
+        let _xdg_guard = clear_env_var("XDG_CONFIG_HOME");
         let config = AppConfig::default();
 
         AppState::seed_safe_paths(&db, &config)
@@ -476,6 +481,8 @@ mod tests {
                 .to_string_lossy()
                 .to_string();
         assert_eq!(path, expected);
+
+        let _ = std::fs::remove_dir_all(&temp_home);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep ACP runtime continuity guidance pointer-first across runtime injection, managed skills, and feature docs
- remove non-actionable runtime context prompt fields such as current_run_id placeholders and continuity source session ids
- add focused regression coverage and implementation notes for the slimmer runtime context contract

## Testing

- cargo test -p agenthub-managed-skills
- cargo test -p agenthub-acp actor_runtime_context_block
