### PR TITLE
fix(acp): upgrade codex rust deps to v120

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,12 +413,14 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-arg0",
+ "codex-config",
  "codex-core",
  "codex-exec-server",
  "codex-features",
  "codex-feedback",
  "codex-login",
  "codex-mcp-server",
+ "codex-models-manager",
  "codex-protocol",
  "codex-shell-command",
  "codex-utils-approval-presets",
@@ -811,21 +813,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "assert_cmd"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
 ]
 
 [[package]]
@@ -1334,7 +1321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde",
 ]
 
@@ -1681,15 +1667,17 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
  "codex-login",
  "codex-plugin",
  "codex-protocol",
+ "os_info",
  "serde",
+ "serde_json",
  "sha1",
  "tokio",
  "tracing",
@@ -1697,11 +1685,13 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
+ "chrono",
  "codex-client",
  "codex-protocol",
  "codex-utils-rustls-provider",
@@ -1709,6 +1699,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "regex-lite",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1722,8 +1713,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,11 +1722,13 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "codex-analytics",
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-backend-client",
  "codex-chatgpt",
  "codex-cloud-requirements",
+ "codex-config",
  "codex-core",
  "codex-exec-server",
  "codex-features",
@@ -1743,9 +1736,12 @@ dependencies = [
  "codex-file-search",
  "codex-git-utils",
  "codex-login",
+ "codex-mcp",
+ "codex-models-manager",
  "codex-otel",
  "codex-protocol",
  "codex-rmcp-client",
+ "codex-rollout",
  "codex-sandboxing",
  "codex-shell-command",
  "codex-state",
@@ -1754,8 +1750,10 @@ dependencies = [
  "codex-utils-cli",
  "codex-utils-json-to-toml",
  "codex-utils-pty",
+ "codex-utils-rustls-provider",
  "constant_time_eq 0.3.1",
  "futures",
+ "gethostname",
  "hmac 0.12.1",
  "jsonwebtoken",
  "owo-colors",
@@ -1770,20 +1768,23 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-core",
+ "codex-exec-server",
  "codex-feedback",
  "codex-protocol",
+ "codex-utils-rustls-provider",
  "futures",
  "serde",
  "serde_json",
@@ -1796,14 +1797,15 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "clap",
  "codex-experimental-api-macros",
  "codex-git-utils",
  "codex-protocol",
+ "codex-shell-command",
  "codex-utils-absolute-path",
  "inventory",
  "rmcp",
@@ -1811,7 +1813,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shlex",
  "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "tracing",
@@ -1821,26 +1822,31 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
+ "codex-exec-server",
+ "codex-utils-absolute-path",
  "similar",
  "thiserror 2.0.18",
+ "tokio",
  "tree-sitter",
  "tree-sitter-bash",
 ]
 
 [[package]]
 name = "codex-arg0"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
+ "codex-exec-server",
  "codex-linux-sandbox",
  "codex-sandboxing",
  "codex-shell-escalation",
+ "codex-utils-absolute-path",
  "codex-utils-home-dir",
  "dotenvy",
  "tempfile",
@@ -1849,8 +1855,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1859,13 +1865,13 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "codex-backend-openapi-models",
  "codex-client",
- "codex-core",
+ "codex-login",
  "codex-protocol",
  "reqwest 0.12.28",
  "serde",
@@ -1874,8 +1880,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1884,26 +1890,25 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "clap",
+ "codex-config",
  "codex-connectors",
  "codex-core",
  "codex-git-utils",
  "codex-login",
- "codex-utils-cargo-bin",
  "codex-utils-cli",
  "serde",
- "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "codex-client"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1928,14 +1933,16 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
  "codex-backend-client",
+ "codex-config",
  "codex-core",
+ "codex-login",
  "codex-otel",
  "codex-protocol",
  "hmac 0.12.1",
@@ -1950,8 +1957,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "serde",
@@ -1963,14 +1970,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-collaboration-mode-templates"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
+
+[[package]]
 name = "codex-config"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
+ "anyhow",
  "codex-app-server-protocol",
  "codex-execpolicy",
+ "codex-features",
+ "codex-git-utils",
+ "codex-model-provider-info",
+ "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "dunce",
  "futures",
  "multimap",
  "schemars 0.8.22",
@@ -1983,12 +2001,13 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
+ "wildmatch",
 ]
 
 [[package]]
 name = "codex-connectors"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -1998,8 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2007,7 +2026,6 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bm25",
- "chardetng",
  "chrono",
  "clap",
  "codex-analytics",
@@ -2022,14 +2040,19 @@ dependencies = [
  "codex-exec-server",
  "codex-execpolicy",
  "codex-features",
+ "codex-feedback",
  "codex-git-utils",
  "codex-hooks",
  "codex-instructions",
  "codex-login",
+ "codex-mcp",
+ "codex-model-provider-info",
+ "codex-models-manager",
  "codex-network-proxy",
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
+ "codex-response-debug-context",
  "codex-rmcp-client",
  "codex-rollout",
  "codex-sandboxing",
@@ -2056,7 +2079,6 @@ dependencies = [
  "csv",
  "dirs",
  "dunce",
- "encoding_rs",
  "env-flags",
  "eventsource-stream",
  "futures",
@@ -2064,7 +2086,6 @@ dependencies = [
  "iana-time-zone",
  "image",
  "indexmap 2.13.0",
- "landlock",
  "libc",
  "notify",
  "once_cell",
@@ -2073,8 +2094,6 @@ dependencies = [
  "regex-lite",
  "reqwest 0.12.28",
  "rmcp",
- "schemars 0.8.22",
- "seccompiler",
  "serde",
  "serde_json",
  "sha1",
@@ -2092,15 +2111,15 @@ dependencies = [
  "url",
  "uuid",
  "which 8.0.2",
- "wildmatch",
+ "whoami",
  "windows-sys 0.52.0",
  "zip",
 ]
 
 [[package]]
 name = "codex-core-skills"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -2127,14 +2146,15 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "arc-swap",
  "async-trait",
  "base64 0.22.1",
  "clap",
  "codex-app-server-protocol",
+ "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-pty",
  "futures",
@@ -2144,12 +2164,13 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2164,8 +2185,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2174,10 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
- "codex-login",
  "codex-otel",
  "codex-protocol",
  "schemars 0.8.22",
@@ -2188,10 +2208,11 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
+ "codex-login",
  "codex-protocol",
  "sentry",
  "tracing",
@@ -2200,8 +2221,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2215,8 +2236,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-utils-absolute-path",
  "futures",
@@ -2233,8 +2254,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2250,8 +2271,8 @@ dependencies = [
 
 [[package]]
 name = "codex-instructions"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-protocol",
  "serde",
@@ -2259,8 +2280,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "keyring",
  "tracing",
@@ -2268,12 +2289,11 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "cc",
  "clap",
- "codex-core",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
@@ -2288,16 +2308,19 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "codex-api",
  "codex-app-server-protocol",
  "codex-client",
  "codex-config",
  "codex-keyring-store",
+ "codex-model-provider-info",
+ "codex-otel",
  "codex-protocol",
  "codex-terminal-detection",
  "codex-utils-template",
@@ -2305,7 +2328,6 @@ dependencies = [
  "os_info",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2319,17 +2341,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-mcp"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
+dependencies = [
+ "anyhow",
+ "async-channel 2.5.0",
+ "codex-async-utils",
+ "codex-config",
+ "codex-login",
+ "codex-otel",
+ "codex-plugin",
+ "codex-protocol",
+ "codex-rmcp-client",
+ "codex-utils-plugins",
+ "futures",
+ "regex-lite",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "sha1",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "codex-mcp-server"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "codex-arg0",
+ "codex-config",
  "codex-core",
  "codex-exec-server",
  "codex-features",
+ "codex-login",
+ "codex-models-manager",
  "codex-protocol",
- "codex-shell-command",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
  "rmcp",
@@ -2343,9 +2395,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-model-provider-info"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
+dependencies = [
+ "codex-api",
+ "codex-app-server-protocol",
+ "codex-protocol",
+ "http 1.4.0",
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
+name = "codex-models-manager"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
+dependencies = [
+ "chrono",
+ "codex-api",
+ "codex-app-server-protocol",
+ "codex-collaboration-mode-templates",
+ "codex-config",
+ "codex-feedback",
+ "codex-login",
+ "codex-model-provider-info",
+ "codex-otel",
+ "codex-protocol",
+ "codex-response-debug-context",
+ "codex-utils-output-truncation",
+ "codex-utils-template",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-network-proxy"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2374,8 +2464,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2406,8 +2496,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-plugins",
@@ -2416,39 +2506,61 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
+ "chardetng",
+ "chrono",
+ "codex-async-utils",
  "codex-execpolicy",
  "codex-git-utils",
+ "codex-network-proxy",
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-string",
  "codex-utils-template",
+ "encoding_rs",
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
+ "landlock",
  "quick-xml",
+ "reqwest 0.12.28",
  "schemars 0.8.22",
+ "seccompiler",
  "serde",
  "serde_json",
  "serde_with",
  "strum 0.27.2",
  "strum_macros 0.28.0",
  "sys-locale",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "ts-rs",
  "uuid",
 ]
 
 [[package]]
+name = "codex-response-debug-context"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
+dependencies = [
+ "base64 0.22.1",
+ "codex-api",
+ "http 1.4.0",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-rmcp-client"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "axum",
  "codex-client",
+ "codex-config",
  "codex-keyring-store",
  "codex-protocol",
  "codex-utils-home-dir",
@@ -2458,7 +2570,6 @@ dependencies = [
  "oauth2",
  "reqwest 0.12.28",
  "rmcp",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2474,8 +2585,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2498,8 +2609,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -2514,8 +2625,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "age",
  "anyhow",
@@ -2533,8 +2644,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -2552,8 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -2582,8 +2693,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2604,32 +2715,36 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
+ "codex-features",
  "codex-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-pty",
  "rmcp",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "dirs",
- "path-absolutize",
+ "dunce",
  "schemars 0.8.22",
  "serde",
  "ts-rs",
@@ -2637,16 +2752,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "lru",
  "sha1",
@@ -2654,19 +2769,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-utils-cargo-bin"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
-dependencies = [
- "assert_cmd",
- "runfiles",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "codex-utils-cli"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -2676,16 +2781,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "codex-utils-image"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2697,8 +2802,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -2706,8 +2811,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2715,8 +2820,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2725,17 +2830,18 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
+ "codex-login",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -2750,8 +2856,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -2761,34 +2867,34 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "regex-lite",
 ]
 
 [[package]]
 name = "codex-utils-template"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.118.0"
-source = "git+https://github.com/openai/codex?rev=b630ce9a4e754d35a1f33e4366ba638d18626142#b630ce9a4e754d35a1f33e4366ba638d18626142"
+version = "0.120.0"
+source = "git+https://github.com/openai/codex?rev=65319eb1400cbd2890c43d572263dabd25f18ba9#65319eb1400cbd2890c43d572263dabd25f18ba9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3577,12 +3683,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -7034,24 +7134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
-name = "path-absolutize"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
-name = "path-dedot"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7373,33 +7455,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "prettyplease"
@@ -8514,11 +8569,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "runfiles"
-version = "0.1.0"
-source = "git+https://github.com/dzbarsky/rules_rust?rev=b56cbaa8465e74127f1ea216f813cd377295ad81#b56cbaa8465e74127f1ea216f813cd377295ad81"
 
 [[package]]
 name = "rust-embed"
@@ -10176,12 +10226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "test-log"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11158,15 +11202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11524,6 +11559,7 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -22,20 +22,22 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-arg0 = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-app-server-client = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-core = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-exec-server = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-features = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-feedback = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-mcp-server = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-protocol = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-login = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-shell-command = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
-codex-utils-cli = { git = "https://github.com/openai/codex", rev = "b630ce9a4e754d35a1f33e4366ba638d18626142" }
+codex-apply-patch = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-config = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-app-server-client = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-core = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-exec-server = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-features = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-feedback = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-mcp-server = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-login = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-models-manager = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-shell-command = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "65319eb1400cbd2890c43d572263dabd25f18ba9" }
 heck = "0.5.0"
 itertools = "0.14.0"
 regex-lite = "0.1"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -1059,7 +1059,7 @@ impl AppServerCodexThread {
                     id: submission_id,
                     msg: EventMsg::TurnStarted(TurnStartedEvent {
                         turn_id: payload.turn.id,
-                        started_at: None,
+                        started_at: payload.turn.started_at,
                         model_context_window: None,
                         collaboration_mode_kind: Default::default(),
                     }),
@@ -2494,14 +2494,14 @@ fn turn_completed_event_msg(turn: &Turn, last_agent_message: Option<String>) -> 
         TurnStatus::Completed => EventMsg::TurnComplete(TurnCompleteEvent {
             turn_id: turn.id.clone(),
             last_agent_message,
-            completed_at: None,
-            duration_ms: None,
+            completed_at: turn.completed_at,
+            duration_ms: turn.duration_ms,
         }),
         TurnStatus::Interrupted => EventMsg::TurnAborted(TurnAbortedEvent {
             turn_id: Some(turn.id.clone()),
             reason: TurnAbortReason::Interrupted,
-            completed_at: None,
-            duration_ms: None,
+            completed_at: turn.completed_at,
+            duration_ms: turn.duration_ms,
         }),
         TurnStatus::Failed => EventMsg::Error(ErrorEvent {
             message: turn

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -24,7 +24,7 @@ use codex_app_server_protocol::{
 use codex_arg0::Arg0DispatchPaths;
 use codex_core::config::Config;
 use codex_core::config_loader::{CloudRequirementsLoader, LoaderOverrides};
-use codex_core::error::CodexErr;
+use codex_exec_server::EnvironmentManager;
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::approvals::{
@@ -33,6 +33,7 @@ use codex_protocol::approvals::{
 };
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::dynamic_tools::DynamicToolCallRequest;
+use codex_protocol::error::CodexErr;
 use codex_protocol::mcp::{CallToolResult, RequestId as McpRequestId};
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs};
@@ -260,11 +261,16 @@ impl AppServerCodexThread {
         active_turn: ActiveTurn,
         op: &Op,
     ) -> Result<SteerFollowUpAction, CodexErr> {
-        let (items, output_schema) = match op {
+        let (items, output_schema, responsesapi_client_metadata) = match op {
             Op::UserInput {
                 items,
                 final_output_json_schema,
-            } => (items.clone(), final_output_json_schema.clone()),
+                responsesapi_client_metadata,
+            } => (
+                items.clone(),
+                final_output_json_schema.clone(),
+                responsesapi_client_metadata.clone(),
+            ),
             _ => return Ok(SteerFollowUpAction::QueueFollowUp),
         };
 
@@ -291,6 +297,7 @@ impl AppServerCodexThread {
                     thread_id,
                     input: items.into_iter().map(Into::into).collect(),
                     expected_turn_id: turn_id,
+                    responsesapi_client_metadata,
                 },
             })
             .await;
@@ -474,6 +481,8 @@ impl AppServerCodexThread {
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 turn_id: String::new(),
                                 last_agent_message: None,
+                                completed_at: None,
+                                duration_ms: None,
                             }),
                         });
                         Ok(())
@@ -1050,6 +1059,7 @@ impl AppServerCodexThread {
                     id: submission_id,
                     msg: EventMsg::TurnStarted(TurnStartedEvent {
                         turn_id: payload.turn.id,
+                        started_at: None,
                         model_context_window: None,
                         collaboration_mode_kind: Default::default(),
                     }),
@@ -1090,6 +1100,7 @@ impl AppServerCodexThread {
                     }),
                 }))
             }
+            ServerNotification::ThreadRealtimeSdp(_) => Ok(None),
             ServerNotification::TurnPlanUpdated(payload) => {
                 let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
                 Ok(submission_id.map(|id| Event {
@@ -1766,6 +1777,8 @@ fn cancel_queued_submissions(state: &mut AppServerState) {
             msg: EventMsg::TurnAborted(TurnAbortedEvent {
                 turn_id: None,
                 reason: TurnAbortReason::Interrupted,
+                completed_at: None,
+                duration_ms: None,
             }),
         });
     }
@@ -2053,6 +2066,7 @@ fn prepare_submission_start(
         Op::UserInput {
             items,
             final_output_json_schema,
+            responsesapi_client_metadata,
         } => {
             state.active_turn = Some(ActiveTurn {
                 submission_id: submission_id.to_string(),
@@ -2077,6 +2091,7 @@ fn prepare_submission_start(
                     summary: state.config.model_reasoning_summary,
                     personality: state.config.personality,
                     output_schema: final_output_json_schema.clone(),
+                    responsesapi_client_metadata: responsesapi_client_metadata.clone(),
                     collaboration_mode: None,
                 }),
             })
@@ -2479,10 +2494,14 @@ fn turn_completed_event_msg(turn: &Turn, last_agent_message: Option<String>) -> 
         TurnStatus::Completed => EventMsg::TurnComplete(TurnCompleteEvent {
             turn_id: turn.id.clone(),
             last_agent_message,
+            completed_at: None,
+            duration_ms: None,
         }),
         TurnStatus::Interrupted => EventMsg::TurnAborted(TurnAbortedEvent {
             turn_id: Some(turn.id.clone()),
             reason: TurnAbortReason::Interrupted,
+            completed_at: None,
+            duration_ms: None,
         }),
         TurnStatus::Failed => EventMsg::Error(ErrorEvent {
             message: turn
@@ -2560,6 +2579,7 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
         loader_overrides: LoaderOverrides::default(),
         cloud_requirements: CloudRequirementsLoader::default(),
         feedback: CodexFeedback::new(),
+        environment_manager: Arc::new(EnvironmentManager::from_env()),
         config_warnings: Vec::new(),
         session_source: codex_protocol::protocol::SessionSource::Unknown,
         enable_codex_api_key_env: false,
@@ -2690,6 +2710,9 @@ mod tests {
             }],
             status: TurnStatus::InProgress,
             error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
         };
 
         let active_turn = resumed_active_turn(
@@ -2715,6 +2738,9 @@ mod tests {
             }],
             status: TurnStatus::InProgress,
             error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
         };
 
         let active_turn = resumed_active_turn(
@@ -2835,6 +2861,9 @@ mod tests {
             items: Vec::new(),
             status: TurnStatus::InProgress,
             error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
         };
 
         let event = turn_completed_event_msg(&turn, None);
@@ -2987,6 +3016,9 @@ mod tests {
             }],
             status: TurnStatus::InProgress,
             error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
         }];
 
         let pending = pending_patch_changes_from_turns(&turns);

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -10,20 +10,17 @@ use agent_client_protocol::{
     SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
     SetSessionModelRequest, SetSessionModelResponse,
 };
+use codex_config::types::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
-    CodexAuth, RolloutRecorder, ThreadManager, ThreadSortKey,
-    auth::AuthManager,
-    config::{
-        Config,
-        types::{McpServerConfig, McpServerTransportConfig},
-    },
-    find_thread_path_by_id_str,
-    models_manager::collaboration_mode_presets::CollaborationModesConfig,
+    RolloutRecorder, ThreadManager, ThreadSortKey, config::Config, find_thread_path_by_id_str,
     parse_cursor,
 };
 use codex_exec_server::EnvironmentManager;
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
-use codex_login::{CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR};
+use codex_login::{
+    AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
+};
+use codex_models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_protocol::{
     ThreadId,
     models::{FunctionCallOutputPayload, ResponseItem},
@@ -85,6 +82,7 @@ impl CodexAgent {
                 default_mode_request_user_input: true,
             },
             Arc::new(EnvironmentManager::from_env()),
+            None,
         );
         Self {
             auth_manager,
@@ -462,6 +460,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
 fn repair_initial_history(history: InitialHistory) -> (InitialHistory, usize) {
     match history {
         InitialHistory::New => (InitialHistory::New, 0),
+        InitialHistory::Cleared => (InitialHistory::Cleared, 0),
         InitialHistory::Forked(mut items) => {
             let repaired = repair_rollout_items(&mut items);
             (InitialHistory::Forked(items), repaired)
@@ -551,7 +550,7 @@ impl Agent for CodexAgent {
                 // Perform browser/device login via codex-rs, then report success/failure to the client.
                 let opts = codex_login::ServerOptions::new(
                     self.config.codex_home.clone(),
-                    codex_core::auth::CLIENT_ID.to_string(),
+                    CLIENT_ID.to_string(),
                     None,
                     self.config.cli_auth_credentials_store_mode,
                 );

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -21,17 +21,18 @@ use agent_client_protocol::{
 use agenthub_managed_skills::managed_skills_root;
 use codex_apply_patch::parse_patch;
 use codex_core::{
-    AuthManager, CodexThread,
+    CodexThread,
     config::{Config, set_project_trust_level},
-    error::CodexErr,
-    models_manager::manager::{ModelsManager, RefreshStrategy},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
 };
+use codex_login::AuthManager;
+use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::{
     approvals::{ElicitationRequest, ElicitationRequestEvent},
     config_types::TrustLevel,
     dynamic_tools::{DynamicToolCallOutputContentItem, DynamicToolCallRequest},
+    error::CodexErr,
     mcp::CallToolResult,
     models::{PermissionProfile, ResponseItem, WebSearchAction},
     openai_models::{ModelPreset, ReasoningEffort},
@@ -770,6 +771,7 @@ impl PromptState {
 
         match event {
             EventMsg::TurnStarted(TurnStartedEvent {
+                started_at: _,
                 model_context_window,
                 collaboration_mode_kind,
                 turn_id,
@@ -994,7 +996,12 @@ impl PromptState {
             }) => {
                 info!("Item completed: thread_id={}, turn_id={}, item={:?}", thread_id, turn_id, item);
             }
-            EventMsg::TurnComplete(TurnCompleteEvent { last_agent_message, turn_id }) => {
+            EventMsg::TurnComplete(TurnCompleteEvent {
+                last_agent_message,
+                turn_id,
+                completed_at: _,
+                duration_ms: _,
+            }) => {
                 info!(
                     "Task {turn_id} completed successfully after {} events. Last agent message: {last_agent_message:?}",
                     self.event_count
@@ -1038,7 +1045,12 @@ impl PromptState {
                     json!({ "message": message, "codex_error_info": codex_error_info }),
                 ));
             }
-            EventMsg::TurnAborted(TurnAbortedEvent { reason, turn_id }) => {
+            EventMsg::TurnAborted(TurnAbortedEvent {
+                reason,
+                turn_id,
+                completed_at: _,
+                duration_ms: _,
+            }) => {
                 info!("Turn {turn_id:?} aborted: {reason:?}");
                 self.abort_pending_interactions();
                 self.finish_ok(StopReason::Cancelled);
@@ -1150,7 +1162,9 @@ impl PromptState {
             | EventMsg::CollabAgentInteractionEnd(..)
             | EventMsg::RealtimeConversationStarted(..)
             | EventMsg::RealtimeConversationRealtime(..)
+            | EventMsg::RealtimeConversationSdp(..)
             | EventMsg::RealtimeConversationClosed(..)
+            | EventMsg::RealtimeConversationListVoicesResponse(..)
             | EventMsg::CollabWaitingBegin(..)
             | EventMsg::CollabWaitingEnd(..)
             | EventMsg::CollabResumeBegin(..)
@@ -3275,6 +3289,7 @@ impl<A: Auth> ThreadActor<A> {
                             text_elements: vec![],
                         }],
                         final_output_json_schema: None,
+                        responsesapi_client_metadata: None,
                     }
                 }
                 "review" => {
@@ -3325,6 +3340,7 @@ impl<A: Auth> ThreadActor<A> {
                     op = Op::UserInput {
                         items,
                         final_output_json_schema: None,
+                        responsesapi_client_metadata: None,
                     }
                 }
             }
@@ -3332,6 +3348,7 @@ impl<A: Auth> ThreadActor<A> {
             op = Op::UserInput {
                 items,
                 final_output_json_schema: None,
+                responsesapi_client_metadata: None,
             }
         }
 
@@ -3565,7 +3582,7 @@ impl<A: Auth> ThreadActor<A> {
         for hunk in &parsed.hunks {
             match hunk {
                 codex_apply_patch::Hunk::AddFile { path, contents } => {
-                    let full_path = self.config.cwd.join(path).ok()?;
+                    let full_path = self.config.cwd.join(path);
                     file_names.push(path.display().to_string());
                     locations.push(ToolCallLocation::new(full_path.clone()));
                     // New file: no old_text, new_text is the contents
@@ -3575,7 +3592,7 @@ impl<A: Auth> ThreadActor<A> {
                     )));
                 }
                 codex_apply_patch::Hunk::DeleteFile { path } => {
-                    let full_path = self.config.cwd.join(path).ok()?;
+                    let full_path = self.config.cwd.join(path);
                     file_names.push(path.display().to_string());
                     locations.push(ToolCallLocation::new(full_path.clone()));
                     // Delete file: old_text would be original content, new_text is empty
@@ -3588,10 +3605,10 @@ impl<A: Auth> ThreadActor<A> {
                     move_path,
                     chunks,
                 } => {
-                    let full_path = self.config.cwd.join(path).ok()?;
+                    let full_path = self.config.cwd.join(path);
                     let dest_path = move_path
                         .as_ref()
-                        .and_then(|p| self.config.cwd.join(p).ok())
+                        .map(|p| self.config.cwd.join(p))
                         .unwrap_or_else(|| full_path.clone());
                     file_names.push(path.display().to_string());
                     locations.push(ToolCallLocation::new(dest_path.clone()));
@@ -4644,6 +4661,7 @@ mod tests {
                     text_elements: vec![]
                 }],
                 final_output_json_schema: None,
+                responsesapi_client_metadata: None,
             }],
             "ops don't match {ops:?}"
         );
@@ -4918,6 +4936,7 @@ mod tests {
                     text_elements: vec![]
                 }],
                 final_output_json_schema: None,
+                responsesapi_client_metadata: None,
             }],
             "ops don't match {ops:?}"
         );
@@ -4968,6 +4987,8 @@ mod tests {
                 thread.emit(EventMsg::TurnComplete(TurnCompleteEvent {
                     last_agent_message: Some("done".to_string()),
                     turn_id: "shared-turn".to_string(),
+                    completed_at: None,
+                    duration_ms: None,
                 }));
 
                 assert_eq!(first_stop_rx.await??, StopReason::EndTurn);
@@ -5033,6 +5054,8 @@ mod tests {
                         msg: EventMsg::TurnComplete(TurnCompleteEvent {
                             last_agent_message: Some("resumed output".to_string()),
                             turn_id: "resumed-turn".to_string(),
+                            completed_at: None,
+                            duration_ms: None,
                         }),
                     })
                     .await;
@@ -5253,6 +5276,8 @@ mod tests {
                 thread.emit(EventMsg::TurnComplete(TurnCompleteEvent {
                     last_agent_message: Some("done".to_string()),
                     turn_id: "shared-turn".to_string(),
+                    completed_at: None,
+                    duration_ms: None,
                 }));
 
                 assert_eq!(first_stop_rx.await??, StopReason::EndTurn);
@@ -5479,6 +5504,8 @@ mod tests {
                         send(EventMsg::TurnComplete(TurnCompleteEvent {
                             last_agent_message: None,
                             turn_id,
+                            completed_at: None,
+                            duration_ms: None,
                         }));
                     } else if prompt == "approval-block" {
                         self.op_tx
@@ -5536,6 +5563,8 @@ mod tests {
                                 msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                     last_agent_message: None,
                                     turn_id: id.to_string(),
+                                    completed_at: None,
+                                    duration_ms: None,
                                 }),
                             })
                             .unwrap();
@@ -5547,6 +5576,7 @@ mod tests {
                             id: submission_id.clone(),
 
                             msg: EventMsg::TurnStarted(TurnStartedEvent {
+                                started_at: None,
                                 model_context_window: None,
                                 collaboration_mode_kind: ModeKind::default(),
                                 turn_id: id.to_string(),
@@ -5571,6 +5601,8 @@ mod tests {
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
+                                completed_at: None,
+                                duration_ms: None,
                             }),
                         })
                         .unwrap();
@@ -5606,6 +5638,8 @@ mod tests {
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
+                                completed_at: None,
+                                duration_ms: None,
                             }),
                         })
                         .unwrap();
@@ -5642,6 +5676,8 @@ mod tests {
                             msg: EventMsg::TurnComplete(TurnCompleteEvent {
                                 last_agent_message: None,
                                 turn_id: id.to_string(),
+                                completed_at: None,
+                                duration_ms: None,
                             }),
                         })
                         .unwrap();
@@ -5660,6 +5696,8 @@ mod tests {
                                 msg: EventMsg::TurnAborted(TurnAbortedEvent {
                                     turn_id: Some(active_prompt_id),
                                     reason: codex_protocol::protocol::TurnAbortReason::Interrupted,
+                                    completed_at: None,
+                                    duration_ms: None,
                                 }),
                             })
                             .unwrap();

--- a/docs/journal/2026-04-12-codex-rust-v120-upgrade.md
+++ b/docs/journal/2026-04-12-codex-rust-v120-upgrade.md
@@ -1,0 +1,45 @@
+# Codex Rust v0.120.0 Upgrade
+
+## Goal
+
+Upgrade `agenthub-codex-acp` from the official `openai/codex` `rust-v0.118.0` baseline to
+`rust-v0.120.0`.
+
+## Source
+
+- official release tag: `rust-v0.120.0`
+- annotated tag object: `84b1753e16766434a86ec29ab7a23984fd0f61fe`
+- pinned release commit: `65319eb1400cbd2890c43d572263dabd25f18ba9`
+
+## Change
+
+- updated all direct `agenthub-codex-acp` git dependencies from the previous `openai/codex`
+  release commit `b630ce9a4e754d35a1f33e4366ba638d18626142` to
+  `65319eb1400cbd2890c43d572263dabd25f18ba9`
+- added direct `codex-config` and `codex-models-manager` dependencies because v0.120.0 no longer
+  exposes those types through the old `codex-core` paths used by `agenthub-codex-acp`
+- updated `agenthub-codex-acp` compatibility code for the v0.120.0 API surface:
+  - auth and models-manager imports now use `codex-login` and `codex-models-manager`
+  - `ThreadManager::new(...)` and `InProcessClientStartArgs` now receive the new optional
+    analytics/environment arguments
+  - `Op::UserInput`, `TurnStartParams`, `TurnSteerParams`, `TurnStartedEvent`,
+    `TurnCompleteEvent`, `TurnAbortedEvent`, and app-server `Turn` test fixtures now populate the
+    new metadata/timing fields
+  - prompt/event translation now tolerates the new realtime notification and history variants
+- kept the repository pinned by commit instead of symbolic tag so dependency provenance stays
+  stable
+
+## Validation
+
+Executed validation for this slice:
+
+```bash
+cargo fmt --all
+cargo check -p agenthub-codex-acp
+cargo test -p agenthub-codex-acp
+```
+
+Result:
+
+- `cargo check -p agenthub-codex-acp` passed
+- `cargo test -p agenthub-codex-acp` passed (`85 passed; 0 failed`)


### PR DESCRIPTION
fix(acp): upgrade codex rust deps to v120

## Summary

- upgrade `agenthub-codex-acp` direct `openai/codex` git dependencies to the official
  `rust-v0.120.0` release commit `65319eb1400cbd2890c43d572263dabd25f18ba9`
- adapt `agenthub-codex-acp` to the v0.120.0 API surface for auth, models manager,
  app-server startup, turn metadata, and realtime/history variants
- record the upgrade and validation details in the journal

## Testing

```bash
cargo fmt --all
cargo check -p agenthub-codex-acp
cargo test -p agenthub-codex-acp
```

## Notes

- this PR is intentionally scoped to `agenthub-codex-acp` compatibility only
