### PR TITLE
fix(web): clarify team execution run wording

### DIFF
--- a/docs/journal/2026-04-18-team-execution-vocabulary-ui-alignment.md
+++ b/docs/journal/2026-04-18-team-execution-vocabulary-ui-alignment.md
@@ -1,0 +1,36 @@
+# Team Execution Vocabulary UI Alignment
+
+## Summary
+
+- tightened Team UI wording so `run` stays framed as a concrete execution partition instead of a
+  generic work-progress synonym;
+- kept the current API/runtime schema unchanged because `TeamRunRecord` still does not expose an
+  additive `attempt_number` projection;
+- limited this pass to user-facing Team run/task surfaces and regression coverage.
+
+## Implementation Notes
+
+- `web/src/pages/team_run_panel.tsx`
+  - changed the run browser helper copy to describe runs as concrete execution history/replay
+    partitions;
+  - clarified the default CTA hint from "Start a new run" to "Start a new execution run";
+  - clarified empty states to say "No execution runs loaded yet".
+- `web/src/pages/team_active_run_panel.tsx`
+  - renamed the card heading to `Active Execution Run`;
+  - renamed the status metadata label to `Execution` to avoid treating the whole panel as a generic
+    task-progress surface.
+- `web/src/pages/team_tasks_panel.tsx`
+  - clarified task detail copy to say `No execution run recorded yet`, `Latest execution run is
+    still in progress`, and `Previous execution runs`.
+
+## Validation
+
+- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx`
+
+## Notes
+
+- Chrome DevTools MCP remained unavailable in this session (`chrome-devtools/list_pages` returned
+  `Transport closed`), so this change only has code-level regression evidence.
+- The broader vocabulary follow-up in `docs/todo.md` remains open. A future additive
+  `attempt_number` projection should only land once runtime semantics are explicit enough to avoid
+  conflating "new run" with "new attempt".

--- a/web/src/pages/team_active_run_panel.tsx
+++ b/web/src/pages/team_active_run_panel.tsx
@@ -37,7 +37,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
   return (
     <div className={cardClassName}>
       <ToolbarRow className="mb-3">
-        <h3 className={titleClassName}>Active Run</h3>
+        <h3 className={titleClassName}>Active Execution Run</h3>
         <div className="flex flex-wrap items-center gap-2">
           <ActionButton
             tone="secondary"
@@ -90,7 +90,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
           <strong>ID:</strong> <code>{run.id}</code>
         </span>
         <span className={metaItemClassName}>
-          <strong>Status:</strong>{" "}
+          <strong>Execution:</strong>{" "}
           <StatusBadge
             label={run.status}
             tone={resolveTeamRunStatusTone(run.status)}

--- a/web/src/pages/team_active_run_panel.tsx
+++ b/web/src/pages/team_active_run_panel.tsx
@@ -42,8 +42,8 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
           <ActionButton
             tone="secondary"
             size="sm"
-            title="Refresh active run"
-            aria-label="Refresh active run"
+            title="Refresh active execution run"
+            aria-label="Refresh active execution run"
             onClick={onRefresh}
           >
             <i className="bi bi-arrow-clockwise" aria-hidden="true" />
@@ -90,7 +90,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
           <strong>ID:</strong> <code>{run.id}</code>
         </span>
         <span className={metaItemClassName}>
-          <strong>Execution:</strong>{" "}
+          <strong>Execution status:</strong>{" "}
           <StatusBadge
             label={run.status}
             tone={resolveTeamRunStatusTone(run.status)}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -813,7 +813,7 @@ describe("team panels interactions", () => {
     );
 
     clickElement(findButtonByText(container, "Delete Team"));
-    clickElement(findButtonByText(container, "Start Run"));
+    clickElement(findButtonByText(container, "Start Execution Run"));
     clickElement(findButtonByAriaLabel(container, "Refresh runs"));
     clickElement(required(container.querySelector(".teams-run-list .team-item"), "run list item missing"));
     clickElement(findButtonByText(container, "Load More"));
@@ -824,6 +824,9 @@ describe("team panels interactions", () => {
     expect(onRefreshRuns).toHaveBeenCalledTimes(1);
     expect(onActiveRunChange).toHaveBeenCalledWith("run-1");
     expect(onLoadMoreRuns).toHaveBeenCalledTimes(1);
+    expect(
+      findButtonByAriaLabel(container, "Start execution run").getAttribute("title")
+    ).toBe("Start a new execution run");
 
     act(() => {
       root.render(
@@ -862,6 +865,9 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain(
       "Concrete execution history and replay partitions for this team."
     );
+    expect(
+      findButtonByAriaLabel(container, "Start execution run").getAttribute("title")
+    ).toBe("Add at least one agent before starting the team runtime or a run.");
   });
 
   it("TeamSidebar hides selector controls in detail mode", () => {
@@ -949,7 +955,7 @@ describe("team panels interactions", () => {
       "Add at least one agent before starting the team runtime or a run."
     );
     expect(container.textContent).not.toContain("Debug → Run Ops");
-    expect(container.textContent).toContain("Start Run");
+    expect(container.textContent).toContain("Start Execution Run");
     expect(container.textContent).not.toContain("Create Run");
     expect(container.querySelector('textarea[aria-label="Run input JSON"]')).toBeNull();
   });
@@ -1006,9 +1012,13 @@ describe("team panels interactions", () => {
     });
 
     expect(container.textContent).toContain("Active Execution Run");
+    expect(container.textContent).toContain("Execution status:");
     expect(container.textContent).toContain("run-1");
     expect(container.textContent).toContain("ctx-1");
-    clickElement(findButtonByAriaLabel(container, "Refresh active run"));
+    expect(
+      findButtonByAriaLabel(container, "Refresh active execution run").getAttribute("title")
+    ).toBe("Refresh active execution run");
+    clickElement(findButtonByAriaLabel(container, "Refresh active execution run"));
     clickElement(findButtonByText(container, "Cancel Run"));
     clickElement(findButtonByText(container, "Resume Run"));
     clickElement(findButtonByText(container, "Restart Run"));
@@ -3771,7 +3781,7 @@ describe("team panels interactions", () => {
     );
     expect(container.textContent).toContain("Open thread");
     expect(container.textContent).toContain("Open # all");
-    expect(container.textContent).toContain("Latest run");
+    expect(container.textContent).toContain("Latest execution run");
     expect(container.textContent).toContain("Shipped the rollout summary.");
     expect(container.textContent).toContain("Task context");
   });
@@ -3994,8 +4004,8 @@ describe("team panels interactions", () => {
             runs={[
               buildRun({
                 id: "run-2",
-                status: "completed",
-                summary: "Latest run summary.",
+                status: "failed",
+                summary: "",
                 input: { task_id: "task-progress" },
                 created_at: 230,
                 started_at: 231,
@@ -4040,6 +4050,8 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("No results.");
 
     clickElement(findInteractiveByText(container, "In progress", "button, label"));
+    expect(container.textContent).toContain("Latest execution run");
+    expect(container.textContent).toContain("Latest execution run failed.");
     expect(container.textContent).toContain("Previous execution runs");
     expect(container.textContent).toContain("Earlier run failed.");
     expect(container.textContent).toContain("No summary recorded.");
@@ -4098,7 +4110,7 @@ describe("team panels interactions", () => {
     clickElement(findButtonByText(container, "Prepare rollout"));
 
     expect(container.textContent).toContain("Task detail");
-    expect(container.textContent).toContain("Latest run");
+    expect(container.textContent).toContain("Latest execution run");
     expect(container.querySelector('[aria-label="Back to Kanban"]')).not.toBeNull();
     expect(container.textContent).not.toContain("Board lanes");
 
@@ -4111,6 +4123,56 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("Board lanes");
     expect(container.textContent).not.toContain("Task detail");
+  });
+
+  it("TeamTasksPanel uses terminal fallback copy for canceled latest execution runs", () => {
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamTasksPanel
+            compactMode={false}
+            developerMode={false}
+            tasks={[
+              buildPanelTask("task-progress", {
+                title: "Prepare rollout",
+                status: "in_progress",
+              }),
+            ]}
+            tasksLoading={false}
+            selectedTaskId="task-progress"
+            onSelectedTaskIdChange={vi.fn()}
+            onRefreshTasks={vi.fn()}
+            onOpenConversation={vi.fn()}
+            busy={null}
+            runs={[
+              buildRun({
+                id: "run-9",
+                status: "canceled",
+                summary: "",
+                input: { task_id: "task-progress" },
+                created_at: 230,
+                started_at: 231,
+                ended_at: 240,
+              }),
+            ]}
+            onOpenRun={vi.fn()}
+            compilePreviewContextId=""
+            onCompilePreviewContextIdChange={vi.fn()}
+            onCompileTaskRunPreview={vi.fn()}
+            canCompileTask={false}
+            compiledRunPreview={null}
+            onUseCompiledRunPayload={vi.fn()}
+            onCreateRunFromCompiledPreview={vi.fn()}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            memberLiveStates={[]}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("Latest execution run");
+    expect(container.textContent).toContain("Latest execution run was canceled.");
   });
 
   it("TeamTasksPanel covers compact reset, run warning tones, and debug disclosure toggles", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -857,7 +857,10 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("Active run `run-hidden` is hidden by filter `completed`.");
     expect(container.textContent).toContain(
-      "No runs loaded yet. Use Debug → Run Ops to create or load runs."
+      "No execution runs loaded yet. Use Debug → Run Ops to create or load runs."
+    );
+    expect(container.textContent).toContain(
+      "Concrete execution history and replay partitions for this team."
     );
   });
 
@@ -1002,7 +1005,7 @@ describe("team panels interactions", () => {
       );
     });
 
-    expect(container.textContent).toContain("Active Run");
+    expect(container.textContent).toContain("Active Execution Run");
     expect(container.textContent).toContain("run-1");
     expect(container.textContent).toContain("ctx-1");
     clickElement(findButtonByAriaLabel(container, "Refresh active run"));
@@ -4037,7 +4040,7 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("No results.");
 
     clickElement(findInteractiveByText(container, "In progress", "button, label"));
-    expect(container.textContent).toContain("Previous runs");
+    expect(container.textContent).toContain("Previous execution runs");
     expect(container.textContent).toContain("Earlier run failed.");
     expect(container.textContent).toContain("No summary recorded.");
     clickElement(findButtonByText(container, "run-1"));

--- a/web/src/pages/team_run_panel.tsx
+++ b/web/src/pages/team_run_panel.tsx
@@ -29,6 +29,7 @@ const RUN_PANEL_LIST_ITEMS_CLASS = "teams-run-list-items flex max-h-80 flex-col 
 const RUN_PANEL_SUBTITLE_CLASS = "text-[10px] font-bold uppercase tracking-widest text-notion-text-muted";
 const RUN_PANEL_HINT_TEXT_CLASS = "text-[13px] text-notion-text-muted italic";
 const RUN_PANEL_FOOT_META_CLASS = "mono text-[10px] font-bold uppercase tracking-widest text-notion-text-muted opacity-70";
+const RUN_PANEL_HELP_TEXT = "Concrete execution history and replay partitions for this team.";
 
 type TeamRunPanelProps = {
   selectedTeam: TeamDefinitionRecord;
@@ -107,13 +108,13 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
         <div className="flex flex-col gap-1">
           <p className={RUN_PANEL_SUBTITLE_CLASS}>Run Browser</p>
           <p className={TEAM_MUTED_TEXT_CLASS}>
-            Team execution is agent-driven.
+            {RUN_PANEL_HELP_TEXT}
           </p>
         </div>
 
         <ToolbarRow className="border-b border-notion-border/50 pb-4">
           <span className={RUN_PANEL_HINT_TEXT_CLASS}>
-            {runBlockedReason ?? "Start a new run for this team."}
+            {runBlockedReason ?? "Start a new execution run for this team."}
           </span>
           <ActionButton
             tone="primary"
@@ -160,8 +161,8 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
           {visibleRuns.length === 0 && (
             <p className={TEAM_MUTED_TEXT_CLASS}>
               {developerMode
-                ? "No runs loaded yet. Use Debug → Run Ops to create or load runs."
-                : "No runs loaded yet. Enable Developer Mode for manual run debugging tools."}
+                ? "No execution runs loaded yet. Use Debug → Run Ops to create or load runs."
+                : "No execution runs loaded yet. Enable Developer Mode for manual run debugging tools."}
             </p>
           )}
           {isActiveRunHiddenByFilter && activeRun && (

--- a/web/src/pages/team_run_panel.tsx
+++ b/web/src/pages/team_run_panel.tsx
@@ -123,10 +123,10 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
               void onStartRun();
             }}
             disabled={busy === "create-run" || !selectedTeamId || !canStartRun}
-            title={runBlockedReason ?? "Start a new run"}
-            aria-label="Start run"
+            title={runBlockedReason ?? "Start a new execution run"}
+            aria-label="Start execution run"
           >
-            {busy === "create-run" ? "Starting..." : "Start Run"}
+            {busy === "create-run" ? "Starting..." : "Start Execution Run"}
           </ActionButton>
         </ToolbarRow>
 

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -476,8 +476,8 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
                       ? latestRun.summary?.trim() ||
                         (latestRun.status === "completed"
                           ? "Completed."
-                          : "Execution in progress.")
-                      : "No run recorded yet."}
+                          : "Latest execution run is still in progress.")
+                      : "No execution run recorded yet."}
                   </p>
                 </div>
                 {latestRun && (
@@ -528,7 +528,7 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
               <div className={TASKS_RUN_CARD_CLASS}>
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p className="text-sm font-bold text-notion-text">Previous runs</p>
+                    <p className="text-sm font-bold text-notion-text">Previous execution runs</p>
                   </div>
                   <Badge className="text-[10px]">
                     {relatedRuns.length - 1}

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -470,13 +470,17 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
             <div className={TASKS_RUN_CARD_CLASS}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-bold text-notion-text">Latest run</p>
+                  <p className="text-sm font-bold text-notion-text">Latest execution run</p>
                   <p className="mt-1 text-[13px] leading-relaxed text-notion-text-muted">
                     {latestRun
                       ? latestRun.summary?.trim() ||
                         (latestRun.status === "completed"
                           ? "Completed."
-                          : "Latest execution run is still in progress.")
+                          : latestRun.status === "failed"
+                            ? "Latest execution run failed."
+                            : latestRun.status === "canceled"
+                              ? "Latest execution run was canceled."
+                              : "Latest execution run is still in progress.")
                       : "No execution run recorded yet."}
                   </p>
                 </div>


### PR DESCRIPTION
## Summary

- clarify Team run/task UI wording so `run` stays framed as a concrete execution partition
- rename the active run card and related helper copy toward `execution run` terminology
- add regression coverage plus a journal note for this incremental vocabulary alignment pass

## Testing

- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx`
- `cd web && npm run build`

## Notes

- Chrome DevTools MCP baseline/regression checks were attempted before and after edits, but `chrome-devtools/list_pages` still failed with `Transport closed` in this session, so this PR only has code-level validation evidence.
