### PR TITLE
fix(team): align runtime event handle naming

### DIFF
--- a/docs/journal/2026-04-12-team-runtime-event-handle-naming.md
+++ b/docs/journal/2026-04-12-team-runtime-event-handle-naming.md
@@ -1,0 +1,45 @@
+# Team Runtime Event Handle Naming
+
+## Goal
+
+Continue the Team execution-vocabulary cleanup on the Rust backend without widening scope into a
+schema or API migration.
+
+## Why
+
+The compatibility rollout already made `runtime_handle_id` the preferred Team step field name in
+Rust and web surfaces, but Team run events still emitted mixed payload names:
+
+- `step_working` / `step_resumed` included both `runtime_handle_id` and legacy
+  `remote_task_id`;
+- `continuity_state_updated` still exposed `source_session_id` even when the value represented the
+  Team step runtime handle.
+
+That kept runtime/debug events semantically noisy and pulled execution telemetry away from the
+canonical vocabulary in `docs/features/team-execution-vocabulary.md`.
+
+## Change
+
+- Added a shared helper in `src/team/manager.rs` for step runtime-handle event payloads.
+- Added a shared helper for continuity-state event payloads.
+- `step_working` and `step_resumed` now emit only `runtime_handle_id`.
+- `continuity_state_updated` now emits `source_runtime_handle_id` instead of
+  `source_session_id`.
+- Kept the SQLite column name (`team_steps.remote_task_id`) and continuity-state record field
+  (`source_session_id`) unchanged for compatibility in this change.
+
+## Validation
+
+Focused regression coverage should verify:
+
+- `step_working` payload keeps `runtime_handle_id` and omits `remote_task_id`;
+- `step_resumed` payload keeps `runtime_handle_id` and omits `remote_task_id`;
+- `continuity_state_updated` payload keeps `source_runtime_handle_id` and omits
+  `source_session_id`.
+
+Recommended commands:
+
+```bash
+cargo test -q complete_step_offloads_large_output_to_workspace_context_artifact --lib
+cargo test -q input_required_and_resume_transitions_update_run_and_emit_events --lib
+```

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -89,6 +89,34 @@ fn is_row_not_found(err: &anyhow::Error) -> bool {
     )
 }
 
+fn build_step_runtime_handle_event_payload(step: &TeamStepRecord, status: &'static str) -> Value {
+    serde_json::json!({
+        "step_id": step.id,
+        "step_key": step.step_key,
+        "status": status,
+        "runtime_handle_id": step.runtime_handle_id,
+    })
+}
+
+fn build_continuity_event_payload(
+    continuity_state: &TeamMemberContinuityStateRecord,
+    step: &TeamStepRecord,
+    continuity_mode: &str,
+    artifact_offload_status: &str,
+) -> Value {
+    serde_json::json!({
+        "team_id": continuity_state.team_id,
+        "member_id": continuity_state.member_id,
+        "step_id": step.id,
+        "step_key": step.step_key,
+        "mode": continuity_mode,
+        "source_run_id": continuity_state.source_run_id,
+        "source_runtime_handle_id": continuity_state.source_session_id,
+        "summary_chars": continuity_state.summary_text.chars().count(),
+        "artifact_offload_status": artifact_offload_status,
+    })
+}
+
 #[derive(Debug, thiserror::Error)]
 enum TaskConversationMessageStoreError {
     #[error("idempotency_key conflicts with an existing task conversation message payload")]
@@ -2045,13 +2073,7 @@ impl TeamManager {
                 .await?;
             }
 
-            let step_payload = serde_json::json!({
-                "step_id": step.id,
-                "step_key": step.step_key,
-                "status": "working",
-                "runtime_handle_id": step.runtime_handle_id,
-                "remote_task_id": step.runtime_handle_id,
-            });
+            let step_payload = build_step_runtime_handle_event_payload(&step, "working");
             sqlx::query(
                 r#"
                 INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
@@ -2263,13 +2285,7 @@ impl TeamManager {
                 .await?;
             }
 
-            let step_payload = serde_json::json!({
-                "step_id": step.id,
-                "step_key": step.step_key,
-                "status": "working",
-                "runtime_handle_id": step.runtime_handle_id,
-                "remote_task_id": step.runtime_handle_id,
-            });
+            let step_payload = build_step_runtime_handle_event_payload(&step, "working");
             sqlx::query(
                 r#"
                 INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
@@ -2435,17 +2451,12 @@ impl TeamManager {
             };
             Self::upsert_member_continuity_state_tx(&mut tx, &continuity_state).await?;
 
-            let mut continuity_payload = serde_json::json!({
-                "team_id": continuity_state.team_id,
-                "member_id": continuity_state.member_id,
-                "step_id": step.id,
-                "step_key": step.step_key,
-                "mode": continuity_mode,
-                "source_run_id": continuity_state.source_run_id,
-                "source_session_id": continuity_state.source_session_id,
-                "summary_chars": continuity_state.summary_text.chars().count(),
-                "artifact_offload_status": artifact_offload_status,
-            });
+            let mut continuity_payload = build_continuity_event_payload(
+                &continuity_state,
+                &step,
+                &continuity_mode,
+                artifact_offload_status,
+            );
             if let Some(payload_obj) = continuity_payload.as_object_mut() {
                 if let Some(pointer_payload) = artifact_pointer_for_event {
                     payload_obj.insert("artifact_pointer".to_string(), pointer_payload);

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1424,7 +1424,10 @@ async fn linked_run_sync_preserves_waiting_tasks() {
         )
         .await
         .expect("create linked run");
-    let after_create = manager.get_task(&task.id).await.expect("reload after create");
+    let after_create = manager
+        .get_task(&task.id)
+        .await
+        .expect("reload after create");
     assert_eq!(after_create.status, TeamTaskStatus::Waiting);
 
     let step = manager
@@ -1897,6 +1900,18 @@ async fn step_lifecycle_transitions_persist_and_emit_events() {
         .list_run_events(&run.id, 100, None)
         .await
         .expect("list run events");
+    let step_working_event = events
+        .iter()
+        .find(|event| event.event_type == "step_working")
+        .expect("step_working event should exist");
+    assert_eq!(
+        step_working_event.payload["runtime_handle_id"],
+        json!("remote-task-1")
+    );
+    assert!(
+        step_working_event.payload.get("remote_task_id").is_none(),
+        "step_working payload should not expose legacy remote_task_id"
+    );
     let event_types: Vec<&str> = events
         .iter()
         .map(|event| event.event_type.as_str())
@@ -2043,6 +2058,14 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
         .iter()
         .find(|event| event.event_type == "continuity_state_updated")
         .expect("continuity_state_updated event should exist");
+    assert_eq!(
+        continuity_event.payload["source_runtime_handle_id"],
+        json!("remote-task-artifact")
+    );
+    assert!(
+        continuity_event.payload.get("source_session_id").is_none(),
+        "continuity_state_updated should not expose legacy source_session_id"
+    );
     assert_eq!(
         continuity_event.payload["artifact_offload_status"],
         json!("persisted")
@@ -2474,6 +2497,32 @@ async fn input_required_and_resume_transitions_update_run_and_emit_events() {
         .list_run_events(&run.id, 100, None)
         .await
         .expect("list run events");
+    let step_resumed_event = events
+        .iter()
+        .find(|event| event.event_type == "step_resumed")
+        .expect("step_resumed event should exist");
+    assert_eq!(
+        step_resumed_event.payload["runtime_handle_id"],
+        json!("remote-task-input")
+    );
+    assert!(
+        step_resumed_event.payload.get("remote_task_id").is_none(),
+        "step_resumed payload should not expose legacy remote_task_id"
+    );
+
+    let continuity_event = events
+        .iter()
+        .find(|event| event.event_type == "continuity_state_updated")
+        .expect("continuity_state_updated event should exist");
+    assert_eq!(
+        continuity_event.payload["source_runtime_handle_id"],
+        json!("remote-task-input")
+    );
+    assert!(
+        continuity_event.payload.get("source_session_id").is_none(),
+        "continuity_state_updated should not expose legacy source_session_id"
+    );
+
     let event_types: Vec<&str> = events
         .iter()
         .map(|event| event.event_type.as_str())


### PR DESCRIPTION
## Summary

- align Team runtime event payloads on the canonical `runtime_handle_id` naming
- stop emitting legacy `remote_task_id` and `source_session_id` keys in Team run events
- add focused regression coverage for step and continuity event payload naming

## Why

`runtime_handle_id` is already the preferred Team step field name across the Rust/web compatibility rollout, but Team run events still exposed mixed legacy names. That kept runtime/debug surfaces semantically noisy and drifted away from the execution vocabulary contract.

This change keeps schema and API compatibility intact by limiting the cleanup to runtime event payloads and tests.

## Testing

- `cargo fmt --all`
- `cargo test -q complete_step_offloads_large_output_to_workspace_context_artifact --lib`
- `cargo test -q input_required_and_resume_transitions_update_run_and_emit_events --lib`

## Docs

- added `docs/journal/2026-04-12-team-runtime-event-handle-naming.md`
