### PR TITLE
fix(team): version memory index contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "agenthub-acp-core",
  "agenthub-config",
  "agenthub-managed-skills",
+ "agenthub-team-domain",
  "agenthub-text",
  "anyhow",
  "async-trait",

--- a/crates/agenthub-acp/BUILD.bazel
+++ b/crates/agenthub-acp/BUILD.bazel
@@ -21,6 +21,7 @@ rust_library(
         "//crates/agenthub-acp-core:agenthub_acp_core",
         "//crates/agenthub-config:agenthub_config",
         "//crates/agenthub-managed-skills:agenthub_managed_skills",
+        "//crates/agenthub-team-domain:agenthub_team_domain",
         "//crates/agenthub-text:agenthub_text",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
@@ -42,6 +43,8 @@ rust_test(
         normal_dev = True,
         proc_macro_dev = True,
     ),
-    deps = all_crate_deps(normal_dev = True),
+    deps = all_crate_deps(normal_dev = True) + [
+        "//crates/agenthub-team-domain:agenthub_team_domain",
+    ],
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 agenthub-acp-core = { path = "../agenthub-acp-core" }
 agenthub-config = { path = "../agenthub-config" }
 agenthub-managed-skills = { path = "../agenthub-managed-skills" }
+agenthub-team-domain = { path = "../agenthub-team-domain" }
 agenthub-text = { path = "../agenthub-text" }
 agent-client-protocol = { version = "0.10.4", features = ["unstable"] }
 anyhow = "1"

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 use agent_client_protocol::{ContentBlock, TextContent};
 use agenthub_acp_core::{AcpSkill, build_skill};
 use agenthub_managed_skills::{ManagedSkillKind, managed_skill_doc};
+use agenthub_team_domain::{
+    TEAM_RUNTIME_STATE_RELATIVE_PATH, continuity_note_relative_path, extract_context_artifact_path,
+};
 use anyhow::{Result, bail};
 
 use crate::AcpActorSkillContext;
@@ -91,36 +94,21 @@ fn build_continuity_lines(context: &AcpActorSkillContext) -> Vec<String> {
             "- continuity_source_execution_run_id: {}",
             continuity.source_run_id
         ),
-        "- continuity_state_path: .cache/context/state.md".to_string(),
+        format!("- continuity_state_path: {TEAM_RUNTIME_STATE_RELATIVE_PATH}"),
     ];
-    if let Some(note_path) = continuity_note_path(&continuity.source_run_id) {
+    if let Some(note_path) = continuity_note_relative_path(&continuity.source_run_id) {
         lines.push(format!("- continuity_note_path: {note_path}"));
     }
     if let Some(artifact_path) = continuity
         .history_window
         .get("artifact_pointer")
-        .and_then(extract_artifact_pointer_path)
+        .and_then(extract_context_artifact_path)
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
         lines.push(format!("- continuity_artifact_path: {artifact_path}"));
     }
     lines
-}
-
-fn continuity_note_path(source_run_id: &str) -> Option<String> {
-    let source_run_id = source_run_id.trim();
-    if source_run_id.is_empty() {
-        return None;
-    }
-    Some(format!(".cache/context/run/{source_run_id}/continuity.md"))
-}
-
-fn extract_artifact_pointer_path(value: &serde_json::Value) -> Option<&str> {
-    value
-        .get("path")
-        .and_then(|path| path.as_str())
-        .or_else(|| value.as_str())
 }
 
 #[cfg(test)]

--- a/crates/agenthub-team-domain/src/lib.rs
+++ b/crates/agenthub-team-domain/src/lib.rs
@@ -1,5 +1,12 @@
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 use serde_json::Value;
+use std::collections::BTreeMap;
+
+pub const TEAM_RUNTIME_STATE_SCHEMA_FAMILY: &str = "team_runtime_state";
+pub const TEAM_RUNTIME_STATE_SCHEMA_VERSION: i64 = 1;
+pub const TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY: &str = "team_continuity_note";
+pub const TEAM_CONTINUITY_NOTE_SCHEMA_VERSION: i64 = 1;
+pub const TEAM_RUNTIME_STATE_RELATIVE_PATH: &str = ".cache/context/state.md";
 
 pub const TEAM_RUN_STATUS_VALUES: [&str; 6] = [
     "submitted",
@@ -121,6 +128,121 @@ impl std::str::FromStr for TeamTaskStatus {
             other => Err(other.to_string()),
         }
     }
+}
+
+pub fn continuity_note_relative_path(source_run_id: &str) -> Option<String> {
+    let source_run_id = source_run_id.trim();
+    if source_run_id.is_empty() {
+        return None;
+    }
+    Some(format!(".cache/context/run/{source_run_id}/continuity.md"))
+}
+
+pub fn extract_context_artifact_path(value: &Value) -> Option<&str> {
+    value
+        .get("path")
+        .and_then(Value::as_str)
+        .or_else(|| value.as_str())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamRuntimeStateIndex {
+    pub schema_family: Option<String>,
+    pub schema_version: Option<i64>,
+    pub updated_at: Option<String>,
+    pub team_id: Option<String>,
+    pub member_id: Option<String>,
+    pub current_execution_run_id: Option<String>,
+    pub continuity_mode: Option<String>,
+    pub continuity_source_execution_run_id: Option<String>,
+    pub continuity_note_path: Option<String>,
+    pub continuity_artifact_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamContinuityNoteHeader {
+    pub schema_family: Option<String>,
+    pub schema_version: Option<i64>,
+    pub updated_at: Option<String>,
+    pub team_id: Option<String>,
+    pub member_id: Option<String>,
+    pub current_execution_run_id: Option<String>,
+    pub continuity_source_execution_run_id: Option<String>,
+    pub continuity_mode: Option<String>,
+    pub continuity_artifact_path: Option<String>,
+}
+
+pub fn parse_team_runtime_state_index(contents: &str) -> Option<TeamRuntimeStateIndex> {
+    let metadata = parse_machine_read_markdown_metadata(contents, "# Team Runtime State")?;
+    Some(TeamRuntimeStateIndex {
+        schema_family: metadata.get("schema_family").cloned(),
+        schema_version: metadata
+            .get("schema_version")
+            .and_then(|value| value.parse::<i64>().ok()),
+        updated_at: metadata.get("updated_at").cloned(),
+        team_id: metadata.get("team_id").cloned(),
+        member_id: metadata.get("member_id").cloned(),
+        current_execution_run_id: metadata.get("current_execution_run_id").cloned(),
+        continuity_mode: metadata.get("continuity_mode").cloned(),
+        continuity_source_execution_run_id: metadata
+            .get("continuity_source_execution_run_id")
+            .cloned(),
+        continuity_note_path: metadata.get("continuity_note_path").cloned(),
+        continuity_artifact_path: metadata.get("continuity_artifact_path").cloned(),
+    })
+}
+
+pub fn parse_team_continuity_note_header(contents: &str) -> Option<TeamContinuityNoteHeader> {
+    let metadata = parse_machine_read_markdown_metadata(contents, "# Team Continuity Note")?;
+    Some(TeamContinuityNoteHeader {
+        schema_family: metadata.get("schema_family").cloned(),
+        schema_version: metadata
+            .get("schema_version")
+            .and_then(|value| value.parse::<i64>().ok()),
+        updated_at: metadata.get("updated_at").cloned(),
+        team_id: metadata.get("team_id").cloned(),
+        member_id: metadata.get("member_id").cloned(),
+        current_execution_run_id: metadata.get("current_execution_run_id").cloned(),
+        continuity_source_execution_run_id: metadata
+            .get("continuity_source_execution_run_id")
+            .cloned(),
+        continuity_mode: metadata.get("continuity_mode").cloned(),
+        continuity_artifact_path: metadata.get("continuity_artifact_path").cloned(),
+    })
+}
+
+fn parse_machine_read_markdown_metadata(
+    contents: &str,
+    expected_title: &str,
+) -> Option<BTreeMap<String, String>> {
+    let mut lines = contents.lines();
+    let title = lines.next()?.trim();
+    if title != expected_title {
+        return None;
+    }
+
+    let mut metadata = BTreeMap::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("## ") {
+            break;
+        }
+        let Some(rest) = trimmed.strip_prefix("- ") else {
+            continue;
+        };
+        let Some((key, value)) = rest.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        metadata.insert(key.to_string(), value.trim().to_string());
+    }
+    Some(metadata)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,9 +402,12 @@ pub enum TeamRunResumeError {
 #[cfg(test)]
 mod tests {
     use super::{
-        TEAM_RUN_CONTINUITY_MODE_VALUES, TEAM_RUN_STATUS_VALUES, TEAM_STEP_STATUS_VALUES,
-        TEAM_TASK_STATUS_VALUES, TeamRunResumeError, TeamStepRecord, TeamStepStatus,
-        TeamTaskStatus,
+        TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY, TEAM_CONTINUITY_NOTE_SCHEMA_VERSION,
+        TEAM_RUN_CONTINUITY_MODE_VALUES, TEAM_RUN_STATUS_VALUES, TEAM_RUNTIME_STATE_SCHEMA_FAMILY,
+        TEAM_RUNTIME_STATE_SCHEMA_VERSION, TEAM_STEP_STATUS_VALUES, TEAM_TASK_STATUS_VALUES,
+        TeamRunResumeError, TeamStepRecord, TeamStepStatus, TeamTaskStatus,
+        continuity_note_relative_path, extract_context_artifact_path,
+        parse_team_continuity_note_header, parse_team_runtime_state_index,
     };
     use serde_json::json;
 
@@ -323,6 +448,92 @@ mod tests {
                 .parse::<TeamTaskStatus>()
                 .expect_err("invalid status"),
             "invalid"
+        );
+    }
+
+    #[test]
+    fn continuity_note_relative_path_uses_source_run_id() {
+        assert_eq!(
+            continuity_note_relative_path("run-42").as_deref(),
+            Some(".cache/context/run/run-42/continuity.md")
+        );
+        assert_eq!(continuity_note_relative_path("   ").as_deref(), None);
+    }
+
+    #[test]
+    fn extract_context_artifact_path_accepts_object_and_legacy_string() {
+        assert_eq!(
+            extract_context_artifact_path(&json!({
+                "path": ".cache/context/run/run-42/artifact-0001.json"
+            })),
+            Some(".cache/context/run/run-42/artifact-0001.json")
+        );
+        assert_eq!(
+            extract_context_artifact_path(&json!(".cache/context/run/run-42/artifact-0001.json")),
+            Some(".cache/context/run/run-42/artifact-0001.json")
+        );
+        assert_eq!(
+            extract_context_artifact_path(&json!({ "other": "value" })),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_team_runtime_state_index_reads_current_schema_metadata() {
+        let parsed = parse_team_runtime_state_index(
+            format!(
+                "# Team Runtime State\n\n- schema_family: {TEAM_RUNTIME_STATE_SCHEMA_FAMILY}\n- schema_version: {TEAM_RUNTIME_STATE_SCHEMA_VERSION}\n- updated_at: 123\n- team_id: team-1\n- member_id: worker\n- current_execution_run_id: run-7\n- continuity_mode: inherit_recent\n- continuity_source_execution_run_id: run-6\n- continuity_note_path: .cache/context/run/run-6/continuity.md\n- continuity_artifact_path: .cache/context/run/run-6/artifact-0001.json\n"
+            )
+            .as_str(),
+        )
+        .expect("parse runtime state");
+        assert_eq!(
+            parsed.schema_family.as_deref(),
+            Some(TEAM_RUNTIME_STATE_SCHEMA_FAMILY)
+        );
+        assert_eq!(
+            parsed.schema_version,
+            Some(TEAM_RUNTIME_STATE_SCHEMA_VERSION)
+        );
+        assert_eq!(parsed.current_execution_run_id.as_deref(), Some("run-7"));
+        assert_eq!(
+            parsed.continuity_note_path.as_deref(),
+            Some(".cache/context/run/run-6/continuity.md")
+        );
+    }
+
+    #[test]
+    fn parse_team_runtime_state_index_accepts_legacy_shape_without_schema() {
+        let parsed = parse_team_runtime_state_index(
+            "# Team Runtime State\n\n- updated_at: 123\n- team_id: team-1\n- member_id: worker\n- current_execution_run_id: run-7\n- continuity_mode: inherit_recent\n",
+        )
+        .expect("parse runtime state");
+        assert_eq!(parsed.schema_family, None);
+        assert_eq!(parsed.schema_version, None);
+        assert_eq!(parsed.team_id.as_deref(), Some("team-1"));
+        assert_eq!(parsed.member_id.as_deref(), Some("worker"));
+    }
+
+    #[test]
+    fn parse_team_continuity_note_header_stops_before_summary_body() {
+        let parsed = parse_team_continuity_note_header(
+            format!(
+                "# Team Continuity Note\n\n- schema_family: {TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY}\n- schema_version: {TEAM_CONTINUITY_NOTE_SCHEMA_VERSION}\n- updated_at: 123\n- team_id: team-1\n- member_id: worker\n- current_execution_run_id: run-7\n- continuity_source_execution_run_id: run-6\n- continuity_mode: inherit_recent\n- continuity_artifact_path: .cache/context/run/run-6/artifact-0001.json\n\n## Summary\nlarge payload\n\n## History Window\n````json\n{{\"schema_version\":1}}\n````\n"
+            )
+            .as_str(),
+        )
+        .expect("parse continuity note");
+        assert_eq!(
+            parsed.schema_family.as_deref(),
+            Some(TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY)
+        );
+        assert_eq!(
+            parsed.schema_version,
+            Some(TEAM_CONTINUITY_NOTE_SCHEMA_VERSION)
+        );
+        assert_eq!(
+            parsed.continuity_artifact_path.as_deref(),
+            Some(".cache/context/run/run-6/artifact-0001.json")
         );
     }
 

--- a/crates/agenthub-team-domain/src/lib.rs
+++ b/crates/agenthub-team-domain/src/lib.rs
@@ -215,7 +215,7 @@ fn parse_machine_read_markdown_metadata(
     contents: &str,
     expected_title: &str,
 ) -> Option<BTreeMap<String, String>> {
-    let mut lines = contents.lines();
+    let mut lines = contents.lines().skip_while(|line| line.trim().is_empty());
     let title = lines.next()?.trim();
     if title != expected_title {
         return None;
@@ -512,6 +512,16 @@ mod tests {
         assert_eq!(parsed.schema_version, None);
         assert_eq!(parsed.team_id.as_deref(), Some("team-1"));
         assert_eq!(parsed.member_id.as_deref(), Some("worker"));
+    }
+
+    #[test]
+    fn parse_team_runtime_state_index_skips_leading_blank_lines() {
+        let parsed = parse_team_runtime_state_index(
+            "\n\n  \n# Team Runtime State\n- team_id: team-1\n- member_id: worker-1\n",
+        )
+        .expect("parse runtime state after leading blank lines");
+        assert_eq!(parsed.team_id.as_deref(), Some("team-1"));
+        assert_eq!(parsed.member_id.as_deref(), Some("worker-1"));
     }
 
     #[test]

--- a/docs/features/team-workspace-memory-contract.md
+++ b/docs/features/team-workspace-memory-contract.md
@@ -206,6 +206,53 @@ The same rule applies to worker project memory:
 - Durable facts promoted from flush output should be written into `.cache/context/memory/*.md` or
   `.agenthubmemory/note/` as concise summaries with source pointers.
 
+### 7) Rolling Upgrade Compatibility Contract
+
+Filesystem-backed Team memory must support mixed-version runtime deployments without requiring one
+atomic workspace rewrite.
+
+Compatibility rules:
+
+- Treat machine-read index files as versioned file protocols, not ad-hoc prompt dumps.
+- Prefer additive evolution:
+  - add new fields or new pointed-to files first;
+  - keep existing stable pointer fields readable for at least one compatibility window;
+  - remove or rename fields only after every supported reader no longer depends on them.
+- Readers must be more tolerant than writers:
+  - new readers should accept missing optional fields, unknown extra fields, and older field
+    shapes when the core pointer contract still resolves;
+  - writers may emit the latest schema, but should preserve compatibility-facing fields until the
+    previous reader generation is retired.
+- Do not require startup-time full-workspace rewrites or destructive migrations just to load
+  context state.
+
+Machine-read file requirements:
+
+- Stable index files such as `state.md` should declare:
+  - `schema_family`
+  - `schema_version`
+- Run-scoped artifacts and machine-read markdown or JSON notes should also carry self-describing
+  schema metadata whenever a runtime parser depends on their structure.
+- `state.md` is the compatibility-facing index for current runtime context, not the full-fidelity
+  state source; detailed continuity or replay material should live behind stable pointers under
+  `.cache/context/run/<run_id>/...`.
+
+Migration strategy:
+
+1. land a backward-compatible reader first;
+2. start writing the new schema or new pointed-to file shape;
+3. keep compatibility fields or dual-read support during the rollout window;
+4. remove legacy fields only after the old reader path is no longer supported.
+
+Practical consequences:
+
+- Pointer paths are the primary stability boundary; index files should change more slowly than the
+  deeper artifact payloads they reference.
+- Append-only files (`decisions.md`, `errors.md`, `log.md`) should accept entry-shape evolution by
+  appending new records rather than rewriting historical entries in place.
+- If a field rename is semantically necessary, prefer a staged dual-read or dual-write window over
+  a one-shot replacement.
+
 ## Operational Notes
 
 - Treat prompt text as the bounded working set, not the durable notebook.
@@ -226,3 +273,5 @@ The same rule applies to worker project memory:
 - [2026-04-10-team-prompt-tail-slimming.md](../journal/2026-04-10-team-prompt-tail-slimming.md)
 - [2026-04-10-runtime-context-identity-compaction.md](../journal/2026-04-10-runtime-context-identity-compaction.md)
 - [2026-04-10-team-workspace-memory-contract.md](../journal/2026-04-10-team-workspace-memory-contract.md)
+- [2026-04-18-team-memory-index-rolling-upgrade.md](../journal/2026-04-18-team-memory-index-rolling-upgrade.md)
+- [2026-04-18-team-memory-index-schema-metadata.md](../journal/2026-04-18-team-memory-index-schema-metadata.md)

--- a/docs/journal/2026-04-18-bazel-acp-team-domain-dependency.md
+++ b/docs/journal/2026-04-18-bazel-acp-team-domain-dependency.md
@@ -1,0 +1,24 @@
+# Bazel ACP Team Domain Dependency
+
+- Date: 2026-04-18
+- PR: #383
+
+## Summary
+
+The Team memory/index compatibility change added a new Rust dependency from `agenthub-acp` to `agenthub-team-domain`, but the Bazel target graph still reflected the old crate boundary. Cargo builds passed because `crates/agenthub-acp/Cargo.toml` declared the path dependency, while Bazel CI failed with an unresolved import for `agenthub_team_domain`.
+
+## Root Cause
+
+- `crates/agenthub-acp/src/actor_runtime_skill.rs` now imports shared Team-domain helpers.
+- `crates/agenthub-acp/Cargo.toml` was updated accordingly.
+- `crates/agenthub-acp/BUILD.bazel` was not updated, so `//crates/agenthub-acp:agenthub_acp` and its test target did not depend on `//crates/agenthub-team-domain:agenthub_team_domain`.
+
+## Fix
+
+- Add `//crates/agenthub-team-domain:agenthub_team_domain` to the `agenthub_acp` Bazel library target.
+- Add the same explicit dependency to `agenthub_acp_tests` so Bazel test builds stay aligned with the library boundary.
+
+## Validation
+
+- GitHub Actions failure logs for PR #383 showed the same unresolved-import error across Bazel Build/Test/Coverage jobs.
+- Local `bazel build/test` attempts no longer reproduced the unresolved-import error, but local Bazel execution remained noisy because of workstation-specific output-base/runtime issues, so the authoritative verification is the PR Bazel rerun on CI.

--- a/docs/journal/2026-04-18-team-memory-index-parser-leading-blank-lines.md
+++ b/docs/journal/2026-04-18-team-memory-index-parser-leading-blank-lines.md
@@ -1,0 +1,17 @@
+# Team Memory Index Parser Leading Blank Lines
+
+- Date: 2026-04-18
+- PR: #383
+
+## Summary
+
+The Team memory/index markdown parser now tolerates leading blank lines before the machine-read title line. This keeps the parser resilient to harmless formatting drift while preserving the existing title and metadata normalization contract.
+
+## Changes
+
+- Update `parse_machine_read_markdown_metadata(...)` to skip leading empty lines before matching the expected markdown title.
+- Add a regression test that parses `# Team Runtime State` content with leading blank lines.
+
+## Validation
+
+- `cargo test -p agenthub-team-domain -- --nocapture` remains the intended focused validation target for the parser helpers in this crate.

--- a/docs/journal/2026-04-18-team-memory-index-rolling-upgrade.md
+++ b/docs/journal/2026-04-18-team-memory-index-rolling-upgrade.md
@@ -1,0 +1,43 @@
+# Team Memory Index Rolling Upgrade
+
+## Summary
+
+- extended the Team workspace memory contract with an explicit rolling-upgrade compatibility
+  section for `.cache/context/` and other machine-read memory/index files
+- defined versioning, additive evolution, and reader/writer compatibility expectations so prompt
+  tail slimming can keep moving state behind filesystem pointers without forcing one-shot workspace
+  migrations
+
+## Why
+
+The current Team prompt-tail work already treats `.cache/context/state.md` and run-scoped notes as
+pointer-first runtime indexes, but the spec did not yet say how those files should evolve across
+mixed-version runtime rollouts.
+
+Without that rule, every new memory/index field risks becoming a de facto breaking change for older
+readers or restart paths that still expect the previous shape.
+
+## Changes
+
+- added `Rolling Upgrade Compatibility Contract` to
+  `docs/features/team-workspace-memory-contract.md`
+- defined these compatibility requirements:
+  - machine-read index files are versioned file protocols
+  - additive changes are preferred over in-place breaking rewrites
+  - readers must tolerate unknown extra fields and older optional shapes
+  - writers may move forward, but should preserve compatibility-facing fields during rollout
+  - startup should not require a full workspace migration just to read Team context
+- clarified that `state.md` is the compatibility-facing current-state index, while higher-fidelity
+  details continue to live under `.cache/context/run/<run_id>/...`
+- documented the recommended rollout order:
+  1. land backward-compatible readers
+  2. switch writers to the new schema or pointed-to file
+  3. keep dual-read or compatibility fields during rollout
+  4. remove legacy fields only after the old reader generation is retired
+
+## Follow-Up
+
+- future Team runtime changes that add machine-read state files should declare `schema_family` and
+  `schema_version` in the file contract instead of relying on implicit field guessing
+- the next prompt-tail slimming changes should follow this contract when introducing additional
+  `state.md` pointers or run-scoped note formats

--- a/docs/journal/2026-04-18-team-memory-index-schema-metadata.md
+++ b/docs/journal/2026-04-18-team-memory-index-schema-metadata.md
@@ -1,0 +1,53 @@
+# Team Memory Index Schema Metadata
+
+## Summary
+
+- added shared Team runtime memory-index helpers under `agenthub-team-domain` so runtime and ACP
+  pointer paths stop drifting independently
+- started writing explicit schema metadata into the machine-read Team runtime files
+  `.cache/context/state.md` and `.cache/context/run/<run_id>/continuity.md`
+- added compatibility-focused tests for both legacy artifact-pointer shape handling and the new
+  schema metadata lines
+
+## Why
+
+The rolling-upgrade spec now says machine-read Team memory/index files should behave like versioned
+file protocols.
+
+Without shared helpers and explicit schema markers, `state.md` and `continuity.md` would still be
+easy to evolve inconsistently across runtime writers and ACP readers.
+
+## Changes
+
+- `crates/agenthub-team-domain/src/lib.rs`
+  - added:
+    - `TEAM_RUNTIME_STATE_SCHEMA_FAMILY`
+    - `TEAM_RUNTIME_STATE_SCHEMA_VERSION`
+    - `TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY`
+    - `TEAM_CONTINUITY_NOTE_SCHEMA_VERSION`
+    - `TEAM_RUNTIME_STATE_RELATIVE_PATH`
+    - `continuity_note_relative_path(...)`
+    - `extract_context_artifact_path(...)`
+- `src/team/manager.rs`
+  - `state.md` now writes:
+    - `schema_family: team_runtime_state`
+    - `schema_version: 1`
+  - `continuity.md` now writes:
+    - `schema_family: team_continuity_note`
+    - `schema_version: 1`
+- `crates/agenthub-acp/src/actor_runtime_skill.rs`
+  - switched continuity note path and artifact pointer extraction to the shared Team-domain helpers
+- tests
+  - Team manager regression now asserts schema metadata in both runtime files
+  - Team-domain unit tests cover object-shaped and legacy string-shaped artifact pointers
+  - Team-domain parsers now cover:
+    - current `state.md` schema metadata parsing
+    - legacy `state.md` parsing without schema fields
+    - `continuity.md` header parsing without reading into summary/history body
+
+## Follow-Up
+
+- future machine-read Team context files should use the same schema metadata pattern instead of
+  ad-hoc field-only contracts
+- the next prompt-tail slimming change can build on these helpers when adding more
+  compatibility-facing pointers to `state.md`

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -12,6 +12,11 @@ use std::{
 };
 
 pub use agenthub_team_domain::TeamRunResumeError;
+use agenthub_team_domain::{
+    TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY, TEAM_CONTINUITY_NOTE_SCHEMA_VERSION,
+    TEAM_RUNTIME_STATE_SCHEMA_FAMILY, TEAM_RUNTIME_STATE_SCHEMA_VERSION,
+    continuity_note_relative_path, extract_context_artifact_path,
+};
 use agenthub_text::truncate_chars;
 use chrono::Utc;
 use serde_json::Value;
@@ -4765,6 +4770,8 @@ fn build_runtime_state_snapshot_text(
     let mut lines = vec![
         "# Team Runtime State".to_string(),
         String::new(),
+        format!("- schema_family: {TEAM_RUNTIME_STATE_SCHEMA_FAMILY}"),
+        format!("- schema_version: {TEAM_RUNTIME_STATE_SCHEMA_VERSION}"),
         format!("- updated_at: {}", continuity_state.updated_at),
         format!("- team_id: {}", owner.team_id),
         format!("- member_id: {}", owner.member_id),
@@ -4801,6 +4808,8 @@ fn build_runtime_continuity_note_text(
     let mut lines = vec![
         "# Team Continuity Note".to_string(),
         String::new(),
+        format!("- schema_family: {TEAM_CONTINUITY_NOTE_SCHEMA_FAMILY}"),
+        format!("- schema_version: {TEAM_CONTINUITY_NOTE_SCHEMA_VERSION}"),
         format!("- updated_at: {}", continuity_state.updated_at),
         format!("- team_id: {}", owner.team_id),
         format!("- member_id: {}", owner.member_id),
@@ -4832,21 +4841,6 @@ fn build_runtime_continuity_note_text(
         String::new(),
     ]);
     lines.join("\n")
-}
-
-fn continuity_note_relative_path(source_run_id: &str) -> Option<String> {
-    let source_run_id = source_run_id.trim();
-    if source_run_id.is_empty() {
-        return None;
-    }
-    Some(format!(".cache/context/run/{source_run_id}/continuity.md"))
-}
-
-fn extract_context_artifact_path(value: &Value) -> Option<&str> {
-    value
-        .get("path")
-        .and_then(Value::as_str)
-        .or_else(|| value.as_str())
 }
 
 #[derive(Debug, Clone)]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2505,6 +2505,8 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
         .join("continuity.md");
     let note_text = std::fs::read_to_string(&note_path).expect("read runtime continuity note");
     assert!(state_text.contains("# Team Runtime State"));
+    assert!(state_text.contains("- schema_family: team_runtime_state"));
+    assert!(state_text.contains("- schema_version: 1"));
     assert!(state_text.contains("- team_id:"));
     assert!(state_text.contains("- member_id: planner"));
     assert!(state_text.contains("- current_execution_run_id:"));
@@ -2512,6 +2514,8 @@ async fn complete_step_offloads_large_output_to_workspace_context_artifact() {
     assert!(state_text.contains(format!("- continuity_note_path: {note_relative_path}").as_str()));
     assert!(state_text.contains(pointer_path));
     assert!(note_text.contains("# Team Continuity Note"));
+    assert!(note_text.contains("- schema_family: team_continuity_note"));
+    assert!(note_text.contains("- schema_version: 1"));
     assert!(note_text.contains("- current_execution_run_id:"));
     assert!(note_text.contains("- continuity_source_execution_run_id:"));
     assert!(note_text.contains("## Summary"));


### PR DESCRIPTION
fix(team): version memory index contracts

## Summary

- add Team-domain shared helpers and constants for runtime memory index paths and artifact-pointer extraction
- write explicit schema metadata into `.cache/context/state.md` and run-scoped `continuity.md`
- add parser coverage for current and legacy Team memory-index shapes so rolling upgrades have a concrete reader contract
- document the rolling-upgrade compatibility contract and schema-metadata follow-up in feature/journal docs

## Testing

- `cargo test -p agenthub-team-domain -- --nocapture`
- `cargo test complete_step_offloads_large_output_to_workspace_context_artifact -- --nocapture`
- `cargo test -p agenthub-acp actor_runtime_context_block_keeps_continuity_pointer_first -- --nocapture`

## Notes

- This PR follows the new rolling-upgrade contract for Team memory/index files by treating `state.md` as a compatibility-facing index and adding explicit schema markers for machine-read files.
