### PR TITLE
docs(team): tighten leader action-first rule

### DIFF
--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -201,7 +201,7 @@ Policy:
 - First-turn leader artifacts may include:
   - opening and summarizing the assigned issue/PR from direct inspection
   - searching the relevant code path or reading the suspect file/module
-  - writing the first ordered plan or task split
+  - writing the first ordered plan or task split into coordination artifacts
   - dispatching the first deterministic worker brief
   - running the narrowest relevant reproduction command
 - A blocker report is valid only when it names the exact missing prerequisite or failure mode; a

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -103,6 +103,8 @@ Leader cold-start:
 3. inspect unfinished items in `TODO.md`
 4. detect whether an existing plan can be resumed
 5. if no resumable plan exists, create a new planning round
+6. when a new concrete request is already actionable, execute the first planning or investigation
+   step in the same turn instead of replying with intent-only narration
 
 Worker cold-start:
 
@@ -185,7 +187,33 @@ Operational consequence:
 - Team prompts and worker skills may still require concise status reporting, but reporting must not
   substitute for the first actionable step when the task is already executable.
 
-### 5.2) CLI-First Enforcement Profile
+### 5.2) Leader Action-First Rule
+
+Leader coordination should also prefer immediate planning evidence over safe intent narration when
+the request is already concrete and no blocker exists.
+
+Policy:
+
+- A leader must not stop at `task received`, `scope confirmed`, or `I will investigate/plan next`
+  when the next planning step is already clear.
+- If a leader describes the next step, it should execute that step in the same turn unless blocked
+  by missing permissions, missing inputs, or runtime failure.
+- First-turn leader artifacts may include:
+  - opening and summarizing the assigned issue/PR from direct inspection
+  - searching the relevant code path or reading the suspect file/module
+  - writing the first ordered plan or task split
+  - dispatching the first deterministic worker brief
+  - running the narrowest relevant reproduction command
+- A blocker report is valid only when it names the exact missing prerequisite or failure mode; a
+  generic planning statement without action or blocker evidence is not sufficient progress.
+
+Operational consequence:
+
+- Team prompts and leader skills may still require concise human-facing status reporting, but
+  reporting must not substitute for the first actionable planning step when the request is already
+  executable.
+
+### 5.3) CLI-First Enforcement Profile
 
 Team collaboration should run with the canonical actor CLI mailbox path as the primary communication path:
 
@@ -205,7 +233,7 @@ Detailed enforcement design:
 
 - `docs/features/actor-foundation.md`
 
-### 5.3) Conversation Event Bus Profile
+### 5.4) Conversation Event Bus Profile
 
 Conversation lane should use event bus as the realtime chat/timeline carrier, while keeping mailbox
 as execution command authority:

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -190,6 +190,8 @@ Run this sequence before the first coordination round of each fresh process star
 6. Human communication rule:
    - Answer human actor directly.
    - Do not reply with "ask worker" or redirect human questions to workers.
+7. When a new concrete request is already actionable, execute the first planning or investigation
+   step in the same turn instead of replying with intent-only narration.
 
 ## AGENTS.md Minimum Template
 
@@ -213,13 +215,27 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 1. Accept inbox work before each coordination round:
    `agenthub actor receive --limit 50`
 2. Parse each accepted message before making routing decisions.
-3. Delegate with deterministic payload JSON:
+3. Execute the first concrete planning/investigation action immediately when the request is already
+   actionable.
+   - Valid first actions include opening the referenced issue/PR, searching the relevant code path,
+     reading the suspect file/module, drafting the first task split, or running the narrowest
+     relevant reproduction command.
+   - Do not spend the first coordination turn only restating scope, constraints, or next actions
+     unless a real blocker prevents tool use.
+   - If blocked, report the blocker together with the exact missing prerequisite or runtime failure.
+4. Delegate with deterministic payload JSON:
    `agenthub actor send --to-actor-id "$WORKER_ID" --text-file .agenthubmemory/mailbox/outbox/task-brief.md`
-4. If a worker is blocked, ask for missing facts or re-scope the task.
-5. Keep a running decision log and conflict resolution summary.
+5. If a worker is blocked, ask for missing facts or re-scope the task.
+6. Keep a running decision log and conflict resolution summary.
 
 ## Reporting And Supervision Contract
 
+- Do not stop at intent narration when a concrete human/team request is assigned to the leader and
+  no blocker exists.
+- If you say what you will do next, execute that first concrete step in the same turn.
+- Treat a pure `I will investigate/plan/check next` message without any accompanying action
+  artifact as a contract violation unless missing permissions, missing inputs, or runtime failure
+  genuinely block execution.
 - Every active worker assignment must have an owner, latest status, latest evidence, and next
   checkpoint recorded in leader coordination artifacts.
 - Require worker updates at assignment start, meaningful progress, blocker discovery, and
@@ -248,6 +264,19 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
   relevant task/doc artifact so the channel message is a summary, not the only durable record.
 - In shared-channel progress updates, explicitly `@` the responsible workers, reviewers, and
   affected stakeholders instead of posting anonymous team-wide status text.
+
+New-request first-turn contract:
+
+- When a new concrete request arrives and the scope is already clear enough to begin, the first
+  leader turn must produce at least one action artifact.
+- Acceptable first-turn artifacts include:
+  - opening and summarizing the assigned issue/PR from direct inspection
+  - searching the relevant code path or reading the suspect file/module
+  - writing the first ordered plan or task split into coordination artifacts
+  - dispatching the first deterministic worker brief
+  - running the narrowest relevant reproduction command
+- `task received`, `scope confirmed`, or `I will now ...` messages do not count as execution
+  artifacts on their own.
 
 ## Collaboration Planning Contract
 

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -217,9 +217,10 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 2. Parse each accepted message before making routing decisions.
 3. Execute the first concrete planning/investigation action immediately when the request is already
    actionable.
-   - Valid first actions include opening the referenced issue/PR, searching the relevant code path,
-     reading the suspect file/module, drafting the first task split, or running the narrowest
-     relevant reproduction command.
+   - Valid first actions include opening and summarizing the assigned issue/PR from direct
+     inspection, searching the relevant code path or reading the suspect file/module, writing the
+     first ordered plan or task split into coordination artifacts, dispatching the first
+     deterministic worker brief, or running the narrowest relevant reproduction command.
    - Do not spend the first coordination turn only restating scope, constraints, or next actions
      unless a real blocker prevents tool use.
    - If blocked, report the blocker together with the exact missing prerequisite or runtime failure.
@@ -230,12 +231,6 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 
 ## Reporting And Supervision Contract
 
-- Do not stop at intent narration when a concrete human/team request is assigned to the leader and
-  no blocker exists.
-- If you say what you will do next, execute that first concrete step in the same turn.
-- Treat a pure `I will investigate/plan/check next` message without any accompanying action
-  artifact as a contract violation unless missing permissions, missing inputs, or runtime failure
-  genuinely block execution.
 - Every active worker assignment must have an owner, latest status, latest evidence, and next
   checkpoint recorded in leader coordination artifacts.
 - Require worker updates at assignment start, meaningful progress, blocker discovery, and
@@ -265,7 +260,7 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 - In shared-channel progress updates, explicitly `@` the responsible workers, reviewers, and
   affected stakeholders instead of posting anonymous team-wide status text.
 
-New-request first-turn contract:
+## New-request First-turn Contract
 
 - When a new concrete request arrives and the scope is already clear enough to begin, the first
   leader turn must produce at least one action artifact.


### PR DESCRIPTION
## Summary

- tighten the leader action-first rule in the stable Team playbook and leader skill
- require leader sessions to produce a same-turn planning/investigation artifact for actionable
  requests instead of intent-only narration
- clarify that leader should acknowledge worker-visible progress through direct coordination before
  relying on shared-channel summaries

## Why

The same execution-quality gap found on the worker side also exists on the leader side: the leader
can understand the next step but still stop at status narration. This PR makes the leader contract
explicitly action-first while keeping the role boundary intact.

## Testing

- docs-only change
