### PR TITLE
fix(web): hide settled permission reviews

### DIFF
--- a/docs/journal/2026-04-17-web-hide-settled-permission-reviews.md
+++ b/docs/journal/2026-04-17-web-hide-settled-permission-reviews.md
@@ -13,6 +13,12 @@ them visible as compact status cards.
 - Pending reviews still render and still trigger the fallback human-review tone.
 - Cancelled reviews remain visible because they do not carry an approval option selection and can
   still be useful as audit context.
+- Review follow-up tightened the helper boundaries:
+  - `filterPermissionsForAgent(...)` once again scopes by `agent_id` only
+  - visibility filtering now lives in `filterVisiblePermissionRecords(...)` and
+    `filterVisiblePermissionsForAgent(...)`
+- Team task pending-review detection now reuses `resolvePermissionCardStatus(...)` so timeout cards
+  derived from `payload.reason` cannot slip back into the pending bucket before polling catches up.
 
 ## Intent
 

--- a/docs/journal/2026-04-17-web-hide-settled-permission-reviews.md
+++ b/docs/journal/2026-04-17-web-hide-settled-permission-reviews.md
@@ -1,0 +1,31 @@
+# Web Hide Settled Permission Reviews
+
+This change hides settled ACP permission review items from the main UI surfaces instead of keeping
+them visible as compact status cards.
+
+## What changed
+
+- Team task conversation now skips permission review cards when the effective status is:
+  - `timeout`
+  - `responded` with a non-empty `selected_option_id` (approved)
+- The same hidden-status rule now applies to ACP debug permission history so the debug tab does not
+  keep showing approved or timed-out review items.
+- Pending reviews still render and still trigger the fallback human-review tone.
+- Cancelled reviews remain visible because they do not carry an approval option selection and can
+  still be useful as audit context.
+
+## Intent
+
+- Keep the Team thread focused on active work that still requires operator action.
+- Remove stale review noise after approval or timeout.
+- Keep filtering consistent across Team task UI and ACP debug history.
+
+## Validation
+
+- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/acp_debug.test.tsx src/app.permission_scope.test.ts`
+
+## MCP verification
+
+- Chrome DevTools MCP baseline and regression checks were both attempted.
+- Both attempts failed before inspection with `Transport closed`, so this change only has unit-test
+  validation and no browser-side MCP evidence.

--- a/web/src/acp_debug.test.tsx
+++ b/web/src/acp_debug.test.tsx
@@ -122,7 +122,7 @@ describe("AcpDebug", () => {
     expect(html).toContain("1 fail");
   });
 
-  it("renders permissions tab with jump/copy controls", () => {
+  it("hides approved and timed out permissions from the permissions tab", () => {
     const html = renderHtml(
       {
         ...baseProps,
@@ -153,10 +153,11 @@ describe("AcpDebug", () => {
       }
     );
     expect(html).toContain("Permissions");
-    expect(html).toContain("Read file");
-    expect(html).toContain("Copy");
-    expect(html).toContain("tool_call call-1");
-    expect(html).toContain("no linked tool call in conversation");
+    expect(html).toContain("No permissions yet.");
+    expect(html).not.toContain("Read file");
+    expect(html).not.toContain("Copy");
+    expect(html).not.toContain("tool_call call-1");
+    expect(html).not.toContain("no linked tool call in conversation");
   });
 
   it("renders raw events tab list when initial tab is raw", () => {

--- a/web/src/app.permission_scope.test.ts
+++ b/web/src/app.permission_scope.test.ts
@@ -44,7 +44,8 @@ import {
 const buildPermission = (
   id: string,
   agentId: string,
-  status = "pending"
+  status = "pending",
+  overrides: Partial<AcpPermissionRecord> = {}
 ): AcpPermissionRecord => ({
   id,
   agent_id: agentId,
@@ -52,6 +53,7 @@ const buildPermission = (
   options: [],
   status,
   created_at: 1,
+  ...overrides,
 });
 
 const buildEvent = (
@@ -150,16 +152,16 @@ describe("filterPermissionsForAgent", () => {
     expect(filterPermissionsForAgent(input, null)).toEqual([]);
   });
 
-  it("keeps only permission records that belong to active agent", () => {
+  it("keeps only visible permission records that belong to active agent", () => {
     const input = [
       buildPermission("p1", "agent-a"),
       buildPermission("p2", "agent-b", "responded"),
       buildPermission("p3", "agent-a", "timeout"),
+      buildPermission("p4", "agent-a", "responded", {
+        selected_option_id: "allow_once",
+      }),
     ];
-    expect(filterPermissionsForAgent(input, "agent-a").map((item) => item.id)).toEqual([
-      "p1",
-      "p3",
-    ]);
+    expect(filterPermissionsForAgent(input, "agent-a").map((item) => item.id)).toEqual(["p1"]);
   });
 });
 
@@ -418,6 +420,9 @@ describe("app helper decisions", () => {
       buildPermission("p-a-1", "agent-a"),
       buildPermission("p-b-1", "agent-b"),
       buildPermission("p-a-2", "agent-a", "responded"),
+      buildPermission("p-a-3", "agent-a", "responded", {
+        selected_option_id: "allow_once",
+      }),
       buildPermission("p-c-1", "agent-c"),
     ];
 

--- a/web/src/app.permission_scope.test.ts
+++ b/web/src/app.permission_scope.test.ts
@@ -9,6 +9,7 @@ import {
   chunkPermissionPollAgentIds,
   decidePermissionJump,
   filterPermissionsForAgent,
+  filterVisiblePermissionsForAgent,
   isAgentsWorkbenchRoute,
   loadAgentsPanelWidthPreference,
   mergePendingPermissionCountMap,
@@ -152,6 +153,24 @@ describe("filterPermissionsForAgent", () => {
     expect(filterPermissionsForAgent(input, null)).toEqual([]);
   });
 
+  it("keeps all permission records that belong to active agent", () => {
+    const input = [
+      buildPermission("p1", "agent-a"),
+      buildPermission("p2", "agent-b", "responded"),
+      buildPermission("p3", "agent-a", "timeout"),
+      buildPermission("p4", "agent-a", "responded", {
+        selected_option_id: "allow_once",
+      }),
+    ];
+    expect(filterPermissionsForAgent(input, "agent-a").map((item) => item.id)).toEqual([
+      "p1",
+      "p3",
+      "p4",
+    ]);
+  });
+});
+
+describe("filterVisiblePermissionsForAgent", () => {
   it("keeps only visible permission records that belong to active agent", () => {
     const input = [
       buildPermission("p1", "agent-a"),
@@ -161,7 +180,9 @@ describe("filterPermissionsForAgent", () => {
         selected_option_id: "allow_once",
       }),
     ];
-    expect(filterPermissionsForAgent(input, "agent-a").map((item) => item.id)).toEqual(["p1"]);
+    expect(filterVisiblePermissionsForAgent(input, "agent-a").map((item) => item.id)).toEqual([
+      "p1",
+    ]);
   });
 });
 
@@ -427,10 +448,10 @@ describe("app helper decisions", () => {
     ];
 
     expect(
-      filterPermissionsForAgent(permissions, "agent-a").map((item) => item.id)
+      filterVisiblePermissionsForAgent(permissions, "agent-a").map((item) => item.id)
     ).toEqual(["p-a-1", "p-a-2"]);
     expect(
-      filterPermissionsForAgent(permissions, "agent-b").map((item) => item.id)
+      filterVisiblePermissionsForAgent(permissions, "agent-b").map((item) => item.id)
     ).toEqual(["p-b-1"]);
   });
 

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -98,6 +98,8 @@ export {
   buildPendingPermissionCountMap,
   chunkPermissionPollAgentIds,
   filterPermissionsForAgent,
+  filterVisiblePermissionRecords,
+  filterVisiblePermissionsForAgent,
   mergePendingPermissionCountMap,
   parsePermissionPollAgentIds,
   resolveGlobalPermissionPollIntervalMs,

--- a/web/src/app_permission_polling.ts
+++ b/web/src/app_permission_polling.ts
@@ -91,9 +91,20 @@ export function filterPermissionsForAgent(
   agentId: string | null
 ): AcpPermissionRecord[] {
   if (!agentId) return [];
-  return items.filter(
-    (item) => item.agent_id === agentId && shouldDisplayPermissionRecord(item)
-  );
+  return items.filter((item) => item.agent_id === agentId);
+}
+
+export function filterVisiblePermissionRecords(
+  items: AcpPermissionRecord[]
+): AcpPermissionRecord[] {
+  return items.filter(shouldDisplayPermissionRecord);
+}
+
+export function filterVisiblePermissionsForAgent(
+  items: AcpPermissionRecord[],
+  agentId: string | null
+): AcpPermissionRecord[] {
+  return filterVisiblePermissionRecords(filterPermissionsForAgent(items, agentId));
 }
 
 export function shouldDisplayPermissionRecord(item: AcpPermissionRecord): boolean {
@@ -104,9 +115,7 @@ export function shouldDisplayPermissionRecord(item: AcpPermissionRecord): boolea
   if (status !== "responded") {
     return true;
   }
-  const selectedOptionId =
-    typeof item.selected_option_id === "string" ? item.selected_option_id.trim() : "";
-  return selectedOptionId.length === 0;
+  return !(item.selected_option_id?.trim());
 }
 
 function defaultScheduleTimeout(

--- a/web/src/app_permission_polling.ts
+++ b/web/src/app_permission_polling.ts
@@ -91,7 +91,22 @@ export function filterPermissionsForAgent(
   agentId: string | null
 ): AcpPermissionRecord[] {
   if (!agentId) return [];
-  return items.filter((item) => item.agent_id === agentId);
+  return items.filter(
+    (item) => item.agent_id === agentId && shouldDisplayPermissionRecord(item)
+  );
+}
+
+export function shouldDisplayPermissionRecord(item: AcpPermissionRecord): boolean {
+  const status = item.status.trim().toLowerCase();
+  if (status === "timeout") {
+    return false;
+  }
+  if (status !== "responded") {
+    return true;
+  }
+  const selectedOptionId =
+    typeof item.selected_option_id === "string" ? item.selected_option_id.trim() : "";
+  return selectedOptionId.length === 0;
 }
 
 function defaultScheduleTimeout(

--- a/web/src/components/acp_debug.tsx
+++ b/web/src/components/acp_debug.tsx
@@ -2,6 +2,7 @@ import { UnstyledButton } from "@mantine/core";
 import React from "react";
 import { AcpConfigOption, AcpRawEvent } from "../acp";
 import { AcpPermissionRecord } from "../api";
+import { shouldDisplayPermissionRecord } from "../app_permission_polling";
 import { OutputLine } from "../output_cache";
 import { ActionButton, ToolbarRow, cx } from "../ui/primitives";
 import {
@@ -140,6 +141,7 @@ function AcpDebugView({
   const [copiedPermissionId, setCopiedPermissionId] = React.useState<string | null>(null);
   const copiedResetTimerRef = React.useRef<number | null>(null);
   const rawRef = React.useRef<HTMLUListElement | null>(null);
+  const visiblePermissionHistory = acpPermissionHistory.filter(shouldDisplayPermissionRecord);
   const markdownTotal = runtimeMetrics.markdownCacheHits + runtimeMetrics.markdownCacheMisses;
   const ansiTotal = runtimeMetrics.ansiCacheHits + runtimeMetrics.ansiCacheMisses;
   const payloadParseSuccess = Math.max(
@@ -502,12 +504,12 @@ function AcpDebugView({
       {tab === "permissions" && (
         <div className={`acp-permissions ${ACP_DEBUG_SECTION_CLASS}`}>
           <h4 className="text-sm font-bold text-notion-text uppercase tracking-widest">Permissions</h4>
-          {acpPermissionHistory.length === 0 && (
+          {visiblePermissionHistory.length === 0 && (
             <div className={ACP_DEBUG_EMPTY_CLASS}>
               No permissions yet.
             </div>
           )}
-          {acpPermissionHistory.map((permission) => {
+          {visiblePermissionHistory.map((permission) => {
             const toolCall = toPermissionToolCall(permission.tool_call);
             const copied = copiedPermissionId === permission.id;
             const canJump = Boolean(permission.tool_call_id?.trim());

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2317,7 +2317,7 @@ describe("team panels interactions", () => {
     expect(progressbar.getAttribute("aria-valuemax")).toBe("2");
   });
 
-  it("TeamTaskPanel renders permission review cards in channel and collapses to status after response", async () => {
+  it("TeamTaskPanel removes approved permission review cards from the channel after response", async () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
     const listPermissionsSpy = vi
       .spyOn(api, "listAcpPermissions")
@@ -2366,8 +2366,6 @@ describe("team panels interactions", () => {
                 agent_id: "worker-agent",
                 tool_name: "git push",
                 summary: "worker requests permission to execute git push.",
-                reason: "review_timeout",
-                reason_text: "Agent review timed out",
                 status: "pending",
                 options: [
                   { option_id: "allow", name: "Allow once", kind: "allow_once" },
@@ -2402,7 +2400,6 @@ describe("team panels interactions", () => {
       await waitForCondition(() => listPermissionsSpy.mock.calls.length > 0);
       await waitForCondition(() => container.textContent?.includes("Awaiting human review") ?? false);
       expect(container.textContent).toContain("git push");
-      expect(container.textContent).toContain("Agent review timed out");
       expect(container.textContent).toContain("Awaiting human review");
       expect(queryButtonByText(container, "Allow once")).not.toBeNull();
       clickElement(queryButtonByText(container, "Allow once"));
@@ -2412,21 +2409,21 @@ describe("team panels interactions", () => {
         option_id: "allow",
         outcome: undefined,
       });
-      await waitForCondition(() =>
-        container.textContent?.includes("Approved · Allow once") ?? false
+      await waitForCondition(
+        () => container.querySelector("[data-team-permission-card='true']") === null
       );
-      expect(container.textContent).toContain("Approved · Allow once");
+      expect(container.textContent).not.toContain("Approved · Allow once");
       expect(queryButtonByText(container, "Allow once")).toBeNull();
       expect(queryButtonByText(container, "Cancel")).toBeNull();
       expect(container.textContent).not.toContain("worker requests permission to execute git push.");
-      expect(container.textContent).not.toContain("Agent review timed out");
+      expect(container.textContent).not.toContain("git push");
     } finally {
       listPermissionsSpy.mockRestore();
       respondPermissionSpy.mockRestore();
     }
   });
 
-  it("TeamTaskPanel collapses timed out permission review cards even before permission polling catches up", async () => {
+  it("TeamTaskPanel hides timed out permission review cards even before permission polling catches up", async () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
     const listPermissionsSpy = vi.spyOn(api, "listAcpPermissions").mockResolvedValue([]);
 
@@ -2486,18 +2483,15 @@ describe("team panels interactions", () => {
         />
       );
 
-      await waitForCondition(() => listPermissionsSpy.mock.calls.length > 0);
-      const permissionCard = required(
-        container.querySelector("[data-team-permission-card='true']"),
-        "permission card missing"
-      ) as HTMLElement;
-      expect(permissionCard.textContent).toContain("git push");
-      expect(permissionCard.textContent).toContain("Timed out");
-      expect(permissionCard.innerHTML).toContain("bg-notion-hover");
-      expect(permissionCard.textContent).not.toContain("worker requests permission to execute git push.");
-      expect(permissionCard.textContent).not.toContain("Agent review timed out");
-      expect(queryButtonByText(permissionCard, "Allow once")).toBeNull();
-      expect(queryButtonByText(permissionCard, "Cancel")).toBeNull();
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(listPermissionsSpy).not.toHaveBeenCalled();
+      expect(container.querySelector("[data-team-permission-card='true']")).toBeNull();
+      expect(container.textContent).not.toContain("git push");
+      expect(container.textContent).not.toContain("Timed out");
+      expect(container.textContent).not.toContain("worker requests permission to execute git push.");
+      expect(container.textContent).not.toContain("Agent review timed out");
     } finally {
       listPermissionsSpy.mockRestore();
     }
@@ -2713,8 +2707,6 @@ describe("team panels interactions", () => {
         agent_id: "worker-agent",
         tool_name: "git push",
         summary: "worker requests permission to execute git push.",
-        reason: "review_timeout",
-        reason_text: "Agent review timed out",
         status: "pending",
         options: [{ option_id: "allow", name: "Allow once", kind: "allow_once" }],
       },
@@ -2757,7 +2749,7 @@ describe("team panels interactions", () => {
     }
   });
 
-  it("TeamTaskPanel tolerates malformed permission record options after refresh", async () => {
+  it("TeamTaskPanel hides approved permission review cards after refresh even with malformed options", async () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
     const listPermissionsSpy = vi.spyOn(api, "listAcpPermissions").mockResolvedValue([
       {
@@ -2835,15 +2827,11 @@ describe("team panels interactions", () => {
 
       await waitForCondition(() => listPermissionsSpy.mock.calls.length > 0);
       await waitForCondition(
-        () => container.textContent?.includes("Approved · Allow once") ?? false
+        () => container.querySelector("[data-team-permission-card='true']") === null
       );
-      const permissionCard = required(
-        container.querySelector("[data-team-permission-card='true']"),
-        "permission card missing"
-      ) as HTMLElement;
-      expect(permissionCard.textContent).toContain("Approved · Allow once");
-      expect(queryButtonByText(permissionCard, "Allow once")).toBeNull();
-      expect(queryButtonByText(permissionCard, "Cancel")).toBeNull();
+      expect(container.textContent).not.toContain("Approved · Allow once");
+      expect(queryButtonByText(container, "Allow once")).toBeNull();
+      expect(queryButtonByText(container, "Cancel")).toBeNull();
     } finally {
       listPermissionsSpy.mockRestore();
     }

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -483,6 +483,18 @@ function resolvePermissionStatusText(
   return status;
 }
 
+function shouldHidePermissionReviewCard(
+  payload: PermissionReviewCardPayload,
+  record?: AcpPermissionRecord
+): boolean {
+  const status = resolvePermissionCardStatus(payload, record);
+  if (status === "timeout") {
+    return true;
+  }
+  const selectedOptionId = normalizeTrimmedString(record?.selected_option_id);
+  return status === "responded" && Boolean(selectedOptionId);
+}
+
 function resolvePermissionToolPreview(payload: PermissionReviewCardPayload): string | null {
   const preview = normalizeTrimmedString(payload.tool_name) ?? normalizeTrimmedString(payload.summary);
   if (!preview) {
@@ -914,11 +926,13 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     () =>
       orderedMessages.flatMap((message) => {
         const payload = parsePermissionReviewCardPayload(message.payload);
+        const record = payload ? permissionRecordsById[payload.permission_id] : undefined;
         return payload
+          && !shouldHidePermissionReviewCard(payload, record)
           ? [{ permissionId: payload.permission_id, agentId: payload.agent_id }]
           : [];
       }),
-    [orderedMessages]
+    [orderedMessages, permissionRecordsById]
   );
   const permissionCardTargetKey = React.useMemo(
     () =>
@@ -936,6 +950,10 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     for (const message of orderedMessages) {
       const payload = parsePermissionReviewCardPayload(message.payload);
       if (!payload) {
+        continue;
+      }
+      const record = permissionRecordsById[payload.permission_id];
+      if (shouldHidePermissionReviewCard(payload, record)) {
         continue;
       }
       const status = permissionRecordsById[payload.permission_id]?.status ?? payload.status ?? "pending";
@@ -1017,6 +1035,10 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         orderedMessages.flatMap((message) => {
           const permissionCardPayload = parsePermissionReviewCardPayload(message.payload);
           if (permissionCardPayload) {
+            const permissionRecord = permissionRecordsById[permissionCardPayload.permission_id];
+            if (shouldHidePermissionReviewCard(permissionCardPayload, permissionRecord)) {
+              return [];
+            }
             return [
               {
                 message,
@@ -1040,7 +1062,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         stickToBottom,
         TEAM_TASK_TAIL_WINDOW_SIZE
       ),
-    [orderedMessages, stickToBottom]
+    [orderedMessages, permissionRecordsById, stickToBottom]
   );
   const visibleWaterfallItems = React.useMemo(
     () =>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -956,7 +956,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
       if (shouldHidePermissionReviewCard(payload, record)) {
         continue;
       }
-      const status = permissionRecordsById[payload.permission_id]?.status ?? payload.status ?? "pending";
+      const status = resolvePermissionCardStatus(payload, record);
       if (status !== "pending" || seen.has(payload.permission_id)) {
         continue;
       }

--- a/web/src/use_app_permissions.ts
+++ b/web/src/use_app_permissions.ts
@@ -7,13 +7,13 @@ import {
   isSamePermissionList, 
 } from "./app_agents_helpers";
 import {
-  parsePermissionPollAgentIds, 
-  buildGlobalPermissionPollAgentIds, 
-  chunkPermissionPollAgentIds, 
-  resolveGlobalPermissionPollIntervalMs, 
-  mergePendingPermissionCountMap, 
-  schedulePermissionPollLoop, 
-  filterPermissionsForAgent 
+  parsePermissionPollAgentIds,
+  buildGlobalPermissionPollAgentIds,
+  chunkPermissionPollAgentIds,
+  resolveGlobalPermissionPollIntervalMs,
+  mergePendingPermissionCountMap,
+  schedulePermissionPollLoop,
+  filterVisiblePermissionsForAgent,
 } from "./app_permission_polling";
 
 const GLOBAL_PERMISSION_POLL_MAX_CONCURRENCY = 4;
@@ -158,8 +158,14 @@ export function useAppPermissions(
     };
   }, [isAgentsRoute, token, activeAgent, developerMode, acpTab, setAcpPermissionHistory]);
 
-  const scopedAcpPermissions = useMemo(() => filterPermissionsForAgent(acpPermissions, activeAgent), [acpPermissions, activeAgent]);
-  const scopedAcpPermissionHistory = useMemo(() => filterPermissionsForAgent(acpPermissionHistory, activeAgent), [acpPermissionHistory, activeAgent]);
+  const scopedAcpPermissions = useMemo(
+    () => filterVisiblePermissionsForAgent(acpPermissions, activeAgent),
+    [acpPermissions, activeAgent]
+  );
+  const scopedAcpPermissionHistory = useMemo(
+    () => filterVisiblePermissionsForAgent(acpPermissionHistory, activeAgent),
+    [acpPermissionHistory, activeAgent]
+  );
 
   return {
     acpPermissions,


### PR DESCRIPTION
fix(web): hide settled permission reviews

## Summary

- hide timed-out permission review cards from Team task conversation instead of collapsing them into compact status bubbles
- hide approved permission review cards from Team task conversation after response instead of keeping the approval status visible inline
- apply the same settled-review filtering to ACP debug permission history
- keep pending reviews visible and keep the fallback human-review tone scoped to genuinely pending reviews
- add a tracked journal note documenting the UI contract and MCP verification outcome

## Testing

- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/acp_debug.test.tsx src/app.permission_scope.test.ts`

## MCP verification

- attempted Chrome DevTools MCP baseline check before edits
- attempted Chrome DevTools MCP regression check after edits
- both attempts failed with `Transport closed`, so this PR includes unit-test evidence only

## Notes

- cancelled permission reviews are still visible; this PR only hides `timeout` and approved (`responded` with `selected_option_id`) items
