### PR TITLE
fix(api): clamp page event pull limits

### DIFF
--- a/docs/journal/2026-04-20-web-event-pull-batch-limit.md
+++ b/docs/journal/2026-04-20-web-event-pull-batch-limit.md
@@ -9,6 +9,7 @@ Reduce UI-facing event fetch batch sizes so routine page loads and incremental h
 - reduced the Agents workbench event pull batch in `web/src/use_app_output_cache.ts` from `80` to `20`;
 - reduced Team run event and Team member event page pull limits in `web/src/pages/team/state.ts` from `100` / `300` to `20`;
 - reduced Team run snapshot `event_limit` / `message_limit` requests in `web/src/pages/team/use_team_actions.ts` from `200` to `20`;
+- clamped the public HTTP event endpoints and Team snapshot event/message query limits to `20` so oversized page-originated requests are bounded server-side as well;
 - updated focused Team action tests to assert the new member event pull batch.
 
 ## Validation

--- a/docs/journal/2026-04-20-web-event-pull-batch-limit.md
+++ b/docs/journal/2026-04-20-web-event-pull-batch-limit.md
@@ -1,0 +1,17 @@
+# Web Event Pull Batch Limit
+
+## Scope
+
+Reduce UI-facing event fetch batch sizes so routine page loads and incremental history pulls do not request hundreds of event rows at once.
+
+## Changes
+
+- reduced the Agents workbench event pull batch in `web/src/use_app_output_cache.ts` from `80` to `20`;
+- reduced Team run event and Team member event page pull limits in `web/src/pages/team/state.ts` from `100` / `300` to `20`;
+- reduced Team run snapshot `event_limit` / `message_limit` requests in `web/src/pages/team/use_team_actions.ts` from `200` to `20`;
+- updated focused Team action tests to assert the new member event pull batch.
+
+## Validation
+
+- `cd web && npm run test -- vite.config.test.ts src/pages/team/use_team_actions.test.tsx`
+- `git diff --check`

--- a/docs/journal/2026-04-20-web-event-pull-batch-limit.md
+++ b/docs/journal/2026-04-20-web-event-pull-batch-limit.md
@@ -10,9 +10,14 @@ Reduce UI-facing event fetch batch sizes so routine page loads and incremental h
 - reduced Team run event and Team member event page pull limits in `web/src/pages/team/state.ts` from `100` / `300` to `20`;
 - reduced Team run snapshot `event_limit` / `message_limit` requests in `web/src/pages/team/use_team_actions.ts` from `200` to `20`;
 - clamped the public HTTP event endpoints and Team snapshot event/message query limits to `20` so oversized page-originated requests are bounded server-side as well;
+- synchronized related frontend defaults and shared constants so mailbox pagination and agent event fetches do not keep assuming `80` / `100` after the server clamp;
+- aligned the Team OpenAPI snapshot/event parameter maxima to `20` so generated docs match the runtime contract;
 - updated focused Team action tests to assert the new member event pull batch.
 
 ## Validation
 
 - `cd web && npm run test -- vite.config.test.ts src/pages/team/use_team_actions.test.tsx`
+- `cd web && npm run test -- vite.config.test.ts src/app.route_shell.test.tsx src/app.runtime_effects.test.tsx src/pages/team/use_team_actions.test.tsx`
+- `cargo test list_events_route_clamps_limit_to_twenty -- --nocapture`
+- `cargo test teams_router_http_contract -- --nocapture`
 - `git diff --check`

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -4051,8 +4051,14 @@ mod tests {
         let body = decode_json_body(response).await;
         let events = body.as_array().expect("events array");
         assert_eq!(events.len(), 20);
-        assert_eq!(events.first().and_then(|event| event["message"].as_str()), Some("event-5"));
-        assert_eq!(events.last().and_then(|event| event["message"].as_str()), Some("event-24"));
+        assert_eq!(
+            events.first().and_then(|event| event["message"].as_str()),
+            Some("event-5")
+        );
+        assert_eq!(
+            events.last().and_then(|event| event["message"].as_str()),
+            Some("event-24")
+        );
     }
 
     #[tokio::test]

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -24,6 +24,7 @@ use crate::team::effective_team_member_skills;
 
 const AGENT_SOURCE_MANUAL: &str = "manual";
 const AGENT_SOURCE_TEAM_FORGE: &str = "team_forge";
+const AGENT_EVENTS_PAGE_LIMIT: i64 = 20;
 
 #[derive(Debug, serde::Deserialize)]
 pub struct CreateAgentRequest {
@@ -478,7 +479,10 @@ async fn list_events(
     Query(query): Query<ListEventsQuery>,
 ) -> Result<Json<Vec<crate::agent::AgentEvent>>, ApiError> {
     let _user = require_user(&headers, &state).await?;
-    let limit = query.limit.unwrap_or(500).clamp(1, 1000);
+    let limit = query
+        .limit
+        .unwrap_or(AGENT_EVENTS_PAGE_LIMIT)
+        .clamp(1, AGENT_EVENTS_PAGE_LIMIT);
     let before_id = query.before_id;
     let events = if let Some(session_id) = query.session_id.as_deref() {
         state
@@ -3971,6 +3975,84 @@ mod tests {
             body.contains("permission request not found for agent"),
             "unexpected error body: {body}"
         );
+    }
+
+    #[tokio::test]
+    async fn list_events_route_clamps_limit_to_twenty() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = router(state.clone());
+        let now = chrono::Utc::now().timestamp();
+
+        sqlx::query(
+            r#"
+            INSERT INTO agents (
+                id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, source, status, created_at, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 1, 'manual', 'running', ?7, ?8)
+            "#,
+        )
+        .bind("events-agent")
+        .bind("events-agent")
+        .bind("/tmp")
+        .bind("agenthub-codex-acp")
+        .bind("[]")
+        .bind("use_existing")
+        .bind(now)
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert agent");
+
+        sqlx::query(
+            r#"
+            INSERT INTO agent_sessions (id, agent_id, status, started_at, ended_at)
+            VALUES (?1, ?2, 'running', ?3, NULL)
+            "#,
+        )
+        .bind("session-events")
+        .bind("events-agent")
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert session");
+
+        let event_db = state
+            .agents
+            .test_event_pool_for_agent("events-agent")
+            .await
+            .expect("event pool");
+        for index in 0..25 {
+            sqlx::query(
+                r#"
+                INSERT INTO agent_events (session_id, seq, ts, stream, message)
+                VALUES (?1, ?2, ?3, 'stdout', ?4)
+                "#,
+            )
+            .bind("session-events")
+            .bind(format!("seq-{index}"))
+            .bind(now + i64::from(index))
+            .bind(format!("event-{index}"))
+            .execute(&event_db)
+            .await
+            .expect("insert event");
+        }
+
+        let response = app
+            .oneshot(build_json_request(
+                Method::GET,
+                "/events-agent/events?limit=100&session_id=session-events",
+                Some(&token),
+                None,
+            ))
+            .await
+            .expect("list events");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = decode_json_body(response).await;
+        let events = body.as_array().expect("events array");
+        assert_eq!(events.len(), 20);
+        assert_eq!(events.first().and_then(|event| event["message"].as_str()), Some("event-5"));
+        assert_eq!(events.last().and_then(|event| event["message"].as_str()), Some("event-24"));
     }
 
     #[tokio::test]

--- a/src/api/openapi/spec.rs
+++ b/src/api/openapi/spec.rs
@@ -523,8 +523,8 @@ pub(super) fn openapi_spec() -> Value {
             "summary": "Get run snapshot",
             "parameters": [
               { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
-              { "name": "event_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } },
-              { "name": "message_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } }
+              { "name": "event_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 20 } },
+              { "name": "message_limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 20 } }
             ],
             "responses": {
               "200": {
@@ -544,7 +544,7 @@ pub(super) fn openapi_spec() -> Value {
             "summary": "List run events",
             "parameters": [
               { "name": "run_id", "in": "path", "required": true, "schema": { "type": "string" } },
-              { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 1000 } },
+              { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 20 } },
               { "name": "before_id", "in": "query", "schema": { "type": "integer", "format": "int64" } }
             ],
             "responses": {

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -213,7 +213,9 @@ pub struct ListTeamRunEventsQuery {
     pub before_id: Option<i64>,
 }
 
-const TEAM_PAGE_EVENT_LIMIT: i64 = 20;
+const TEAM_PAGE_SNAPSHOT_LIMIT: i64 = 20;
+const TEAM_PAGE_EVENT_LIMIT: i64 = TEAM_PAGE_SNAPSHOT_LIMIT;
+const TEAM_PAGE_MESSAGE_LIMIT: i64 = TEAM_PAGE_SNAPSHOT_LIMIT;
 
 #[derive(Debug, Deserialize)]
 pub struct TeamRunSnapshotQuery {
@@ -1108,8 +1110,8 @@ async fn get_team_run_snapshot(
         .clamp(1, TEAM_PAGE_EVENT_LIMIT);
     let message_limit = query
         .message_limit
-        .unwrap_or(TEAM_PAGE_EVENT_LIMIT)
-        .clamp(1, TEAM_PAGE_EVENT_LIMIT);
+        .unwrap_or(TEAM_PAGE_MESSAGE_LIMIT)
+        .clamp(1, TEAM_PAGE_MESSAGE_LIMIT);
     let latest_events = state
         .teams
         .list_run_events(&run_id, event_limit, None)

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -213,6 +213,8 @@ pub struct ListTeamRunEventsQuery {
     pub before_id: Option<i64>,
 }
 
+const TEAM_PAGE_EVENT_LIMIT: i64 = 20;
+
 #[derive(Debug, Deserialize)]
 pub struct TeamRunSnapshotQuery {
     pub event_limit: Option<i64>,
@@ -1100,8 +1102,14 @@ async fn get_team_run_snapshot(
         .await
         .map_err(map_team_internal_error)?;
 
-    let event_limit = query.event_limit.unwrap_or(120).clamp(1, 500);
-    let message_limit = query.message_limit.unwrap_or(120).clamp(1, 500);
+    let event_limit = query
+        .event_limit
+        .unwrap_or(TEAM_PAGE_EVENT_LIMIT)
+        .clamp(1, TEAM_PAGE_EVENT_LIMIT);
+    let message_limit = query
+        .message_limit
+        .unwrap_or(TEAM_PAGE_EVENT_LIMIT)
+        .clamp(1, TEAM_PAGE_EVENT_LIMIT);
     let latest_events = state
         .teams
         .list_run_events(&run_id, event_limit, None)
@@ -1186,7 +1194,10 @@ async fn list_team_run_events(
 ) -> Result<Json<Vec<TeamRunEventRecord>>, ApiError> {
     let user = require_user(&headers, &state).await?;
     ensure_run_access_for_user(&state, &run_id, &user).await?;
-    let limit = query.limit.unwrap_or(500).clamp(1, 1000);
+    let limit = query
+        .limit
+        .unwrap_or(TEAM_PAGE_EVENT_LIMIT)
+        .clamp(1, TEAM_PAGE_EVENT_LIMIT);
     let events = state
         .teams
         .list_run_events(&run_id, limit, query.before_id)

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -575,6 +575,50 @@ async fn teams_router_http_contract() {
     assert_eq!(paged.len(), 1);
     assert_eq!(paged[0]["event_type"], "run_submitted");
 
+    for index in 0..25 {
+        sqlx::query(
+            r#"
+            INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
+            VALUES (?1, NULL, 'agent_message', ?2, ?3)
+            "#,
+        )
+        .bind(&run_id)
+        .bind(2_000 + i64::from(index))
+        .bind(format!("{{\"text\":\"bulk-{index}\"}}"))
+        .execute(&state.db)
+        .await
+        .expect("insert extra run events");
+    }
+
+    let clamped_events_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/runs/{run_id}/events?limit=100"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("list clamped events via router");
+    assert_eq!(clamped_events_resp.status(), StatusCode::OK);
+    let clamped_events = decode_json_body(clamped_events_resp).await;
+    let clamped_events = clamped_events.as_array().expect("clamped events array");
+    assert_eq!(clamped_events.len(), 20);
+
+    let snapshot_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/runs/{run_id}/snapshot?event_limit=100&message_limit=100"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("snapshot via router");
+    assert_eq!(snapshot_resp.status(), StatusCode::OK);
+    let snapshot = decode_json_body(snapshot_resp).await;
+    assert_eq!(snapshot["latest_events"].as_array().map(Vec::len), Some(20));
+
     let create_step_run_resp = app
         .clone()
         .oneshot(build_json_request(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -5,7 +5,7 @@ import {
 
 export const AGENT_SOURCE_MANUAL = "manual";
 export const AGENT_SOURCE_TEAM_FORGE = "team_forge";
-export const AGENT_EVENT_PAGE_SIZE = 80;
+export const AGENT_EVENT_PAGE_SIZE = 20;
 
 export type AgentConfig = {
   name: string;

--- a/web/src/app.route_shell.test.tsx
+++ b/web/src/app.route_shell.test.tsx
@@ -310,7 +310,7 @@ describe("App route shell wiring", () => {
     expect(listAgentEventsMock).toHaveBeenCalledWith(
       "token-root",
       "agent-running",
-      80,
+      20,
       undefined
     );
   });

--- a/web/src/app.runtime_effects.test.tsx
+++ b/web/src/app.runtime_effects.test.tsx
@@ -45,7 +45,7 @@ vi.mock("./api", () => ({
     getAdminSettings: getAdminSettingsMock,
   },
   parseApiErrorMessage: vi.fn(() => null),
-  AGENT_EVENT_PAGE_SIZE: 80,
+  AGENT_EVENT_PAGE_SIZE: 20,
 }));
 
 vi.mock("./push", () => ({
@@ -688,6 +688,6 @@ describe("App runtime viewport effects", () => {
   });
 
   it("uses the smaller ACP initial event page size budget", () => {
-    expect(AGENT_EVENT_PAGE_SIZE).toBe(80);
+    expect(AGENT_EVENT_PAGE_SIZE).toBe(20);
   });
 });

--- a/web/src/pages/team/state.ts
+++ b/web/src/pages/team/state.ts
@@ -126,8 +126,8 @@ export type TeamCreateState = TeamCreateDraftState & {
 
 export type TeamCreateAction = { type: "patch"; patch: Partial<TeamCreateState> };
 
-export const EVENT_PAGE_LIMIT = 100;
-export const MEMBER_EVENT_PAGE_LIMIT = 300;
+export const EVENT_PAGE_LIMIT = 20;
+export const MEMBER_EVENT_PAGE_LIMIT = 20;
 export const TEAM_RUN_PAGE_LIMIT = 50;
 export const DEFAULT_WORKTREE_ROOT = "~/.agenthub/worktrees";
 

--- a/web/src/pages/team/state.ts
+++ b/web/src/pages/team/state.ts
@@ -172,7 +172,7 @@ export const DEFAULT_TEAM_MAILBOX_STATE: TeamMailboxState = {
   chatStickToBottom: true,
   chatSeenByConversation: {},
   inboxActorId: "",
-  inboxLimit: "100",
+  inboxLimit: "20",
   inboxAfterId: "",
   inboxIncludeDelivered: false,
   inbox: [],

--- a/web/src/pages/team/use_team_actions.test.tsx
+++ b/web/src/pages/team/use_team_actions.test.tsx
@@ -307,7 +307,7 @@ describe("useTeamActions", () => {
       expect(listAgentEvents).toHaveBeenCalledWith(
         "token-1",
         "worker-agent",
-        300,
+        20,
         "runtime-session-1",
         undefined
       );
@@ -351,7 +351,7 @@ describe("useTeamActions", () => {
       expect(listAgentEvents).toHaveBeenCalledWith(
         "token-1",
         "agent-123",
-        300,
+        20,
         "runtime-session-1",
         undefined
       );

--- a/web/src/pages/team/use_team_actions.test.tsx
+++ b/web/src/pages/team/use_team_actions.test.tsx
@@ -47,7 +47,7 @@ function createBaseOptions(overrides: Partial<TeamActionsInput> = {}): TeamActio
     activeRunIdForSelectedTeam: null,
     activeRunForSelectedTeam: null,
     inboxActorId: "",
-    inboxLimit: "100",
+    inboxLimit: "20",
     inboxAfterId: "",
     inboxIncludeDelivered: false,
     selectedMemberAgentId: null,
@@ -149,7 +149,7 @@ describe("useTeamActions", () => {
       runsBeforeCreatedAt: 111,
       selectedStepId: "step-1",
       inboxActorId: "leader-1",
-      inboxLimit: "100",
+      inboxLimit: "20",
       inboxAfterId: "10",
       inboxIncludeDelivered: false,
     });

--- a/web/src/pages/team/use_team_actions.ts
+++ b/web/src/pages/team/use_team_actions.ts
@@ -369,8 +369,8 @@ export function useTeamActions(options: UseTeamActionsOptions) {
       setSnapshotLoading(true);
       try {
         const next = await teamApi.getTeamRunSnapshot(runId, {
-          event_limit: 200,
-          message_limit: 200,
+          event_limit: 20,
+          message_limit: 20,
         });
         setSnapshot(next);
         return next;

--- a/web/src/pages/team/use_team_actions.ts
+++ b/web/src/pages/team/use_team_actions.ts
@@ -369,8 +369,8 @@ export function useTeamActions(options: UseTeamActionsOptions) {
       setSnapshotLoading(true);
       try {
         const next = await teamApi.getTeamRunSnapshot(runId, {
-          event_limit: 20,
-          message_limit: 20,
+          event_limit: EVENT_PAGE_LIMIT,
+          message_limit: EVENT_PAGE_LIMIT,
         });
         setSnapshot(next);
         return next;

--- a/web/src/use_app_output_cache.ts
+++ b/web/src/use_app_output_cache.ts
@@ -46,7 +46,7 @@ export function useAppOutputCache(
   setAgents: Dispatch<SetStateAction<AgentRecord[]>>
 ) {
   const token = auth?.token ?? null;
-  const eventLimit = 80;
+  const eventLimit = 20;
   const maxCachedEvents = DEFAULT_OUTPUT_CACHE_MAX_EVENTS;
   const maxCachedSessions = DEFAULT_OUTPUT_CACHE_MAX_SESSIONS;
 


### PR DESCRIPTION
## Summary

- reduce UI-facing agent and team event pull batches to `20`
- clamp the public page-facing event APIs and snapshot event/message query limits to `20` server-side as well
- add focused frontend and router regression coverage plus a journal note

## Validation

- `cd web && npm run test -- vite.config.test.ts src/pages/team/use_team_actions.test.tsx`
- `cargo test list_events_route_clamps_limit_to_twenty -- --nocapture`
- `cargo test teams_router_http_contract -- --nocapture`
- `git diff --check`
