### PR TITLE
fix(team): align context artifacts with runtime workdir

### DIFF
--- a/docs/journal/2026-04-11-team-runtime-context-layout-bootstrap.md
+++ b/docs/journal/2026-04-11-team-runtime-context-layout-bootstrap.md
@@ -1,0 +1,69 @@
+# Team Runtime Context Layout Bootstrap
+
+## Summary
+
+Bootstrapped the Team runtime workspace `.cache/context` layout during agent startup so leader and
+worker sessions both begin with the same filesystem-backed context skeleton instead of creating
+ad-hoc paths only when specific artifact writes happen later.
+
+## Changes
+
+- Replaced the leader-only workdir helper with a Team runtime workspace initializer in
+  `src/agent/manager.rs`.
+- The startup path now initializes the Team workspace context layout from
+  `src/agent/manager/session.rs`.
+- The initializer:
+  - still creates the leader coordination workdir when it does not exist yet;
+  - creates `.cache/context/run/` and `.cache/context/memory/`;
+  - creates empty index files:
+    - `state.md`
+    - `decisions.md`
+    - `errors.md`
+    - `log.md`
+    - `memory/profile.md`
+    - `memory/project_facts.md`
+    - `memory/decision_journal.md`
+    - `memory/open_questions.md`
+- Added focused unit coverage for:
+  - leader workspace bootstrap;
+  - worker workspace bootstrap in an existing workdir;
+  - non-Team contexts remaining no-op;
+  - invalid leader path error reporting.
+- Added TeamManager-side runtime workspace resolution so continuity artifacts and memory-flush
+  artifacts are written under the derived Team runtime workspace, not the base persisted agent
+  config workdir.
+- Added a leader-path regression test to confirm oversized continuity artifacts land under the
+  derived leader coordination workspace.
+- Centralized Team actor-context construction and member-role lookup into shared Team helpers so
+  runtime startup and TeamManager artifact resolution stop re-encoding the same role/context rules
+  in multiple places.
+
+## Why
+
+This is a small backend step toward the workspace-scoped context isolation contract in
+`docs/features/team-workspace-memory-contract.md`:
+
+- Team members should write into their own workspace-local `.cache/context` tree.
+- Runtime-owned context paths should be predictable before continuity offload or memory flush
+  features attempt to persist artifacts.
+- The startup path is the right place to establish the contract because it is where the final
+  runtime workdir is already resolved for leader and worker roles.
+
+## Validation
+
+- Ran `cargo test -q ensure_team_runtime_workspace_layout --lib`
+- Result: `4 passed; 0 failed`
+- Ran `cargo test -q complete_step_offloads_large_output_to_workspace_context_artifact --lib`
+- Result: `1 passed; 0 failed`
+- Ran `cargo test -q complete_step_offloads_large_output_to_leader_runtime_workspace_context_artifact --lib`
+- Result: `1 passed; 0 failed`
+- Audited `src/team` and `src/agent` filesystem write sites for Team runtime-owned `.cache/context`
+  writes; no additional obvious backend paths were found still targeting the base persisted
+  `agents.workdir`.
+
+## Follow-up
+
+- This does not yet enforce or migrate every context write in the runtime onto the new stable index
+  files.
+- `AGENTS.md`, workspace-root `TODO.md`, and worker `.agenthubmemory/` remain higher-level runtime
+  or agent responsibilities and were intentionally left unchanged in this patch.

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -186,7 +186,7 @@ fn short_random_token() -> String {
         .collect::<String>()
 }
 
-fn derive_worker_runtime_root(workdir: &str) -> String {
+pub(crate) fn derive_worker_runtime_root(workdir: &str) -> String {
     let path = Path::new(workdir);
     path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -194,7 +194,10 @@ fn derive_worker_runtime_root(workdir: &str) -> String {
         .unwrap_or_else(|| workdir.to_string())
 }
 
-fn derive_leader_runtime_workdir(workdir: &str, actor_context: &AcpActorSkillContext) -> String {
+pub(crate) fn derive_leader_runtime_workdir(
+    workdir: &str,
+    actor_context: &AcpActorSkillContext,
+) -> String {
     // Team leader continuity should survive ordinary runtime restarts, so the derived
     // coordination workspace is keyed by actor + scope and intentionally excludes the
     // per-launch AgentHub runtime session id.
@@ -210,6 +213,31 @@ fn derive_leader_runtime_workdir(workdir: &str, actor_context: &AcpActorSkillCon
         .join(format!("{actor_token}-{scope_token}"))
         .to_string_lossy()
         .to_string()
+}
+
+pub(crate) fn derive_team_runtime_workdir(
+    workdir: &str,
+    actor_context: &AcpActorSkillContext,
+    worktree_mode: &WorktreeMode,
+) -> String {
+    match actor_context.member_role.as_deref() {
+        Some(TEAM_MEMBER_ROLE_LEADER) => derive_leader_runtime_workdir(workdir, actor_context),
+        Some(TEAM_MEMBER_ROLE_WORKER) if matches!(worktree_mode, WorktreeMode::CreateWorktree) => {
+            let actor_token = compact_token(&actor_context.actor_id, "worker", 24);
+            let scope_token = actor_context
+                .current_run_id
+                .as_deref()
+                .or(actor_context.team_id.as_deref())
+                .map(|value| compact_token(value, "scope", 24))
+                .unwrap_or_else(|| "scope".to_string());
+            let root = derive_worker_runtime_root(workdir);
+            Path::new(&root)
+                .join(format!("{actor_token}-{scope_token}"))
+                .to_string_lossy()
+                .to_string()
+        }
+        _ => workdir.to_string(),
+    }
 }
 
 fn build_runtime_start_policy(
@@ -241,7 +269,8 @@ fn build_runtime_start_policy(
             }
             let context = actor_context
                 .ok_or_else(|| anyhow::anyhow!("leader role policy requires actor context"))?;
-            policy.workdir = derive_leader_runtime_workdir(expanded_workdir, context);
+            policy.workdir =
+                derive_team_runtime_workdir(expanded_workdir, context, &policy.worktree_mode);
             if Path::new(&policy.workdir).exists() && !Path::new(&policy.workdir).is_dir() {
                 anyhow::bail!(
                     "team leader policy requires directory workdir (agent_id={} workdir={})",
@@ -262,19 +291,10 @@ fn build_runtime_start_policy(
                 let context = actor_context
                     .ok_or_else(|| anyhow::anyhow!("worker role policy requires actor context"))?;
                 let actor_token = compact_token(&context.actor_id, "worker", 24);
-                let scope_token = context
-                    .current_run_id
-                    .as_deref()
-                    .or(context.team_id.as_deref())
-                    .map(|value| compact_token(value, "scope", 24))
-                    .unwrap_or_else(|| "scope".to_string());
                 // Worker runtime workdirs are stable for the current actor + scope and should
                 // not change just because AgentHub generated a new per-launch runtime session id.
-                let root = derive_worker_runtime_root(expanded_workdir);
-                let workdir = Path::new(&root)
-                    .join(format!("{actor_token}-{scope_token}"))
-                    .to_string_lossy()
-                    .to_string();
+                let workdir =
+                    derive_team_runtime_workdir(expanded_workdir, context, &policy.worktree_mode);
                 let branch = format!("worker-{actor_token}-{}", short_random_token());
                 policy.workdir = workdir;
                 policy.worktree_repo = Some(repo.to_string());
@@ -295,24 +315,73 @@ fn build_runtime_start_policy(
     Ok(policy)
 }
 
-fn ensure_team_leader_workdir_exists(
+fn ensure_team_runtime_workspace_layout(
     actor_context: Option<&AcpActorSkillContext>,
     workdir: &str,
 ) -> anyhow::Result<()> {
-    let is_team_leader = matches!(
-        actor_context.and_then(|context| context.member_role.as_deref()),
-        Some(TEAM_MEMBER_ROLE_LEADER)
-    );
-    if is_team_leader
-        && !Path::new(workdir).exists()
-        && let Err(err) = std::fs::create_dir_all(workdir)
-    {
-        return Err(anyhow::anyhow!(
-            "failed to create leader workdir: workdir={} error={}",
+    let Some(role) = actor_context.and_then(|context| context.member_role.as_deref()) else {
+        return Ok(());
+    };
+    if role != TEAM_MEMBER_ROLE_LEADER && role != TEAM_MEMBER_ROLE_WORKER {
+        return Ok(());
+    }
+
+    let workdir_path = Path::new(workdir);
+    if role == TEAM_MEMBER_ROLE_LEADER && !workdir_path.exists() {
+        std::fs::create_dir_all(workdir_path).map_err(|err| {
+            anyhow::anyhow!(
+                "failed to create team runtime workdir: workdir={} error={}",
+                workdir,
+                err
+            )
+        })?;
+    }
+
+    if !workdir_path.exists() {
+        return Ok(());
+    }
+    if !workdir_path.is_dir() {
+        anyhow::bail!("team runtime workdir is not a directory: workdir={workdir}");
+    }
+
+    let context_root = workdir_path.join(".cache").join("context");
+    std::fs::create_dir_all(context_root.join("run")).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to create team runtime context run dir: workdir={} error={}",
             workdir,
             err
-        ));
+        )
+    })?;
+    std::fs::create_dir_all(context_root.join("memory")).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to create team runtime context memory dir: workdir={} error={}",
+            workdir,
+            err
+        )
+    })?;
+
+    for relative_path in [
+        "state.md",
+        "decisions.md",
+        "errors.md",
+        "log.md",
+        "memory/profile.md",
+        "memory/project_facts.md",
+        "memory/decision_journal.md",
+        "memory/open_questions.md",
+    ] {
+        let path = context_root.join(relative_path);
+        if !path.exists() {
+            std::fs::write(&path, "").map_err(|err| {
+                anyhow::anyhow!(
+                    "failed to initialize team runtime context file: path={} error={}",
+                    path.display(),
+                    err
+                )
+            })?;
+        }
     }
+
     Ok(())
 }
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -315,7 +315,7 @@ fn build_runtime_start_policy(
     Ok(policy)
 }
 
-fn ensure_team_runtime_workspace_layout(
+async fn ensure_team_runtime_workspace_layout(
     actor_context: Option<&AcpActorSkillContext>,
     workdir: &str,
 ) -> anyhow::Result<()> {
@@ -327,32 +327,46 @@ fn ensure_team_runtime_workspace_layout(
     }
 
     let workdir_path = Path::new(workdir);
-    if role == TEAM_MEMBER_ROLE_LEADER && !workdir_path.exists() {
-        std::fs::create_dir_all(workdir_path).map_err(|err| {
-            anyhow::anyhow!(
-                "failed to create team runtime workdir: workdir={} error={}",
+    match tokio::fs::metadata(workdir_path).await {
+        Ok(metadata) => {
+            if !metadata.is_dir() {
+                anyhow::bail!("team runtime workdir is not a directory: workdir={workdir}");
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            if role != TEAM_MEMBER_ROLE_LEADER {
+                return Ok(());
+            }
+            tokio::fs::create_dir_all(workdir_path).await.map_err(|create_err| {
+                anyhow::anyhow!(
+                    "failed to create team runtime workdir: workdir={} error={}",
+                    workdir,
+                    create_err
+                )
+            })?;
+        }
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to stat team runtime workdir: workdir={} error={}",
                 workdir,
                 err
-            )
-        })?;
-    }
-
-    if !workdir_path.exists() {
-        return Ok(());
-    }
-    if !workdir_path.is_dir() {
-        anyhow::bail!("team runtime workdir is not a directory: workdir={workdir}");
+            ));
+        }
     }
 
     let context_root = workdir_path.join(".cache").join("context");
-    std::fs::create_dir_all(context_root.join("run")).map_err(|err| {
+    tokio::fs::create_dir_all(context_root.join("run"))
+        .await
+        .map_err(|err| {
         anyhow::anyhow!(
             "failed to create team runtime context run dir: workdir={} error={}",
             workdir,
             err
         )
     })?;
-    std::fs::create_dir_all(context_root.join("memory")).map_err(|err| {
+    tokio::fs::create_dir_all(context_root.join("memory"))
+        .await
+        .map_err(|err| {
         anyhow::anyhow!(
             "failed to create team runtime context memory dir: workdir={} error={}",
             workdir,
@@ -371,14 +385,31 @@ fn ensure_team_runtime_workspace_layout(
         "memory/open_questions.md",
     ] {
         let path = context_root.join(relative_path);
-        if !path.exists() {
-            std::fs::write(&path, "").map_err(|err| {
-                anyhow::anyhow!(
-                    "failed to initialize team runtime context file: path={} error={}",
+        match tokio::fs::metadata(&path).await {
+            Ok(metadata) => {
+                if !metadata.is_file() {
+                    anyhow::bail!(
+                        "team runtime context path is not a file: path={}",
+                        path.display()
+                    );
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::write(&path, "").await.map_err(|write_err| {
+                    anyhow::anyhow!(
+                        "failed to initialize team runtime context file: path={} error={}",
+                        path.display(),
+                        write_err
+                    )
+                })?;
+            }
+            Err(err) => {
+                return Err(anyhow::anyhow!(
+                    "failed to stat team runtime context file: path={} error={}",
                     path.display(),
                     err
-                )
-            })?;
+                ));
+            }
         }
     }
 

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -423,6 +423,7 @@ impl AgentManager {
         }
         if let Err(err) =
             ensure_team_runtime_workspace_layout(actor_context.as_ref(), &start_policy.workdir)
+                .await
         {
             let message = err.to_string();
             let _ = self

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -11,7 +11,8 @@ use super::executor::LocalExecutionRequest;
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
 use super::{
     AGENT_STOP_WAIT_TIMEOUT, AgentHandle, AgentInput, AgentManager, build_runtime_start_policy,
-    ensure_team_leader_workdir_exists, normalize_agent_loop_config, spawn_agent_loop_controller,
+    ensure_team_runtime_workspace_layout, normalize_agent_loop_config,
+    spawn_agent_loop_controller,
 };
 use crate::acp::{
     AcpActorSkillContext, AgenthubAcpEventSink, SpawnAcpSessionRequest, load_safe_paths,
@@ -421,7 +422,7 @@ impl AgentManager {
             return Err(err);
         }
         if let Err(err) =
-            ensure_team_leader_workdir_exists(actor_context.as_ref(), &start_policy.workdir)
+            ensure_team_runtime_workspace_layout(actor_context.as_ref(), &start_policy.workdir)
         {
             let message = err.to_string();
             let _ = self

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -6,7 +6,7 @@ use super::codec::{is_acp_message, status_from_str, stream_to_str};
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
 use super::{
     AgentRecord, AgentStatus, OutputStream, WorktreeMode, build_runtime_start_policy,
-    ensure_team_leader_workdir_exists, status_to_str, stream_from_str,
+    ensure_team_runtime_workspace_layout, status_to_str, stream_from_str,
 };
 use crate::acp::{AcpActorSkillContext, AcpPromptDeliveryPolicy, AcpRuntimeLocation};
 use crate::path_utils::expand_tilde;
@@ -393,7 +393,7 @@ fn runtime_start_policy_reuses_leader_workspace_across_launch_ids() {
 }
 
 #[test]
-fn ensure_team_leader_workdir_exists_creates_missing_leader_dir() {
+fn ensure_team_runtime_workspace_layout_creates_missing_leader_dir() {
     let path = std::env::temp_dir().join(format!("agenthub-leader-workdir-{}", Uuid::new_v4()));
     let workdir = path.to_string_lossy().to_string();
     let ctx = AcpActorSkillContext {
@@ -408,13 +408,65 @@ fn ensure_team_leader_workdir_exists_creates_missing_leader_dir() {
     };
 
     assert!(!path.exists(), "temp path should not exist before test");
-    ensure_team_leader_workdir_exists(Some(&ctx), &workdir).expect("create leader workdir");
+    ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .expect("create leader runtime workspace");
     assert!(path.exists(), "leader workdir should be created");
     assert!(path.is_dir(), "leader workdir should be a directory");
+    assert!(
+        path.join(".cache/context/run").is_dir(),
+        "leader context run dir should exist"
+    );
+    assert!(
+        path.join(".cache/context/memory").is_dir(),
+        "leader context memory dir should exist"
+    );
+    for relative_path in [
+        ".cache/context/state.md",
+        ".cache/context/decisions.md",
+        ".cache/context/errors.md",
+        ".cache/context/log.md",
+        ".cache/context/memory/profile.md",
+        ".cache/context/memory/project_facts.md",
+        ".cache/context/memory/decision_journal.md",
+        ".cache/context/memory/open_questions.md",
+    ] {
+        assert!(
+            path.join(relative_path).is_file(),
+            "leader context file should exist: {relative_path}"
+        );
+    }
 }
 
 #[test]
-fn ensure_team_leader_workdir_exists_ignores_non_leader_context() {
+fn ensure_team_runtime_workspace_layout_initializes_worker_context_in_existing_workdir() {
+    let path = std::env::temp_dir().join(format!("agenthub-worker-workdir-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&path).expect("create temp workdir");
+    let workdir = path.to_string_lossy().to_string();
+    let ctx = AcpActorSkillContext {
+        team_id: Some("team-worker".to_string()),
+        current_run_id: Some("run-worker".to_string()),
+        actor_id: "worker-1".to_string(),
+        default_channel: "default".to_string(),
+        member_role: Some("worker".to_string()),
+        member_skills: Vec::new(),
+        contract_version: None,
+        continuity: None,
+    };
+
+    ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .expect("worker runtime workspace should initialize context layout");
+    assert!(
+        path.join(".cache/context/run").is_dir(),
+        "worker context run dir should exist"
+    );
+    assert!(
+        path.join(".cache/context/memory").is_dir(),
+        "worker context memory dir should exist"
+    );
+}
+
+#[test]
+fn ensure_team_runtime_workspace_layout_ignores_non_team_context() {
     let path = std::env::temp_dir().join(format!("agenthub-non-leader-workdir-{}", Uuid::new_v4()));
     let workdir = path.to_string_lossy().to_string();
     let ctx = AcpActorSkillContext {
@@ -429,16 +481,16 @@ fn ensure_team_leader_workdir_exists_ignores_non_leader_context() {
     };
 
     assert!(!path.exists(), "temp path should not exist before test");
-    ensure_team_leader_workdir_exists(Some(&ctx), &workdir)
-        .expect("non-leader should not require directory creation");
+    ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .expect("non-team context should not require directory creation");
     assert!(
         !path.exists(),
-        "non-leader helper path should not be created automatically"
+        "non-team helper path should not be created automatically"
     );
 }
 
 #[test]
-fn ensure_team_leader_workdir_exists_reports_creation_error() {
+fn ensure_team_runtime_workspace_layout_reports_creation_error() {
     let root = std::env::temp_dir().join(format!("agenthub-leader-file-{}", Uuid::new_v4()));
     std::fs::create_dir_all(&root).expect("create temp root");
     let file_path = root.join("not-a-dir");
@@ -456,10 +508,10 @@ fn ensure_team_leader_workdir_exists_reports_creation_error() {
         continuity: None,
     };
 
-    let err = ensure_team_leader_workdir_exists(Some(&ctx), &workdir)
+    let err = ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
         .expect_err("invalid leader path should fail directory creation");
     assert!(
-        err.to_string().contains("failed to create leader workdir"),
+        err.to_string().contains("failed to create team runtime workdir"),
         "err={err}"
     );
 }

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -392,8 +392,8 @@ fn runtime_start_policy_reuses_leader_workspace_across_launch_ids() {
     assert_eq!(first.workdir, second.workdir);
 }
 
-#[test]
-fn ensure_team_runtime_workspace_layout_creates_missing_leader_dir() {
+#[tokio::test]
+async fn ensure_team_runtime_workspace_layout_creates_missing_leader_dir() {
     let path = std::env::temp_dir().join(format!("agenthub-leader-workdir-{}", Uuid::new_v4()));
     let workdir = path.to_string_lossy().to_string();
     let ctx = AcpActorSkillContext {
@@ -409,6 +409,7 @@ fn ensure_team_runtime_workspace_layout_creates_missing_leader_dir() {
 
     assert!(!path.exists(), "temp path should not exist before test");
     ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .await
         .expect("create leader runtime workspace");
     assert!(path.exists(), "leader workdir should be created");
     assert!(path.is_dir(), "leader workdir should be a directory");
@@ -437,8 +438,8 @@ fn ensure_team_runtime_workspace_layout_creates_missing_leader_dir() {
     }
 }
 
-#[test]
-fn ensure_team_runtime_workspace_layout_initializes_worker_context_in_existing_workdir() {
+#[tokio::test]
+async fn ensure_team_runtime_workspace_layout_initializes_worker_context_in_existing_workdir() {
     let path = std::env::temp_dir().join(format!("agenthub-worker-workdir-{}", Uuid::new_v4()));
     std::fs::create_dir_all(&path).expect("create temp workdir");
     let workdir = path.to_string_lossy().to_string();
@@ -454,6 +455,7 @@ fn ensure_team_runtime_workspace_layout_initializes_worker_context_in_existing_w
     };
 
     ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .await
         .expect("worker runtime workspace should initialize context layout");
     assert!(
         path.join(".cache/context/run").is_dir(),
@@ -465,8 +467,8 @@ fn ensure_team_runtime_workspace_layout_initializes_worker_context_in_existing_w
     );
 }
 
-#[test]
-fn ensure_team_runtime_workspace_layout_ignores_non_team_context() {
+#[tokio::test]
+async fn ensure_team_runtime_workspace_layout_ignores_non_team_context() {
     let path = std::env::temp_dir().join(format!("agenthub-non-leader-workdir-{}", Uuid::new_v4()));
     let workdir = path.to_string_lossy().to_string();
     let ctx = AcpActorSkillContext {
@@ -482,6 +484,7 @@ fn ensure_team_runtime_workspace_layout_ignores_non_team_context() {
 
     assert!(!path.exists(), "temp path should not exist before test");
     ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .await
         .expect("non-team context should not require directory creation");
     assert!(
         !path.exists(),
@@ -489,8 +492,8 @@ fn ensure_team_runtime_workspace_layout_ignores_non_team_context() {
     );
 }
 
-#[test]
-fn ensure_team_runtime_workspace_layout_reports_creation_error() {
+#[tokio::test]
+async fn ensure_team_runtime_workspace_layout_reports_creation_error() {
     let root = std::env::temp_dir().join(format!("agenthub-leader-file-{}", Uuid::new_v4()));
     std::fs::create_dir_all(&root).expect("create temp root");
     let file_path = root.join("not-a-dir");
@@ -509,9 +512,40 @@ fn ensure_team_runtime_workspace_layout_reports_creation_error() {
     };
 
     let err = ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .await
         .expect_err("invalid leader path should fail directory creation");
     assert!(
-        err.to_string().contains("failed to create team runtime workdir"),
+        err.to_string().contains("failed to stat team runtime workdir"),
+        "err={err}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_team_runtime_workspace_layout_reports_non_file_context_entries() {
+    let path = std::env::temp_dir().join(format!(
+        "agenthub-leader-workdir-conflict-{}",
+        Uuid::new_v4()
+    ));
+    let conflicting_file = path.join(".cache/context/state.md");
+    std::fs::create_dir_all(&conflicting_file).expect("create conflicting directory");
+    let workdir = path.to_string_lossy().to_string();
+    let ctx = AcpActorSkillContext {
+        team_id: Some("team-leader".to_string()),
+        current_run_id: Some("run-leader".to_string()),
+        actor_id: "leader-3".to_string(),
+        default_channel: "default".to_string(),
+        member_role: Some("leader".to_string()),
+        member_skills: Vec::new(),
+        contract_version: None,
+        continuity: None,
+    };
+
+    let err = ensure_team_runtime_workspace_layout(Some(&ctx), &workdir)
+        .await
+        .expect_err("directory at context file path should fail");
+    assert!(
+        err.to_string()
+            .contains("team runtime context path is not a file"),
         "err={err}"
     );
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@ mod triggers;
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) use manager::derive_team_runtime_workdir;
 pub use manager::{AgentManager, AgentSendInputError};
 pub(crate) use node::{
     AGENT_NODE_MAIN_ID, build_main_agent_node_record, normalize_target_node_id,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -1895,7 +1895,7 @@ impl TeamManager {
         now: i64,
     ) -> anyhow::Result<Option<ContextArtifactPointer>> {
         let Some(workspace) =
-            load_team_member_context_workspace_tx(tx, owner.team_id, owner.run_id, owner.member_id)
+            load_team_member_context_workspace_tx(tx, owner.team_id, owner.member_id)
                 .await?
         else {
             return Ok(None);
@@ -3467,15 +3467,14 @@ fn build_context_artifact_pointer_payload(pointer: &ContextArtifactPointer) -> V
 async fn load_team_member_context_workspace_tx(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     team_id: &str,
-    run_id: &str,
     member_id: &str,
 ) -> anyhow::Result<Option<TeamMemberContextWorkspace>> {
     let row = sqlx::query(
         r#"
         SELECT a.workdir, a.worktree_mode, td.spec_json
-        FROM agents a
-        JOIN team_definitions td ON td.id = ?1
+        FROM agents a, team_definitions td
         WHERE a.id = ?2
+          AND td.id = ?1
         "#,
     )
     .bind(team_id)
@@ -3503,7 +3502,7 @@ async fn load_team_member_context_workspace_tx(
             .and_then(|spec| team_member_role_from_spec(&spec, member_id))
     {
         let actor_context =
-            build_team_member_actor_context_for_role(team_id, Some(run_id), member_id, &member_role);
+            build_team_member_actor_context_for_role(team_id, None, member_id, &member_role);
         derive_team_runtime_workdir(&workdir, &actor_context, &worktree_mode)
     } else {
         workdir

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -44,8 +44,10 @@ use super::{
     TeamConversationRecord, TeamDefinitionConfig, TeamDefinitionRecord,
     TeamMemberContinuityStateRecord, TeamRunEventRecord, TeamRunRecord, TeamRunStatus,
     TeamStepRecord, TeamStepStatus, TeamTaskRecord, TeamTaskStatus,
-    normalize_optional_idempotency_key_input,
+    build_team_member_actor_context_for_role, normalize_optional_idempotency_key_input,
+    team_member_role_from_spec,
 };
+use crate::agent::{WorktreeMode, derive_team_runtime_workdir};
 use crate::agent::event_message_codec::decode_message_from_storage;
 use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
@@ -91,6 +93,11 @@ fn is_row_not_found(err: &anyhow::Error) -> bool {
 enum TaskConversationMessageStoreError {
     #[error("idempotency_key conflicts with an existing task conversation message payload")]
     IdempotencyConflict,
+}
+
+#[derive(Debug, Clone)]
+struct TeamMemberContextWorkspace {
+    runtime_workdir: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -1887,18 +1894,10 @@ impl TeamManager {
         artifact_payload: Value,
         now: i64,
     ) -> anyhow::Result<Option<ContextArtifactPointer>> {
-        let Some(workdir) = sqlx::query_scalar::<_, String>(
-            r#"
-            SELECT workdir
-            FROM agents
-            WHERE id = ?1
-            "#,
-        )
-        .bind(owner.member_id)
-        .fetch_optional(&mut **tx)
-        .await?
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty()) else {
+        let Some(workspace) =
+            load_team_member_context_workspace_tx(tx, owner.team_id, owner.run_id, owner.member_id)
+                .await?
+        else {
             return Ok(None);
         };
 
@@ -1913,7 +1912,7 @@ impl TeamManager {
         .fetch_one(&mut **tx)
         .await?;
 
-        let run_context_dir = PathBuf::from(&workdir)
+        let run_context_dir = PathBuf::from(&workspace.runtime_workdir)
             .join(".cache")
             .join("context")
             .join("run")
@@ -3463,6 +3462,54 @@ fn build_context_artifact_pointer_payload(pointer: &ContextArtifactPointer) -> V
         "size_bytes": pointer.artifact_size_bytes,
         "checksum": pointer.content_checksum.as_str(),
     })
+}
+
+async fn load_team_member_context_workspace_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    team_id: &str,
+    run_id: &str,
+    member_id: &str,
+) -> anyhow::Result<Option<TeamMemberContextWorkspace>> {
+    let row = sqlx::query(
+        r#"
+        SELECT a.workdir, a.worktree_mode, td.spec_json
+        FROM agents a
+        JOIN team_definitions td ON td.id = ?1
+        WHERE a.id = ?2
+        "#,
+    )
+    .bind(team_id)
+    .bind(member_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let workdir = row.get::<String, _>("workdir").trim().to_string();
+    if workdir.is_empty() {
+        return Ok(None);
+    }
+    let worktree_mode = match row.get::<String, _>("worktree_mode").trim() {
+        "create_worktree" => WorktreeMode::CreateWorktree,
+        "reuse_worktree" => WorktreeMode::ReuseWorktree,
+        _ => WorktreeMode::UseExisting,
+    };
+    let spec_json = row.get::<String, _>("spec_json");
+
+    let runtime_workdir = if let Some(member_role) =
+        serde_json::from_str::<Value>(&spec_json)
+            .ok()
+            .and_then(|spec| team_member_role_from_spec(&spec, member_id))
+    {
+        let actor_context =
+            build_team_member_actor_context_for_role(team_id, Some(run_id), member_id, &member_role);
+        derive_team_runtime_workdir(&workdir, &actor_context, &worktree_mode)
+    } else {
+        workdir
+    };
+
+    Ok(Some(TeamMemberContextWorkspace { runtime_workdir }))
 }
 
 async fn load_memory_flush_team_id_tx(

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::codec::team_run_status_from_str;
 use super::{TeamManager, TeamRunResumeError};
+use crate::acp::{AcpActorSkillContext, DEFAULT_ACTOR_CHANNEL};
+use crate::agent::{WorktreeMode, derive_team_runtime_workdir};
 use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use crate::team::{
@@ -2048,6 +2050,124 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
     assert!(
         continuity_event.payload.get("artifact_pointer").is_some(),
         "continuity_state_updated should include artifact pointer metadata"
+    );
+
+    let _ = std::fs::remove_dir_all(workspace);
+}
+
+#[tokio::test]
+async fn complete_step_offloads_large_output_to_leader_runtime_workspace_context_artifact() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time after epoch")
+        .as_nanos();
+    let workspace =
+        std::env::temp_dir().join(format!("agenthub-leader-context-artifact-{unique_suffix}"));
+    std::fs::create_dir_all(&workspace).expect("create workspace directory");
+    let workspace_text = workspace.to_string_lossy().to_string();
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, source, status, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 0, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind("planner")
+    .bind("planner")
+    .bind(&workspace_text)
+    .bind("codex")
+    .bind("[]")
+    .bind("use_existing")
+    .bind("manual")
+    .bind("idle")
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert planner agent");
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "leader-artifact-team".to_string(),
+            description: Some("team with leader continuity output".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner","role":"leader"}]
+            }),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(&team.id, Some("ctx-artifact"), json!({"payload":"start"}))
+        .await
+        .expect("create run");
+    let step = manager
+        .submit_step(
+            &run.id,
+            "large_step",
+            "planner",
+            Vec::new(),
+            Some(json!({"goal":"emit large output"})),
+        )
+        .await
+        .expect("submit step");
+    let _ = manager
+        .start_step(&step.id, Some("remote-task-artifact"))
+        .await
+        .expect("start step");
+
+    manager
+        .complete_step(
+            &step.id,
+            Some(json!({
+                "summary":"large payload",
+                "details": "x".repeat(12_000),
+                "api_key":"secret-value"
+            })),
+        )
+        .await
+        .expect("complete step");
+
+    let artifact_row = sqlx::query(
+        r#"
+        SELECT artifact_path
+        FROM team_context_artifacts
+        WHERE run_id = ?1 AND member_id = ?2
+        ORDER BY artifact_seq DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(&run.id)
+    .bind("planner")
+    .fetch_one(&db)
+    .await
+    .expect("fetch context artifact row");
+    let artifact_path: String = artifact_row.get("artifact_path");
+    let expected_runtime_workdir = derive_team_runtime_workdir(
+        &workspace_text,
+        &AcpActorSkillContext {
+            team_id: Some(team.id.clone()),
+            current_run_id: Some(run.id.clone()),
+            actor_id: "planner".to_string(),
+            default_channel: DEFAULT_ACTOR_CHANNEL.to_string(),
+            member_role: Some("leader".to_string()),
+            member_skills: Vec::new(),
+            contract_version: None,
+            continuity: None,
+        },
+        &WorktreeMode::UseExisting,
+    );
+    let expected_prefix = std::path::Path::new(&expected_runtime_workdir)
+        .join(".cache/context/run")
+        .to_string_lossy()
+        .to_string();
+    assert!(
+        artifact_path.starts_with(&expected_prefix),
+        "artifact path should be under derived leader runtime workspace: {artifact_path}"
     );
 
     let _ = std::fs::remove_dir_all(workspace);

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2151,7 +2151,7 @@ async fn complete_step_offloads_large_output_to_leader_runtime_workspace_context
         &workspace_text,
         &AcpActorSkillContext {
             team_id: Some(team.id.clone()),
-            current_run_id: Some(run.id.clone()),
+            current_run_id: None,
             actor_id: "planner".to_string(),
             default_channel: DEFAULT_ACTOR_CHANNEL.to_string(),
             member_role: Some("leader".to_string()),

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -65,6 +65,7 @@ pub(crate) fn collect_team_member_ids(spec: &Value) -> Vec<String> {
 }
 
 pub(crate) fn team_member_role_from_spec(spec: &Value, member_id: &str) -> Option<String> {
+    let member_id = member_id.trim();
     let members = spec.get("members")?.as_array()?;
     members
         .iter()

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -6,6 +6,7 @@ mod runtime;
 
 use std::collections::HashSet;
 
+use crate::acp::{AcpActorSkillContext, DEFAULT_ACTOR_CHANNEL};
 pub use agenthub_team_actor::{
     ActorMessageRecord as TeamActorMessageRecord, ActorMessageStatus as TeamActorMessageStatus,
     ActorMessageTransport as TeamActorMessageTransport,
@@ -61,6 +62,42 @@ pub(crate) fn collect_team_member_ids(spec: &Value) -> Vec<String> {
         }
     }
     member_ids
+}
+
+pub(crate) fn team_member_role_from_spec(spec: &Value, member_id: &str) -> Option<String> {
+    let members = spec.get("members")?.as_array()?;
+    members
+        .iter()
+        .find(|member| {
+            member
+                .get("member_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                == Some(member_id)
+        })
+        .and_then(|member| member.get("role"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|role| !role.is_empty())
+        .map(str::to_string)
+}
+
+pub(crate) fn build_team_member_actor_context_for_role(
+    team_id: &str,
+    run_id: Option<&str>,
+    member_id: &str,
+    member_role: &str,
+) -> AcpActorSkillContext {
+    AcpActorSkillContext {
+        team_id: Some(team_id.to_string()),
+        current_run_id: run_id.map(str::to_string),
+        actor_id: member_id.to_string(),
+        default_channel: DEFAULT_ACTOR_CHANNEL.to_string(),
+        member_role: Some(member_role.to_string()),
+        member_skills: Vec::new(),
+        contract_version: None,
+        continuity: None,
+    }
 }
 
 pub(crate) fn normalize_optional_idempotency_key_input(value: Option<&str>) -> Option<String> {

--- a/src/team/runtime.rs
+++ b/src/team/runtime.rs
@@ -6,10 +6,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Error as SqlxError;
 
-use crate::acp::{AcpActorSkillContext, DEFAULT_ACTOR_CHANNEL};
+use crate::acp::AcpActorSkillContext;
 use crate::agent::{AgentManager, AgentRecord, WorktreeMode, normalize_target_node_id};
 use crate::path_utils::{expand_tilde, is_path_allowed, normalize_path};
-use crate::team::{TeamDefinitionRecord, TeamRuntimeStatus};
+use crate::team::{
+    TeamDefinitionRecord, TeamRuntimeStatus, build_team_member_actor_context_for_role,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TeamRuntimeStartError {
@@ -125,16 +127,12 @@ fn build_team_member_actor_context(
     team_id: &str,
     member: &TeamRuntimeMemberSpec,
 ) -> anyhow::Result<AcpActorSkillContext> {
-    Ok(AcpActorSkillContext {
-        team_id: Some(team_id.to_string()),
-        current_run_id: None,
-        actor_id: member.member_id.clone(),
-        default_channel: DEFAULT_ACTOR_CHANNEL.to_string(),
-        member_role: Some(member.role.clone()),
-        member_skills: Vec::new(),
-        contract_version: None,
-        continuity: None,
-    })
+    Ok(build_team_member_actor_context_for_role(
+        team_id,
+        None,
+        &member.member_id,
+        &member.role,
+    ))
 }
 
 fn team_member_actor_context_matches(


### PR DESCRIPTION
fix(team): align context artifacts with runtime workdir

## Summary

- bootstrap Team runtime workspace `.cache/context` layout during agent startup for leader and worker sessions
- align TeamManager continuity and memory-flush artifact writes with the derived Team runtime workdir instead of the base persisted agent workdir
- centralize Team member role lookup and actor-context construction helpers so runtime startup and artifact persistence share the same derivation rules

## Testing

- `cargo test -q ensure_team_runtime_workspace_layout --lib`
- `cargo test -q complete_step_offloads_large_output_to_workspace_context_artifact --lib`
- `cargo test -q complete_step_offloads_large_output_to_leader_runtime_workspace_context_artifact --lib`

## Docs

- added `docs/journal/2026-04-11-team-runtime-context-layout-bootstrap.md`
