### PR TITLE
fix(actor): tighten agent loop ACP activity filter

### DIFF
--- a/docs/journal/2026-04-11-agent-loop-acp-activity-filter.md
+++ b/docs/journal/2026-04-11-agent-loop-acp-activity-filter.md
@@ -1,0 +1,25 @@
+# Agent Loop ACP Activity Filter
+
+## Summary
+
+Tightened `agent_loop` idle rearm semantics so the watchdog tracks ACP silence only, matching the
+phase-1 contract.
+
+## Change
+
+- Added a focused `is_agent_loop_activity_output(...)` helper in `src/agent/manager.rs`.
+- The loop controller now rearms only when the session receives non-loop `OutputStream::Acp`
+  activity.
+- `system`, `stdout`, and `stderr` events no longer reset the idle deadline for ACP watchdog
+  prompts.
+
+## Why
+
+The original controller reset its deadline on any output for the same session except its own
+synthetic loop prompt. That meant unrelated runtime noise could postpone loop follow-up prompts even
+though the feature is documented as watching ACP silence only.
+
+## Validation
+
+- `cargo test -q agent_loop_activity_counts_non_loop_acp_output_only --lib`
+- `cargo test -q agent_loop_rearm_requires_same_session_and_real_acp_activity --lib`

--- a/docs/journal/2026-04-11-agent-loop-acp-activity-filter.md
+++ b/docs/journal/2026-04-11-agent-loop-acp-activity-filter.md
@@ -10,8 +10,10 @@ phase-1 contract.
 - Added a focused `is_agent_loop_activity_output(...)` helper in `src/agent/manager.rs`.
 - The loop controller now rearms only when the session receives non-loop `OutputStream::Acp`
   activity.
-- `system`, `stdout`, and `stderr` events no longer reset the idle deadline for ACP watchdog
-  prompts.
+- `system`, `stdout`, and `stderr` events no longer directly reset the idle deadline for ACP
+  watchdog prompts.
+- A `broadcast::RecvError::Lagged(_)` still rearms conservatively because receiver overflow can
+  hide real ACP activity even when noisy non-ACP output contributed to the lag.
 
 ## Why
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -449,6 +449,14 @@ fn is_agent_loop_user_message(message: &str) -> bool {
             .is_some_and(|value| value.starts_with(AGENT_LOOP_MESSAGE_ID_PREFIX))
 }
 
+fn is_agent_loop_activity_output(output: &AgentOutput) -> bool {
+    matches!(output.stream, OutputStream::Acp) && !is_agent_loop_user_message(&output.message)
+}
+
+fn should_rearm_agent_loop_for_output(session_id: &str, output: &AgentOutput) -> bool {
+    output.session_id == session_id && is_agent_loop_activity_output(output)
+}
+
 fn is_agent_user_message(message: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(message)
         .ok()
@@ -529,10 +537,7 @@ fn spawn_agent_loop_controller(
                 },
                 event = output_rx.recv() => match event {
                     Ok(output) => {
-                        if output.session_id != session_id {
-                            continue;
-                        }
-                        if is_agent_loop_user_message(&output.message) {
+                        if !should_rearm_agent_loop_for_output(session_id.as_str(), &output) {
                             continue;
                         }
                         deadline = tokio::time::Instant::now() + Duration::from_secs(config.idle_seconds as u64);

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -5,7 +5,8 @@ use super::acp_provider::{
 use super::codec::{is_acp_message, status_from_str, stream_to_str};
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
 use super::{
-    AgentOutput, AgentRecord, AgentStatus, OutputStream, WorktreeMode,
+    AGENT_LOOP_MESSAGE_ID_PREFIX, AgentOutput, AgentRecord, AgentStatus, OutputStream,
+    WorktreeMode,
     build_runtime_start_policy, ensure_team_runtime_workspace_layout,
     is_agent_loop_activity_output, should_rearm_agent_loop_for_output, status_to_str,
     stream_from_str,
@@ -92,8 +93,9 @@ fn agent_loop_activity_counts_non_loop_acp_output_only() {
     );
 
     let loop_input = AgentOutput {
-        message: r#"{"type":"user_message","text":"loop prompt","message_id":"agent-loop:seq-2"}"#
-            .to_string(),
+        message: format!(
+            r#"{{"type":"user_message","text":"loop prompt","message_id":"{AGENT_LOOP_MESSAGE_ID_PREFIX}seq-2"}}"#
+        ),
         ..base.clone()
     };
     assert!(
@@ -139,8 +141,9 @@ fn agent_loop_rearm_requires_same_session_and_real_acp_activity() {
     );
 
     let synthetic_loop = AgentOutput {
-        message: r#"{"type":"user_message","text":"loop prompt","message_id":"agent-loop:seq-2"}"#
-            .to_string(),
+        message: format!(
+            r#"{{"type":"user_message","text":"loop prompt","message_id":"{AGENT_LOOP_MESSAGE_ID_PREFIX}seq-2"}}"#
+        ),
         ..base.clone()
     };
     assert!(

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -5,8 +5,10 @@ use super::acp_provider::{
 use super::codec::{is_acp_message, status_from_str, stream_to_str};
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
 use super::{
-    AgentRecord, AgentStatus, OutputStream, WorktreeMode, build_runtime_start_policy,
-    ensure_team_runtime_workspace_layout, status_to_str, stream_from_str,
+    AgentOutput, AgentRecord, AgentStatus, OutputStream, WorktreeMode,
+    build_runtime_start_policy, ensure_team_runtime_workspace_layout,
+    is_agent_loop_activity_output, should_rearm_agent_loop_for_output, status_to_str,
+    stream_from_str,
 };
 use crate::acp::{AcpActorSkillContext, AcpPromptDeliveryPolicy, AcpRuntimeLocation};
 use crate::path_utils::expand_tilde;
@@ -64,6 +66,97 @@ fn stream_roundtrip() {
         let parsed = stream_from_str(s);
         assert_eq!(stream, parsed);
     }
+}
+
+#[test]
+fn agent_loop_activity_counts_non_loop_acp_output_only() {
+    let base = AgentOutput {
+        event_id: 1,
+        agent_id: "agent-1".to_string(),
+        session_id: "session-1".to_string(),
+        seq: "seq-1".to_string(),
+        ts: 1,
+        stream: OutputStream::Acp,
+        message: r#"{"type":"agent_message","message":"working"}"#.to_string(),
+    };
+    assert!(is_agent_loop_activity_output(&base));
+
+    let human_input = AgentOutput {
+        message: r#"{"type":"user_message","text":"please continue","message_id":"human-1"}"#
+            .to_string(),
+        ..base.clone()
+    };
+    assert!(
+        is_agent_loop_activity_output(&human_input),
+        "human ACP user_message should rearm the loop"
+    );
+
+    let loop_input = AgentOutput {
+        message: r#"{"type":"user_message","text":"loop prompt","message_id":"agent-loop:seq-2"}"#
+            .to_string(),
+        ..base.clone()
+    };
+    assert!(
+        !is_agent_loop_activity_output(&loop_input),
+        "synthetic loop prompt must not rearm the loop"
+    );
+
+    let system_output = AgentOutput {
+        stream: OutputStream::System,
+        message: "process exited".to_string(),
+        ..base
+    };
+    assert!(
+        !is_agent_loop_activity_output(&system_output),
+        "non-ACP output should not reset ACP silence tracking"
+    );
+}
+
+#[test]
+fn agent_loop_rearm_requires_same_session_and_real_acp_activity() {
+    let base = AgentOutput {
+        event_id: 1,
+        agent_id: "agent-1".to_string(),
+        session_id: "session-1".to_string(),
+        seq: "seq-1".to_string(),
+        ts: 1,
+        stream: OutputStream::Acp,
+        message: r#"{"type":"agent_message","message":"working"}"#.to_string(),
+    };
+
+    assert!(
+        should_rearm_agent_loop_for_output("session-1", &base),
+        "matching-session ACP activity should rearm"
+    );
+
+    let other_session = AgentOutput {
+        session_id: "session-2".to_string(),
+        ..base.clone()
+    };
+    assert!(
+        !should_rearm_agent_loop_for_output("session-1", &other_session),
+        "other-session activity must not rearm"
+    );
+
+    let synthetic_loop = AgentOutput {
+        message: r#"{"type":"user_message","text":"loop prompt","message_id":"agent-loop:seq-2"}"#
+            .to_string(),
+        ..base.clone()
+    };
+    assert!(
+        !should_rearm_agent_loop_for_output("session-1", &synthetic_loop),
+        "synthetic loop prompt must not rearm"
+    );
+
+    let non_acp = AgentOutput {
+        stream: OutputStream::System,
+        message: "process exited".to_string(),
+        ..base
+    };
+    assert!(
+        !should_rearm_agent_loop_for_output("session-1", &non_acp),
+        "non-ACP output must not rearm"
+    );
 }
 
 #[test]


### PR DESCRIPTION
fix(actor): tighten agent loop ACP activity filter

## Summary

- limit `agent_loop` idle rearm behavior to real ACP activity instead of resetting on unrelated session output
- require same-session ACP activity when deciding whether the watchdog should rearm
- add focused regression coverage for ACP-only activity filtering and same-session rearm behavior

## Testing

- `cargo test -q agent_loop_activity_counts_non_loop_acp_output_only --lib`
- `cargo test -q agent_loop_rearm_requires_same_session_and_real_acp_activity --lib`

## Docs

- added `docs/journal/2026-04-11-agent-loop-acp-activity-filter.md`
