### PR TITLE
fix(team): slim continuity tails and run wording

### DIFF
--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -55,7 +55,7 @@ fn build_actor_runtime_context_text(context: &AcpActorSkillContext) -> String {
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        lines.push(format!("- current_run_id: {run_id}"));
+        lines.push(format!("- current_execution_run_id: {run_id}"));
     }
     if let Some(member_role) = context
         .member_role
@@ -87,9 +87,15 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
     };
     let mut lines = vec![
         format!("- continuity_mode: {}", continuity.mode),
-        format!("- continuity_source_run_id: {}", continuity.source_run_id),
+        format!(
+            "- continuity_source_execution_run_id: {}",
+            continuity.source_run_id
+        ),
         "- continuity_state_path: .cache/context/state.md".to_string(),
     ];
+    if let Some(note_path) = continuity_note_path(&continuity.source_run_id) {
+        lines.push(format!("- continuity_note_path: {note_path}"));
+    }
     if let Some(artifact_path) = continuity
         .history_window
         .get("artifact_pointer")
@@ -100,6 +106,14 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
         lines.push(format!("- continuity_artifact_path: {artifact_path}"));
     }
     lines
+}
+
+fn continuity_note_path(source_run_id: &str) -> Option<String> {
+    let source_run_id = source_run_id.trim();
+    if source_run_id.is_empty() {
+        return None;
+    }
+    Some(format!(".cache/context/run/{source_run_id}/continuity.md"))
 }
 
 fn extract_artifact_pointer_path(value: &serde_json::Value) -> Option<&str> {
@@ -176,7 +190,7 @@ mod tests {
             panic!("expected text content block");
         };
         assert!(text.text.contains("team_id: team-7"));
-        assert!(text.text.contains("current_run_id: run-42"));
+        assert!(text.text.contains("current_execution_run_id: run-42"));
         assert!(text.text.contains("actor_id: planner"));
         assert!(text.text.contains("default_channel: coordination"));
         assert!(text.text.contains("contract_version: v1"));
@@ -198,7 +212,7 @@ mod tests {
         let ContentBlock::Text(text) = block else {
             panic!("expected text content block");
         };
-        assert!(!text.text.contains("current_run_id: n/a"));
+        assert!(!text.text.contains("current_execution_run_id: n/a"));
     }
 
     #[test]
@@ -229,6 +243,10 @@ mod tests {
         assert!(
             text.text
                 .contains("continuity_state_path: .cache/context/state.md")
+        );
+        assert!(
+            text.text
+                .contains("continuity_note_path: .cache/context/run/run-41/continuity.md")
         );
         assert!(
             text.text.contains(

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -2370,16 +2370,25 @@ Fallback to the user-level review contract.
         };
         assert!(runtime_block.text.contains("AgentHub runtime context:"));
         assert!(runtime_block.text.contains("actor_id: planner"));
-        assert!(runtime_block.text.contains("current_run_id: run-42"));
         assert!(
             runtime_block
                 .text
-                .contains("continuity_source_run_id: run-41")
+                .contains("current_execution_run_id: run-42")
+        );
+        assert!(
+            runtime_block
+                .text
+                .contains("continuity_source_execution_run_id: run-41")
         );
         assert!(
             runtime_block
                 .text
                 .contains("continuity_state_path: .cache/context/state.md")
+        );
+        assert!(
+            runtime_block
+                .text
+                .contains("continuity_note_path: .cache/context/run/run-41/continuity.md")
         );
         assert!(!runtime_block.text.contains("continuity_summary:"));
     }

--- a/docs/journal/2026-04-18-team-prompt-tail-and-execution-run-wording.md
+++ b/docs/journal/2026-04-18-team-prompt-tail-and-execution-run-wording.md
@@ -1,0 +1,36 @@
+# Team Prompt Tail And Execution Run Wording
+
+## Summary
+
+- continued Team prompt-tail slimming by moving continuity detail out of inline runtime prompt text and into a run-scoped filesystem note
+- tightened Team runtime and web wording so concrete execution partitions are labeled as `execution run` instead of a generic `run` surface label
+
+## Prompt Tail Follow-up
+
+- `src/team/manager.rs` now writes a compact continuity note to
+  `.cache/context/run/<source_run_id>/continuity.md`
+- `.cache/context/state.md` stays as the compact index and now points to:
+  - `current_execution_run_id`
+  - `continuity_source_execution_run_id`
+  - `continuity_note_path`
+  - `continuity_artifact_path` when present
+- the ACP runtime context block now stays pointer-first and exposes
+  `continuity_note_path` instead of relying on inline continuity summary prose
+
+## Execution Vocabulary Follow-up
+
+- Team web tabs and run-focused controls now use `Execution Runs` / `Execution Run`
+  wording in the primary UI shell
+- active-run actions and task-detail affordances now say
+  `Resume Execution Run`, `Restart Execution Run`, and `Open Execution Run`
+- run-required empty states now point users to the `Execution Runs` tab explicitly
+
+## Validation
+
+- `cargo test complete_step_offloads_large_output_to_workspace_context_artifact -- --nocapture`
+- `cargo test complete_step_keeps_success_when_runtime_state_snapshot_write_fails -- --nocapture`
+- `cargo test -p agenthub-acp actor_runtime_context_block_keeps_continuity_pointer_first -- --nocapture`
+- `cargo test -p agenthub-acp prompt_prefix_blocks_append_runtime_context_after_skills -- --nocapture`
+- `cargo fmt`
+- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx src/pages/team/team_debug_panels.test.tsx src/pages/team/team_workspace_header.test.tsx`
+- `cd web && npm run build`

--- a/docs/journal/2026-04-18-team-prompt-tail-and-execution-run-wording.md
+++ b/docs/journal/2026-04-18-team-prompt-tail-and-execution-run-wording.md
@@ -34,3 +34,13 @@
 - `cargo fmt`
 - `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx src/pages/team/team_debug_panels.test.tsx src/pages/team/team_workspace_header.test.tsx`
 - `cd web && npm run build`
+
+## Review Follow-up
+
+- moved runtime state snapshot and continuity note writes out of the open SQLite transaction: the
+  transaction now prepares a write plan, commits, then performs best-effort filesystem writes
+- switched the continuity note history-window fence to four backticks to avoid accidental markdown
+  fence breakage from embedded JSON content
+- aligned the continuity note regression test with `source_run_id`
+- updated Team page Playwright fixtures to look for `Execution Runs` instead of the old `Runs`
+  label

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2133,74 +2133,89 @@ impl TeamManager {
         }))
     }
 
-    async fn write_runtime_state_snapshot_tx(
+    async fn prepare_runtime_state_snapshot_write_tx(
         &self,
         tx: &mut sqlx::Transaction<'_, Sqlite>,
         owner: ContextArtifactOwner<'_>,
         continuity_mode: &str,
         continuity_state: &TeamMemberContinuityStateRecord,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<RuntimeStateSnapshotWritePlan>> {
         let Some(workspace) =
             load_team_member_context_workspace_tx(tx, owner.team_id, owner.member_id).await?
         else {
-            return Ok(());
+            return Ok(None);
         };
 
-        let state_path = PathBuf::from(&workspace.runtime_workdir)
+        let workspace_root = PathBuf::from(&workspace.runtime_workdir);
+        let state_path = workspace_root
             .join(".cache")
             .join("context")
             .join("state.md");
-        if let Some(relative_note_path) =
-            continuity_note_relative_path(&continuity_state.source_run_id)
-        {
-            let note_path = PathBuf::from(&workspace.runtime_workdir).join(&relative_note_path);
+        let continuity_note = continuity_note_relative_path(&continuity_state.source_run_id).map(
+            |relative_note_path| {
+                let note_path = workspace_root.join(relative_note_path);
+                let note_text =
+                    build_runtime_continuity_note_text(owner, continuity_mode, continuity_state);
+                (note_path, note_text)
+            },
+        );
+        let state_text =
+            build_runtime_state_snapshot_text(owner, continuity_mode, continuity_state);
+        Ok(Some(RuntimeStateSnapshotWritePlan {
+            team_id: owner.team_id.to_string(),
+            run_id: owner.run_id.to_string(),
+            member_id: owner.member_id.to_string(),
+            state_path,
+            state_text,
+            continuity_note,
+        }))
+    }
+
+    async fn write_runtime_state_snapshot_best_effort(
+        plan: RuntimeStateSnapshotWritePlan,
+    ) -> anyhow::Result<()> {
+        if let Some((note_path, note_text)) = plan.continuity_note.as_ref() {
             if let Some(parent) = note_path.parent()
                 && let Err(err) = tokio::fs::create_dir_all(parent).await
             {
                 tracing::warn!(
-                    team_id = owner.team_id,
-                    run_id = owner.run_id,
-                    member_id = owner.member_id,
+                    team_id = plan.team_id,
+                    run_id = plan.run_id,
+                    member_id = plan.member_id,
                     path = %note_path.display(),
                     "team manager failed to create runtime continuity note dir: {}",
                     err
                 );
-            } else {
-                let note_text =
-                    build_runtime_continuity_note_text(owner, continuity_mode, continuity_state);
-                if let Err(err) = tokio::fs::write(&note_path, note_text).await {
-                    tracing::warn!(
-                        team_id = owner.team_id,
-                        run_id = owner.run_id,
-                        member_id = owner.member_id,
-                        path = %note_path.display(),
-                        "team manager failed to write runtime continuity note: {}",
-                        err
-                    );
-                }
+            } else if let Err(err) = tokio::fs::write(note_path, note_text).await {
+                tracing::warn!(
+                    team_id = plan.team_id,
+                    run_id = plan.run_id,
+                    member_id = plan.member_id,
+                    path = %note_path.display(),
+                    "team manager failed to write runtime continuity note: {}",
+                    err
+                );
             }
         }
-        if let Some(parent) = state_path.parent()
+        if let Some(parent) = plan.state_path.parent()
             && let Err(err) = tokio::fs::create_dir_all(parent).await
         {
             tracing::warn!(
-                team_id = owner.team_id,
-                run_id = owner.run_id,
-                member_id = owner.member_id,
-                path = %state_path.display(),
+                team_id = plan.team_id,
+                run_id = plan.run_id,
+                member_id = plan.member_id,
+                path = %plan.state_path.display(),
                 "team manager failed to create runtime state snapshot dir: {}",
                 err
             );
             return Ok(());
         }
-        let state_text =
-            build_runtime_state_snapshot_text(owner, continuity_mode, continuity_state);
-        if let Err(err) = tokio::fs::write(&state_path, state_text).await {
+        if let Err(err) = tokio::fs::write(&plan.state_path, plan.state_text).await {
             tracing::warn!(
-                team_id = owner.team_id,
-                run_id = owner.run_id,
-                member_id = owner.member_id,
-                path = %state_path.display(),
+                team_id = plan.team_id,
+                run_id = plan.run_id,
+                member_id = plan.member_id,
+                path = %plan.state_path.display(),
                 "team manager failed to write runtime state snapshot: {}",
                 err
             );
@@ -2877,6 +2892,7 @@ impl TeamManager {
         .execute(&mut *tx)
         .await?;
         let step = load_step_record_tx(&mut tx, step_id).await?;
+        let mut runtime_state_snapshot: Option<RuntimeStateSnapshotWritePlan> = None;
 
         if update.rows_affected() > 0 {
             let mut round_artifact_pointer = None;
@@ -3001,18 +3017,19 @@ impl TeamManager {
                 updated_at: now,
             };
             Self::upsert_member_continuity_state_tx(&mut tx, &continuity_state).await?;
-            self.write_runtime_state_snapshot_tx(
-                &mut tx,
-                ContextArtifactOwner {
-                    team_id: &team_id,
-                    run_id: &step.run_id,
-                    member_id: &step.member_id,
-                    session_id: step.runtime_handle_id.as_deref(),
-                },
-                &continuity_mode,
-                &continuity_state,
-            )
-            .await?;
+            runtime_state_snapshot = self
+                .prepare_runtime_state_snapshot_write_tx(
+                    &mut tx,
+                    ContextArtifactOwner {
+                        team_id: &team_id,
+                        run_id: &step.run_id,
+                        member_id: &step.member_id,
+                        session_id: step.runtime_handle_id.as_deref(),
+                    },
+                    &continuity_mode,
+                    &continuity_state,
+                )
+                .await?;
 
             let mut continuity_payload = build_continuity_event_payload(
                 &continuity_state,
@@ -3127,6 +3144,9 @@ impl TeamManager {
         }
 
         tx.commit().await?;
+        if let Some(plan) = runtime_state_snapshot {
+            Self::write_runtime_state_snapshot_best_effort(plan).await?;
+        }
         Ok(step)
     }
 
@@ -4727,6 +4747,16 @@ struct ContextArtifactOwner<'a> {
     session_id: Option<&'a str>,
 }
 
+#[derive(Debug, Clone)]
+struct RuntimeStateSnapshotWritePlan {
+    team_id: String,
+    run_id: String,
+    member_id: String,
+    state_path: PathBuf,
+    state_text: String,
+    continuity_note: Option<(PathBuf, String)>,
+}
+
 fn build_runtime_state_snapshot_text(
     owner: ContextArtifactOwner<'_>,
     continuity_mode: &str,
@@ -4796,9 +4826,9 @@ fn build_runtime_continuity_note_text(
         continuity_state.summary_text.clone(),
         String::new(),
         "## History Window".to_string(),
-        "```json".to_string(),
+        "````json".to_string(),
         history_window,
-        "```".to_string(),
+        "````".to_string(),
         String::new(),
     ]);
     lines.join("\n")

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2150,6 +2150,36 @@ impl TeamManager {
             .join(".cache")
             .join("context")
             .join("state.md");
+        if let Some(relative_note_path) =
+            continuity_note_relative_path(&continuity_state.source_run_id)
+        {
+            let note_path = PathBuf::from(&workspace.runtime_workdir).join(&relative_note_path);
+            if let Some(parent) = note_path.parent()
+                && let Err(err) = tokio::fs::create_dir_all(parent).await
+            {
+                tracing::warn!(
+                    team_id = owner.team_id,
+                    run_id = owner.run_id,
+                    member_id = owner.member_id,
+                    path = %note_path.display(),
+                    "team manager failed to create runtime continuity note dir: {}",
+                    err
+                );
+            } else {
+                let note_text =
+                    build_runtime_continuity_note_text(owner, continuity_mode, continuity_state);
+                if let Err(err) = tokio::fs::write(&note_path, note_text).await {
+                    tracing::warn!(
+                        team_id = owner.team_id,
+                        run_id = owner.run_id,
+                        member_id = owner.member_id,
+                        path = %note_path.display(),
+                        "team manager failed to write runtime continuity note: {}",
+                        err
+                    );
+                }
+            }
+        }
         if let Some(parent) = state_path.parent()
             && let Err(err) = tokio::fs::create_dir_all(parent).await
         {
@@ -4708,14 +4738,16 @@ fn build_runtime_state_snapshot_text(
         format!("- updated_at: {}", continuity_state.updated_at),
         format!("- team_id: {}", owner.team_id),
         format!("- member_id: {}", owner.member_id),
-        format!("- current_run_id: {}", owner.run_id),
+        format!("- current_execution_run_id: {}", owner.run_id),
         format!("- continuity_mode: {continuity_mode}"),
         format!(
-            "- continuity_source_run_id: {}",
+            "- continuity_source_execution_run_id: {}",
             continuity_state.source_run_id
         ),
-        format!("- continuity_summary: {}", continuity_state.summary_text),
     ];
+    if let Some(note_path) = continuity_note_relative_path(&continuity_state.source_run_id) {
+        lines.push(format!("- continuity_note_path: {note_path}"));
+    }
     if let Some(artifact_path) = continuity_state
         .history_window
         .get("artifact_pointer")
@@ -4727,6 +4759,57 @@ fn build_runtime_state_snapshot_text(
     }
     lines.push(String::new());
     lines.join("\n")
+}
+
+fn build_runtime_continuity_note_text(
+    owner: ContextArtifactOwner<'_>,
+    continuity_mode: &str,
+    continuity_state: &TeamMemberContinuityStateRecord,
+) -> String {
+    let history_window = serde_json::to_string_pretty(&continuity_state.history_window)
+        .unwrap_or_else(|_| continuity_state.history_window.to_string());
+    let mut lines = vec![
+        "# Team Continuity Note".to_string(),
+        String::new(),
+        format!("- updated_at: {}", continuity_state.updated_at),
+        format!("- team_id: {}", owner.team_id),
+        format!("- member_id: {}", owner.member_id),
+        format!("- current_execution_run_id: {}", owner.run_id),
+        format!(
+            "- continuity_source_execution_run_id: {}",
+            continuity_state.source_run_id
+        ),
+        format!("- continuity_mode: {continuity_mode}"),
+    ];
+    if let Some(artifact_path) = continuity_state
+        .history_window
+        .get("artifact_pointer")
+        .and_then(extract_context_artifact_path)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("- continuity_artifact_path: {artifact_path}"));
+    }
+    lines.extend([
+        String::new(),
+        "## Summary".to_string(),
+        continuity_state.summary_text.clone(),
+        String::new(),
+        "## History Window".to_string(),
+        "```json".to_string(),
+        history_window,
+        "```".to_string(),
+        String::new(),
+    ]);
+    lines.join("\n")
+}
+
+fn continuity_note_relative_path(source_run_id: &str) -> Option<String> {
+    let source_run_id = source_run_id.trim();
+    if source_run_id.is_empty() {
+        return None;
+    }
+    Some(format!(".cache/context/run/{source_run_id}/continuity.md"))
 }
 
 fn extract_context_artifact_path(value: &Value) -> Option<&str> {

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2495,13 +2495,24 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
     );
     let state_path = workspace.join(".cache/context/state.md");
     let state_text = std::fs::read_to_string(&state_path).expect("read runtime state snapshot");
+    let note_path = workspace
+        .join(".cache/context/run")
+        .join(&run.id)
+        .join("continuity.md");
+    let note_text = std::fs::read_to_string(&note_path).expect("read runtime continuity note");
     assert!(state_text.contains("# Team Runtime State"));
     assert!(state_text.contains("- team_id:"));
     assert!(state_text.contains("- member_id: planner"));
-    assert!(state_text.contains("- current_run_id:"));
+    assert!(state_text.contains("- current_execution_run_id:"));
     assert!(state_text.contains("- continuity_mode: inherit_recent"));
-    assert!(state_text.contains("- continuity_summary: large payload"));
+    assert!(state_text.contains("- continuity_note_path: .cache/context/run/"));
     assert!(state_text.contains(pointer_path));
+    assert!(note_text.contains("# Team Continuity Note"));
+    assert!(note_text.contains("- current_execution_run_id:"));
+    assert!(note_text.contains("- continuity_source_execution_run_id:"));
+    assert!(note_text.contains("## Summary"));
+    assert!(note_text.contains("large payload"));
+    assert!(note_text.contains("## History Window"));
 
     let events = manager
         .list_run_events(&run.id, 100, None)

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2495,9 +2495,13 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
     );
     let state_path = workspace.join(".cache/context/state.md");
     let state_text = std::fs::read_to_string(&state_path).expect("read runtime state snapshot");
+    let note_relative_path = format!(
+        ".cache/context/run/{}/continuity.md",
+        continuity.source_run_id
+    );
     let note_path = workspace
         .join(".cache/context/run")
-        .join(&run.id)
+        .join(&continuity.source_run_id)
         .join("continuity.md");
     let note_text = std::fs::read_to_string(&note_path).expect("read runtime continuity note");
     assert!(state_text.contains("# Team Runtime State"));
@@ -2505,7 +2509,7 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
     assert!(state_text.contains("- member_id: planner"));
     assert!(state_text.contains("- current_execution_run_id:"));
     assert!(state_text.contains("- continuity_mode: inherit_recent"));
-    assert!(state_text.contains("- continuity_note_path: .cache/context/run/"));
+    assert!(state_text.contains(format!("- continuity_note_path: {note_relative_path}").as_str()));
     assert!(state_text.contains(pointer_path));
     assert!(note_text.contains("# Team Continuity Note"));
     assert!(note_text.contains("- current_execution_run_id:"));

--- a/web/src/pages/team/state.ts
+++ b/web/src/pages/team/state.ts
@@ -19,7 +19,7 @@ export type TeamTab =
 export const TEAM_TAB_ITEMS: ReadonlyArray<{ value: TeamTab; label: string }> = [
   { value: "conversation", label: "Conversation" },
   { value: "tasks", label: "Tasks" },
-  { value: "runs", label: "Runs" },
+  { value: "runs", label: "Execution Runs" },
   { value: "agent_acp", label: "Agent ACP" },
   { value: "overview", label: "Overview" },
   { value: "events", label: "Events" },

--- a/web/src/pages/team/team_debug_panels.test.tsx
+++ b/web/src/pages/team/team_debug_panels.test.tsx
@@ -78,14 +78,14 @@ describe("Team debug panels", () => {
         <TeamRunRequiredPanel
           chrome={chrome}
           title="Mailbox Raw"
-          body="Mailbox raw operations require an active run."
+          body="Mailbox raw operations require an active execution run."
           onGoToRuns={vi.fn()}
         />
       </MantineProvider>
     );
 
     expect(html).toContain("Mailbox Raw");
-    expect(html).toContain("Mailbox raw operations require an active run.");
-    expect(html).toContain("Go to Runs");
+    expect(html).toContain("Mailbox raw operations require an active execution run.");
+    expect(html).toContain("Go to Execution Runs");
   });
 });

--- a/web/src/pages/team/team_debug_panels.tsx
+++ b/web/src/pages/team/team_debug_panels.tsx
@@ -270,7 +270,7 @@ export const TeamRunRequiredPanel = React.memo(function TeamRunRequiredPanel({
           className={chrome.panelSecondaryButtonClassName}
           onClick={onGoToRuns}
         >
-          Go to Runs
+          Go to Execution Runs
         </ActionButton>
       </div>
     </SurfaceCard>

--- a/web/src/pages/team/team_workspace_header.test.tsx
+++ b/web/src/pages/team/team_workspace_header.test.tsx
@@ -58,7 +58,7 @@ function renderHtml(override: Partial<React.ComponentProps<typeof TeamWorkspaceH
         selectedTeamRuntimeOnline={3}
         selectedTeamRuntimeTotal={3}
         selectedTeamRuntimeControlTone={baseRuntimeTone}
-        workspaceAdvancedTabItems={[{ value: "runs", label: "Runs" }]}
+        workspaceAdvancedTabItems={[{ value: "runs", label: "Execution Runs" }]}
         isAdvancedWorkspace={false}
         showRunActionsInAdvanced
         activeRunStatus="working"

--- a/web/src/pages/team_active_run_panel.tsx
+++ b/web/src/pages/team_active_run_panel.tsx
@@ -55,7 +55,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
             onClick={onCancel}
             disabled={busy === "cancel-run" || run.status === "canceled"}
           >
-            Cancel Run
+            Cancel Execution Run
           </ActionButton>
           <ActionButton
             tone="secondary"
@@ -68,7 +68,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
                 : "Resume is available for failed/canceled runs"
             }
           >
-            Resume Run
+            Resume Execution Run
           </ActionButton>
           <ActionButton
             tone="secondary"
@@ -81,13 +81,13 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
                 : "Restart is available for completed/failed/canceled runs"
             }
           >
-            Restart Run
+            Restart Execution Run
           </ActionButton>
         </div>
       </ToolbarRow>
       <div className="mt-3 grid min-w-0 gap-2 text-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3">
         <span className={metaItemClassName}>
-          <strong>ID:</strong> <code>{run.id}</code>
+          <strong>Execution run:</strong> <code>{run.id}</code>
         </span>
         <span className={metaItemClassName}>
           <strong>Execution status:</strong>{" "}

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -791,7 +791,7 @@ describe("TeamPage smoke render", () => {
         button.textContent?.replace(/\s+/g, " ").trim() ?? ""
       );
       expect(buttonLabels).toContain("More");
-      expect(buttonLabels).not.toContain("Runs");
+      expect(buttonLabels).not.toContain("Execution Runs");
     } finally {
       act(() => {
         root.unmount();

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -3733,9 +3733,9 @@ export function TeamPage(props: TeamPageProps) {
 
               {showNoActiveRunNotice && (
                 <div className={teamSectionCardClassName}>
-                  <h3 className={teamSectionTitleClassName}>No Active Run</h3>
+                  <h3 className={teamSectionTitleClassName}>No Active Execution Run</h3>
                   <p className={teamSectionBodyTextClassName}>
-                    Select an existing run or start one in the Runs tab before opening this panel.
+                    Select an existing execution run or start one in the Execution Runs tab before opening this panel.
                   </p>
                   <div className="mt-3">
                     <ActionButton
@@ -3744,7 +3744,7 @@ export function TeamPage(props: TeamPageProps) {
                       className={panelSecondaryButtonClassName}
                       onClick={() => setTab("runs")}
                     >
-                      Go to Runs
+                      Go to Execution Runs
                     </ActionButton>
                   </div>
                 </div>
@@ -3875,7 +3875,7 @@ export function TeamPage(props: TeamPageProps) {
                       </h3>
                       <p className={teamSectionBodyTextClassName}>
                         {isAgentWorkspace
-                          ? "This agent is selected, but there is no active run context for its direct thread yet. Use Runs to inspect execution history or wait for the next task."
+                          ? "This agent is selected, but there is no active execution run context for its direct thread yet. Use Execution Runs to inspect execution history or wait for the next task."
                           : "Execution mailbox is run-scoped. Start or select a run to inspect delivery and direct member conversations."}
                       </p>
                       <div className="mt-3">
@@ -3885,7 +3885,7 @@ export function TeamPage(props: TeamPageProps) {
                           className={panelSecondaryButtonClassName}
                           onClick={() => setTab("runs")}
                         >
-                          Go to Runs
+                          Go to Execution Runs
                         </ActionButton>
                       </div>
                     </div>
@@ -3983,7 +3983,7 @@ export function TeamPage(props: TeamPageProps) {
                         <TeamRunRequiredPanel
                           chrome={teamDebugChrome}
                           title="Step Ops"
-                          body="Step operations require an active run. Start or select one in the Runs tab first."
+                          body="Step operations require an active execution run. Start or select one in the Execution Runs tab first."
                           onGoToRuns={() => setTab("runs")}
                         />
                       )}
@@ -4028,7 +4028,7 @@ export function TeamPage(props: TeamPageProps) {
                         <TeamRunRequiredPanel
                           chrome={teamDebugChrome}
                           title="Mailbox Raw"
-                          body="Mailbox raw operations require an active run. Start or select one in the Runs tab first."
+                          body="Mailbox raw operations require an active execution run. Start or select one in the Execution Runs tab first."
                           onGoToRuns={() => setTab("runs")}
                         />
                       )}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -566,7 +566,7 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("Teams · 2");
     expect(container.textContent).toContain("# all");
-    expect(container.textContent).not.toContain("Runs");
+    expect(container.textContent).not.toContain("Execution Runs");
     expect(container.textContent).not.toContain("Advanced");
 
     act(() => {
@@ -814,7 +814,7 @@ describe("team panels interactions", () => {
 
     clickElement(findButtonByText(container, "Delete Team"));
     clickElement(findButtonByText(container, "Start Execution Run"));
-    clickElement(findButtonByAriaLabel(container, "Refresh runs"));
+    clickElement(findButtonByAriaLabel(container, "Refresh execution runs"));
     clickElement(required(container.querySelector(".teams-run-list .team-item"), "run list item missing"));
     clickElement(findButtonByText(container, "Load More"));
 
@@ -863,7 +863,7 @@ describe("team panels interactions", () => {
       "No execution runs loaded yet. Use Debug → Run Ops to create or load runs."
     );
     expect(container.textContent).toContain(
-      "Concrete execution history and replay partitions for this team."
+      "Concrete execution runs and replay partitions for this team."
     );
     expect(
       findButtonByAriaLabel(container, "Start execution run").getAttribute("title")
@@ -971,7 +971,7 @@ describe("team panels interactions", () => {
     });
 
     expect(container.querySelector('[data-team-surface="workflow-tabs"]')).not.toBeNull();
-    expect(container.textContent).toContain("Runs");
+    expect(container.textContent).toContain("Execution Runs");
     expect(container.textContent).toContain("Conversation");
     expect(container.textContent).toContain("Agent ACP");
     expect(container.textContent).toContain("Debug");
@@ -1019,9 +1019,9 @@ describe("team panels interactions", () => {
       findButtonByAriaLabel(container, "Refresh active execution run").getAttribute("title")
     ).toBe("Refresh active execution run");
     clickElement(findButtonByAriaLabel(container, "Refresh active execution run"));
-    clickElement(findButtonByText(container, "Cancel Run"));
-    clickElement(findButtonByText(container, "Resume Run"));
-    clickElement(findButtonByText(container, "Restart Run"));
+    clickElement(findButtonByText(container, "Cancel Execution Run"));
+    clickElement(findButtonByText(container, "Resume Execution Run"));
+    clickElement(findButtonByText(container, "Restart Execution Run"));
     expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onResume).toHaveBeenCalledTimes(1);
@@ -3756,7 +3756,7 @@ describe("team panels interactions", () => {
     clickElement(findButtonByText(container, "Compile Preview"));
     clickElement(findButtonByText(container, "Use Payload in Create Run"));
     clickElement(findButtonByText(container, "Create Run from Preview"));
-    clickElement(findButtonByText(container, "Open Run"));
+    clickElement(findButtonByText(container, "Open Execution Run"));
 
     expect(container.querySelector('[data-team-compile-preview="true"]')).not.toBeNull();
     expect(onRefreshTasks).toHaveBeenCalledTimes(1);

--- a/web/src/pages/team_run_panel.tsx
+++ b/web/src/pages/team_run_panel.tsx
@@ -29,7 +29,7 @@ const RUN_PANEL_LIST_ITEMS_CLASS = "teams-run-list-items flex max-h-80 flex-col 
 const RUN_PANEL_SUBTITLE_CLASS = "text-[10px] font-bold uppercase tracking-widest text-notion-text-muted";
 const RUN_PANEL_HINT_TEXT_CLASS = "text-[13px] text-notion-text-muted italic";
 const RUN_PANEL_FOOT_META_CLASS = "mono text-[10px] font-bold uppercase tracking-widest text-notion-text-muted opacity-70";
-const RUN_PANEL_HELP_TEXT = "Concrete execution history and replay partitions for this team.";
+const RUN_PANEL_HELP_TEXT = "Concrete execution runs and replay partitions for this team.";
 
 type TeamRunPanelProps = {
   selectedTeam: TeamDefinitionRecord;
@@ -106,7 +106,7 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
 
       <InsetSurface className="teams-run-list flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <p className={RUN_PANEL_SUBTITLE_CLASS}>Run Browser</p>
+          <p className={RUN_PANEL_SUBTITLE_CLASS}>Execution Run Browser</p>
           <p className={TEAM_MUTED_TEXT_CLASS}>
             {RUN_PANEL_HELP_TEXT}
           </p>
@@ -131,7 +131,7 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
         </ToolbarRow>
 
         <ToolbarRow className="teams-run-list-head mt-2">
-          <h3 className="text-[13px] font-bold text-notion-text uppercase tracking-tight">Runs</h3>
+          <h3 className="text-[13px] font-bold text-notion-text uppercase tracking-tight">Execution Runs</h3>
           <div className="actions flex flex-wrap items-center gap-2">
             <NativeSelect
               className="w-full sm:w-[164px]"
@@ -149,8 +149,8 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
                 void onRefreshRuns();
               }}
               disabled={runsLoading}
-              title="Refresh runs"
-              aria-label="Refresh runs"
+              title="Refresh execution runs"
+              aria-label="Refresh execution runs"
             >
               <i className="bi bi-arrow-clockwise" aria-hidden="true" />
             </ActionButton>

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -497,7 +497,7 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
                 <>
                   <div className="mt-4 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
                     <div className={TASKS_DETAIL_META_ITEM_CLASS}>
-                      <strong className="text-[9px] font-bold uppercase tracking-widest text-notion-text-muted">Run</strong>
+                      <strong className="text-[9px] font-bold uppercase tracking-widest text-notion-text-muted">Execution run</strong>
                       <div className="mono mt-1 text-[11px] text-notion-text">{latestRun.id}</div>
                     </div>
                     <div className={TASKS_DETAIL_META_ITEM_CLASS}>
@@ -521,7 +521,7 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
                   </div>
                   <div className="mt-4 flex flex-wrap items-center gap-2">
                     <ActionButton tone="secondary" size="md" onClick={() => onOpenRun(latestRun.id)}>
-                      Open Run
+                      Open Execution Run
                     </ActionButton>
                   </div>
                 </>

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -1585,7 +1585,7 @@ test("team page keeps single-column proportions on mobile viewport", async ({
   await page.setViewportSize({ width: 390, height: 844 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Team Mobile");
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
 
   await expect(page.locator(".teams-main").getByText("Team Mobile", { exact: true })).toBeVisible();
 
@@ -1781,7 +1781,7 @@ test("team page desktop keeps long metadata blocks non-overlapping", async ({
   await page.setViewportSize({ width: 1366, height: 900 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Team Desktop");
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await expect(page.locator(".teams-main").getByText("Team Desktop", { exact: true })).toBeVisible();
   await openAdvancedView(page, "Overview");
   await expect(page.locator(".teams-member-list .team-member-row")).toHaveCount(3);
@@ -2199,7 +2199,7 @@ test("team quant workflow creates team and launches run", async ({ page }) => {
     .fill('{"objective":"daily rebalance + crypto hedge","risk_limit":"max_dd_5pct"}');
   await page.getByRole("button", { name: "Create Run", exact: true }).click();
 
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await expect(page.locator(".teams-run-list .team-item").first()).toContainText(
     "quant-run-1"
   );
@@ -2735,7 +2735,7 @@ test("team chat-first path compiles preview, creates run, and captures worker pl
   await expect(page.getByText("Negotiate scope with leader")).toBeVisible();
 
   await page.getByRole("button", { name: "Create Run from Preview" }).click();
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await expect(page.locator(".teams-run-list .team-item").first()).toContainText(runId);
   expect(createRunRequests).toHaveLength(1);
   expect(createRunRequests[0]).toMatchObject({
@@ -2765,7 +2765,7 @@ test("team chat-first path compiles preview, creates run, and captures worker pl
   await expect(page.locator(".teams-step-body")).not.toContainText("Loading discovery card...");
   await expect(page.locator(".teams-step-body")).toContainText("acp_gemini");
 
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await openAdvancedView(page, "Events");
   await expect(page.locator(".teams-event-list")).toContainText(
     "Final deliverable prepared and returned to user."
@@ -3306,7 +3306,7 @@ test("team mailbox IM mode supports conversation focus, unread, auto-follow and 
     .fill('{"type":"chat_message","text":"advanced-mailbox-ping"}');
   await advancedPanel.getByRole("button", { name: "Send Message" }).click();
 
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await openAdvancedView(page, "Overview");
   await page
     .locator(".teams-member-list .team-member-row", { hasText: "Worker Agent Two (worker)" })
@@ -3348,7 +3348,7 @@ test("team list supports deleting selected team", async ({ page }) => {
   await expect(page.locator(".team-item", { hasText: "Team Delete A" })).toBeVisible();
   await expect(page.locator(".team-item", { hasText: "Team Delete B" })).toBeVisible();
   await openTeamFromSelector(page, "Team Delete A");
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
   await expect(page.locator(".teams-main").getByText("Team Delete A", { exact: true })).toBeVisible();
 
   page.once("dialog", (dialog) => dialog.accept());
@@ -3424,7 +3424,7 @@ test("team run list keeps per-team filters and uses before_created_at cursor pag
 
   await gotoTeams(page);
   await openTeamFromSelector(page, "Team A");
-  await openMainTeamAction(page, "Runs");
+  await openMainTeamAction(page, "Execution Runs");
 
   const runFilter = page.getByLabel("Run status filter");
   await expect(runFilter).toHaveValue("all");


### PR DESCRIPTION
## Summary

- move Team continuity detail from the compact runtime state index into a run-scoped `continuity.md` note and keep ACP runtime context pointer-first
- rename Team run-focused UI copy to `Execution Runs` / `Execution Run` so concrete execution partitions stay distinct from task ownership and planning surfaces
- cover the continuity note/index contract and execution-run wording with focused Rust and web regression tests

## Testing

- `cargo test complete_step_offloads_large_output_to_workspace_context_artifact -- --nocapture`
- `cargo test complete_step_keeps_success_when_runtime_state_snapshot_write_fails -- --nocapture`
- `cargo test -p agenthub-acp actor_runtime_context_block_keeps_continuity_pointer_first -- --nocapture`
- `cargo test -p agenthub-acp prompt_prefix_blocks_append_runtime_context_after_skills -- --nocapture`
- `cargo fmt`
- `cd web && npm run test -- vite.config.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx src/pages/team/team_debug_panels.test.tsx src/pages/team/team_workspace_header.test.tsx`
- `cd web && npm run build`

## Chrome DevTools MCP

- verified the local browser transport recovered and could open the local Vite page through Chrome DevTools MCP
- the browser check was only a minimal transport/page-load smoke check because the local dev server was frontend-only and returned the expected bootstrap JSON error without a backend API
