### PR TITLE
docs(userdocs): align recent product updates

### DIFF
--- a/docs/journal/2026-04-20-userdocs-rust-195-codex-121-alignment.md
+++ b/docs/journal/2026-04-20-userdocs-rust-195-codex-121-alignment.md
@@ -1,0 +1,25 @@
+## Summary
+
+Aligned user-facing documentation with the merged Rust `1.95.0` and Codex
+`0.121.x` repository baseline.
+
+## Updated Pages
+
+- `userdocs/docs/getting-started/installation.md`
+- `userdocs/docs/getting-started/configuration-basics.md`
+- `userdocs/docs/operations/troubleshooting.md`
+
+## What Changed
+
+- Made the validated local build baseline explicit in installation docs:
+  - Rust `1.95.0`
+  - default ACP adapter `agenthub-codex-acp`
+  - official Codex `0.121.x`
+- Clarified that custom `codex_acp.binary` overrides should stay protocol-
+  compatible with the same ACP surface.
+- Added a focused troubleshooting section for stale or incompatible ACP adapter
+  binaries that start and exit immediately.
+
+## Validation
+
+Documentation-only change. No code or config behavior was modified.

--- a/docs/journal/2026-04-20-userdocs-rust-195-codex-121-alignment.md
+++ b/docs/journal/2026-04-20-userdocs-rust-195-codex-121-alignment.md
@@ -5,9 +5,13 @@ Aligned user-facing documentation with the merged Rust `1.95.0` and Codex
 
 ## Updated Pages
 
+- `userdocs/docs/intro.md`
 - `userdocs/docs/getting-started/installation.md`
 - `userdocs/docs/getting-started/configuration-basics.md`
 - `userdocs/docs/operations/troubleshooting.md`
+- `userdocs/docs/overview/feature-overview.md`
+- `userdocs/docs/overview/architecture-overview.md`
+- `userdocs/docs/advanced/team-workbench.md`
 
 ## What Changed
 
@@ -19,6 +23,11 @@ Aligned user-facing documentation with the merged Rust `1.95.0` and Codex
   compatible with the same ACP surface.
 - Added a focused troubleshooting section for stale or incompatible ACP adapter
   binaries that start and exit immediately.
+- Refreshed Team/user-facing feature descriptions to match recent product
+  changes:
+  - channel-first Team shell language
+  - explicit `Execution Runs` terminology
+  - token-based Agent Node onboarding
 
 ## Validation
 

--- a/userdocs/docs/advanced/team-workbench.md
+++ b/userdocs/docs/advanced/team-workbench.md
@@ -100,7 +100,7 @@ In practice:
 Team Workbench is now task-first:
 
 - `Kanban` is the durable coordination surface
-- `Channels` (`# all`) are a separate stable shared lane, not a workspace task you need to
+- `Channels` (`# all`) provide a separate stable shared lane, not a workspace task you need to
   recover manually from Kanban ordering
 - human requests and clarifications live in `Channels`; leader/runtime turns agreed work into
   canonical Kanban tasks

--- a/userdocs/docs/advanced/team-workbench.md
+++ b/userdocs/docs/advanced/team-workbench.md
@@ -10,9 +10,9 @@ Team Workbench (`/teams`) is AgentHub's multi-agent collaboration surface.
 
 Think about Team Workbench as three connected layers:
 
-- **Conversation** (`# all`): the human-facing shared thread
+- **Channels** (`# all` by default): the human-facing shared lane
 - **Kanban**: the canonical task lane
-- **Runs and debug surfaces**: execution telemetry and deep inspection
+- **Execution Runs and debug surfaces**: execution telemetry and deep inspection
 
 On smaller screens, Team Workbench switches between two panes instead of stacking
 everything into one page:
@@ -22,14 +22,25 @@ everything into one page:
 
 Use the header toggle to move between them.
 
-The important distinction is that Team `runs` and `steps` are execution and
-debug artifacts. They are not the primary planning surface.
+The important distinction is that Team `Execution Runs` and `steps` are
+execution and debug artifacts. They are not the primary planning surface.
+
+## Recent Updates
+
+Recent Team workbench updates changed the operator-facing shape in a few useful
+ways:
+
+- the shell is now more clearly `Channels`-first
+- run history is consistently labeled `Execution Runs`
+- the left rail carries most Team switching and workspace navigation
+- the shared `# all` lane stays the default place for human goals and team-wide
+  coordination
 
 ## Main UI Areas
 
-- **Channel**:
-  - shared conversation thread, usually `# all`
-  - `# all` is a stable Team-level conversation target resolved by the backend, not whichever task
+- **Channels**:
+  - shared channel lane, usually `# all`
+  - `# all` is a stable Team-level channel target resolved by the backend, not whichever task
     happens to be visible first in the Kanban list
   - optimized for live coordination: the composer stays pinned to the bottom and the workbench
     shows a bounded recent-10 message window by default
@@ -40,7 +51,7 @@ debug artifacts. They are not the primary planning surface.
   - not the place for human operators to manually author canonical Team tasks
 - **Agents**:
   - member list and per-member entry into `Agent ACP`
-- **Runs**:
+- **Execution Runs**:
   - explicit execution history, start, and selection
 - **Advanced / Debug**:
   - lower-level execution and inspection tools
@@ -49,30 +60,30 @@ debug artifacts. They are not the primary planning surface.
 
 Healthy Team usage usually follows a stable split:
 
-- humans talk in `Conversation`
+- humans talk in `Channels`, usually `# all`
 - the leader turns agreed work into canonical tasks
 - workers report progress and facts without taking over planning
 - `Kanban` stays the source of truth for task state
-- `Runs` and `Agent ACP` stay available for debugging, not for day-to-day
+- `Execution Runs` and `Agent ACP` stay available for debugging, not for day-to-day
   planning
 
-If `Runs` becomes the main place people track work, the Team model is usually
-drifting too close to raw execution details.
+If `Execution Runs` becomes the main place people track work, the Team model is
+usually drifting too close to raw execution details.
 
 ## Typical Workflow
 
 1. Create or select a Team.
 2. Start the Team runtime.
-3. Use `Conversation` to state the goal and constraints.
+3. Use `Channels`, usually `# all`, to state the goal and constraints.
 4. Let the leader turn agreed work into canonical Kanban tasks.
 5. Track ownership and progress in `Kanban`.
-6. Drop into `Agent ACP`, `Runs`, or `Advanced` only when you need execution
-   details or debugging.
+6. Drop into `Agent ACP`, `Execution Runs`, or `Advanced` only when you need
+   execution details or debugging.
 
-## Mentions And Shared Conversation
+## Mentions And Shared Channels
 
 - No `@mention`: message is team-wide and the leader should respond first.
-- `@member_id`: message is still visible in the shared thread, but it
+- `@member_id`: message is still visible in the shared channel, but it
   prioritizes the mentioned member or members.
 - Workers can contribute direct implementation progress or scoped answers, but
   planning and final synthesis still converge through the leader.
@@ -89,12 +100,12 @@ In practice:
 Team Workbench is now task-first:
 
 - `Kanban` is the durable coordination surface
-- `Conversation` (`# all`) is a separate stable shared thread, not a workspace task you need to
+- `Channels` (`# all`) are a separate stable shared lane, not a workspace task you need to
   recover manually from Kanban ordering
-- human requests and clarifications live in `Conversation`; leader/runtime turns agreed work into
+- human requests and clarifications live in `Channels`; leader/runtime turns agreed work into
   canonical Kanban tasks
 - the normal Team UI and public HTTP surface do not expose direct canonical task creation; requests
-  go through `Conversation` and leader/runtime materialize tasks onto `Kanban`
+  go through `Channels` and leader/runtime materialize tasks onto `Kanban`
 - tasks can exist without an assigned member yet
 - assignment can happen later as the plan becomes clearer
 - step/run data remains execution telemetry, not the primary ownership model
@@ -103,22 +114,20 @@ The workbench also refreshes more aggressively on resume:
 
 - runtime state rechecks on focus / reconnect
 - `Kanban` refreshes on resume instead of only waiting for the next poll
-- shared `Conversation` refreshes immediately on restore/reconnect in addition to SSE
+- shared `Channels` refresh immediately on restore/reconnect in addition to SSE
 
 This keeps context attached to the task instead of fragmenting it across many
 small execution steps.
 
 ## Shared Channel Connection Model
 
-The Team header exposes the shared-thread connection state directly:
-
-- `ONLINE · SSE CONNECTED` means the Team-level shared conversation stream is live
-- a manual channel refresh action is still available when you want to force a fresh pull
+The Team header keeps the shared channel connection state compact instead of
+turning it into a heavyweight status bar.
 
 The shared channel is intentionally tuned for live coordination, not infinite
 log browsing. The default Team surface keeps only a small recent window in
-memory so the workbench stays responsive. If you need deeper execution history
-or raw event detail, drop into `Agent ACP`, `Runs`, or other debug surfaces
+memory so the workbench stays responsive. If you need deeper execution history,
+or raw event detail, drop into `Agent ACP`, `Execution Runs`, or other debug surfaces
 instead of treating `# all` as the primary archive.
 
 ## What To Watch Operationally
@@ -127,7 +136,7 @@ instead of treating `# all` as the primary archive.
 - whether the Team runtime has correctly fallen back to `stopped` / `degraded` after members exit
 - whether a member that already exited no longer shows a stale `running` badge after refresh
 - whether Kanban ownership matches the real executing member
-- whether `Conversation` and `Kanban` stay in sync with the current plan
+- whether `Channels` and `Kanban` stay in sync with the current plan
 - whether permission review requests route to the expected reviewer
 
 ## Agent ACP In Team Mode
@@ -141,7 +150,7 @@ Use `Teams -> Agents -> Agent ACP` when you need to inspect one member deeply:
   and `Force New Session` when the active ACP runtime exposes them
 
 Use this sparingly during normal Team work. The primary human workflow should
-still live in `Conversation` and `Kanban`.
+still live in `Channels` and `Kanban`.
 
 When a provider returns structured selector options, AgentHub uses those
 provider-driven choices instead of forcing you to type raw model or mode IDs by

--- a/userdocs/docs/getting-started/configuration-basics.md
+++ b/userdocs/docs/getting-started/configuration-basics.md
@@ -101,6 +101,14 @@ ACP (Agent Control Protocol) provider settings.
 | `default_mode` | string | `"auto"` | Default ACP mode (`auto`, `full`, `suggest`) |
 | `multi_agent_enabled` | boolean | `true` | Force Codex ACP `Feature::Collab` on AgentHub-managed sessions |
 
+The built-in adapter path assumes the repository's current ACP baseline:
+
+- `agenthub-codex-acp`
+- official Codex `0.121.x`
+
+If you point `codex_acp.binary` at a custom binary, keep it compatible with the
+same ACP protocol surface before mixing it into a shared deployment.
+
 ### `[history]` Section
 
 Event history retention settings.

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Prerequisites
 
-- Rust (stable toolchain)
+- Rust `1.95.0` (stable toolchain baseline)
 - Node.js 20+
 - Git
 
@@ -56,6 +56,14 @@ cargo run -- -c /path/to/config.toml
 ```
 
 By default, AgentHub serves the UI at `http://localhost:8080`.
+
+## ACP Provider Baseline
+
+The default ACP adapter binary is `agenthub-codex-acp`.
+
+- Current repository baseline: official Codex `0.121.x`
+- If you override `codex_acp.binary`, keep the replacement ACP binary protocol-
+  compatible with the same Codex generation
 
 ## Optional App Install
 

--- a/userdocs/docs/intro.md
+++ b/userdocs/docs/intro.md
@@ -15,7 +15,7 @@ AgentHub is built for the operational side of agent work:
 
 - keep agent sessions alive after the browser tab closes
 - inspect structured ACP history instead of relying on raw scrollback
-- manage Team workflows with explicit shared conversation and task surfaces
+- manage Team workflows with explicit shared channels, Kanban, and execution surfaces
 - route execution to remote nodes with actor p2p control and mailbox relay when
   one machine is not enough
 - keep runtime state, history, and operator control in one place
@@ -29,7 +29,7 @@ That changes a few things:
 
 - reconnecting to a session should be normal, not a recovery edge case
 - output should stay structured and reviewable after the original run ends
-- multi-agent collaboration should use explicit coordination surfaces instead of
+- multi-agent collaboration should use explicit shared channels and task surfaces instead of
   ad-hoc shell copy/paste
 - remote execution should preserve the same actor and mailbox model instead of
   introducing a separate control plane
@@ -41,8 +41,8 @@ AgentHub has four primary user-facing surfaces:
 - **Agents**: create, start, stop, reconnect, and inspect single-agent runs
 - **Conversation and ACP timelines**: review plans, tool calls, command output,
   and debug events as structured history
-- **Teams**: coordinate leader/worker collaboration with shared conversation and
-  task tracking
+- **Teams**: coordinate leader/worker collaboration with shared channels,
+  Kanban, and execution tracking
 - **Agent Nodes and actor p2p**: extend execution onto remote machines without
   moving the control plane, while keeping mailbox/control traffic on the same
   operational model

--- a/userdocs/docs/operations/troubleshooting.md
+++ b/userdocs/docs/operations/troubleshooting.md
@@ -89,7 +89,7 @@ journalctl -u agenthub -n 100 --no-pager
 |-------|------------|----------|
 | Invalid workdir | Check path exists | Create directory or choose different path |
 | Path outside safe_paths | Check `safe_paths` config | Add path to config or use allowed path |
-| Missing ACP binary | `which agenthub-codex-acp` | Install the bundled ACP adapter or set `codex_acp.binary` |
+| Missing ACP binary | Check configured `codex_acp.binary` (or startup logs showing `config codex_acp_binary`) and verify that exact path exists and is executable | Install the bundled ACP adapter or set `codex_acp.binary` to a valid executable |
 | Permission denied | Check directory permissions | `chmod 755 /path/to/workdir` |
 
 ### "Workdir path must be within allowed safe paths"
@@ -115,17 +115,15 @@ handshake / startup errors.
 
 **Diagnostic Steps**:
 
-1. Check which binary AgentHub is launching:
+1. Check which binary AgentHub is launching by inspecting the configured
+   `codex_acp.binary` value first.
+2. Verify that exact adapter binary is the expected one:
    ```bash
-   which agenthub-codex-acp
+   /path/to/your-configured-agenthub-codex-acp --version
    ```
-2. Verify the adapter binary is the expected one:
-   ```bash
-   agenthub-codex-acp --version
-   ```
-3. Compare it to the repository baseline:
-   - Rust `1.95.0`
-   - official Codex `0.121.x`
+3. Compare the binary path and reported adapter version to the deployed
+   AgentHub build, or rebuild/replace the adapter from the same repository
+   revision if you are unsure they match.
 
 **Solutions**:
 

--- a/userdocs/docs/operations/troubleshooting.md
+++ b/userdocs/docs/operations/troubleshooting.md
@@ -89,7 +89,7 @@ journalctl -u agenthub -n 100 --no-pager
 |-------|------------|----------|
 | Invalid workdir | Check path exists | Create directory or choose different path |
 | Path outside safe_paths | Check `safe_paths` config | Add path to config or use allowed path |
-| Missing ACP binary | `which agenthub-codex-acp` | Install ACP provider or set `codex_acp.binary` |
+| Missing ACP binary | `which agenthub-codex-acp` | Install the bundled ACP adapter or set `codex_acp.binary` |
 | Permission denied | Check directory permissions | `chmod 755 /path/to/workdir` |
 
 ### "Workdir path must be within allowed safe paths"
@@ -107,6 +107,32 @@ journalctl -u agenthub -n 100 --no-pager
 2. Use `create_worktree` mode (uses configured `default_root`)
 
 3. Restart AgentHub after config changes
+
+### ACP Binary Starts But Fails Immediately
+
+**Symptoms**: Agent starts and exits quickly, or the server logs show ACP
+handshake / startup errors.
+
+**Diagnostic Steps**:
+
+1. Check which binary AgentHub is launching:
+   ```bash
+   which agenthub-codex-acp
+   ```
+2. Verify the adapter binary is the expected one:
+   ```bash
+   agenthub-codex-acp --version
+   ```
+3. Compare it to the repository baseline:
+   - Rust `1.95.0`
+   - official Codex `0.121.x`
+
+**Solutions**:
+
+- Rebuild from the current repository state if the binary is stale
+- Avoid mixing an older fork-pinned ACP binary into a newer AgentHub deployment
+- If you intentionally use a custom ACP binary, set `codex_acp.binary` to that
+  exact path and verify protocol compatibility first
 
 ### "Agent is already running"
 

--- a/userdocs/docs/overview/architecture-overview.md
+++ b/userdocs/docs/overview/architecture-overview.md
@@ -61,9 +61,11 @@ through the UI instead of relying only on raw process output.
 
 The Team model has three layers:
 
-- `Conversation` for human-facing shared discussion
+- `Channels` for human-facing shared coordination, with `# all` as the default
+  shared lane
 - `Kanban` for canonical task state
-- `Runs` plus debug surfaces for execution telemetry and deep inspection
+- `Execution Runs` plus debug surfaces for execution telemetry and deep
+  inspection
 
 This keeps collaboration state separate from lower-level execution artifacts.
 

--- a/userdocs/docs/overview/feature-overview.md
+++ b/userdocs/docs/overview/feature-overview.md
@@ -41,20 +41,34 @@ The exact controls depend on the active ACP provider and runtime.
 
 ## Team Workbench
 
-`/teams` adds a multi-agent workflow surface with clear role boundaries.
+`/teams` adds a multi-agent workspace surface with clear role boundaries.
 
 Key concepts:
 
-- `Conversation` (`# all`) is the shared human-facing thread
-- `Conversation` is resolved as one stable Team-level thread, not inferred from the visible Kanban
+- `Channels` lead the Team shell, with `# all` as the default shared lane
+- the shared channel is stable Team state, not inferred from the visible Kanban
   slice
 - `Kanban` is the canonical task lane
-- `Runs` and debug surfaces are execution artifacts, not the primary planning
-  surface
+- `Execution Runs` and debug surfaces are execution artifacts, not the primary
+  planning surface
 - `Agent ACP` lets you inspect a specific member deeply when needed
 
 Use this when planning, implementation, and review should be coordinated rather
 than collapsed into one session.
+
+## Recent Product Updates
+
+Recent merges worth knowing before rollout or operator training:
+
+- **Workspace shell convergence**: Team pages now use a more compact
+  workspace shell with clearer `Channels`-first navigation and less duplicated
+  chrome.
+- **Execution wording cleanup**: Team run history is presented as
+  `Execution Runs` to distinguish planning state from raw execution artifacts.
+- **Token-based Agent Node onboarding**: remote node join now uses explicit
+  bootstrap tokens from the `Agents` page instead of QR-style node onboarding.
+- **Rust / Codex baseline refresh**: local builds and bundled ACP integration
+  now track Rust `1.95.0` and the official Codex `0.121.x` line.
 
 ## Installable Web App And Push
 


### PR DESCRIPTION
## Summary

- align user-facing docs with the merged Rust `1.95.0` and Codex `0.121.x` baseline
- refresh Team and product overview pages to reflect recent workspace, channel-first, and node-onboarding updates
- add troubleshooting guidance for stale or incompatible ACP adapter binaries

## What Changed

- `userdocs/docs/getting-started/installation.md`
  - document Rust `1.95.0` as the current stable toolchain baseline
  - document `agenthub-codex-acp` / Codex `0.121.x` as the ACP baseline
- `userdocs/docs/getting-started/configuration-basics.md`
  - clarify expectations for `codex_acp.binary` overrides
- `userdocs/docs/operations/troubleshooting.md`
  - add a focused ACP binary compatibility troubleshooting section
- `userdocs/docs/intro.md`
- `userdocs/docs/overview/feature-overview.md`
- `userdocs/docs/overview/architecture-overview.md`
- `userdocs/docs/advanced/team-workbench.md`
  - refresh Team descriptions around `Channels`, `Kanban`, and `Execution Runs`
  - highlight recent shell, wording, and token-based Agent Node onboarding updates
- `docs/journal/2026-04-20-userdocs-rust-195-codex-121-alignment.md`
  - record the userdocs alignment scope

## Validation

- docs-only change
- no code paths, APIs, or runtime behavior changed
