### PR TITLE
docs(team): tighten mailbox polling discipline

### DIFF
--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -201,7 +201,7 @@ Policy:
 - First-turn leader artifacts may include:
   - opening and summarizing the assigned issue/PR from direct inspection
   - searching the relevant code path or reading the suspect file/module
-  - writing the first ordered plan or task split
+  - writing the first ordered plan or task split into coordination artifacts
   - dispatching the first deterministic worker brief
   - running the narrowest relevant reproduction command
 - A blocker report is valid only when it names the exact missing prerequisite or failure mode; a

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -113,8 +113,9 @@ Worker cold-start:
 1. load shared Team AGENTS index (injected builtin `team-agents-index`) and role-relevant guidance from `AGENTS.md` + required skills
 2. load worker-specific AGENTS index (injected builtin `team-worker-agents-index`)
 3. inspect unfinished `TODO.md` entries and, in concrete project repos, `.agenthubmemory/TODO.md`
-4. if startup/resume finds pending assignment state, pull mailbox and continue resumable
-   assignments; otherwise wait for an explicit pushed mailbox signal instead of proactive polling
+4. if startup/resume finds pending assignment state in local TODO/runtime continuity artifacts,
+   pull mailbox and continue resumable assignments; otherwise wait for an explicit mailbox wake
+   signal instead of proactive polling
 5. when a new concrete assignment is already actionable, execute the first inspection or implementation step in the same turn instead of replying with intent-only narration
 6. report status/evidence back to leader
 7. once an assignment is accepted, keep executing that lane until completion, blocker, input wait,
@@ -193,7 +194,7 @@ Operational consequence:
   substitute for the first actionable step when the task is already executable.
 - Mailbox remains the authoritative coordination path, but it should not be used as the default
   source of "what next?" while an accepted worker lane is still executable.
-- New worker work should normally start from an explicit pushed mailbox signal, not from proactive
+- New worker work should normally start from an explicit mailbox wake signal, not from proactive
   polling.
 
 ### 5.2) Leader Action-First Rule
@@ -223,7 +224,7 @@ Operational consequence:
   executable.
 - Mailbox remains authoritative for coordination, but the leader should not keep re-polling it to
   choose the next move while the current coordination lane still has a clear executable path.
-- New leader coordination work should normally start from an explicit pushed mailbox signal, not
+- New leader coordination work should normally start from an explicit mailbox wake signal, not
   from proactive polling.
 
 ### 5.3) CLI-First Enforcement Profile

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -105,15 +105,20 @@ Leader cold-start:
 5. if no resumable plan exists, create a new planning round
 6. when a new concrete request is already actionable, execute the first planning or investigation
    step in the same turn instead of replying with intent-only narration
+7. after a leader-owned lane becomes active, keep working from current evidence until the lane
+   reaches a clear checkpoint instead of re-polling mailbox for the next step by default
 
 Worker cold-start:
 
 1. load shared Team AGENTS index (injected builtin `team-agents-index`) and role-relevant guidance from `AGENTS.md` + required skills
 2. load worker-specific AGENTS index (injected builtin `team-worker-agents-index`)
 3. inspect unfinished `TODO.md` entries and, in concrete project repos, `.agenthubmemory/TODO.md`
-4. pull mailbox and continue resumable assignments first
+4. if startup/resume finds pending assignment state, pull mailbox and continue resumable
+   assignments; otherwise wait for an explicit pushed mailbox signal instead of proactive polling
 5. when a new concrete assignment is already actionable, execute the first inspection or implementation step in the same turn instead of replying with intent-only narration
 6. report status/evidence back to leader
+7. once an assignment is accepted, keep executing that lane until completion, blocker, input wait,
+   or explicit handoff before polling mailbox again by default
 
 Self-maintenance and deferred follow-up:
 
@@ -186,6 +191,10 @@ Operational consequence:
 
 - Team prompts and worker skills may still require concise status reporting, but reporting must not
   substitute for the first actionable step when the task is already executable.
+- Mailbox remains the authoritative coordination path, but it should not be used as the default
+  source of "what next?" while an accepted worker lane is still executable.
+- New worker work should normally start from an explicit pushed mailbox signal, not from proactive
+  polling.
 
 ### 5.2) Leader Action-First Rule
 
@@ -212,6 +221,10 @@ Operational consequence:
 - Team prompts and leader skills may still require concise human-facing status reporting, but
   reporting must not substitute for the first actionable planning step when the request is already
   executable.
+- Mailbox remains authoritative for coordination, but the leader should not keep re-polling it to
+  choose the next move while the current coordination lane still has a clear executable path.
+- New leader coordination work should normally start from an explicit pushed mailbox signal, not
+  from proactive polling.
 
 ### 5.3) CLI-First Enforcement Profile
 

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -113,8 +113,9 @@ Worker cold-start:
 1. load shared Team AGENTS index (injected builtin `team-agents-index`) and role-relevant guidance from `AGENTS.md` + required skills
 2. load worker-specific AGENTS index (injected builtin `team-worker-agents-index`)
 3. inspect unfinished `TODO.md` entries and, in concrete project repos, `.agenthubmemory/TODO.md`
-4. if startup/resume finds pending assignment state in local TODO/runtime continuity artifacts,
-   pull mailbox and continue resumable assignments; otherwise wait for an explicit mailbox wake
+4. if startup/resume finds pending assignment state already visible in local TODOs,
+   `.agenthubmemory/`, or runtime continuity artifacts, pull mailbox and continue resumable
+   assignments; otherwise send an idle summary/request and then wait for an explicit mailbox wake
    signal instead of proactive polling
 5. when a new concrete assignment is already actionable, execute the first inspection or implementation step in the same turn instead of replying with intent-only narration
 6. report status/evidence back to leader

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -103,6 +103,8 @@ Leader cold-start:
 3. inspect unfinished items in `TODO.md`
 4. detect whether an existing plan can be resumed
 5. if no resumable plan exists, create a new planning round
+6. when a new concrete request is already actionable, execute the first planning or investigation
+   step in the same turn instead of replying with intent-only narration
 
 Worker cold-start:
 
@@ -185,7 +187,33 @@ Operational consequence:
 - Team prompts and worker skills may still require concise status reporting, but reporting must not
   substitute for the first actionable step when the task is already executable.
 
-### 5.2) CLI-First Enforcement Profile
+### 5.2) Leader Action-First Rule
+
+Leader coordination should also prefer immediate planning evidence over safe intent narration when
+the request is already concrete and no blocker exists.
+
+Policy:
+
+- A leader must not stop at `task received`, `scope confirmed`, or `I will investigate/plan next`
+  when the next planning step is already clear.
+- If a leader describes the next step, it should execute that step in the same turn unless blocked
+  by missing permissions, missing inputs, or runtime failure.
+- First-turn leader artifacts may include:
+  - opening and summarizing the assigned issue/PR from direct inspection
+  - searching the relevant code path or reading the suspect file/module
+  - writing the first ordered plan or task split
+  - dispatching the first deterministic worker brief
+  - running the narrowest relevant reproduction command
+- A blocker report is valid only when it names the exact missing prerequisite or failure mode; a
+  generic planning statement without action or blocker evidence is not sufficient progress.
+
+Operational consequence:
+
+- Team prompts and leader skills may still require concise human-facing status reporting, but
+  reporting must not substitute for the first actionable planning step when the request is already
+  executable.
+
+### 5.3) CLI-First Enforcement Profile
 
 Team collaboration should run with the canonical actor CLI mailbox path as the primary communication path:
 
@@ -205,7 +233,7 @@ Detailed enforcement design:
 
 - `docs/features/actor-foundation.md`
 
-### 5.3) Conversation Event Bus Profile
+### 5.4) Conversation Event Bus Profile
 
 Conversation lane should use event bus as the realtime chat/timeline carrier, while keeping mailbox
 as execution command authority:

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -196,6 +196,29 @@ Run this sequence before the first coordination round of each fresh process star
    mailbox just to decide the next step; continue from the current evidence until the lane reaches
    a clear checkpoint, completion, or blocker.
 
+## Mailbox Polling Discipline
+
+- Do not proactively poll mailbox just to discover or choose the next coordination lane.
+- Only consume mailbox when one of these entry conditions is true:
+  - startup/resume requires processing already-pending assignments already visible in `TODO.md`,
+    leader coordination artifacts, or runtime continuity artifacts
+  - runtime surfaces an explicit mailbox wake signal
+  - a human/operator explicitly instructs you to check mailbox
+  - ACP/runtime requires immediate control-flow handling such as permission review
+- After you accept a concrete leader-owned request or coordination lane, do not poll mailbox again
+  just to decide the next step while the current lane still has a clear executable path.
+- Only return to mailbox early when:
+  - the current lane is fully delegated, answered, blocked, waiting, in review, or otherwise
+    reaches a clear checkpoint
+  - runtime surfaces a new explicit mailbox wake signal that changes priority
+  - a human/operator explicitly interrupts or reassigns the current lane
+  - ACP/runtime requires an immediate permission review or equivalent control-flow action
+
+Definition:
+- `explicit mailbox wake signal`: an external runtime-visible notification that new direct mailbox
+  work is pending for the current run/session, for example a surfaced "direct mailbox message
+  pending" prompt or equivalent provider/runtime push.
+
 ## AGENTS.md Minimum Template
 
 Use this structure when creating or refreshing leader workspace `AGENTS.md`:

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -283,7 +283,7 @@ Mailbox polling discipline:
 - Do not proactively poll mailbox just to discover or choose the next task.
 - Only consume mailbox when one of these entry conditions is true:
   - startup/resume requires processing already-pending coordination messages
-  - runtime surfaces an explicit direct-mailbox pending/push signal
+  - runtime surfaces an explicit mailbox wake signal
   - a human/operator explicitly instructs the leader to check mailbox
   - ACP/runtime requires immediate control-flow handling such as permission review
 - After a leader accepts a concrete request or active coordination lane, mailbox polling must not
@@ -292,10 +292,15 @@ Mailbox polling discipline:
   completion, blocker, or explicit handoff.
 - Only re-enter mailbox early when:
   - the current lane is finished or fully handed off
-  - runtime surfaces a new explicit direct-mailbox pending/push signal that changes priority
+  - runtime surfaces a new explicit mailbox wake signal that changes priority
   - a human/operator explicitly interrupts or reassigns work
   - ACP/runtime requires immediate control-flow handling such as permission review
   - a worker reply is required to unblock a waiting coordination path
+
+Definition:
+- `explicit mailbox wake signal`: an external runtime-visible notification that new direct mailbox
+  work is pending for the current run/session, for example a surfaced "direct mailbox message
+  pending" prompt or equivalent provider/runtime push.
 ## Collaboration Planning Contract
 
 - Read worker cards before delegation and treat them as the primary source for capability matching.

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -190,6 +190,8 @@ Run this sequence before the first coordination round of each fresh process star
 6. Human communication rule:
    - Answer human actor directly.
    - Do not reply with "ask worker" or redirect human questions to workers.
+7. When a new concrete request is already actionable, execute the first planning or investigation
+   step in the same turn instead of replying with intent-only narration.
 
 ## AGENTS.md Minimum Template
 
@@ -213,13 +215,27 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 1. Accept inbox work before each coordination round:
    `agenthub actor receive --limit 50`
 2. Parse each accepted message before making routing decisions.
-3. Delegate with deterministic payload JSON:
+3. Execute the first concrete planning/investigation action immediately when the request is already
+   actionable.
+   - Valid first actions include opening the referenced issue/PR, searching the relevant code path,
+     reading the suspect file/module, drafting the first task split, or running the narrowest
+     relevant reproduction command.
+   - Do not spend the first coordination turn only restating scope, constraints, or next actions
+     unless a real blocker prevents tool use.
+   - If blocked, report the blocker together with the exact missing prerequisite or runtime failure.
+4. Delegate with deterministic payload JSON:
    `agenthub actor send --to-actor-id "$WORKER_ID" --text-file .agenthubmemory/mailbox/outbox/task-brief.md`
-4. If a worker is blocked, ask for missing facts or re-scope the task.
-5. Keep a running decision log and conflict resolution summary.
+5. If a worker is blocked, ask for missing facts or re-scope the task.
+6. Keep a running decision log and conflict resolution summary.
 
 ## Reporting And Supervision Contract
 
+- Do not stop at intent narration when a concrete human/team request is assigned to the leader and
+  no blocker exists.
+- If you say what you will do next, execute that first concrete step in the same turn.
+- Treat a pure `I will investigate/plan/check next` message without any accompanying action
+  artifact as a contract violation unless missing permissions, missing inputs, or runtime failure
+  genuinely block execution.
 - Every active worker assignment must have an owner, latest status, latest evidence, and next
   checkpoint recorded in leader coordination artifacts.
 - Require worker updates at assignment start, meaningful progress, blocker discovery, and
@@ -248,6 +264,19 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
   relevant task/doc artifact so the channel message is a summary, not the only durable record.
 - In shared-channel progress updates, explicitly `@` the responsible workers, reviewers, and
   affected stakeholders instead of posting anonymous team-wide status text.
+
+New-request first-turn contract:
+
+- When a new concrete request arrives and the scope is already clear enough to begin, the first
+  leader turn must produce at least one action artifact.
+- Acceptable first-turn artifacts include:
+  - opening and summarizing the assigned issue/PR from direct inspection
+  - searching the relevant code path or reading the suspect file/module
+  - writing the first ordered plan or task split into coordination artifacts
+  - dispatching the first deterministic worker brief
+  - running the narrowest relevant reproduction command
+- `task received`, `scope confirmed`, or `I will now ...` messages do not count as execution
+  artifacts on their own.
 
 ## Collaboration Planning Contract
 

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -217,9 +217,10 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 2. Parse each accepted message before making routing decisions.
 3. Execute the first concrete planning/investigation action immediately when the request is already
    actionable.
-   - Valid first actions include opening the referenced issue/PR, searching the relevant code path,
-     reading the suspect file/module, drafting the first task split, or running the narrowest
-     relevant reproduction command.
+   - Valid first actions include opening and summarizing the assigned issue/PR from direct
+     inspection, searching the relevant code path or reading the suspect file/module, writing the
+     first ordered plan or task split into coordination artifacts, dispatching the first
+     deterministic worker brief, or running the narrowest relevant reproduction command.
    - Do not spend the first coordination turn only restating scope, constraints, or next actions
      unless a real blocker prevents tool use.
    - If blocked, report the blocker together with the exact missing prerequisite or runtime failure.
@@ -230,12 +231,6 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 
 ## Reporting And Supervision Contract
 
-- Do not stop at intent narration when a concrete human/team request is assigned to the leader and
-  no blocker exists.
-- If you say what you will do next, execute that first concrete step in the same turn.
-- Treat a pure `I will investigate/plan/check next` message without any accompanying action
-  artifact as a contract violation unless missing permissions, missing inputs, or runtime failure
-  genuinely block execution.
 - Every active worker assignment must have an owner, latest status, latest evidence, and next
   checkpoint recorded in leader coordination artifacts.
 - Require worker updates at assignment start, meaningful progress, blocker discovery, and
@@ -265,7 +260,7 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
 - In shared-channel progress updates, explicitly `@` the responsible workers, reviewers, and
   affected stakeholders instead of posting anonymous team-wide status text.
 
-New-request first-turn contract:
+## New-request First-turn Contract
 
 - When a new concrete request arrives and the scope is already clear enough to begin, the first
   leader turn must produce at least one action artifact.

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -192,6 +192,9 @@ Run this sequence before the first coordination round of each fresh process star
    - Do not reply with "ask worker" or redirect human questions to workers.
 7. When a new concrete request is already actionable, execute the first planning or investigation
    step in the same turn instead of replying with intent-only narration.
+8. After you accept a concrete leader-owned request or active coordination lane, do not re-poll
+   mailbox just to decide the next step; continue from the current evidence until the lane reaches
+   a clear checkpoint, completion, or blocker.
 
 ## AGENTS.md Minimum Template
 
@@ -228,6 +231,8 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
    `agenthub actor send --to-actor-id "$WORKER_ID" --text-file .agenthubmemory/mailbox/outbox/task-brief.md`
 5. If a worker is blocked, ask for missing facts or re-scope the task.
 6. Keep a running decision log and conflict resolution summary.
+7. Return to mailbox only after the current coordination lane reaches a clear checkpoint
+   (`delegated`, `answered`, `blocked`, `waiting`, `in_review`, or equivalent completion state).
 
 ## Reporting And Supervision Contract
 
@@ -272,6 +277,25 @@ Use this structure when creating or refreshing leader workspace `AGENTS.md`:
   - running the narrowest relevant reproduction command
 - `task received`, `scope confirmed`, or `I will now ...` messages do not count as execution
   artifacts on their own.
+
+Mailbox polling discipline:
+
+- Do not proactively poll mailbox just to discover or choose the next task.
+- Only consume mailbox when one of these entry conditions is true:
+  - startup/resume requires processing already-pending coordination messages
+  - runtime surfaces an explicit direct-mailbox pending/push signal
+  - a human/operator explicitly instructs the leader to check mailbox
+  - ACP/runtime requires immediate control-flow handling such as permission review
+- After a leader accepts a concrete request or active coordination lane, mailbox polling must not
+  become the default mechanism for choosing the next step.
+- Continue from the current issue/code/task evidence until the lane reaches a clear checkpoint,
+  completion, blocker, or explicit handoff.
+- Only re-enter mailbox early when:
+  - the current lane is finished or fully handed off
+  - runtime surfaces a new explicit direct-mailbox pending/push signal that changes priority
+  - a human/operator explicitly interrupts or reassigns work
+  - ACP/runtime requires immediate control-flow handling such as permission review
+  - a worker reply is required to unblock a waiting coordination path
 
 ## Collaboration Planning Contract
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -129,18 +129,18 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 3. Determine phase alignment:
    - If pending task is implementation/research, run in `Communication and collaboration`.
    - If pending task is summary/evidence wrap-up, run in `Consensus formation` or `Result integration`.
-4. If no unfinished worker items or locally resumable assignment artifacts exist, wait for an
-   explicit mailbox wake signal instead of proactively polling mailbox in a loop.
-5. If no unfinished worker items or locally resumable assignment artifacts exist, send an `idle`
+4. If no unfinished worker items or locally resumable assignment artifacts exist, send an `idle`
    status summary and request next task from leader.
+5. Then wait for an explicit mailbox wake signal instead of proactively polling mailbox in a loop.
 6. Persist durable project notes in `.agenthubmemory/journal/` and `.agenthubmemory/note/`; use
    `.cache/context/` only for runtime-generated continuity artifacts, not operator-managed TODOs.
 
-Mailbox polling discipline:
+## Mailbox Polling Discipline
 
 - Do not proactively poll mailbox just to discover or choose the next task.
 - Only consume mailbox when one of these entry conditions is true:
-  - startup/resume requires processing already-pending assignments
+  - startup/resume requires processing already-pending assignments already visible in local TODOs,
+    `.agenthubmemory/`, or runtime continuity artifacts
   - runtime surfaces an explicit mailbox wake signal
   - a human/operator explicitly instructs you to check mailbox
   - ACP/runtime requires immediate control-flow handling such as permission review
@@ -208,7 +208,7 @@ Mailbox polling discipline:
 
 ## Worker Loop
 
-1. Enter mailbox only when startup/resume or an explicit mailbox wake signal requires it:
+1. Enter mailbox only when one of the mailbox polling discipline entry conditions applies:
    `agenthub actor receive --limit 50`
 2. Parse the accepted task and validate required fields.
 3. Execute the first concrete investigation or implementation step immediately.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -129,9 +129,10 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 3. Determine phase alignment:
    - If pending task is implementation/research, run in `Communication and collaboration`.
    - If pending task is summary/evidence wrap-up, run in `Consensus formation` or `Result integration`.
-4. If no unfinished worker items exist, wait for an explicit pushed assignment signal instead of
-   proactively polling mailbox in a loop.
-5. If no assignment exists, send an `idle` status summary and request next task from leader.
+4. If no unfinished worker items or locally resumable assignment artifacts exist, wait for an
+   explicit mailbox wake signal instead of proactively polling mailbox in a loop.
+5. If no unfinished worker items or locally resumable assignment artifacts exist, send an `idle`
+   status summary and request next task from leader.
 6. Persist durable project notes in `.agenthubmemory/journal/` and `.agenthubmemory/note/`; use
    `.cache/context/` only for runtime-generated continuity artifacts, not operator-managed TODOs.
 
@@ -140,7 +141,7 @@ Mailbox polling discipline:
 - Do not proactively poll mailbox just to discover or choose the next task.
 - Only consume mailbox when one of these entry conditions is true:
   - startup/resume requires processing already-pending assignments
-  - runtime surfaces an explicit direct-mailbox pending/push signal
+  - runtime surfaces an explicit mailbox wake signal
   - a human/operator explicitly instructs you to check mailbox
   - ACP/runtime requires immediate control-flow handling such as permission review
 - After you accept a concrete assignment, do not poll mailbox again just to decide the next step.
@@ -152,7 +153,7 @@ Mailbox polling discipline:
   - a required checkpoint/report has been sent
 - Only return to mailbox early when:
   - the current task is fully handed off or finished
-  - runtime surfaces a new explicit direct-mailbox pending/push signal that changes priority
+  - runtime surfaces a new explicit mailbox wake signal that changes priority
   - a human/operator explicitly interrupts or reassigns work
   - ACP/runtime requires an immediate permission review or equivalent control-flow action
 - Do not use newly fetched mailbox traffic as the default source of "what should I do next?" while
@@ -207,7 +208,7 @@ Mailbox polling discipline:
 
 ## Worker Loop
 
-1. Enter mailbox only when startup/resume or an explicit pushed pending-message signal requires it:
+1. Enter mailbox only when startup/resume or an explicit mailbox wake signal requires it:
    `agenthub actor receive --limit 50`
 2. Parse the accepted task and validate required fields.
 3. Execute the first concrete investigation or implementation step immediately.
@@ -228,7 +229,7 @@ Mailbox polling discipline:
    - escalate quickly when task acceptance or ownership needs leader intervention
 8. Return to mailbox only after the current assignment reaches a clear checkpoint (`completed`,
    `blocked`, `input_required`, explicit handoff, equivalent review-ready state, or a new explicit
-   pushed pending-message signal).
+   mailbox wake signal).
 
 New-assignment first-turn contract:
 - When a new concrete bug/task arrives and the scope is already clear enough to begin, your first
@@ -242,6 +243,11 @@ New-assignment first-turn contract:
   artifacts on their own.
 - If permissions or missing environment prerequisites block execution, state that explicitly and
   name the exact missing permission/input/runtime failure.
+
+Definition:
+- `explicit mailbox wake signal`: an external runtime-visible notification that new direct mailbox
+  work is pending for the current run/session, for example a surfaced "direct mailbox message
+  pending" prompt or equivalent provider/runtime push.
 
 Step execution contract:
 - `single_pass` step: execute the bounded change once, then report evidence or blocker.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -129,10 +129,34 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 3. Determine phase alignment:
    - If pending task is implementation/research, run in `Communication and collaboration`.
    - If pending task is summary/evidence wrap-up, run in `Consensus formation` or `Result integration`.
-4. If no unfinished worker items exist, proceed to mailbox assignment loop.
+4. If no unfinished worker items exist, wait for an explicit pushed assignment signal instead of
+   proactively polling mailbox in a loop.
 5. If no assignment exists, send an `idle` status summary and request next task from leader.
 6. Persist durable project notes in `.agenthubmemory/journal/` and `.agenthubmemory/note/`; use
    `.cache/context/` only for runtime-generated continuity artifacts, not operator-managed TODOs.
+
+Mailbox polling discipline:
+
+- Do not proactively poll mailbox just to discover or choose the next task.
+- Only consume mailbox when one of these entry conditions is true:
+  - startup/resume requires processing already-pending assignments
+  - runtime surfaces an explicit direct-mailbox pending/push signal
+  - a human/operator explicitly instructs you to check mailbox
+  - ACP/runtime requires immediate control-flow handling such as permission review
+- After you accept a concrete assignment, do not poll mailbox again just to decide the next step.
+- Treat the accepted assignment as the active lane and keep executing from local evidence, TODOs,
+  and workspace state until one of these happens:
+  - the task/step is completed
+  - a real blocker is reached
+  - human or external input is required
+  - a required checkpoint/report has been sent
+- Only return to mailbox early when:
+  - the current task is fully handed off or finished
+  - runtime surfaces a new explicit direct-mailbox pending/push signal that changes priority
+  - a human/operator explicitly interrupts or reassigns work
+  - ACP/runtime requires an immediate permission review or equivalent control-flow action
+- Do not use newly fetched mailbox traffic as the default source of "what should I do next?" while
+  the current assignment still has a clear executable path.
 
 ## Reporting Expectations
 
@@ -183,7 +207,7 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 
 ## Worker Loop
 
-1. Accept inbox work and find the latest unhandled assignment:
+1. Enter mailbox only when startup/resume or an explicit pushed pending-message signal requires it:
    `agenthub actor receive --limit 50`
 2. Parse the accepted task and validate required fields.
 3. Execute the first concrete investigation or implementation step immediately.
@@ -202,6 +226,9 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
    - do not wait for repeated nudges when the next executable step is already clear
    - send prompt progress updates when evidence changes, scope shifts, or blockers appear
    - escalate quickly when task acceptance or ownership needs leader intervention
+8. Return to mailbox only after the current assignment reaches a clear checkpoint (`completed`,
+   `blocked`, `input_required`, explicit handoff, equivalent review-ready state, or a new explicit
+   pushed pending-message signal).
 
 New-assignment first-turn contract:
 - When a new concrete bug/task arrives and the scope is already clear enough to begin, your first


### PR DESCRIPTION
## Summary

- tighten mailbox polling discipline for both leader and worker skills
- clarify that new work should normally start from an explicit pushed mailbox signal instead of
  proactive polling
- record the same rule in the stable Team collaboration playbook

## Why

The action-first rules still left one execution gap: agents could keep using mailbox polling as the
default source of "what next?" even while the current lane remained executable. This PR narrows
that behavior so mailbox stays authoritative for coordination, but not the default step selector.

## Testing

- docs-only change
