### PR TITLE
docs(skills): prefer reusable approval for repeated commands

### DIFF
--- a/crates/agenthub-managed-skills/src/lib.rs
+++ b/crates/agenthub-managed-skills/src/lib.rs
@@ -389,9 +389,12 @@ Protocol rules:
 - Treat the runtime context block as the canonical source for the current actor identity and default run scope.
 - Use `actor inbox` only for inspection/debugging or historical mailbox review.
 - Keep `actor ack` for repair, recovery, or manual compensation flows.
-- When ACP approval offers the same least-privilege scope as both a one-time and a reusable option,
-  prefer the reusable approval for frequently repeated trusted command families (for example
-  `agenthub actor ...`) so the session does not churn on identical prompts.
+- When ACP approval offers the same least-privilege scope with different approval persistence
+  options (for example, one-time vs reusable), choose the shortest duration that still avoids
+  unnecessary repeated prompts.
+- For frequently repeated trusted command families such as actor (`agenthub actor`), prefer a
+  session-scoped reusable approval when available; otherwise choose the least broad reusable option
+  offered so the session does not churn on identical prompts.
 - For `actor permission-review-respond`, choose any allow/session/persistent approval by passing the
   concrete request-provided `--option-id`; do not invent `--outcome always`.
 - `actor permission-review-respond --outcome` currently supports only `cancelled`.

--- a/crates/agenthub-managed-skills/src/lib.rs
+++ b/crates/agenthub-managed-skills/src/lib.rs
@@ -389,6 +389,9 @@ Protocol rules:
 - Treat the runtime context block as the canonical source for the current actor identity and default run scope.
 - Use `actor inbox` only for inspection/debugging or historical mailbox review.
 - Keep `actor ack` for repair, recovery, or manual compensation flows.
+- When ACP approval offers the same least-privilege scope as both a one-time and a reusable option,
+  prefer the reusable approval for frequently repeated trusted command families (for example
+  `agenthub actor ...`) so the session does not churn on identical prompts.
 - For `actor permission-review-respond`, choose any allow/session/persistent approval by passing the
   concrete request-provided `--option-id`; do not invent `--outcome always`.
 - `actor permission-review-respond --outcome` currently supports only `cancelled`.

--- a/docs/journal/2026-04-16-approval-persistence-guidance.md
+++ b/docs/journal/2026-04-16-approval-persistence-guidance.md
@@ -1,0 +1,9 @@
+# Approval Persistence Guidance
+
+- Updated the runtime-injected actor skill guidance to prefer reusable approvals over one-time
+  approvals when ACP offers the same least-privilege scope for frequently repeated trusted command
+  families such as `agenthub actor ...`.
+- Mirrored the same guidance in the Team leader and worker role skills so permission-review
+  decisions stay consistent with the runtime-injected prompt text.
+- The intent is prompt-level only: do not broaden approval scope, but avoid repeated one-time
+  approvals when the same safe prefix will predictably be used many times in the same workflow.

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -63,11 +63,14 @@ You are the coordinator for a multi-agent team run.
   peer-delegation mailbox task.
 - If ACP exposes a permission review action in your current session, inspect the requested command,
   path/scope, and offered approval options before responding.
-- Approve only the least-privilege option justified by the current task; otherwise cancel/reject
+- Approve only the least-privilege scope justified by the current task; otherwise cancel/reject
   and route the follow-up work through normal team coordination.
-- If the same least-privilege scope is offered as both a one-time and reusable approval, prefer
-  the reusable approval for frequently repeated trusted command families such as `agenthub actor`
-  so ongoing coordination does not keep paying repeated approval overhead.
+- If that same least-privilege scope is offered with different approval persistence options
+  (for example, one-time vs reusable), choose the shortest duration that still avoids unnecessary
+  repeated prompts for the current workflow.
+- For frequently repeated trusted command families such as actor (`agenthub actor`), prefer a
+  session-scoped reusable approval when available; otherwise choose the least broad reusable option
+  offered so the session does not churn on identical prompts.
 - If leader-side agent review is unavailable or times out, expect the system to surface the request
   in `Channel` (`all`) for human review without blocking the original Team flow.
 

--- a/skills/team/team-leader-orchestrator.SKILL.md
+++ b/skills/team/team-leader-orchestrator.SKILL.md
@@ -65,6 +65,9 @@ You are the coordinator for a multi-agent team run.
   path/scope, and offered approval options before responding.
 - Approve only the least-privilege option justified by the current task; otherwise cancel/reject
   and route the follow-up work through normal team coordination.
+- If the same least-privilege scope is offered as both a one-time and reusable approval, prefer
+  the reusable approval for frequently repeated trusted command families such as `agenthub actor`
+  so ongoing coordination does not keep paying repeated approval overhead.
 - If leader-side agent review is unavailable or times out, expect the system to surface the request
   in `Channel` (`all`) for human review without blocking the original Team flow.
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -52,11 +52,14 @@ findings.
 - Only review a Team ACP permission request when ACP exposes the review action in your current
   session.
 - Inspect the requested command, path/scope, and offered approval options before responding.
-- Approve only the least-privilege option justified by the current task; otherwise cancel/reject
+- Approve only the least-privilege scope justified by the current task; otherwise cancel/reject
   and report the blocker or follow-up work back to leader.
-- If the same least-privilege scope is offered as both a one-time and reusable approval, prefer
-  the reusable approval for frequently repeated trusted command families such as `agenthub actor`
-  so normal mailbox/runtime coordination does not keep re-prompting.
+- If that same least-privilege scope is offered with different approval persistence options
+  (for example, one-time vs reusable), choose the shortest duration that still avoids unnecessary
+  repeated prompts for the current workflow.
+- For frequently repeated trusted command families such as actor (`agenthub actor`), prefer a
+  session-scoped reusable approval when available; otherwise choose the least broad reusable option
+  offered so the session does not churn on identical prompts.
 - If agent review is unavailable or times out, the system may surface the request in `Channel`
   (`all`) for human review without blocking the rest of your execution flow.
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -54,6 +54,9 @@ findings.
 - Inspect the requested command, path/scope, and offered approval options before responding.
 - Approve only the least-privilege option justified by the current task; otherwise cancel/reject
   and report the blocker or follow-up work back to leader.
+- If the same least-privilege scope is offered as both a one-time and reusable approval, prefer
+  the reusable approval for frequently repeated trusted command families such as `agenthub actor`
+  so normal mailbox/runtime coordination does not keep re-prompting.
 - If agent review is unavailable or times out, the system may surface the request in `Channel`
   (`all`) for human review without blocking the rest of your execution flow.
 


### PR DESCRIPTION
## Summary

- prefer reusable approval guidance over one-time approval when ACP offers the same least-privilege scope for frequently repeated trusted command families such as `agenthub actor ...`
- mirror that guidance in the runtime-injected managed skill text and the Team leader/worker skills
- record the prompt-level policy change in a dated journal note

## Testing

- `cargo fmt --all --check`
