### PR TITLE
docs(team): record worker action-first rule

### DIFF
--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -110,7 +110,8 @@ Worker cold-start:
 2. load worker-specific AGENTS index (injected builtin `team-worker-agents-index`)
 3. inspect unfinished `TODO.md` entries and, in concrete project repos, `.agenthubmemory/TODO.md`
 4. pull mailbox and continue resumable assignments first
-5. report status/evidence back to leader
+5. when a new concrete assignment is already actionable, execute the first inspection or implementation step in the same turn instead of replying with intent-only narration
+6. report status/evidence back to leader
 
 Self-maintenance and deferred follow-up:
 
@@ -160,7 +161,31 @@ Mailbox operational priority (suggested):
 - medium: member card/discovery broadcasts
 - low: routine assignment updates
 
-### 5.1) CLI-First Enforcement Profile
+### 5.1) Worker Action-First Rule
+
+Worker execution should prefer immediate evidence-producing action over safe intent narration when
+the assignment is already concrete and no blocker exists.
+
+Policy:
+
+- A worker must not stop at `task received`, `scope confirmed`, or `I will investigate next` when
+  the next executable step is already clear.
+- If a worker describes the next step, it should execute that step in the same turn unless blocked
+  by missing permissions, missing inputs, or runtime failure.
+- First-turn execution artifacts may include:
+  - opening and summarizing the assigned issue/PR from direct inspection
+  - searching the relevant code path
+  - reading the suspect file/module and narrowing the likely fault boundary
+  - running the narrowest relevant reproduction command or focused test
+- A blocker report is valid only when it names the exact missing prerequisite or failure mode; a
+  generic plan without action or blocker evidence is not sufficient progress.
+
+Operational consequence:
+
+- Team prompts and worker skills may still require concise status reporting, but reporting must not
+  substitute for the first actionable step when the task is already executable.
+
+### 5.2) CLI-First Enforcement Profile
 
 Team collaboration should run with the canonical actor CLI mailbox path as the primary communication path:
 
@@ -180,7 +205,7 @@ Detailed enforcement design:
 
 - `docs/features/actor-foundation.md`
 
-### 5.2) Conversation Event Bus Profile
+### 5.3) Conversation Event Bus Profile
 
 Conversation lane should use event bus as the realtime chat/timeline carrier, while keeping mailbox
 as execution command authority:


### PR DESCRIPTION
## Summary

- record the worker action-first rule in the stable Team collaboration playbook
- clarify that actionable assignments should produce a same-turn execution artifact instead of
  intent-only narration
- document valid first-turn execution artifacts and blocker requirements

## Why

This captures a recurring execution-quality lesson in a stable feature spec instead of leaving it
only in a journal entry or role skill. The rule now lives in the long-term Team collaboration
contract.

## Testing

- docs-only change
