### PR TITLE
docs(team): tighten worker action-first contract

### DIFF
--- a/docs/journal/2026-04-14-worker-action-first-contract.md
+++ b/docs/journal/2026-04-14-worker-action-first-contract.md
@@ -1,5 +1,11 @@
 # Worker Action-First Contract Tightening
 
+## Summary
+
+- tightened the worker execution skill so concrete assignments cannot stop at intent narration
+- required the worker to execute the first actionable step in the same turn when no blocker exists
+- documented the expected first-turn execution artifacts for new concrete assignments
+
 ## Why
 
 Worker sessions were too willing to acknowledge a new concrete assignment with a clean status
@@ -27,3 +33,7 @@ failing to advance execution.
 - Keep the reporting discipline, but make reporting subordinate to immediate execution when the
   task is already actionable.
 - Reduce cases where leader/human sees progress language without any new evidence artifact.
+
+## Validation
+
+- N/A (docs-only skill/journal change)

--- a/docs/journal/2026-04-14-worker-action-first-contract.md
+++ b/docs/journal/2026-04-14-worker-action-first-contract.md
@@ -1,0 +1,29 @@
+# Worker Action-First Contract Tightening
+
+## Why
+
+Worker sessions were too willing to acknowledge a new concrete assignment with a clean status
+summary and an intention statement ("I will investigate next") without performing the first actual
+inspection step in the same turn. That behavior is safe but too passive: it preserves clarity while
+failing to advance execution.
+
+## What changed
+
+- Tightened `skills/team/team-worker-executor.SKILL.md`.
+- Added an explicit rule that a concrete assigned task with no blocker must not stop at intent
+  narration.
+- Added a same-turn execution rule: if the worker describes the next step, it must execute that
+  concrete step in the same turn unless blocked by missing permissions, missing inputs, or runtime
+  failure.
+- Added a first-turn contract for new assignments:
+  - acceptable first-turn artifacts include issue/PR/file inspection, code search, or a focused
+    reproduction command;
+  - pure "task received / scope confirmed / I will ..." summaries do not count as execution.
+
+## Intended effect
+
+- Shift worker behavior from "clear planning statement first" to "minimal action plus concise
+  status".
+- Keep the reporting discipline, but make reporting subordinate to immediate execution when the
+  task is already actionable.
+- Reduce cases where leader/human sees progress language without any new evidence artifact.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -136,6 +136,11 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 
 ## Reporting Expectations
 
+- Do not stop at intent narration when a concrete task is assigned and no blocker exists.
+- If you say what you will do next, execute that first concrete step in the same turn.
+- Treat a pure "I will investigate/fix/check next" message without any accompanying action as a
+  contract violation unless missing permissions, missing inputs, or runtime failure genuinely block
+  execution.
 - Send a start update when beginning a non-trivial assignment.
 - Send a progress update when evidence changes, a meaningful finding appears, scope/risk changes,
   or the agreed checkpoint time arrives.
@@ -181,15 +186,35 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 1. Accept inbox work and find the latest unhandled assignment:
    `agenthub actor receive --limit 50`
 2. Parse the accepted task and validate required fields.
-3. Execute with minimal, auditable changes.
-4. Reply to leader with status, evidence, and findings:
+3. Execute the first concrete investigation or implementation step immediately.
+   - Valid first steps include opening the referenced issue/PR, searching the relevant code path,
+     reading the suspect file, or running the narrowest relevant reproduction test.
+   - Do not spend the first execution turn restating scope, constraints, or next actions unless a
+     real blocker prevents tool use.
+   - If a blocker exists, report the blocker together with the missing prerequisite instead of
+     writing a generic plan.
+4. Execute with minimal, auditable changes.
+5. Reply to leader with status, evidence, and findings:
    `agenthub actor send --to-actor-id "$LEADER_ID" --text-file .agenthubmemory/mailbox/outbox/execution-update.md`
-5. Include phase metadata when reporting substantial progress:
+6. Include phase metadata when reporting substantial progress:
    `{"phase":"communication_and_collaboration|consensus_formation|result_integration", ...}`
-6. Proactively advance the assigned task:
+7. Proactively advance the assigned task:
    - do not wait for repeated nudges when the next executable step is already clear
    - send prompt progress updates when evidence changes, scope shifts, or blockers appear
    - escalate quickly when task acceptance or ownership needs leader intervention
+
+New-assignment first-turn contract:
+- When a new concrete bug/task arrives and the scope is already clear enough to begin, your first
+  turn must produce at least one action artifact.
+- Acceptable first-turn artifacts include:
+  - one or more executed inspection commands
+  - a file/issue/PR that was actually opened and summarized from evidence
+  - a focused reproduction command
+  - a narrowed suspect function/module list based on direct code or issue inspection
+- "Task received", "scope confirmed", or "I will now ..." messages do not count as execution
+  artifacts on their own.
+- If permissions or missing environment prerequisites block execution, state that explicitly and
+  name the exact missing permission/input/runtime failure.
 
 Step execution contract:
 - `single_pass` step: execute the bounded change once, then report evidence or blocker.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -193,7 +193,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
      real blocker prevents tool use.
    - If a blocker exists, report the blocker together with the missing prerequisite instead of
      writing a generic plan.
-4. Execute with minimal, auditable changes.
+4. Continue execution with minimal, auditable changes.
 5. Reply to leader with status, evidence, and findings:
    `agenthub actor send --to-actor-id "$LEADER_ID" --text-file .agenthubmemory/mailbox/outbox/execution-update.md`
 6. Include phase metadata when reporting substantial progress:


### PR DESCRIPTION
## Summary

- tighten the worker execution skill so concrete assignments cannot stop at intent narration
- require the worker to execute the first actionable investigation/implementation step in the same turn
- document the action-first contract tightening in the implementation journal

## Why

Worker sessions were too willing to acknowledge a clear assignment with a status summary plus
"I will ..." language, without producing any actual execution evidence in the same turn. This PR
narrows that behavior so reporting remains useful but no longer substitutes for action.

## Testing

- docs/skill change only
- no code or runtime behavior changed directly
