### PR TITLE
fix(team): move continuity tail to state paths

### DIFF
--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use agent_client_protocol::{ContentBlock, TextContent};
 use agenthub_acp_core::{AcpSkill, build_skill};
 use agenthub_managed_skills::{ManagedSkillKind, managed_skill_doc};
-use agenthub_text::truncate_chars;
 use anyhow::{Result, bail};
 
 use crate::AcpActorSkillContext;
@@ -86,12 +85,28 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
     let Some(continuity) = context.continuity.as_ref() else {
         return Vec::new();
     };
-    let summary = truncate_chars(continuity.summary_text.as_str(), 400);
-    vec![
+    let mut lines = vec![
         format!("- continuity_mode: {}", continuity.mode),
         format!("- continuity_source_run_id: {}", continuity.source_run_id),
-        format!("- continuity_summary: {summary}"),
-    ]
+        "- continuity_state_path: .cache/context/state.md".to_string(),
+    ];
+    if let Some(artifact_path) = continuity
+        .history_window
+        .get("artifact_pointer")
+        .and_then(extract_artifact_pointer_path)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("- continuity_artifact_path: {artifact_path}"));
+    }
+    lines
+}
+
+fn extract_artifact_pointer_path(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("path")
+        .and_then(|path| path.as_str())
+        .or_else(|| value.as_str())
 }
 
 #[cfg(test)]
@@ -213,11 +228,16 @@ mod tests {
         };
         assert!(
             text.text
-                .contains("continuity_summary: Continue implementation with the same branch.")
+                .contains("continuity_state_path: .cache/context/state.md")
         );
+        assert!(
+            text.text.contains(
+                "continuity_artifact_path: .cache/context/run/run-41/artifact-0001-continuity-output.json"
+            )
+        );
+        assert!(!text.text.contains("continuity_summary:"));
         assert!(!text.text.contains("continuity_history_window_json"));
         assert!(!text.text.contains("continuity_detail_policy"));
         assert!(!text.text.contains("continuity_source_session_id"));
-        assert!(!text.text.contains("artifact-0001-continuity-output.json"));
     }
 }

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -2376,6 +2376,12 @@ Fallback to the user-level review contract.
                 .text
                 .contains("continuity_source_run_id: run-41")
         );
+        assert!(
+            runtime_block
+                .text
+                .contains("continuity_state_path: .cache/context/state.md")
+        );
+        assert!(!runtime_block.text.contains("continuity_summary:"));
     }
 
     #[test]

--- a/docs/journal/2026-04-18-team-prompt-tail-state-paths.md
+++ b/docs/journal/2026-04-18-team-prompt-tail-state-paths.md
@@ -1,0 +1,41 @@
+# Team Prompt Tail State Paths
+
+## Summary
+
+- advanced the Team prompt-tail slimming follow-up by moving continuity recovery detail into the
+  workspace-backed runtime state index instead of replaying it inline on every ACP turn;
+- kept the ACP runtime context block pointer-first: it now points at `.cache/context/state.md` and
+  any persisted continuity artifact path, instead of embedding `continuity_summary` prose;
+- preserved continuity mode and source run identity in the prompt so recovery still has enough
+  routing context without carrying a replay-sized tail.
+
+## Implementation Notes
+
+- `src/team/manager.rs`
+  - after each continuity update, rewrite workspace `.cache/context/state.md` with a compact Team
+    runtime state snapshot;
+  - include current run id, continuity mode, source run id, short continuity summary, and optional
+    continuity artifact path in the file-backed snapshot.
+- `crates/agenthub-acp/src/actor_runtime_skill.rs`
+  - changed the injected ACP runtime context block to emit:
+    - `continuity_mode`
+    - `continuity_source_run_id`
+    - `continuity_state_path: .cache/context/state.md`
+    - `continuity_artifact_path` when available
+  - removed inline `continuity_summary` from the prompt block;
+  - accepted both legacy string and current object-shaped `artifact_pointer` payloads so prompt
+    rendering stays compatible with older continuity records.
+- `crates/agenthub-acp/src/lib.rs`
+  - updated prompt-prefix regression coverage for the new pointer-first runtime context contract.
+
+## Validation
+
+- `cargo test complete_step_offloads_large_output_to_workspace_context_artifact -- --nocapture`
+- `cargo test -p agenthub-acp actor_runtime_context_block_keeps_continuity_pointer_first -- --nocapture`
+- `cargo test -p agenthub-acp prompt_prefix_blocks_append_runtime_context_after_skills -- --nocapture`
+- `cargo fmt`
+
+## Notes
+
+- This does not close the broader TODO item yet; it only moves one dynamic continuity slice from
+  prompt prose into filesystem-backed runtime state.

--- a/docs/journal/2026-04-18-team-prompt-tail-state-paths.md
+++ b/docs/journal/2026-04-18-team-prompt-tail-state-paths.md
@@ -39,3 +39,8 @@
 
 - This does not close the broader TODO item yet; it only moves one dynamic continuity slice from
   prompt prose into filesystem-backed runtime state.
+- Review follow-up tightened the runtime path:
+  - `state.md` snapshot writes are now async and best-effort, so transient filesystem issues do
+    not roll back `complete_step`;
+  - manager-side snapshot rendering now accepts both legacy string and current object-shaped
+    `artifact_pointer` payloads, matching the ACP runtime block compatibility path.

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2151,11 +2151,30 @@ impl TeamManager {
             .join("context")
             .join("state.md");
         if let Some(parent) = state_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            if let Err(err) = tokio::fs::create_dir_all(parent).await {
+                tracing::warn!(
+                    team_id = owner.team_id,
+                    run_id = owner.run_id,
+                    member_id = owner.member_id,
+                    path = %state_path.display(),
+                    "team manager failed to create runtime state snapshot dir: {}",
+                    err
+                );
+                return Ok(());
+            }
         }
         let state_text =
             build_runtime_state_snapshot_text(owner, continuity_mode, continuity_state);
-        std::fs::write(&state_path, state_text)?;
+        if let Err(err) = tokio::fs::write(&state_path, state_text).await {
+            tracing::warn!(
+                team_id = owner.team_id,
+                run_id = owner.run_id,
+                member_id = owner.member_id,
+                path = %state_path.display(),
+                "team manager failed to write runtime state snapshot: {}",
+                err
+            );
+        }
         Ok(())
     }
 
@@ -4700,8 +4719,7 @@ fn build_runtime_state_snapshot_text(
     if let Some(artifact_path) = continuity_state
         .history_window
         .get("artifact_pointer")
-        .and_then(|value| value.get("path"))
-        .and_then(Value::as_str)
+        .and_then(extract_context_artifact_path)
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
@@ -4709,6 +4727,13 @@ fn build_runtime_state_snapshot_text(
     }
     lines.push(String::new());
     lines.join("\n")
+}
+
+fn extract_context_artifact_path(value: &Value) -> Option<&str> {
+    value
+        .get("path")
+        .and_then(Value::as_str)
+        .or_else(|| value.as_str())
 }
 
 #[derive(Debug, Clone)]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2150,18 +2150,18 @@ impl TeamManager {
             .join(".cache")
             .join("context")
             .join("state.md");
-        if let Some(parent) = state_path.parent() {
-            if let Err(err) = tokio::fs::create_dir_all(parent).await {
-                tracing::warn!(
-                    team_id = owner.team_id,
-                    run_id = owner.run_id,
-                    member_id = owner.member_id,
-                    path = %state_path.display(),
-                    "team manager failed to create runtime state snapshot dir: {}",
-                    err
-                );
-                return Ok(());
-            }
+        if let Some(parent) = state_path.parent()
+            && let Err(err) = tokio::fs::create_dir_all(parent).await
+        {
+            tracing::warn!(
+                team_id = owner.team_id,
+                run_id = owner.run_id,
+                member_id = owner.member_id,
+                path = %state_path.display(),
+                "team manager failed to create runtime state snapshot dir: {}",
+                err
+            );
+            return Ok(());
         }
         let state_text =
             build_runtime_state_snapshot_text(owner, continuity_mode, continuity_state);

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2133,6 +2133,32 @@ impl TeamManager {
         }))
     }
 
+    async fn write_runtime_state_snapshot_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, Sqlite>,
+        owner: ContextArtifactOwner<'_>,
+        continuity_mode: &str,
+        continuity_state: &TeamMemberContinuityStateRecord,
+    ) -> anyhow::Result<()> {
+        let Some(workspace) =
+            load_team_member_context_workspace_tx(tx, owner.team_id, owner.member_id).await?
+        else {
+            return Ok(());
+        };
+
+        let state_path = PathBuf::from(&workspace.runtime_workdir)
+            .join(".cache")
+            .join("context")
+            .join("state.md");
+        if let Some(parent) = state_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let state_text =
+            build_runtime_state_snapshot_text(owner, continuity_mode, continuity_state);
+        std::fs::write(&state_path, state_text)?;
+        Ok(())
+    }
+
     #[allow(dead_code)]
     pub async fn start_step(
         &self,
@@ -2926,6 +2952,18 @@ impl TeamManager {
                 updated_at: now,
             };
             Self::upsert_member_continuity_state_tx(&mut tx, &continuity_state).await?;
+            self.write_runtime_state_snapshot_tx(
+                &mut tx,
+                ContextArtifactOwner {
+                    team_id: &team_id,
+                    run_id: &step.run_id,
+                    member_id: &step.member_id,
+                    session_id: step.runtime_handle_id.as_deref(),
+                },
+                &continuity_mode,
+                &continuity_state,
+            )
+            .await?;
 
             let mut continuity_payload = build_continuity_event_payload(
                 &continuity_state,
@@ -4638,6 +4676,39 @@ struct ContextArtifactOwner<'a> {
     run_id: &'a str,
     member_id: &'a str,
     session_id: Option<&'a str>,
+}
+
+fn build_runtime_state_snapshot_text(
+    owner: ContextArtifactOwner<'_>,
+    continuity_mode: &str,
+    continuity_state: &TeamMemberContinuityStateRecord,
+) -> String {
+    let mut lines = vec![
+        "# Team Runtime State".to_string(),
+        String::new(),
+        format!("- updated_at: {}", continuity_state.updated_at),
+        format!("- team_id: {}", owner.team_id),
+        format!("- member_id: {}", owner.member_id),
+        format!("- current_run_id: {}", owner.run_id),
+        format!("- continuity_mode: {continuity_mode}"),
+        format!(
+            "- continuity_source_run_id: {}",
+            continuity_state.source_run_id
+        ),
+        format!("- continuity_summary: {}", continuity_state.summary_text),
+    ];
+    if let Some(artifact_path) = continuity_state
+        .history_window
+        .get("artifact_pointer")
+        .and_then(|value| value.get("path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("- continuity_artifact_path: {artifact_path}"));
+    }
+    lines.push(String::new());
+    lines.join("\n")
 }
 
 #[derive(Debug, Clone)]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2532,6 +2532,95 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
 }
 
 #[tokio::test]
+async fn complete_step_keeps_success_when_runtime_state_snapshot_write_fails() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time after epoch")
+        .as_nanos();
+    let workspace =
+        std::env::temp_dir().join(format!("agenthub-context-state-write-fail-{unique_suffix}"));
+    std::fs::create_dir_all(workspace.join(".cache/context"))
+        .expect("create workspace context directory");
+    std::fs::create_dir_all(workspace.join(".cache/context/state.md"))
+        .expect("create conflicting state snapshot path");
+    let workspace_text = workspace.to_string_lossy().to_string();
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, source, status, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 0, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind("planner")
+    .bind("planner")
+    .bind(&workspace_text)
+    .bind("codex")
+    .bind("[]")
+    .bind("use_existing")
+    .bind("manual")
+    .bind("idle")
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert planner agent");
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "state-write-fail-team".to_string(),
+            description: Some("team with conflicting runtime state path".to_string()),
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(&team.id, Some("ctx-write-fail"), json!({"payload":"start"}))
+        .await
+        .expect("create run");
+    let step = manager
+        .submit_step(
+            &run.id,
+            "state_write_fail_step",
+            "planner",
+            Vec::new(),
+            Some(json!({"goal":"exercise best-effort state snapshot write"})),
+        )
+        .await
+        .expect("submit step");
+    let _ = manager
+        .start_step(&step.id, Some("remote-task-state-write-fail"))
+        .await
+        .expect("start step");
+
+    let completed = manager
+        .complete_step(
+            &step.id,
+            Some(json!({
+                "summary":"best effort snapshot",
+                "details":"state snapshot should not block completion"
+            })),
+        )
+        .await
+        .expect("complete step should succeed despite snapshot write failure");
+
+    assert_eq!(completed.status, TeamStepStatus::Completed);
+    let continuity = manager
+        .get_member_continuity_state(&team.id, "planner")
+        .await
+        .expect("get continuity state")
+        .expect("continuity state should exist");
+    assert_eq!(continuity.summary_text, "best effort snapshot");
+
+    let run_after_complete = manager.get_run(&run.id).await.expect("get run");
+    assert_eq!(run_after_complete.status, TeamRunStatus::Completed);
+    let _ = std::fs::remove_dir_all(workspace);
+}
+
+#[tokio::test]
 async fn complete_step_offloads_large_output_to_leader_runtime_workspace_context_artifact() {
     let db = setup_test_db().await;
     let manager = TeamManager::new(db.clone());

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2493,6 +2493,15 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
         artifact_content.contains("[redacted]"),
         "sensitive keys should be redacted in persisted artifact"
     );
+    let state_path = workspace.join(".cache/context/state.md");
+    let state_text = std::fs::read_to_string(&state_path).expect("read runtime state snapshot");
+    assert!(state_text.contains("# Team Runtime State"));
+    assert!(state_text.contains("- team_id:"));
+    assert!(state_text.contains("- member_id: planner"));
+    assert!(state_text.contains("- current_run_id:"));
+    assert!(state_text.contains("- continuity_mode: inherit_recent"));
+    assert!(state_text.contains("- continuity_summary: large payload"));
+    assert!(state_text.contains(pointer_path));
 
     let events = manager
         .list_run_events(&run.id, 100, None)


### PR DESCRIPTION
## Summary

- persist compact Team continuity snapshots into workspace `.cache/context/state.md`
- switch the ACP runtime context block to pointer-first continuity paths instead of inline summary prose
- cover the new runtime-state snapshot and ACP context contract with focused regression tests

## Testing

- `cargo test complete_step_offloads_large_output_to_workspace_context_artifact -- --nocapture`
- `cargo test -p agenthub-acp actor_runtime_context_block_keeps_continuity_pointer_first -- --nocapture`
- `cargo test -p agenthub-acp prompt_prefix_blocks_append_runtime_context_after_skills -- --nocapture`
- `cargo fmt`
