### PR TITLE
chore(web): consolidate team task panel primitives

### DIFF
--- a/docs/journal/2026-04-11-team-task-panel-primitives.md
+++ b/docs/journal/2026-04-11-team-task-panel-primitives.md
@@ -12,16 +12,21 @@ shells.
   - added `EmptyState`
   - added `KeyValueList`
   - added `KeyValueItem`
+  - added `ConversationBubble`
+  - added `MenuOptionButton`
 - `web/src/pages/team_task_panel.tsx`
   - moved the seen-progress hovercard into a focused local component
   - moved developer-mode message details into a focused local component backed by
     shared key/value primitives
   - switched channel loading/empty feedback to the shared empty-state primitive
+  - switched mention suggestions onto shared compact option rows
+  - switched chat and command shells onto a shared conversation-bubble primitive
 - `web/src/ui/primitives.test.tsx`
-  - added SSR coverage for the new empty-state and key/value primitives
+  - added SSR coverage for the new empty-state, metadata, bubble, and menu-row primitives
 - `web/src/pages/team_panels.test.tsx`
   - added regression coverage for the expanded message-details panel
   - added regression coverage for the empty channel state
+  - added regression coverage for mention suggestion rows and shared bubble shell rendering
 
 ## Validation
 

--- a/docs/journal/2026-04-11-team-task-panel-primitives.md
+++ b/docs/journal/2026-04-11-team-task-panel-primitives.md
@@ -1,0 +1,32 @@
+# Team Task Panel Primitive Consolidation
+
+## Summary
+
+Continued the Team frontend primitive rollout on `web/src/pages/team_task_panel.tsx`
+so the conversation surface stops carrying its own bespoke empty-state and metadata
+shells.
+
+## Changed
+
+- `web/src/ui/primitives.tsx`
+  - added `EmptyState`
+  - added `KeyValueList`
+  - added `KeyValueItem`
+- `web/src/pages/team_task_panel.tsx`
+  - moved the seen-progress hovercard into a focused local component
+  - moved developer-mode message details into a focused local component backed by
+    shared key/value primitives
+  - switched channel loading/empty feedback to the shared empty-state primitive
+- `web/src/ui/primitives.test.tsx`
+  - added SSR coverage for the new empty-state and key/value primitives
+- `web/src/pages/team_panels.test.tsx`
+  - added regression coverage for the expanded message-details panel
+  - added regression coverage for the empty channel state
+
+## Validation
+
+- Chrome DevTools MCP baseline attempt before edits: blocked because the local
+  `chrome-devtools` transport closed before a page session could be established
+- `cd web && npm run test -- src/ui/primitives.test.tsx src/pages/team_panels.test.tsx`
+- `cd web && npm run lint -- src/ui/primitives.tsx src/ui/primitives.test.tsx src/pages/team_task_panel.tsx src/pages/team_panels.test.tsx`
+- `cd web && npm run build`

--- a/docs/journal/2026-04-11-team-task-panel-primitives.md
+++ b/docs/journal/2026-04-11-team-task-panel-primitives.md
@@ -16,6 +16,7 @@ shells.
   - added `MenuOptionButton`
   - added `CompactButton`
   - added `CompactIconButton`
+  - added `Badge`
 - `web/src/pages/team_task_panel.tsx`
   - moved the seen-progress hovercard into a focused local component
   - moved developer-mode message details into a focused local component backed by
@@ -24,6 +25,7 @@ shells.
   - switched mention suggestions onto shared compact option rows
   - switched chat and command shells onto a shared conversation-bubble primitive
   - switched dense message meta controls onto shared compact button primitives
+  - switched permission status and seen-state recipient chips onto a shared badge primitive
 - `web/src/ui/primitives.test.tsx`
   - added SSR coverage for the new empty-state, metadata, bubble, and menu-row primitives
   - added SSR coverage for the compact button primitives

--- a/docs/journal/2026-04-11-team-task-panel-primitives.md
+++ b/docs/journal/2026-04-11-team-task-panel-primitives.md
@@ -14,6 +14,8 @@ shells.
   - added `KeyValueItem`
   - added `ConversationBubble`
   - added `MenuOptionButton`
+  - added `CompactButton`
+  - added `CompactIconButton`
 - `web/src/pages/team_task_panel.tsx`
   - moved the seen-progress hovercard into a focused local component
   - moved developer-mode message details into a focused local component backed by
@@ -21,8 +23,10 @@ shells.
   - switched channel loading/empty feedback to the shared empty-state primitive
   - switched mention suggestions onto shared compact option rows
   - switched chat and command shells onto a shared conversation-bubble primitive
+  - switched dense message meta controls onto shared compact button primitives
 - `web/src/ui/primitives.test.tsx`
   - added SSR coverage for the new empty-state, metadata, bubble, and menu-row primitives
+  - added SSR coverage for the compact button primitives
 - `web/src/pages/team_panels.test.tsx`
   - added regression coverage for the expanded message-details panel
   - added regression coverage for the empty channel state

--- a/docs/journal/2026-04-12-team-tasks-panel-primitives.md
+++ b/docs/journal/2026-04-12-team-tasks-panel-primitives.md
@@ -1,0 +1,22 @@
+# Team Tasks Panel Primitive Follow-up
+
+## Summary
+
+Continued the shared Team UI primitive rollout on `web/src/pages/team_tasks_panel.tsx`
+after the `TeamTaskPanel` cleanup, focusing on repeated lane-count and empty-state
+shells instead of changing task lifecycle behavior.
+
+## Changed
+
+- `web/src/pages/team_tasks_panel.tsx`
+  - switched lane count badges to the shared `Badge` primitive
+  - switched previous-run count badges to the shared `Badge` primitive
+  - switched board loading / empty / no-result affordances to the shared `EmptyState` primitive
+- `web/src/pages/team_panels.test.tsx`
+  - added regression coverage for the empty task-board state
+
+## Validation
+
+- `cd web && npm run test -- src/ui/primitives.test.tsx src/pages/team_panels.test.tsx`
+- `cd web && npm run lint -- src/ui/primitives.tsx src/ui/primitives.test.tsx src/pages/team_task_panel.tsx src/pages/team_tasks_panel.tsx src/pages/team_panels.test.tsx`
+- `cd web && npm run build`

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3343,6 +3343,7 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Waiting");
     expect(container.textContent).toContain("In review");
     expect(container.textContent).toContain("Completed");
+    expect(container.textContent).toContain("1");
     expect(container.textContent).toContain("Prepare rollout");
     expect(container.textContent).toContain("owner Worker One");
     expect(container.textContent).toContain(
@@ -3435,6 +3436,40 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("Prepare rollout");
     expect(container.textContent).not.toContain("Loading tasks...");
+  });
+
+  it("TeamTasksPanel renders shared empty states for an empty board", () => {
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamTasksPanel
+            compactMode={false}
+            developerMode={false}
+            tasks={[]}
+            tasksLoading={false}
+            selectedTaskId=""
+            onSelectedTaskIdChange={vi.fn()}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[]}
+            onOpenRun={vi.fn()}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("No tasks yet.");
   });
 
   it("TeamTasksPanel uses a separate compact detail page and can close back to Kanban", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -1796,6 +1796,55 @@ describe("team panels interactions", () => {
     expect(bodyShell.nextElementSibling).toBe(composer);
   });
 
+  it("TeamTaskPanel renders mention suggestions with shared option rows", () => {
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("");
+      return (
+        <TeamTaskPanel
+          developerMode={false}
+          messageDraft={draft}
+          onMessageDraftChange={setDraft}
+          onSendMessage={vi.fn()}
+          messages={[]}
+          memberLiveStates={[
+            {
+              member_id: "worker-agent",
+              role: "worker",
+              agent_name: "Worker Agent",
+              lifecycle_status: "running",
+              lifecycle_tone: "active",
+              run_status: "working",
+              step_status: "working",
+              pending_inbox_count: 0,
+              current_work: "shipping patch",
+            },
+          ]}
+          memberIds={["worker-agent"]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const draftTextarea = required(
+      container.querySelector("#team-task-panel-message") as HTMLTextAreaElement | null,
+      "draft textarea missing"
+    );
+    changeInputValue(draftTextarea, "@W");
+
+    const option = required(
+      container.querySelector('[data-team-mention-option="worker-agent"]') as HTMLButtonElement | null,
+      "mention option missing"
+    );
+    expect(option.textContent).toContain("Worker Agent");
+    expect(option.textContent).toContain("@Worker Agent");
+    expect(option.className).toContain("flex w-full items-center justify-between");
+  });
+
   it("TeamTaskPanel renders canonical agent replies already persisted in shared thread", () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
 
@@ -2744,6 +2793,9 @@ describe("team panels interactions", () => {
 
     expect(container.querySelector('[data-team-channel-bubble="human"]')).not.toBeNull();
     expect(container.querySelector('[data-team-channel-bubble="agent"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-team-channel-bubble="agent"]')?.className
+    ).toContain("rounded-[18px]");
   });
 
   it("TeamTaskPanel constrains rich chat bubbles for mobile-width markdown content", async () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2082,6 +2082,112 @@ describe("team panels interactions", () => {
     expect(container.querySelector('[role="progressbar"]')).toBeNull();
   });
 
+  it("TeamTaskPanel covers thread loading state and partial read progress chips", () => {
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        tasksLoading={false}
+        onRefreshTasks={vi.fn()}
+        messageDraft=""
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRefreshMessages={vi.fn()}
+        messages={[]}
+        humanActorId="user"
+        memberLiveStates={[
+          buildMemberLiveState({
+            member_id: "leader-agent",
+            role: "leader",
+            agent_name: "Leader Agent",
+            current_work: "replying in thread",
+          }),
+          buildMemberLiveState({
+            member_id: "worker-agent",
+            role: "worker",
+            agent_name: "Worker Agent",
+            current_work: "reading shared updates",
+          }),
+          buildMemberLiveState({
+            member_id: "reviewer-agent",
+            role: "worker",
+            agent_name: "Reviewer Agent",
+            current_work: "waiting for inbox",
+          }),
+        ]}
+        memberIds={["leader-agent", "worker-agent", "reviewer-agent"]}
+        conversationTitle="worker-thread"
+        isSharedConversation={false}
+        messagesLoading={true}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+      />
+    );
+
+    expect(container.textContent).toContain("Loading thread...");
+    const threadTextarea = required(
+      container.querySelector('textarea[placeholder="Reply in thread"]') as HTMLTextAreaElement | null,
+      "thread reply textarea missing"
+    );
+    expect(threadTextarea).not.toBeNull();
+    expect(findButtonByAriaLabel(container, "Refresh thread")).not.toBeNull();
+
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        tasksLoading={false}
+        onRefreshTasks={vi.fn()}
+        messageDraft=""
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRefreshMessages={vi.fn()}
+        messages={[
+          buildTaskMessage(41, {
+            from_actor_id: "leader-agent",
+            to_actor_id: null,
+            route: "group_chat",
+            payload: { type: "chat_message", text: "partial read state" },
+          }),
+        ]}
+        seenByMessageId={{ 41: ["worker-agent"] }}
+        humanActorId="user"
+        memberLiveStates={[
+          buildMemberLiveState({
+            member_id: "leader-agent",
+            role: "leader",
+            agent_name: "Leader Agent",
+          }),
+          buildMemberLiveState({
+            member_id: "worker-agent",
+            role: "worker",
+            agent_name: "Worker Agent",
+          }),
+          buildMemberLiveState({
+            member_id: "reviewer-agent",
+            role: "worker",
+            agent_name: "Reviewer Agent",
+          }),
+        ]}
+        memberIds={["leader-agent", "worker-agent", "reviewer-agent"]}
+        messagesLoading={false}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+      />
+    );
+
+    const readProgressButton = findButtonByAriaLabel(container, "Seen by 1 of 2 recipients");
+    expect(readProgressButton.getAttribute("title")).toBe("Seen by 1 of 2 recipients");
+    const progressbar = required(
+      readProgressButton.querySelector('[role="progressbar"]'),
+      "progressbar missing"
+    );
+    expect(progressbar.getAttribute("aria-valuenow")).toBe("1");
+    expect(progressbar.getAttribute("aria-valuemax")).toBe("2");
+  });
+
   it("TeamTaskPanel renders permission review cards in channel and collapses to status after response", async () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
     const listPermissionsSpy = vi
@@ -3660,6 +3766,116 @@ describe("team panels interactions", () => {
     });
 
     expect(container.textContent).toContain("No tasks yet.");
+  });
+
+  it("TeamTasksPanel covers loading, filtered no-results, and previous-runs branches", () => {
+    const onOpenRun = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamTasksPanel
+            compactMode={false}
+            developerMode={false}
+            tasks={[]}
+            tasksLoading={true}
+            selectedTaskId=""
+            onSelectedTaskIdChange={vi.fn()}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[]}
+            onOpenRun={onOpenRun}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("Loading tasks...");
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamTasksPanel
+            compactMode={false}
+            developerMode={false}
+            tasks={[
+              buildPanelTask("task-open", { title: "Investigate bug", status: "open" }),
+              buildPanelTask("task-progress", {
+                title: "Prepare rollout",
+                status: "in_progress",
+              }),
+            ]}
+            tasksLoading={false}
+            selectedTaskId="task-progress"
+            onSelectedTaskIdChange={vi.fn()}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[
+              buildRun({
+                id: "run-2",
+                status: "completed",
+                summary: "Latest run summary.",
+                input: { task_id: "task-progress" },
+                created_at: 230,
+                started_at: 231,
+                ended_at: 240,
+              }),
+              buildRun({
+                id: "run-1",
+                status: "failed",
+                summary: "Earlier run failed.",
+                input: { task_id: "task-progress" },
+                created_at: 200,
+                started_at: 201,
+                ended_at: 210,
+              }),
+              buildRun({
+                id: "run-0",
+                status: "canceled",
+                summary: "",
+                input: { task_id: "task-progress" },
+                created_at: 180,
+                started_at: 181,
+                ended_at: 182,
+              }),
+            ]}
+            onOpenRun={onOpenRun}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </MantineProvider>
+      );
+    });
+
+    clickElement(findInteractiveByText(container, "Canceled", "button, label"));
+    expect(container.textContent).toContain("No results.");
+
+    clickElement(findInteractiveByText(container, "In progress", "button, label"));
+    expect(container.textContent).toContain("Previous runs");
+    expect(container.textContent).toContain("Earlier run failed.");
+    expect(container.textContent).toContain("No summary recorded.");
+    clickElement(findButtonByText(container, "run-1"));
+    expect(onOpenRun).toHaveBeenCalledWith("run-1");
   });
 
   it("TeamTasksPanel uses a separate compact detail page and can close back to Kanban", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3084,6 +3084,85 @@ describe("team panels interactions", () => {
     expect(container.textContent).not.toContain("route");
   });
 
+  it("TeamTaskPanel renders message details with shared key/value metadata when developer mode expands an item", () => {
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+          developerMode
+          tasksLoading={false}
+          onRefreshTasks={vi.fn()}
+          messageDraft=""
+          onMessageDraftChange={vi.fn()}
+          onSendMessage={vi.fn()}
+          onRefreshMessages={vi.fn()}
+          messages={[
+            buildTaskMessage(7, {
+              from_actor_id: "leader-agent",
+              to_actor_id: "worker-agent",
+              route: "direct",
+              payload: { type: "chat_message", text: "debug details" },
+            }),
+          ]}
+          humanActorId="user"
+          memberLiveStates={[
+            {
+              member_id: "leader-agent",
+              role: "leader",
+              agent_name: "LeaderAgent",
+              lifecycle_status: "working",
+              lifecycle_tone: "active",
+              run_status: "working",
+              step_status: "waiting",
+              pending_inbox_count: 0,
+              current_work: "reviewing worker progress",
+            },
+          ]}
+          memberIds={["leader-agent", "worker-agent"]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+    );
+
+    clickElement(findButtonByText(container, "Show details"));
+    expect(container.textContent).toContain("source");
+    expect(container.textContent).toContain("from");
+    expect(container.textContent).toContain("leader-agent");
+    expect(container.textContent).toContain("to");
+    expect(container.textContent).toContain("worker-agent");
+    expect(container.textContent).toContain("route");
+    expect(container.textContent).toContain("work");
+    expect(container.textContent).toContain("working/waiting");
+    expect(container.textContent).toContain("current_work");
+    expect(container.textContent).toContain("reviewing worker progress");
+  });
+
+  it("TeamTaskPanel renders the shared empty state when the channel has no messages", () => {
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+          developerMode={false}
+          tasksLoading={false}
+          onRefreshTasks={vi.fn()}
+          messageDraft=""
+          onMessageDraftChange={vi.fn()}
+          onSendMessage={vi.fn()}
+          onRefreshMessages={vi.fn()}
+          messages={[]}
+          humanActorId="user"
+          memberLiveStates={[]}
+          memberIds={["leader-agent"]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+    );
+
+    expect(container.textContent).toContain("No channel messages yet.");
+  });
+
   it("TeamTasksPanel supports task filters, workflow guidance, linked runs, and debug compile actions", () => {
     const onSelectedTaskIdChange = vi.fn();
     const onRefreshTasks = vi.fn();

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -1966,6 +1966,135 @@ describe("team panels interactions", () => {
     expect(option.className).toContain("flex w-full items-center justify-between");
   });
 
+  it("TeamTaskPanel sends on Enter and applies mention selection on mouse down", () => {
+    const onSendMessage = vi.fn();
+
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("");
+      return (
+        <TeamTaskPanel
+          developerMode={false}
+          messageDraft={draft}
+          onMessageDraftChange={setDraft}
+          onSendMessage={onSendMessage}
+          messages={[]}
+          memberLiveStates={[
+            buildMemberLiveState({
+              member_id: "worker-agent",
+              role: "worker",
+              agent_name: "Worker Agent",
+            }),
+          ]}
+          memberIds={["worker-agent"]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const draftTextarea = required(
+      container.querySelector("#team-task-panel-message") as HTMLTextAreaElement | null,
+      "draft textarea missing"
+    );
+    changeInputValue(draftTextarea, "@W");
+
+    const option = required(
+      container.querySelector('[data-team-mention-option="worker-agent"]') as HTMLButtonElement | null,
+      "mention option missing"
+    );
+    act(() => {
+      option.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+
+    expect(draftTextarea.value).toContain("@Worker Agent");
+
+    act(() => {
+      draftTextarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onSendMessage).toHaveBeenCalledWith({
+      text: "<at>worker-agent</at>",
+      mentionActorIds: ["worker-agent"],
+    });
+  });
+
+  it("TeamTaskPanel supports IME-aware mention keyboard navigation", async () => {
+    const onSendMessage = vi.fn();
+
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("");
+      return (
+        <TeamTaskPanel
+          developerMode={false}
+          messageDraft={draft}
+          onMessageDraftChange={setDraft}
+          onSendMessage={onSendMessage}
+          messages={[]}
+          memberLiveStates={[
+            buildMemberLiveState({
+              member_id: "worker-agent",
+              role: "worker",
+              agent_name: "Worker Agent",
+            }),
+            buildMemberLiveState({
+              member_id: "reviewer-agent",
+              role: "worker",
+              agent_name: "Reviewer Agent",
+            }),
+          ]}
+          memberIds={["worker-agent", "reviewer-agent"]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const draftTextarea = required(
+      container.querySelector("#team-task-panel-message") as HTMLTextAreaElement | null,
+      "draft textarea missing"
+    );
+
+    act(() => {
+      draftTextarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+      draftTextarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+    });
+
+    changeInputValue(draftTextarea, "@");
+    expect(container.querySelectorAll("[data-team-mention-option]")).toHaveLength(2);
+
+    act(() => {
+      draftTextarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })
+      );
+      draftTextarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true, cancelable: true })
+      );
+      draftTextarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+      );
+    });
+    expect(container.querySelector("[data-team-mention-option]")).toBeNull();
+
+    changeInputValue(draftTextarea, "@W");
+    act(() => {
+      draftTextarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true })
+      );
+      draftTextarea.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+    });
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
   it("TeamTaskPanel renders canonical agent replies already persisted in shared thread", () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
 
@@ -3942,6 +4071,88 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("Board lanes");
     expect(container.textContent).not.toContain("Task detail");
+  });
+
+  it("TeamTasksPanel covers compact reset, run warning tones, and debug disclosure toggles", () => {
+    function CompactTaskHarness() {
+      const [selectedTaskId, setSelectedTaskId] = React.useState("task-progress");
+      const [showSelectedTask, setShowSelectedTask] = React.useState(true);
+      return (
+        <div>
+          <button type="button" onClick={() => setShowSelectedTask(false)}>
+            Hide selected task
+          </button>
+          <TeamTasksPanel
+            compactMode={true}
+            developerMode={true}
+            tasks={
+              showSelectedTask
+                ? [
+                    buildPanelTask("task-progress", {
+                      title: "Prepare rollout",
+                      status: "in_progress",
+                      context: { owner: "leader" },
+                    }),
+                  ]
+                : [buildPanelTask("task-open", { title: "Investigate bug", status: "open" })]
+            }
+            tasksLoading={false}
+            selectedTaskId={selectedTaskId}
+            onSelectedTaskIdChange={setSelectedTaskId}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[
+              buildRun({
+                id: "run-input",
+                status: "input_required",
+                summary: "Need human input.",
+                input: { task_id: "task-progress" },
+              }),
+              buildRun({
+                id: "run-submitted",
+                status: "submitted",
+                summary: "Queued.",
+                input: { task_id: "task-progress" },
+              }),
+            ]}
+            onOpenRun={vi.fn()}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </div>
+      );
+    }
+
+    renderWithMantine(root, <CompactTaskHarness />);
+
+    clickElement(findButtonByText(container, "Prepare rollout"));
+    expect(container.textContent).toContain("Prepare rollout");
+    expect(container.textContent).toContain("Need human input.");
+    expect(container.innerHTML).toContain("title=\"run status: input_required\"");
+    expect(container.innerHTML).toContain("title=\"run status: submitted\"");
+
+    const details = required(
+      container.querySelector("details") as HTMLDetailsElement | null,
+      "developer details missing"
+    );
+    act(() => {
+      details.open = true;
+      details.dispatchEvent(new Event("toggle", { bubbles: true }));
+    });
+    expect(container.textContent).toContain("Hide");
+
+    clickElement(findButtonByText(container, "Hide selected task"));
+    expect(container.textContent).toContain("Investigate bug");
+    expect(container.textContent).not.toContain("Prepare rollout");
   });
 
   it("TeamMemberAcpPanel renders ACP conversation for selected member", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2137,6 +2137,7 @@ describe("team panels interactions", () => {
       ) as HTMLElement;
       expect(permissionCard.textContent).toContain("git push");
       expect(permissionCard.textContent).toContain("Timed out");
+      expect(permissionCard.innerHTML).toContain("bg-notion-hover");
       expect(permissionCard.textContent).not.toContain("worker requests permission to execute git push.");
       expect(permissionCard.textContent).not.toContain("Agent review timed out");
       expect(queryButtonByText(permissionCard, "Allow once")).toBeNull();
@@ -3188,6 +3189,9 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("working/waiting");
     expect(container.textContent).toContain("current_work");
     expect(container.textContent).toContain("reviewing worker progress");
+    expect(container.innerHTML).toContain("<dl");
+    expect(container.innerHTML).toContain("<dt");
+    expect(container.innerHTML).toContain("<dd");
   });
 
   it("TeamTaskPanel renders the shared empty state when the channel has no messages", () => {

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -14,7 +14,16 @@ import {
 } from "./team/team_conversation_viewport";
 import { isTeamImeComposing } from "./team/team_text_helpers";
 import { NOTION_FLOATING_PANEL_CLASS } from "../ui/floating_surfaces";
-import { ActionButton, IconButton, SurfaceCard, ToolbarRow } from "../ui/primitives";
+import {
+  ActionButton,
+  EmptyState,
+  IconButton,
+  InsetSurface,
+  KeyValueItem,
+  KeyValueList,
+  SurfaceCard,
+  ToolbarRow,
+} from "../ui/primitives";
 import { TeamMemberLiveState } from "./team/member_helpers";
 import {
   applyMentionAtTag,
@@ -147,15 +156,11 @@ const TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS =
   "flex min-w-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_HEADER_META_CLASS = "flex shrink-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_DETAILS_CLASS =
-  "mt-3 rounded-lg border border-notion-border bg-notion-sidebar/30 p-3";
+  "mt-3 p-3 sm:p-3";
 const TEAM_TASK_ACTIVITY_DETAILS_BUTTON_CLASS =
   "inline-flex items-center rounded-md border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted transition hover:bg-notion-hover";
 const TEAM_TASK_PERMISSION_CARD_ERROR_CLASS =
   "text-[11px] font-medium text-red-600";
-const TEAM_TASK_ACTIVITY_DETAILS_GRID_CLASS =
-  "grid gap-x-4 gap-y-1.5 text-[11px] text-notion-text-muted sm:grid-cols-2";
-const TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS =
-  "mono font-bold text-notion-text opacity-70";
 const TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS =
   "inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-notion-border bg-white p-0.5 text-[10px] font-medium text-notion-text-muted transition hover:bg-notion-hover";
 const TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS =
@@ -528,6 +533,24 @@ type PermissionReviewCardProps = {
   onRespond: (payload: PermissionReviewCardPayload, optionId?: string) => void;
 };
 
+type SeenProgressHoverCardProps = {
+  itemKey: string;
+  seenActorIds: string[];
+  seenProgress: SeenProgressState;
+  memberDisplayNamesById: Map<string, string>;
+};
+
+type ActivityDetailsPanelProps = {
+  item: {
+    streamLabel: string;
+    sequence: number;
+    fromActorId: string;
+    toActorId?: string | null;
+    routeOrStatus: string;
+  };
+  state?: TeamMemberLiveState;
+};
+
 function PermissionReviewCard(props: PermissionReviewCardProps) {
   const { payload, permissionRecord, busy, errorText, onRespond } = props;
   const status = resolvePermissionCardStatus(payload, permissionRecord);
@@ -632,6 +655,123 @@ function resolveSeenProgressState(
     unreadCount: unreadActorIds.length,
     progress: totalCount > 0 ? Math.round((readCount / totalCount) * 100) : 0,
   };
+}
+
+function SeenProgressHoverCard({
+  itemKey,
+  seenActorIds,
+  seenProgress,
+  memberDisplayNamesById,
+}: SeenProgressHoverCardProps) {
+  return (
+    <HoverCard openDelay={120} closeDelay={80} position="top-end" shadow="md" radius="md">
+      <HoverCard.Target>
+        {seenActorIds.length === 0 ? (
+          <button
+            type="button"
+            className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
+            aria-label="Pending delivery"
+            title="Pending delivery"
+          >
+            <span className={TEAM_TASK_ACTIVITY_DELIVERY_PENDING_CLASS} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
+            aria-label={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
+            title={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
+          >
+            <span
+              className={TEAM_TASK_ACTIVITY_SEEN_DIAL_CLASS}
+              role="progressbar"
+              aria-valuenow={seenProgress.readCount}
+              aria-valuemin={0}
+              aria-valuemax={seenProgress.totalCount}
+              style={
+                {
+                  "--value": seenProgress.progress,
+                  "--size": "1rem",
+                  "--thickness": "1rem",
+                  width: "var(--size)",
+                  height: "var(--size)",
+                  background: `conic-gradient(rgba(31,122,61,0.82) calc(var(--value) * 1%), rgba(55,53,47,0.12) 0)`,
+                } satisfies SeenDialStyle
+              }
+            />
+          </button>
+        )}
+      </HoverCard.Target>
+      <HoverCard.Dropdown className={TEAM_TASK_ACTIVITY_SEEN_CARD_CLASS}>
+        {seenActorIds.length === 0 ? (
+          <>
+            <div className={TEAM_TASK_ACTIVITY_SEEN_SUMMARY_CLASS}>Delivery</div>
+            <div className={TEAM_TASK_ACTIVITY_SEEN_COUNT_CLASS}>Pending delivery</div>
+          </>
+        ) : (
+          <>
+            <div className={TEAM_TASK_ACTIVITY_SEEN_SUMMARY_CLASS}>Read state</div>
+            <div className={TEAM_TASK_ACTIVITY_SEEN_COUNT_CLASS}>
+              {`${seenProgress.readCount} read · ${seenProgress.unreadCount} unread`}
+            </div>
+            {seenProgress.readActorIds.length > 0 && (
+              <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_CLASS}>
+                <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Read</div>
+                <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
+                  {seenProgress.readActorIds.map((actorId) => (
+                    <span
+                      key={`${itemKey}-read-${actorId}`}
+                      className="rounded-full border border-notion-border bg-white px-2 py-0.5"
+                    >
+                      {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {seenProgress.unreadActorIds.length > 0 && (
+              <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_CLASS}>
+                <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Unread</div>
+                <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
+                  {seenProgress.unreadActorIds.map((actorId) => (
+                    <span
+                      key={`${itemKey}-unread-${actorId}`}
+                      className="rounded-full border border-dashed border-notion-border bg-transparent px-2 py-0.5"
+                    >
+                      {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}
+
+function ActivityDetailsPanel({ item, state }: ActivityDetailsPanelProps) {
+  return (
+    <InsetSurface className={TEAM_TASK_ACTIVITY_DETAILS_CLASS}>
+      <KeyValueList>
+        <KeyValueItem label="source" value={item.streamLabel} />
+        <KeyValueItem label="seq" value={item.sequence} />
+        <KeyValueItem label="from" value={item.fromActorId} valueClassName="mono" />
+        <KeyValueItem label="to" value={item.toActorId ?? "-"} valueClassName="mono" />
+        <KeyValueItem label="route" value={item.routeOrStatus} />
+        {state ? (
+          <>
+            <KeyValueItem label="work" value={`${state.run_status}/${state.step_status}`} />
+            <KeyValueItem label="agent" value={state.lifecycle_status} />
+            {state.current_work ? (
+              <KeyValueItem label="current_work" value={state.current_work} />
+            ) : null}
+          </>
+        ) : null}
+      </KeyValueList>
+    </InsetSurface>
+  );
 }
 
 function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
@@ -1148,98 +1288,12 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                     {(shouldShowSeenMeta || developerMode) && (
                       <div className={TEAM_TASK_ACTIVITY_HEADER_META_CLASS}>
                         {shouldShowSeenMeta && (
-                          <HoverCard
-                            openDelay={120}
-                            closeDelay={80}
-                            position="top-end"
-                            shadow="md"
-                            radius="md"
-                          >
-                            <HoverCard.Target>
-                              {seenActorIds.length === 0 ? (
-                                <button
-                                  type="button"
-                                  className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
-                                  aria-label="Pending delivery"
-                                  title="Pending delivery"
-                                >
-                                  <span className={TEAM_TASK_ACTIVITY_DELIVERY_PENDING_CLASS} />
-                                </button>
-                              ) : (
-                                <button
-                                  type="button"
-                                  className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
-                                  aria-label={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
-                                  title={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
-                                >
-                                  <span
-                                    className={TEAM_TASK_ACTIVITY_SEEN_DIAL_CLASS}
-                                    role="progressbar"
-                                    aria-valuenow={seenProgress.readCount}
-                                    aria-valuemin={0}
-                                    aria-valuemax={seenProgress.totalCount}
-                                    style={
-                                      {
-                                        "--value": seenProgress.progress,
-                                        "--size": "1rem",
-                                        "--thickness": "1rem",
-                                        width: "var(--size)",
-                                        height: "var(--size)",
-                                        background: `conic-gradient(rgba(31,122,61,0.82) calc(var(--value) * 1%), rgba(55,53,47,0.12) 0)`,
-                                      } satisfies SeenDialStyle
-                                    }
-                                  />
-                                </button>
-                              )}
-                            </HoverCard.Target>
-                            <HoverCard.Dropdown className={TEAM_TASK_ACTIVITY_SEEN_CARD_CLASS}>
-                              {seenActorIds.length === 0 ? (
-                                <>
-                                  <div className={TEAM_TASK_ACTIVITY_SEEN_SUMMARY_CLASS}>Delivery</div>
-                                  <div className={TEAM_TASK_ACTIVITY_SEEN_COUNT_CLASS}>
-                                    Pending delivery
-                                  </div>
-                                </>
-                              ) : (
-                                <>
-                                  <div className={TEAM_TASK_ACTIVITY_SEEN_SUMMARY_CLASS}>Read state</div>
-                                  <div className={TEAM_TASK_ACTIVITY_SEEN_COUNT_CLASS}>
-                                    {`${seenProgress.readCount} read · ${seenProgress.unreadCount} unread`}
-                                  </div>
-                                  {seenProgress.readActorIds.length > 0 && (
-                                    <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_CLASS}>
-                                      <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Read</div>
-                                      <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
-                                        {seenProgress.readActorIds.map((actorId) => (
-                                          <span
-                                            key={`${item.key}-read-${actorId}`}
-                                            className="rounded-full border border-notion-border bg-white px-2 py-0.5"
-                                          >
-                                            {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
-                                          </span>
-                                        ))}
-                                      </div>
-                                    </div>
-                                  )}
-                                  {seenProgress.unreadActorIds.length > 0 && (
-                                    <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_CLASS}>
-                                      <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Unread</div>
-                                      <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
-                                        {seenProgress.unreadActorIds.map((actorId) => (
-                                          <span
-                                            key={`${item.key}-unread-${actorId}`}
-                                            className="rounded-full border border-dashed border-notion-border bg-transparent px-2 py-0.5"
-                                          >
-                                            {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
-                                          </span>
-                                        ))}
-                                      </div>
-                                    </div>
-                                  )}
-                                </>
-                              )}
-                            </HoverCard.Dropdown>
-                          </HoverCard>
+                          <SeenProgressHoverCard
+                            itemKey={item.key}
+                            seenActorIds={seenActorIds}
+                            seenProgress={seenProgress}
+                            memberDisplayNamesById={memberDisplayNamesById}
+                          />
                         )}
                         {developerMode && (
                           <button
@@ -1289,62 +1343,17 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                     </div>
                   )}
                   {developerMode && expandedItemKeys[item.key] && (
-                    <div className={TEAM_TASK_ACTIVITY_DETAILS_CLASS}>
-                      <dl className={TEAM_TASK_ACTIVITY_DETAILS_GRID_CLASS}>
-                      <div>
-                        <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>source</dt>
-                        <dd>{item.streamLabel}</dd>
-                      </div>
-                      <div>
-                        <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>seq</dt>
-                        <dd>{item.sequence}</dd>
-                      </div>
-                      <div>
-                        <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>from</dt>
-                        <dd className="mono">{item.fromActorId}</dd>
-                      </div>
-                      <div>
-                        <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>to</dt>
-                        <dd className="mono">{item.toActorId ?? "-"}</dd>
-                      </div>
-                      <div>
-                        <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>route</dt>
-                        <dd>{item.routeOrStatus}</dd>
-                      </div>
-                      {state && (
-                        <>
-                          <div>
-                            <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>work</dt>
-                            <dd>{state.run_status}/{state.step_status}</dd>
-                          </div>
-                          <div>
-                            <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>agent</dt>
-                            <dd>{state.lifecycle_status}</dd>
-                          </div>
-                          {state.current_work && (
-                            <div className="sm:col-span-2">
-                              <dt className={TEAM_TASK_ACTIVITY_DETAILS_LABEL_CLASS}>current_work</dt>
-                              <dd>{state.current_work}</dd>
-                            </div>
-                          )}
-                        </>
-                      )}
-                      </dl>
-                    </div>
+                    <ActivityDetailsPanel item={item} state={state} />
                   )}
                 </div>
               </div>
             );
           })}
           {showInitialThreadLoading && (
-            <div className={TEAM_TASK_MESSAGE_EMPTY_CLASS}>
-              Loading thread...
-            </div>
+            <EmptyState title="Loading thread..." className={TEAM_TASK_MESSAGE_EMPTY_CLASS} />
           )}
           {!showInitialThreadLoading && visibleWaterfallItems.length === 0 && (
-            <div className={TEAM_TASK_MESSAGE_EMPTY_CLASS}>
-              {emptyStateText}
-            </div>
+            <EmptyState title={emptyStateText} className={TEAM_TASK_MESSAGE_EMPTY_CLASS} />
           )}
             </div>
           </div>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -16,6 +16,7 @@ import { isTeamImeComposing } from "./team/team_text_helpers";
 import { NOTION_FLOATING_PANEL_CLASS } from "../ui/floating_surfaces";
 import {
   ActionButton,
+  Badge,
   CompactButton,
   CompactIconButton,
   ConversationBubble,
@@ -562,7 +563,7 @@ function PermissionReviewCard(props: PermissionReviewCardProps) {
     <div className={cardClassName} data-team-permission-card="true">
       <div className={TEAM_TASK_PERMISSION_CARD_HEADER_CLASS}>
         <span className={TEAM_TASK_PERMISSION_CARD_TITLE_CLASS}>{toolLabel}</span>
-        <span className={TEAM_TASK_PERMISSION_CARD_STATUS_CLASS}>{statusText}</span>
+        <Badge className={TEAM_TASK_PERMISSION_CARD_STATUS_CLASS}>{statusText}</Badge>
       </div>
       {!isPending && toolPreview && toolPreview !== toolLabel && (
         <div className={TEAM_TASK_PERMISSION_CARD_COMPACT_PREVIEW_CLASS}>{toolPreview}</div>
@@ -711,12 +712,14 @@ function SeenProgressHoverCard({
                 <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Read</div>
                 <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
                   {seenProgress.readActorIds.map((actorId) => (
-                    <span
+                    <Badge
                       key={`${itemKey}-read-${actorId}`}
-                      className="rounded-full border border-notion-border bg-white px-2 py-0.5"
+                      tone="outline"
+                      shape="pill"
+                      className="text-[11px]"
                     >
                       {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
-                    </span>
+                    </Badge>
                   ))}
                 </div>
               </div>
@@ -726,12 +729,14 @@ function SeenProgressHoverCard({
                 <div className={TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS}>Unread</div>
                 <div className={TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS}>
                   {seenProgress.unreadActorIds.map((actorId) => (
-                    <span
+                    <Badge
                       key={`${itemKey}-unread-${actorId}`}
-                      className="rounded-full border border-dashed border-notion-border bg-transparent px-2 py-0.5"
+                      tone="dashed"
+                      shape="pill"
+                      className="text-[11px]"
                     >
                       {resolveDisplayName(actorId, memberDisplayNamesById, actorId)}
-                    </span>
+                    </Badge>
                   ))}
                 </div>
               </div>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -16,11 +16,13 @@ import { isTeamImeComposing } from "./team/team_text_helpers";
 import { NOTION_FLOATING_PANEL_CLASS } from "../ui/floating_surfaces";
 import {
   ActionButton,
+  ConversationBubble,
   EmptyState,
   IconButton,
   InsetSurface,
   KeyValueItem,
   KeyValueList,
+  MenuOptionButton,
   SurfaceCard,
   ToolbarRow,
 } from "../ui/primitives";
@@ -43,8 +45,6 @@ import {
   TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_TEXTAREA_CLASS,
   TEAM_TASK_ACTIVITY_AUTHOR_CLASS,
-  TEAM_TASK_ACTIVITY_BUBBLE_AGENT_CLASS,
-  TEAM_TASK_ACTIVITY_BUBBLE_HUMAN_CLASS,
   TEAM_TASK_ACTIVITY_BODY_CLASS,
   TEAM_TASK_ACTIVITY_COMMAND_BODY_CLASS,
   TEAM_TASK_ACTIVITY_CONTENT_AGENT_CLASS,
@@ -180,12 +180,10 @@ const TEAM_TASK_ACTIVITY_SEEN_SECTION_TITLE_CLASS =
   "text-[9px] font-bold uppercase tracking-widest text-notion-text-muted";
 const TEAM_TASK_TAIL_WINDOW_SIZE = DEFAULT_TEAM_CONVERSATION_TAIL_WINDOW_SIZE;
 const TEAM_TASK_TAIL_WINDOW_ESTIMATED_ITEM_HEIGHT = 80;
-const TEAM_TASK_MENTION_OPTION_BUTTON_BASE_CLASS =
-  "flex w-full items-center justify-between px-3 py-1 text-left text-sm transition";
-const TEAM_TASK_MENTION_OPTION_BUTTON_ACTIVE_CLASS =
-  "bg-brand-primary/10 text-brand-primary";
-const TEAM_TASK_MENTION_OPTION_BUTTON_IDLE_CLASS =
-  "text-ui-text-primary hover:bg-ui-surface-soft";
+const TEAM_TASK_ACTIVITY_BUBBLE_HUMAN_TONE_CLASS =
+  "border-notion-accent/15 bg-notion-accent-bg/72";
+const TEAM_TASK_ACTIVITY_BUBBLE_AGENT_TONE_CLASS =
+  "border-notion-border-subtle bg-white";
 function getPermissionToneAudioContextConstructor(): PermissionToneAudioContextConstructor | null {
   if (typeof window === "undefined") {
     return null;
@@ -288,13 +286,13 @@ function resolveActivityContentClassName(
   }`;
 }
 
-function resolveActivityBubbleClassName(
+function resolveActivityBubbleToneClassName(
   actorId: string,
   humanActorId: string
 ): string {
   return isHumanMailboxActor(actorId, humanActorId)
-    ? TEAM_TASK_ACTIVITY_BUBBLE_HUMAN_CLASS
-    : TEAM_TASK_ACTIVITY_BUBBLE_AGENT_CLASS;
+    ? TEAM_TASK_ACTIVITY_BUBBLE_HUMAN_TONE_CLASS
+    : TEAM_TASK_ACTIVITY_BUBBLE_AGENT_TONE_CLASS;
 }
 
 function normalizeTrimmedString(value: unknown): string | null {
@@ -1324,23 +1322,23 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                       />
                     </div>
                   ) : isCompactCommandLikeText(item.text) ? (
-                    <div
+                    <ConversationBubble
                       data-team-channel-bubble={isHumanAuthor ? "human" : "agent"}
-                      className={resolveActivityBubbleClassName(item.fromActorId, humanActorId)}
+                      className={resolveActivityBubbleToneClassName(item.fromActorId, humanActorId)}
                     >
                       <pre className={TEAM_TASK_ACTIVITY_COMMAND_BODY_CLASS}>{item.text}</pre>
-                    </div>
+                    </ConversationBubble>
                   ) : (
-                    <div
+                    <ConversationBubble
                       data-team-channel-bubble={isHumanAuthor ? "human" : "agent"}
-                      className={resolveActivityBubbleClassName(item.fromActorId, humanActorId)}
+                      className={resolveActivityBubbleToneClassName(item.fromActorId, humanActorId)}
                     >
                       <TeamThreadRichText
                         className={TEAM_TASK_ACTIVITY_BODY_CLASS}
                         text={item.text}
                         renderSanitizedHtml={renderTeamMessageHtml}
                       />
-                    </div>
+                    </ConversationBubble>
                   )}
                   {developerMode && expandedItemKeys[item.key] && (
                     <ActivityDetailsPanel item={item} state={state} />
@@ -1463,20 +1461,16 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
           }}
         />
         {activeMention && filteredMentionCandidates.length > 0 && (
-          <div className="mt-2 rounded-lg border border-ui-border bg-ui-surface shadow-sm">
+          <SurfaceCard className="mt-2 overflow-hidden border-ui-border bg-ui-surface shadow-sm">
             <div className="px-3 py-1 text-xs text-ui-text-muted">
               Select teammate mention (`@` without selection stays plain text)
             </div>
             <div className="max-h-44 overflow-auto py-1">
               {filteredMentionCandidates.map((candidate, index) => (
-                <button
-                  type="button"
+                <MenuOptionButton
                   key={candidate.actorId}
-                  className={`${TEAM_TASK_MENTION_OPTION_BUTTON_BASE_CLASS} ${
-                    index === activeMentionIndex
-                      ? TEAM_TASK_MENTION_OPTION_BUTTON_ACTIVE_CLASS
-                      : TEAM_TASK_MENTION_OPTION_BUTTON_IDLE_CLASS
-                  }`}
+                  active={index === activeMentionIndex}
+                  data-team-mention-option={candidate.actorId}
                   onMouseDown={(event) => {
                     event.preventDefault();
                     applyMentionSelection(candidate);
@@ -1484,10 +1478,10 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                 >
                   <span>{candidate.label}</span>
                   <span className="text-[11px] text-ui-text-muted">{`@${candidate.label}`}</span>
-                </button>
+                </MenuOptionButton>
               ))}
             </div>
-          </div>
+          </SurfaceCard>
         )}
         <ToolbarRow className="mt-0.5 gap-2">
           <span className={TEAM_TASK_SHORTCUT_CLASS}>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -16,6 +16,8 @@ import { isTeamImeComposing } from "./team/team_text_helpers";
 import { NOTION_FLOATING_PANEL_CLASS } from "../ui/floating_surfaces";
 import {
   ActionButton,
+  CompactButton,
+  CompactIconButton,
   ConversationBubble,
   EmptyState,
   IconButton,
@@ -157,12 +159,8 @@ const TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS =
 const TEAM_TASK_ACTIVITY_HEADER_META_CLASS = "flex shrink-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_DETAILS_CLASS =
   "mt-3 p-3 sm:p-3";
-const TEAM_TASK_ACTIVITY_DETAILS_BUTTON_CLASS =
-  "inline-flex items-center rounded-md border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted transition hover:bg-notion-hover";
 const TEAM_TASK_PERMISSION_CARD_ERROR_CLASS =
   "text-[11px] font-medium text-red-600";
-const TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS =
-  "inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-notion-border bg-white p-0.5 text-[10px] font-medium text-notion-text-muted transition hover:bg-notion-hover";
 const TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS =
   "mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-notion-text-muted";
 const TEAM_TASK_ACTIVITY_DELIVERY_PENDING_CLASS =
@@ -665,18 +663,14 @@ function SeenProgressHoverCard({
     <HoverCard openDelay={120} closeDelay={80} position="top-end" shadow="md" radius="md">
       <HoverCard.Target>
         {seenActorIds.length === 0 ? (
-          <button
-            type="button"
-            className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
+          <CompactIconButton
             aria-label="Pending delivery"
             title="Pending delivery"
           >
             <span className={TEAM_TASK_ACTIVITY_DELIVERY_PENDING_CLASS} />
-          </button>
+          </CompactIconButton>
         ) : (
-          <button
-            type="button"
-            className={TEAM_TASK_ACTIVITY_SEEN_BUTTON_CLASS}
+          <CompactIconButton
             aria-label={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
             title={`Seen by ${seenProgress.readCount} of ${seenProgress.totalCount} recipients`}
           >
@@ -697,7 +691,7 @@ function SeenProgressHoverCard({
                 } satisfies SeenDialStyle
               }
             />
-          </button>
+          </CompactIconButton>
         )}
       </HoverCard.Target>
       <HoverCard.Dropdown className={TEAM_TASK_ACTIVITY_SEEN_CARD_CLASS}>
@@ -1294,9 +1288,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                           />
                         )}
                         {developerMode && (
-                          <button
-                            type="button"
-                            className={TEAM_TASK_ACTIVITY_DETAILS_BUTTON_CLASS}
+                          <CompactButton
                             onClick={() =>
                               setExpandedItemKeys((current) => ({
                                 ...current,
@@ -1306,7 +1298,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                             aria-expanded={Boolean(expandedItemKeys[item.key])}
                           >
                             {expandedItemKeys[item.key] ? "Hide details" : "Show details"}
-                          </button>
+                          </CompactButton>
                         )}
                       </div>
                     )}

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -22,7 +22,6 @@ import {
   ConversationBubble,
   EmptyState,
   IconButton,
-  InsetSurface,
   KeyValueItem,
   KeyValueList,
   MenuOptionButton,
@@ -158,7 +157,8 @@ const TEAM_TASK_ACTIVITY_HEADER_ROW_CLASS =
 const TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS =
   "flex min-w-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_HEADER_META_CLASS = "flex shrink-0 items-center gap-2";
-const TEAM_TASK_ACTIVITY_DETAILS_CLASS = "mt-3 p-3 sm:p-3";
+const TEAM_TASK_ACTIVITY_DETAILS_CLASS =
+  "mt-3 rounded-xl border border-notion-border bg-notion-sidebar/10 p-3";
 const TEAM_TASK_PERMISSION_CARD_ERROR_CLASS =
   "text-[11px] font-medium text-red-600";
 const TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS =
@@ -632,7 +632,7 @@ type ActivityDetailsPanelProps = {
 
 function ActivityDetailsPanel({ item, state }: ActivityDetailsPanelProps) {
   return (
-    <InsetSurface className={TEAM_TASK_ACTIVITY_DETAILS_CLASS}>
+    <div className={TEAM_TASK_ACTIVITY_DETAILS_CLASS}>
       <KeyValueList>
         <KeyValueItem label="source" value={item.streamLabel} />
         <KeyValueItem label="seq" value={item.sequence} />
@@ -649,7 +649,7 @@ function ActivityDetailsPanel({ item, state }: ActivityDetailsPanelProps) {
           </>
         ) : null}
       </KeyValueList>
-    </InsetSurface>
+    </div>
   );
 }
 
@@ -1454,7 +1454,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
           }}
         />
         {activeMention && filteredMentionCandidates.length > 0 && (
-          <SurfaceCard className="mt-2 overflow-hidden border-ui-border bg-ui-surface shadow-sm">
+          <div className="mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm">
             <div className="px-3 py-1 text-xs text-ui-text-muted">
               Select teammate mention (`@` without selection stays plain text)
             </div>
@@ -1474,7 +1474,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                 </MenuOptionButton>
               ))}
             </div>
-          </SurfaceCard>
+          </div>
         )}
         <ToolbarRow className="mt-0.5 gap-2">
           <span className={TEAM_TASK_SHORTCUT_CLASS}>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -159,7 +159,7 @@ const TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS =
   "flex min-w-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_HEADER_META_CLASS = "flex shrink-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_DETAILS_CLASS =
-  "mt-3 p-3";
+  "mt-3 p-3 sm:p-3";
 const TEAM_TASK_PERMISSION_CARD_ERROR_CLASS =
   "text-[11px] font-medium text-red-600";
 const TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS =

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -159,7 +159,7 @@ const TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS =
   "flex min-w-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_HEADER_META_CLASS = "flex shrink-0 items-center gap-2";
 const TEAM_TASK_ACTIVITY_DETAILS_CLASS =
-  "mt-3 p-3 sm:p-3";
+  "mt-3 p-3";
 const TEAM_TASK_PERMISSION_CARD_ERROR_CLASS =
   "text-[11px] font-medium text-red-600";
 const TEAM_TASK_ACTIVITY_SEEN_LIST_CLASS =
@@ -534,7 +534,7 @@ type SeenProgressHoverCardProps = {
   itemKey: string;
   seenActorIds: string[];
   seenProgress: SeenProgressState;
-  memberDisplayNamesById: Map<string, string>;
+  memberDisplayNamesById: Record<string, string>;
 };
 
 type ActivityDetailsPanelProps = {

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -67,7 +67,7 @@ const TASKS_BOARD_SCROLL_CLASS = "-mx-1 overflow-x-auto px-1 pb-4";
 const TASKS_BOARD_COLUMN_META_CLASS =
   "text-[10px] font-bold uppercase tracking-widest text-notion-text-muted";
 const TASKS_BOARD_STACK_CLASS = "mt-4 flex min-h-0 flex-1 flex-col gap-2";
-const TASKS_BOARD_EMPTY_CLASS = "bg-white/50 italic";
+const TASKS_BOARD_EMPTY_CLASS = "italic";
 const TASKS_BOARD_CARD_IDLE_CLASS = TASKS_BOARD_CARD_CLASS;
 const TASKS_BOARD_CARD_META_ROW_CLASS =
   "flex w-full items-center justify-between gap-2 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted opacity-70";

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -9,6 +9,8 @@ import type {
 import { StatusBadge, type StatusTone } from "../components/status_badge";
 import {
   ActionButton,
+  Badge,
+  EmptyState,
   SelectableListItem,
   ToolbarRow,
 } from "../ui/primitives";
@@ -65,8 +67,7 @@ const TASKS_BOARD_SCROLL_CLASS = "-mx-1 overflow-x-auto px-1 pb-4";
 const TASKS_BOARD_COLUMN_META_CLASS =
   "text-[10px] font-bold uppercase tracking-widest text-notion-text-muted";
 const TASKS_BOARD_STACK_CLASS = "mt-4 flex min-h-0 flex-1 flex-col gap-2";
-const TASKS_BOARD_EMPTY_CLASS =
-  "rounded-md border border-dashed border-notion-border bg-white/50 px-3 py-4 text-sm text-notion-text-muted italic text-center";
+const TASKS_BOARD_EMPTY_CLASS = "bg-white/50 italic";
 const TASKS_BOARD_CARD_IDLE_CLASS = TASKS_BOARD_CARD_CLASS;
 const TASKS_BOARD_CARD_META_ROW_CLASS =
   "flex w-full items-center justify-between gap-2 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted opacity-70";
@@ -324,9 +325,9 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
                       <h4 className="text-sm font-bold text-notion-text">
                         {column.label}
                       </h4>
-                      <span className="rounded-sm bg-notion-hover px-1.5 py-0.5 text-[10px] font-bold text-notion-text-muted">
+                      <Badge className="text-[10px]">
                         {laneTasks.length}
-                      </span>
+                      </Badge>
                     </div>
                     <p className={`mt-1 ${TASKS_BOARD_COLUMN_META_CLASS}`}>
                       {column.description}
@@ -342,19 +343,20 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
 
                 <div className={TASKS_BOARD_STACK_CLASS}>
                   {showInitialLoadingState && (
-                    <div className={TASKS_BOARD_EMPTY_CLASS}>Loading tasks...</div>
+                    <EmptyState title="Loading tasks..." className={TASKS_BOARD_EMPTY_CLASS} />
                   )}
                   {!showInitialLoadingState && tasks.length === 0 && (
-                    <div className={TASKS_BOARD_EMPTY_CLASS}>
-                      No tasks yet.
-                    </div>
+                    <EmptyState title="No tasks yet." className={TASKS_BOARD_EMPTY_CLASS} />
                   )}
                   {!showInitialLoadingState && tasks.length > 0 && laneTasks.length === 0 && (
-                    <div className={TASKS_BOARD_EMPTY_CLASS}>
-                      {statusFilter === "all"
-                        ? formatTaskEmptyLabel(column.status)
-                        : "No results."}
-                    </div>
+                    <EmptyState
+                      title={
+                        statusFilter === "all"
+                          ? formatTaskEmptyLabel(column.status)
+                          : "No results."
+                      }
+                      className={TASKS_BOARD_EMPTY_CLASS}
+                    />
                   )}
                   {!showInitialLoadingState &&
                     laneTasks.map((task) => (
@@ -528,9 +530,9 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
                   <div>
                     <p className="text-sm font-bold text-notion-text">Previous runs</p>
                   </div>
-                  <span className="rounded-sm bg-notion-hover px-1.5 py-0.5 text-[10px] font-bold text-notion-text-muted">
+                  <Badge className="text-[10px]">
                     {relatedRuns.length - 1}
-                  </span>
+                  </Badge>
                 </div>
                 <div className="mt-4 space-y-2">
                   {relatedRuns.slice(1, 4).map((run) => (

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -226,4 +226,20 @@ describe("ui primitives", () => {
     expect(outlineHtml).toContain("rounded-full px-2 py-0.5");
     expect(dashedHtml).toContain("border border-dashed border-notion-border bg-transparent");
   });
+
+  it("renders notice, menu, and empty-state fallback branches", () => {
+    const idleOptionHtml = renderHtml(<MenuOptionButton>Idle option</MenuOptionButton>);
+    const dangerNoticeHtml = renderHtml(
+      <InlineNotice tone="danger">Permission request failed.</InlineNotice>
+    );
+    const childEmptyStateHtml = renderHtml(
+      <EmptyState>
+        <span data-testid="empty-child">child</span>
+      </EmptyState>
+    );
+
+    expect(idleOptionHtml).toContain("text-ui-text-primary hover:bg-ui-surface-soft");
+    expect(dangerNoticeHtml).toContain("border-state-error-border bg-state-error-bg/60");
+    expect(childEmptyStateHtml).toContain('data-testid="empty-child"');
+  });
 });

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -171,6 +171,7 @@ describe("ui primitives", () => {
     );
 
     expect(subtleHtml).toContain("bg-notion-hover");
+    expect(subtleHtml).toContain("<span");
     expect(subtleHtml).toContain("Awaiting human review");
     expect(outlineHtml).toContain("border border-notion-border bg-white");
     expect(outlineHtml).toContain("rounded-full px-2 py-0.5");

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -4,6 +4,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   ActionButton,
+  CompactButton,
+  CompactIconButton,
   ConversationBubble,
   EmptyState,
   IconButton,
@@ -135,5 +137,21 @@ describe("ui primitives", () => {
     expect(bubbleHtml).toContain("Bubble");
     expect(optionHtml).toContain("bg-brand-primary/10 text-brand-primary");
     expect(optionHtml).toContain('data-testid="mention-worker"');
+  });
+
+  it("renders compact action primitives for dense toolbars", () => {
+    const compactButtonHtml = renderHtml(
+      <CompactButton data-testid="details-toggle">Show details</CompactButton>
+    );
+    const compactIconHtml = renderHtml(
+      <CompactIconButton aria-label="Seen by 1 recipient">
+        <span />
+      </CompactIconButton>
+    );
+
+    expect(compactButtonHtml).toContain("text-[10px] font-bold uppercase tracking-wider");
+    expect(compactButtonHtml).toContain('data-testid="details-toggle"');
+    expect(compactIconHtml).toContain("h-5 min-w-5 items-center justify-center");
+    expect(compactIconHtml).toContain('aria-label="Seen by 1 recipient"');
   });
 });

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -119,6 +119,9 @@ describe("ui primitives", () => {
     expect(emptyHtml).toContain("No messages yet");
     expect(emptyHtml).toContain("Start the conversation from the channel composer.");
     expect(metadataHtml).toContain("grid-cols-[auto,minmax(0,1fr)]");
+    expect(metadataHtml).toContain("<dl");
+    expect(metadataHtml).toContain("<dt");
+    expect(metadataHtml).toContain("<dd");
     expect(metadataHtml).toContain('data-testid="meta-source"');
     expect(metadataHtml).toContain("leader-agent");
     expect(metadataHtml).toContain("mono");
@@ -134,7 +137,7 @@ describe("ui primitives", () => {
       </MenuOptionButton>
     );
 
-    expect(bubbleHtml).toContain("rounded-[18px] border px-3.5 py-2.25 shadow-notion-soft");
+    expect(bubbleHtml).toContain("rounded-[18px] border px-3.5 py-2.5 shadow-notion-soft");
     expect(bubbleHtml).toContain("Bubble");
     expect(optionHtml).toContain("bg-brand-primary/10 text-brand-primary");
     expect(optionHtml).toContain('data-testid="mention-worker"');

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   ActionButton,
+  Badge,
   CompactButton,
   CompactIconButton,
   ConversationBubble,
@@ -153,5 +154,23 @@ describe("ui primitives", () => {
     expect(compactButtonHtml).toContain('data-testid="details-toggle"');
     expect(compactIconHtml).toContain("h-5 min-w-5 items-center justify-center");
     expect(compactIconHtml).toContain('aria-label="Seen by 1 recipient"');
+  });
+
+  it("renders badge variants for compact status and recipient chips", () => {
+    const subtleHtml = renderHtml(
+      <Badge className="text-[10px] uppercase tracking-wider">Awaiting human review</Badge>
+    );
+    const outlineHtml = renderHtml(
+      <Badge tone="outline" shape="pill">Worker Agent</Badge>
+    );
+    const dashedHtml = renderHtml(
+      <Badge tone="dashed" shape="pill">Leader Agent</Badge>
+    );
+
+    expect(subtleHtml).toContain("bg-notion-hover");
+    expect(subtleHtml).toContain("Awaiting human review");
+    expect(outlineHtml).toContain("border border-notion-border bg-white");
+    expect(outlineHtml).toContain("rounded-full px-2 py-0.5");
+    expect(dashedHtml).toContain("border border-dashed border-notion-border bg-transparent");
   });
 });

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -4,11 +4,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   ActionButton,
+  ConversationBubble,
   EmptyState,
   IconButton,
   InsetSurface,
   KeyValueItem,
   KeyValueList,
+  MenuOptionButton,
   PanelHeader,
   SelectableListItem,
   StatusPill,
@@ -117,5 +119,21 @@ describe("ui primitives", () => {
     expect(metadataHtml).toContain('data-testid="meta-source"');
     expect(metadataHtml).toContain("leader-agent");
     expect(metadataHtml).toContain("mono");
+  });
+
+  it("renders conversation bubbles and compact menu option buttons", () => {
+    const bubbleHtml = renderHtml(
+      <ConversationBubble className="border-notion-border-subtle bg-white">Bubble</ConversationBubble>
+    );
+    const optionHtml = renderHtml(
+      <MenuOptionButton active data-testid="mention-worker">
+        Worker
+      </MenuOptionButton>
+    );
+
+    expect(bubbleHtml).toContain("rounded-[18px] border px-3.5 py-2.25 shadow-notion-soft");
+    expect(bubbleHtml).toContain("Bubble");
+    expect(optionHtml).toContain("bg-brand-primary/10 text-brand-primary");
+    expect(optionHtml).toContain('data-testid="mention-worker"');
   });
 });

--- a/web/src/ui/primitives.test.tsx
+++ b/web/src/ui/primitives.test.tsx
@@ -4,8 +4,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   ActionButton,
+  EmptyState,
   IconButton,
   InsetSurface,
+  KeyValueItem,
+  KeyValueList,
   PanelHeader,
   SelectableListItem,
   StatusPill,
@@ -94,5 +97,25 @@ describe("ui primitives", () => {
     expect(activeHtml).not.toContain("mantine-UnstyledButton-root");
     expect(idleHtml).not.toContain("ring-1 ring-notion-accent/30");
     expect(activeHtml).toContain('type="button"');
+  });
+
+  it("renders empty states and key/value metadata primitives", () => {
+    const emptyHtml = renderHtml(
+      <EmptyState title="No messages yet" body="Start the conversation from the channel composer." />
+    );
+    const metadataHtml = renderHtml(
+      <KeyValueList>
+        <KeyValueItem label="source" value="group_chat" data-testid="meta-source" />
+        <KeyValueItem label="from" value="leader-agent" valueClassName="mono" />
+      </KeyValueList>
+    );
+
+    expect(emptyHtml).toContain("border-dashed border-notion-border/80");
+    expect(emptyHtml).toContain("No messages yet");
+    expect(emptyHtml).toContain("Start the conversation from the channel composer.");
+    expect(metadataHtml).toContain("grid-cols-[auto,minmax(0,1fr)]");
+    expect(metadataHtml).toContain('data-testid="meta-source"');
+    expect(metadataHtml).toContain("leader-agent");
+    expect(metadataHtml).toContain("mono");
   });
 });

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -241,7 +241,7 @@ export function StatusPill({ className, ...props }: StatusPillProps) {
   return <span className={cx(STATUS_PILL_BASE_CLASS, className)} {...props} />;
 }
 
-type BadgeProps = React.ComponentPropsWithoutRef<typeof Box> & {
+type BadgeProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, "component"> & {
   tone?: keyof typeof BADGE_TONE_CLASS;
   shape?: keyof typeof BADGE_SHAPE_CLASS;
 };
@@ -347,7 +347,7 @@ export function InlineNotice({ tone = "info", className, ...props }: InlineNotic
   );
 }
 
-type KeyValueListProps = React.ComponentPropsWithoutRef<typeof Box>;
+type KeyValueListProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, "component">;
 
 export function KeyValueList({ className, ...props }: KeyValueListProps) {
   return <Box component="dl" className={cx(KEY_VALUE_LIST_BASE_CLASS, className)} {...props} />;

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -252,6 +252,7 @@ export function Badge({
 }: BadgeProps) {
   return (
     <Box
+      component="span"
       className={cx(BADGE_BASE_CLASS, BADGE_TONE_CLASS[tone], BADGE_SHAPE_CLASS[shape], className)}
       {...props}
     />

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -62,6 +62,17 @@ const ICON_BUTTON_TONE_CLASS = {
 
 const STATUS_PILL_BASE_CLASS =
   "inline-flex shrink-0 items-center rounded-full border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted";
+const EMPTY_STATE_BASE_CLASS =
+  "rounded-xl border border-dashed border-notion-border/80 bg-notion-sidebar/10 px-4 py-5 text-center";
+const EMPTY_STATE_TITLE_CLASS = "text-sm font-semibold text-notion-text";
+const EMPTY_STATE_BODY_CLASS = "mt-1 text-[13px] leading-relaxed text-notion-text-muted";
+const KEY_VALUE_LIST_BASE_CLASS =
+  "grid grid-cols-[auto,minmax(0,1fr)] items-start gap-x-3 gap-y-1.5";
+const KEY_VALUE_ITEM_BASE_CLASS = "contents";
+const KEY_VALUE_LABEL_CLASS =
+  "mono text-[11px] font-bold uppercase tracking-wide text-notion-text opacity-70";
+const KEY_VALUE_VALUE_CLASS =
+  "min-w-0 break-words text-[11px] leading-relaxed text-notion-text-muted";
 
 type SurfaceCardProps = React.ComponentPropsWithoutRef<typeof Box>;
 
@@ -206,4 +217,52 @@ type StatusPillProps = React.HTMLAttributes<HTMLSpanElement>;
 
 export function StatusPill({ className, ...props }: StatusPillProps) {
   return <span className={cx(STATUS_PILL_BASE_CLASS, className)} {...props} />;
+}
+
+type EmptyStateProps = React.ComponentPropsWithoutRef<typeof Box> & {
+  title?: React.ReactNode;
+  body?: React.ReactNode;
+};
+
+export function EmptyState({ title, body, className, children, ...props }: EmptyStateProps) {
+  return (
+    <Box className={cx(EMPTY_STATE_BASE_CLASS, className)} {...props}>
+      {title ? <Box className={EMPTY_STATE_TITLE_CLASS}>{title}</Box> : null}
+      {body ? <Box className={EMPTY_STATE_BODY_CLASS}>{body}</Box> : null}
+      {children}
+    </Box>
+  );
+}
+
+type KeyValueListProps = React.ComponentPropsWithoutRef<typeof Box>;
+
+export function KeyValueList({ className, ...props }: KeyValueListProps) {
+  return <Box className={cx(KEY_VALUE_LIST_BASE_CLASS, className)} {...props} />;
+}
+
+type KeyValueItemProps = {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  labelClassName?: string;
+  valueClassName?: string;
+} & Omit<React.ComponentPropsWithoutRef<typeof Box>, "children">;
+
+export function KeyValueItem({
+  label,
+  value,
+  className,
+  labelClassName,
+  valueClassName,
+  ...props
+}: KeyValueItemProps) {
+  return (
+    <Box className={cx(KEY_VALUE_ITEM_BASE_CLASS, className)} {...props}>
+      <Box component="span" className={cx(KEY_VALUE_LABEL_CLASS, labelClassName)}>
+        {label}
+      </Box>
+      <Box component="span" className={cx(KEY_VALUE_VALUE_CLASS, valueClassName)}>
+        {value}
+      </Box>
+    </Box>
+  );
 }

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -62,6 +62,12 @@ const ICON_BUTTON_TONE_CLASS = {
 
 const STATUS_PILL_BASE_CLASS =
   "inline-flex shrink-0 items-center rounded-full border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted";
+const CONVERSATION_BUBBLE_BASE_CLASS =
+  "mt-1 min-w-0 max-w-full overflow-hidden rounded-[18px] border px-3.5 py-2.25 shadow-notion-soft";
+const MENU_OPTION_BUTTON_BASE_CLASS =
+  "flex w-full items-center justify-between px-3 py-1 text-left text-sm transition";
+const MENU_OPTION_BUTTON_ACTIVE_CLASS = "bg-brand-primary/10 text-brand-primary";
+const MENU_OPTION_BUTTON_IDLE_CLASS = "text-ui-text-primary hover:bg-ui-surface-soft";
 const EMPTY_STATE_BASE_CLASS =
   "rounded-xl border border-dashed border-notion-border/80 bg-notion-sidebar/10 px-4 py-5 text-center";
 const EMPTY_STATE_TITLE_CLASS = "text-sm font-semibold text-notion-text";
@@ -218,6 +224,35 @@ type StatusPillProps = React.HTMLAttributes<HTMLSpanElement>;
 export function StatusPill({ className, ...props }: StatusPillProps) {
   return <span className={cx(STATUS_PILL_BASE_CLASS, className)} {...props} />;
 }
+
+type ConversationBubbleProps = React.ComponentPropsWithoutRef<typeof Box>;
+
+export function ConversationBubble({ className, ...props }: ConversationBubbleProps) {
+  return <Box className={cx(CONVERSATION_BUBBLE_BASE_CLASS, className)} {...props} />;
+}
+
+type MenuOptionButtonProps = React.ComponentPropsWithoutRef<"button"> & {
+  active?: boolean;
+};
+
+export const MenuOptionButton = React.forwardRef<HTMLButtonElement, MenuOptionButtonProps>(
+  function MenuOptionButton({ active = false, className, type = "button", ...props }, ref) {
+    return (
+      <Box
+        ref={ref}
+        component="button"
+        type={type}
+        className={cx(
+          MENU_OPTION_BUTTON_BASE_CLASS,
+          active ? MENU_OPTION_BUTTON_ACTIVE_CLASS : MENU_OPTION_BUTTON_IDLE_CLASS,
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+MenuOptionButton.displayName = "MenuOptionButton";
 
 type EmptyStateProps = React.ComponentPropsWithoutRef<typeof Box> & {
   title?: React.ReactNode;

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -68,6 +68,10 @@ const MENU_OPTION_BUTTON_BASE_CLASS =
   "flex w-full items-center justify-between px-3 py-1 text-left text-sm transition";
 const MENU_OPTION_BUTTON_ACTIVE_CLASS = "bg-brand-primary/10 text-brand-primary";
 const MENU_OPTION_BUTTON_IDLE_CLASS = "text-ui-text-primary hover:bg-ui-surface-soft";
+const COMPACT_BUTTON_BASE_CLASS =
+  "inline-flex items-center rounded-md border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted transition hover:bg-notion-hover active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50";
+const COMPACT_ICON_BUTTON_BASE_CLASS =
+  "inline-flex h-5 min-w-5 items-center justify-center rounded-md border border-notion-border bg-white p-0.5 text-[10px] font-medium text-notion-text-muted transition hover:bg-notion-hover active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50";
 const EMPTY_STATE_BASE_CLASS =
   "rounded-xl border border-dashed border-notion-border/80 bg-notion-sidebar/10 px-4 py-5 text-center";
 const EMPTY_STATE_TITLE_CLASS = "text-sm font-semibold text-notion-text";
@@ -253,6 +257,40 @@ export const MenuOptionButton = React.forwardRef<HTMLButtonElement, MenuOptionBu
   }
 );
 MenuOptionButton.displayName = "MenuOptionButton";
+
+type CompactButtonProps = React.ComponentPropsWithoutRef<"button">;
+
+export const CompactButton = React.forwardRef<HTMLButtonElement, CompactButtonProps>(
+  function CompactButton({ className, type = "button", ...props }, ref) {
+    return (
+      <Box
+        ref={ref}
+        component="button"
+        type={type}
+        className={cx(COMPACT_BUTTON_BASE_CLASS, className)}
+        {...props}
+      />
+    );
+  }
+);
+CompactButton.displayName = "CompactButton";
+
+type CompactIconButtonProps = React.ComponentPropsWithoutRef<"button">;
+
+export const CompactIconButton = React.forwardRef<HTMLButtonElement, CompactIconButtonProps>(
+  function CompactIconButton({ className, type = "button", ...props }, ref) {
+    return (
+      <Box
+        ref={ref}
+        component="button"
+        type={type}
+        className={cx(COMPACT_ICON_BUTTON_BASE_CLASS, className)}
+        {...props}
+      />
+    );
+  }
+);
+CompactIconButton.displayName = "CompactIconButton";
 
 type EmptyStateProps = React.ComponentPropsWithoutRef<typeof Box> & {
   title?: React.ReactNode;

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -73,7 +73,7 @@ const BADGE_SHAPE_CLASS = {
   pill: "rounded-full px-2 py-0.5",
 } as const;
 const CONVERSATION_BUBBLE_BASE_CLASS =
-  "mt-1 min-w-0 max-w-full overflow-hidden rounded-[18px] border px-3.5 py-2.25 shadow-notion-soft";
+  "mt-1 min-w-0 max-w-full overflow-hidden rounded-[18px] border px-3.5 py-2.5 shadow-notion-soft";
 const MENU_OPTION_BUTTON_BASE_CLASS =
   "flex w-full items-center justify-between px-3 py-1 text-left text-sm transition";
 const MENU_OPTION_BUTTON_ACTIVE_CLASS = "bg-brand-primary/10 text-brand-primary";
@@ -339,7 +339,7 @@ export function EmptyState({ title, body, className, children, ...props }: Empty
 type KeyValueListProps = React.ComponentPropsWithoutRef<typeof Box>;
 
 export function KeyValueList({ className, ...props }: KeyValueListProps) {
-  return <Box className={cx(KEY_VALUE_LIST_BASE_CLASS, className)} {...props} />;
+  return <Box component="dl" className={cx(KEY_VALUE_LIST_BASE_CLASS, className)} {...props} />;
 }
 
 type KeyValueItemProps = {
@@ -359,10 +359,10 @@ export function KeyValueItem({
 }: KeyValueItemProps) {
   return (
     <Box className={cx(KEY_VALUE_ITEM_BASE_CLASS, className)} {...props}>
-      <Box component="span" className={cx(KEY_VALUE_LABEL_CLASS, labelClassName)}>
+      <Box component="dt" className={cx(KEY_VALUE_LABEL_CLASS, labelClassName)}>
         {label}
       </Box>
-      <Box component="span" className={cx(KEY_VALUE_VALUE_CLASS, valueClassName)}>
+      <Box component="dd" className={cx(KEY_VALUE_VALUE_CLASS, valueClassName)}>
         {value}
       </Box>
     </Box>

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -62,6 +62,16 @@ const ICON_BUTTON_TONE_CLASS = {
 
 const STATUS_PILL_BASE_CLASS =
   "inline-flex shrink-0 items-center rounded-full border border-notion-border bg-white px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted";
+const BADGE_BASE_CLASS = "inline-flex items-center font-bold text-notion-text-muted";
+const BADGE_TONE_CLASS = {
+  subtle: "bg-notion-hover",
+  outline: "border border-notion-border bg-white",
+  dashed: "border border-dashed border-notion-border bg-transparent",
+} as const;
+const BADGE_SHAPE_CLASS = {
+  tag: "rounded-sm px-1.5 py-0.5",
+  pill: "rounded-full px-2 py-0.5",
+} as const;
 const CONVERSATION_BUBBLE_BASE_CLASS =
   "mt-1 min-w-0 max-w-full overflow-hidden rounded-[18px] border px-3.5 py-2.25 shadow-notion-soft";
 const MENU_OPTION_BUTTON_BASE_CLASS =
@@ -227,6 +237,25 @@ type StatusPillProps = React.HTMLAttributes<HTMLSpanElement>;
 
 export function StatusPill({ className, ...props }: StatusPillProps) {
   return <span className={cx(STATUS_PILL_BASE_CLASS, className)} {...props} />;
+}
+
+type BadgeProps = React.ComponentPropsWithoutRef<typeof Box> & {
+  tone?: keyof typeof BADGE_TONE_CLASS;
+  shape?: keyof typeof BADGE_SHAPE_CLASS;
+};
+
+export function Badge({
+  tone = "subtle",
+  shape = "tag",
+  className,
+  ...props
+}: BadgeProps) {
+  return (
+    <Box
+      className={cx(BADGE_BASE_CLASS, BADGE_TONE_CLASS[tone], BADGE_SHAPE_CLASS[shape], className)}
+      {...props}
+    />
+  );
 }
 
 type ConversationBubbleProps = React.ComponentPropsWithoutRef<typeof Box>;

--- a/web/src/ui/primitives.tsx
+++ b/web/src/ui/primitives.tsx
@@ -358,7 +358,7 @@ type KeyValueItemProps = {
   value: React.ReactNode;
   labelClassName?: string;
   valueClassName?: string;
-} & Omit<React.ComponentPropsWithoutRef<typeof Box>, "children">;
+} & Omit<React.ComponentPropsWithoutRef<typeof Box>, "children" | "component">;
 
 export function KeyValueItem({
   label,

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -324,7 +324,7 @@ export const TEAM_TASK_PERMISSION_CARD_TITLE_CLASS =
   "text-[13px] font-bold tracking-tight text-notion-text";
 
 export const TEAM_TASK_PERMISSION_CARD_STATUS_CLASS =
-  "inline-flex items-center rounded-sm bg-notion-hover px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-text-muted";
+  "text-[10px] uppercase tracking-wider";
 
 export const TEAM_TASK_PERMISSION_CARD_COMPACT_PREVIEW_CLASS =
   "mono mt-1 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-[10px] text-notion-text-muted opacity-70";


### PR DESCRIPTION
## Summary

- continue consolidating Team frontend surfaces onto shared UI primitives
- migrate more of `TeamTaskPanel` and `TeamTasksPanel` onto reusable Mantine + Tailwind primitives instead of local one-off shells
- document both primitive follow-ups in the dated frontend journal

## What Changed

- extend `web/src/ui/primitives.tsx` with:
  - `EmptyState`
  - `KeyValueList`
  - `KeyValueItem`
  - `ConversationBubble`
  - `MenuOptionButton`
  - `CompactButton`
  - `CompactIconButton`
  - `Badge`
- refactor `web/src/pages/team_task_panel.tsx` to use shared primitives for:
  - loading / empty states
  - developer-mode message details metadata
  - chat + command bubble shells
  - mention suggestion rows
  - dense message meta controls
  - permission status and seen-state recipient chips
- refactor `web/src/pages/team_tasks_panel.tsx` to use shared primitives for:
  - lane count badges
  - previous-run count badges
  - board loading / empty / no-result states
- add/update focused regression coverage in:
  - `web/src/ui/primitives.test.tsx`
  - `web/src/pages/team_panels.test.tsx`
- record the primitive follow-up in:
  - `docs/journal/2026-04-11-team-task-panel-primitives.md`
  - `docs/journal/2026-04-12-team-tasks-panel-primitives.md`

## Validation

- `cd web && npm run test -- src/ui/primitives.test.tsx src/pages/team_panels.test.tsx`
- `cd web && npm run lint -- src/ui/primitives.tsx src/ui/primitives.test.tsx src/ui/tailwind_classes.ts src/pages/team_task_panel.tsx src/pages/team_tasks_panel.tsx src/pages/team_panels.test.tsx`
- `cd web && npm run build`

## Notes

- Chrome DevTools MCP baseline was attempted before edits, but the local `chrome-devtools` transport closed before a usable page session could be established.
