### PR TITLE
fix(team): restore kanban scroll

### DIFF
--- a/docs/journal/2026-04-17-team-kanban-scroll.md
+++ b/docs/journal/2026-04-17-team-kanban-scroll.md
@@ -1,0 +1,36 @@
+# Team Kanban Scroll
+
+## Summary
+
+Restored vertical scrolling for the Team Kanban surface after the Team workbench
+layout refactors left the panel inside an `overflow-hidden` shell without its own
+scroll container.
+
+## Changed
+
+- `web/src/pages/team_tasks_panel.tsx`
+  - made the Kanban surface itself vertically scrollable with contained overscroll
+  - kept the existing workbench shell layout unchanged so conversation and other
+    Team surfaces do not inherit a broader scroll behavior change
+- `web/src/pages/team_panels.test.tsx`
+  - added regression coverage to ensure the Kanban surface keeps vertical scroll
+    classes
+
+## Root Cause
+
+- `web/src/styles.css` keeps `html`, `body`, and `.app` on `overflow: hidden`
+- `web/src/ui/tailwind_classes.ts` defines `TEAM_PANEL_CARD_CLASS` with
+  `overflow-hidden`
+- unlike the conversation surface, `TeamTasksPanel` did not create an inner
+  `overflow-y-auto` container, so long Kanban content was clipped instead of
+  scrollable
+
+## Validation
+
+- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx`
+
+## Notes
+
+- Chrome DevTools MCP validation was attempted before and after the change, but the
+  local MCP transport closed before a page session could be established. The code
+  change therefore relies on targeted frontend regression tests for this patch.

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3823,6 +3823,51 @@ describe("team panels interactions", () => {
     expect(container.textContent).not.toContain("Prepare rolloutAgents pick this task up automatically");
   });
 
+  it("TeamTasksPanel keeps the kanban surface vertically scrollable", () => {
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamTasksPanel
+            compactMode={false}
+            developerMode={false}
+            tasks={[
+              buildPanelTask("task-open", { title: "Investigate bug", status: "open" }),
+              buildPanelTask("task-progress", {
+                title: "Prepare rollout",
+                status: "in_progress",
+              }),
+            ]}
+            tasksLoading={false}
+            selectedTaskId="task-open"
+            onSelectedTaskIdChange={vi.fn()}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[]}
+            onOpenRun={vi.fn()}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const kanbanSurface = required(
+      container.querySelector('[data-team-surface="kanban"]') as HTMLDivElement | null,
+      "kanban surface missing"
+    );
+    expect(kanbanSurface.className).toContain("overflow-y-auto");
+    expect(kanbanSurface.className).toContain("overscroll-y-contain");
+  });
+
   it("TeamTasksPanel keeps rendered task cards visible during background refresh", () => {
     act(() => {
       root.render(

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -671,7 +671,10 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
   );
 
   return (
-    <div className={`${TEAM_PANEL_CARD_CLASS} p-4`} data-team-surface="kanban">
+    <div
+      className={`${TEAM_PANEL_CARD_CLASS} overflow-y-auto overscroll-y-contain p-4`}
+      data-team-surface="kanban"
+    >
       <ToolbarRow className={TEAM_PANEL_TOOLBAR_CLASS}>
         <h3 className={TEAM_PANEL_TITLE_CLASS}>Kanban</h3>
         <div className={TEAM_PANEL_TOOLBAR_ACTIONS_CLASS}>


### PR DESCRIPTION
fix(team): restore kanban scroll

## Summary
- restore vertical scrolling on the Team Kanban surface without changing the broader Team workbench shell scroll model
- add a regression test that locks the Kanban surface to `overflow-y-auto` with contained overscroll
- document the root cause, validation command, and browser-validation limitation in `docs/journal/2026-04-17-team-kanban-scroll.md`

## Root Cause
- the Team workbench shell keeps `html`, `body`, and `.app` on `overflow: hidden`
- `TEAM_PANEL_CARD_CLASS` also applies `overflow-hidden`
- unlike the conversation surface, `TeamTasksPanel` did not create its own vertical scroll container, so long Kanban content was clipped instead of scrollable

## Testing
- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx`

## Notes
- Chrome DevTools MCP validation was attempted before and after the change, but the local MCP transport closed before a page session could be established