### PR TITLE
fix(acp): upgrade Codex to 0.122

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,8 +1696,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1714,9 +1714,10 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
+ "async-channel",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -1742,8 +1743,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1759,6 +1760,7 @@ dependencies = [
  "codex-cloud-requirements",
  "codex-config",
  "codex-core",
+ "codex-core-plugins",
  "codex-exec-server",
  "codex-features",
  "codex-feedback",
@@ -1804,8 +1806,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -1827,13 +1829,12 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "clap",
  "codex-experimental-api-macros",
- "codex-git-utils",
  "codex-protocol",
  "codex-shell-command",
  "codex-utils-absolute-path",
@@ -1852,8 +1853,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1867,8 +1868,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1885,8 +1886,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1895,8 +1896,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-backend-openapi-models",
@@ -1910,8 +1911,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1920,11 +1921,12 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "clap",
+ "codex-app-server-protocol",
  "codex-config",
  "codex-connectors",
  "codex-core",
@@ -1937,8 +1939,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1963,8 +1965,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1987,9 +1989,10 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
+ "async-channel",
  "async-trait",
  "codex-protocol",
  "deno_core_icudata",
@@ -2003,24 +2006,23 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 
 [[package]]
 name = "codex-config"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
  "codex-execpolicy",
  "codex-features",
- "codex-git-utils",
  "codex-model-provider-info",
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
- "dunce",
+ "codex-utils-path",
  "futures",
  "multimap",
  "schemars 0.8.22",
@@ -2038,8 +2040,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2049,8 +2051,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2068,6 +2070,7 @@ dependencies = [
  "codex-code-mode",
  "codex-config",
  "codex-connectors",
+ "codex-core-plugins",
  "codex-core-skills",
  "codex-exec-server",
  "codex-execpolicy",
@@ -2078,6 +2081,7 @@ dependencies = [
  "codex-instructions",
  "codex-login",
  "codex-mcp",
+ "codex-model-provider",
  "codex-model-provider-info",
  "codex-models-manager",
  "codex-network-proxy",
@@ -2109,6 +2113,7 @@ dependencies = [
  "codex-utils-template",
  "codex-windows-sandbox",
  "core-foundation 0.9.4",
+ "crypto_box",
  "csv",
  "dirs",
  "dunce",
@@ -2131,6 +2136,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2 0.10.9",
  "shlex",
  "similar",
  "tempfile",
@@ -2151,9 +2157,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-core-plugins"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
+dependencies = [
+ "chrono",
+ "codex-app-server-protocol",
+ "codex-config",
+ "codex-core-skills",
+ "codex-exec-server",
+ "codex-git-utils",
+ "codex-login",
+ "codex-plugin",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-plugins",
+ "dirs",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "codex-core-skills"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -2166,6 +2200,7 @@ dependencies = [
  "codex-protocol",
  "codex-skills",
  "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
  "codex-utils-plugins",
  "dirs",
  "dunce",
@@ -2181,8 +2216,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2205,8 +2240,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2221,8 +2256,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2231,8 +2266,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2244,8 +2279,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -2257,8 +2292,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2272,9 +2307,11 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
+ "codex-exec-server",
+ "codex-protocol",
  "codex-utils-absolute-path",
  "futures",
  "once_cell",
@@ -2290,8 +2327,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2308,8 +2345,8 @@ dependencies = [
 
 [[package]]
 name = "codex-instructions"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-protocol",
  "serde",
@@ -2317,8 +2354,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "keyring",
  "tracing",
@@ -2326,14 +2363,15 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "cc",
  "clap",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
+ "globset",
  "landlock",
  "libc",
  "pkg-config",
@@ -2345,13 +2383,13 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "codex-api",
  "codex-app-server-protocol",
  "codex-client",
  "codex-config",
@@ -2361,6 +2399,7 @@ dependencies = [
  "codex-protocol",
  "codex-terminal-detection",
  "codex-utils-template",
+ "ed25519-dalek",
  "once_cell",
  "os_info",
  "rand 0.9.4",
@@ -2379,13 +2418,14 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "async-channel",
  "codex-async-utils",
  "codex-config",
+ "codex-exec-server",
  "codex-login",
  "codex-otel",
  "codex-plugin",
@@ -2407,8 +2447,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2432,9 +2472,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-model-provider"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
+dependencies = [
+ "async-trait",
+ "codex-api",
+ "codex-login",
+ "codex-model-provider-info",
+ "codex-protocol",
+ "http 1.4.0",
+]
+
+[[package]]
 name = "codex-model-provider-info"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2446,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2456,6 +2509,7 @@ dependencies = [
  "codex-config",
  "codex-feedback",
  "codex-login",
+ "codex-model-provider",
  "codex-model-provider-info",
  "codex-otel",
  "codex-protocol",
@@ -2471,8 +2525,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,8 +2555,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2533,8 +2587,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-plugins",
@@ -2543,20 +2597,20 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "chardetng",
  "chrono",
  "codex-async-utils",
  "codex-execpolicy",
- "codex-git-utils",
  "codex-network-proxy",
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-string",
  "codex-utils-template",
  "encoding_rs",
+ "globset",
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
@@ -2580,8 +2634,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2591,13 +2645,14 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "axum",
  "codex-client",
  "codex-config",
+ "codex-exec-server",
  "codex-keyring-store",
  "codex-protocol",
  "codex-utils-home-dir",
@@ -2622,8 +2677,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,14 +2701,15 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
  "dunce",
  "libc",
+ "regex-lite",
  "serde_json",
  "tracing",
  "url",
@@ -2662,8 +2718,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "age",
  "anyhow",
@@ -2681,8 +2737,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -2700,8 +2756,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2720,8 +2776,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -2730,8 +2786,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2752,31 +2808,35 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "async-trait",
  "chrono",
  "codex-git-utils",
  "codex-protocol",
  "codex-rollout",
+ "codex-state",
+ "prost",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
@@ -2792,8 +2852,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "dirs",
  "dunce",
@@ -2804,16 +2864,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "lru",
  "sha1",
@@ -2822,8 +2882,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -2833,8 +2893,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2842,8 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2855,8 +2915,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -2864,8 +2924,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2873,8 +2933,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2883,8 +2943,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -2895,8 +2955,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -2911,8 +2971,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -2922,34 +2982,34 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "regex-lite",
 ]
 
 [[package]]
 name = "codex-utils-template"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex?rev=d65ed92a5e440972626965d0af9a6345179783bc#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.122.0"
+source = "git+https://github.com/openai/codex?rev=230dcadee609fa99d6162fe1107457030e5270a7#230dcadee609fa99d6162fe1107457030e5270a7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2960,6 +3020,7 @@ dependencies = [
  "codex-utils-string",
  "dirs-next",
  "dunce",
+ "glob",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -3285,6 +3346,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "blake2",
+ "crypto_secretbox",
+ "curve25519-dalek",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher 0.4.4",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "d65ed92a5e440972626965d0af9a6345179783bc",
+    commit = "230dcadee609fa99d6162fe1107457030e5270a7",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -27,23 +27,23 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-config = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-arg0 = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-app-server-client = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-core = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-exec-server = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-features = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-feedback = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-mcp-server = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-protocol = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-login = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-models-manager = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-shell-command = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
-codex-utils-cli = { git = "https://github.com/openai/codex", rev = "d65ed92a5e440972626965d0af9a6345179783bc" }
+codex-apply-patch = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-config = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-app-server-client = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-core = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-exec-server = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-features = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-feedback = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-mcp-server = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-login = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-models-manager = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-shell-command = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "230dcadee609fa99d6162fe1107457030e5270a7" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -1233,6 +1233,7 @@ impl AppServerCodexThread {
                             server,
                             tool,
                             arguments,
+                            mcp_app_resource_uri,
                             ..
                         },
                     ) => Some(Event {
@@ -1244,6 +1245,7 @@ impl AppServerCodexThread {
                                 tool,
                                 arguments: Some(arguments),
                             },
+                            mcp_app_resource_uri,
                         }),
                     }),
                     (
@@ -1440,6 +1442,7 @@ impl AppServerCodexThread {
                             server,
                             tool,
                             arguments,
+                            mcp_app_resource_uri,
                             result,
                             error,
                             duration_ms,
@@ -1470,6 +1473,7 @@ impl AppServerCodexThread {
                                     tool,
                                     arguments: Some(arguments),
                                 },
+                                mcp_app_resource_uri,
                                 duration: duration_ms
                                     .and_then(|ms| u64::try_from(ms).ok())
                                     .map(Duration::from_millis)
@@ -1622,6 +1626,18 @@ impl AppServerCodexThread {
                     message: format_config_warning_message(payload),
                 }),
             })),
+            ServerNotification::Warning(payload) => {
+                let submission_id = {
+                    let state = self.state.lock().await;
+                    active_submission_id(&state).unwrap_or_else(noop_submission_id)
+                };
+                Ok(Some(Event {
+                    id: submission_id,
+                    msg: EventMsg::Warning(WarningEvent {
+                        message: payload.message,
+                    }),
+                }))
+            }
             ServerNotification::ThreadClosed(_) => {
                 let mut state = self.state.lock().await;
                 let Some(active_turn) = state.active_turn.clone() else {
@@ -1663,6 +1679,7 @@ impl AppServerCodexThread {
             | ServerNotification::McpServerOauthLoginCompleted(_)
             | ServerNotification::AccountRateLimitsUpdated(_)
             | ServerNotification::AppListUpdated(_)
+            | ServerNotification::ExternalAgentConfigImportCompleted(_)
             | ServerNotification::FsChanged(_)
             | ServerNotification::FuzzyFileSearchSessionUpdated(_)
             | ServerNotification::FuzzyFileSearchSessionCompleted(_)

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -13,8 +13,8 @@ use agent_client_protocol_legacy::{
 };
 use codex_config::types::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
-    RolloutRecorder, ThreadManager, ThreadSortKey, config::Config, find_thread_path_by_id_str,
-    parse_cursor,
+    RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
+    find_thread_path_by_id_str, parse_cursor,
 };
 use codex_exec_server::EnvironmentManager;
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
@@ -149,11 +149,13 @@ impl CodexAgent {
                                 },
                                 env_http_headers: None,
                             },
+                            experimental_environment: None,
                             required: false,
                             enabled: true,
                             supports_parallel_tool_calls: false,
                             startup_timeout_sec: None,
                             tool_timeout_sec: None,
+                            default_tools_approval_mode: None,
                             disabled_tools: None,
                             enabled_tools: None,
                             disabled_reason: None,
@@ -186,11 +188,13 @@ impl CodexAgent {
                                 env_vars: vec![],
                                 cwd: Some(cwd.to_path_buf()),
                             },
+                            experimental_environment: None,
                             required: false,
                             enabled: true,
                             supports_parallel_tool_calls: false,
                             startup_timeout_sec: None,
                             tool_timeout_sec: None,
+                            default_tools_approval_mode: None,
                             disabled_tools: None,
                             enabled_tools: None,
                             disabled_reason: None,
@@ -711,6 +715,7 @@ impl Agent for CodexAgent {
             SESSION_LIST_PAGE_SIZE,
             cursor_obj.as_ref(),
             ThreadSortKey::UpdatedAt,
+            SortDirection::Desc,
             &[
                 SessionSource::Cli,
                 SessionSource::VSCode,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -49,7 +49,7 @@ use codex_protocol::{
         ItemCompletedEvent, ItemStartedEvent, McpInvocation, McpStartupCompleteEvent,
         McpStartupUpdateEvent, McpToolCallBeginEvent, McpToolCallEndEvent, ModelRerouteEvent,
         NetworkApprovalContext, NetworkPolicyRuleAction, Op, PatchApplyBeginEvent,
-        PatchApplyEndEvent, PatchApplyStatus, ReasoningContentDeltaEvent,
+        PatchApplyEndEvent, PatchApplyStatus, PatchApplyUpdatedEvent, ReasoningContentDeltaEvent,
         ReasoningRawContentDeltaEvent, ReviewDecision, ReviewOutputEvent, ReviewRequest,
         ReviewTarget, RolloutItem, SandboxPolicy, StreamErrorEvent, TerminalInteractionEvent,
         TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
@@ -757,6 +757,7 @@ impl PromptState {
             | EventMsg::McpToolCallEnd(..)
             | EventMsg::ApplyPatchApprovalRequest(..)
             | EventMsg::PatchApplyBegin(..)
+            | EventMsg::PatchApplyUpdated(..)
             | EventMsg::PatchApplyEnd(..)
             | EventMsg::TurnStarted(..)
             | EventMsg::TurnComplete(..)
@@ -948,24 +949,30 @@ impl PromptState {
             EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
                 call_id,
                 invocation,
+                mcp_app_resource_uri,
+                ..
             }) => {
                 info!(
                     "MCP tool call begin: call_id={call_id}, invocation={} {}",
                     invocation.server, invocation.tool
                 );
-                self.start_mcp_tool_call(client, call_id, invocation).await;
+                self.start_mcp_tool_call(client, call_id, invocation, mcp_app_resource_uri)
+                    .await;
             }
             EventMsg::McpToolCallEnd(McpToolCallEndEvent {
                 call_id,
                 invocation,
+                mcp_app_resource_uri,
                 duration,
                 result,
+                ..
             }) => {
                 info!(
                     "MCP tool call ended: call_id={call_id}, invocation={} {}, duration={duration:?}",
                     invocation.server, invocation.tool
                 );
-                self.end_mcp_tool_call(client, call_id, result).await;
+                self.end_mcp_tool_call(client, call_id, result, mcp_app_resource_uri)
+                    .await;
             }
             EventMsg::ApplyPatchApprovalRequest(event) => {
                 info!(
@@ -982,6 +989,14 @@ impl PromptState {
                     event.call_id, event.auto_approved
                 );
                 self.start_patch_apply(client, event).await;
+            }
+            EventMsg::PatchApplyUpdated(event) => {
+                info!(
+                    "Patch apply updated: call_id={}, changed_files={}",
+                    event.call_id,
+                    event.changes.len()
+                );
+                self.update_patch_apply(client, event).await;
             }
             EventMsg::PatchApplyEnd(event) => {
                 info!(
@@ -1363,6 +1378,25 @@ impl PromptState {
             .await;
     }
 
+    async fn update_patch_apply(&self, client: &SessionClient, event: PatchApplyUpdatedEvent) {
+        let raw_output = serde_json::json!(&event);
+        let PatchApplyUpdatedEvent {
+            call_id, changes, ..
+        } = event;
+
+        let mut fields = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::InProgress)
+            .raw_output(raw_output);
+
+        if let Some((title, locations, content)) = collect_tool_call_content_from_changes(changes) {
+            fields = fields.title(title).locations(locations).content(content);
+        }
+
+        client
+            .send_tool_call_update(ToolCallUpdate::new(call_id, fields))
+            .await;
+    }
+
     async fn start_dynamic_tool_call(
         &self,
         client: &SessionClient,
@@ -1384,15 +1418,16 @@ impl PromptState {
         client: &SessionClient,
         call_id: String,
         invocation: McpInvocation,
+        mcp_app_resource_uri: Option<String>,
     ) {
         let title = format!("Tool: {}/{}", invocation.server, invocation.tool);
-        client
-            .send_tool_call(
-                ToolCall::new(call_id, title)
-                    .status(ToolCallStatus::InProgress)
-                    .raw_input(serde_json::json!(&invocation)),
-            )
-            .await;
+        let mut tool_call = ToolCall::new(call_id, title)
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!(&invocation));
+        if let Some(content) = mcp_tool_call_content(Vec::new(), mcp_app_resource_uri.as_deref()) {
+            tool_call = tool_call.content(content);
+        }
+        client.send_tool_call(tool_call).await;
     }
 
     async fn end_dynamic_tool_call(
@@ -1450,38 +1485,41 @@ impl PromptState {
         client: &SessionClient,
         call_id: String,
         result: Result<CallToolResult, String>,
+        mcp_app_resource_uri: Option<String>,
     ) {
-        let is_error = match result.as_ref() {
-            Ok(result) => result.is_error.unwrap_or_default(),
-            Err(_) => true,
-        };
-        let raw_output = match result.as_ref() {
-            Ok(result) => serde_json::json!(result),
-            Err(err) => serde_json::json!(err),
+        let (status, raw_output, content) = match result {
+            Ok(result) => {
+                let raw_output = serde_json::json!(&result);
+                let content = result
+                    .content
+                    .into_iter()
+                    .filter_map(|content| serde_json::from_value::<ContentBlock>(content).ok())
+                    .map(|content| ToolCallContent::Content(Content::new(content)))
+                    .collect();
+                (
+                    if result.is_error.unwrap_or_default() {
+                        ToolCallStatus::Failed
+                    } else {
+                        ToolCallStatus::Completed
+                    },
+                    raw_output,
+                    mcp_tool_call_content(content, mcp_app_resource_uri.as_deref()),
+                )
+            }
+            Err(err) => (
+                ToolCallStatus::Failed,
+                serde_json::json!(&err),
+                mcp_tool_call_content(Vec::new(), mcp_app_resource_uri.as_deref()),
+            ),
         };
 
         client
             .send_tool_call_update(ToolCallUpdate::new(
                 call_id,
                 ToolCallUpdateFields::new()
-                    .status(if is_error {
-                        ToolCallStatus::Failed
-                    } else {
-                        ToolCallStatus::Completed
-                    })
+                    .status(status)
                     .raw_output(raw_output)
-                    .content(result.ok().filter(|result| !result.content.is_empty()).map(
-                        |result| {
-                            result
-                                .content
-                                .into_iter()
-                                .filter_map(|content| {
-                                    serde_json::from_value::<ContentBlock>(content).ok()
-                                })
-                                .map(|content| ToolCallContent::Content(Content::new(content)))
-                                .collect()
-                        },
-                    )),
+                    .content(content),
             ))
             .await;
     }
@@ -3892,6 +3930,7 @@ fn should_attach_detached_submission(msg: &EventMsg) -> bool {
             | EventMsg::McpToolCallEnd(..)
             | EventMsg::ApplyPatchApprovalRequest(..)
             | EventMsg::PatchApplyBegin(..)
+            | EventMsg::PatchApplyUpdated(..)
             | EventMsg::PatchApplyEnd(..)
             | EventMsg::TurnDiff(..)
             | EventMsg::WebSearchBegin(..)
@@ -4386,6 +4425,47 @@ fn extract_tool_call_content_from_changes(
     )
 }
 
+fn collect_tool_call_content_from_changes(
+    changes: HashMap<PathBuf, FileChange>,
+) -> Option<(String, Vec<ToolCallLocation>, Vec<ToolCallContent>)> {
+    if changes.is_empty() {
+        return None;
+    }
+
+    let (title, locations, content) = extract_tool_call_content_from_changes(changes);
+    Some((title, locations, content.collect()))
+}
+
+fn mcp_tool_call_content(
+    mut content: Vec<ToolCallContent>,
+    mcp_app_resource_uri: Option<&str>,
+) -> Option<Vec<ToolCallContent>> {
+    let Some(uri) = mcp_app_resource_uri.filter(|uri| !uri.is_empty()) else {
+        return (!content.is_empty()).then_some(content);
+    };
+
+    let already_present = content.iter().any(|item| {
+        matches!(
+            item,
+            ToolCallContent::Content(Content {
+                content: ContentBlock::ResourceLink(ResourceLink { uri: existing_uri, .. }),
+                ..
+            }) if existing_uri == uri
+        )
+    });
+    if !already_present {
+        content.insert(
+            0,
+            ToolCallContent::Content(Content::new(ContentBlock::ResourceLink(ResourceLink::new(
+                uri.to_string(),
+                uri.to_string(),
+            )))),
+        );
+    }
+
+    Some(content)
+}
+
 /// Extract title and call_id from a WebSearchAction (used for replay)
 fn web_search_action_to_title_and_id(
     id: &Option<String>,
@@ -4493,8 +4573,10 @@ mod tests {
         }
     }
 
-    fn test_config() -> anyhow::Result<Config> {
-        Config::load_default_with_cli_overrides(vec![]).map_err(Into::into)
+    async fn test_config() -> anyhow::Result<Config> {
+        Config::load_default_with_cli_overrides(vec![])
+            .await
+            .map_err(Into::into)
     }
 
     fn current_dir_abs() -> anyhow::Result<AbsolutePathBuf> {
@@ -4961,7 +5043,7 @@ mod tests {
                     SessionClient::with_client(session_id.clone(), client, Arc::default());
                 let thread = Arc::new(SharedSubmissionThread::new("shared-submission"));
                 let models_manager = Arc::new(StubModelsManager);
-                let config = test_config()?;
+                let config = test_config().await?;
                 let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -5022,7 +5104,7 @@ mod tests {
                     SessionClient::with_client(session_id, client.clone(), Arc::default());
                 let thread = Arc::new(StubCodexThread::new());
                 let models_manager = Arc::new(StubModelsManager);
-                let config = test_config()?;
+                let config = test_config().await?;
                 let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
                 let mut actor = ThreadActor::new(
@@ -5097,7 +5179,7 @@ mod tests {
         let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
         let thread = Arc::new(StubCodexThread::new());
         let models_manager = Arc::new(StubModelsManager);
-        let config = test_config()?;
+        let config = test_config().await?;
         let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
         let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut actor = ThreadActor::new(
@@ -5199,7 +5281,7 @@ mod tests {
                     SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
                 let thread = Arc::new(SharedSubmissionThread::new("shared-submission"));
                 let models_manager = Arc::new(StubModelsManager);
-                let config = test_config()?;
+                let config = test_config().await?;
                 let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
                 let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -5350,7 +5432,7 @@ mod tests {
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
         let models_manager = Arc::new(StubModelsManager);
-        let config = test_config()?;
+        let config = test_config().await?;
         let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
         let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -6569,6 +6651,207 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_tool_call_update_preserves_mcp_app_resource_uri() -> anyhow::Result<()> {
+        LocalSet::new()
+            .run_until(async {
+                let session_id = SessionId::new("test");
+                let client = Arc::new(StubClient::new());
+                let session_client =
+                    SessionClient::with_client(session_id, client.clone(), Arc::default());
+                let thread = Arc::new(StubCodexThread::new());
+                let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+                let (message_tx, _message_rx) = tokio::sync::mpsc::unbounded_channel();
+                let mut prompt_state =
+                    PromptState::new("submission-id".to_string(), thread, message_tx, response_tx);
+                let resource_uri = "https://example.com/widget".to_string();
+                let invocation = McpInvocation {
+                    server: "sample".to_string(),
+                    tool: "render".to_string(),
+                    arguments: None,
+                };
+
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
+                            call_id: "call-1".to_string(),
+                            invocation: invocation.clone(),
+                            mcp_app_resource_uri: Some(resource_uri.clone()),
+                        }),
+                    )
+                    .await;
+
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::McpToolCallEnd(McpToolCallEndEvent {
+                            call_id: "call-1".to_string(),
+                            invocation,
+                            mcp_app_resource_uri: Some(resource_uri.clone()),
+                            duration: Duration::from_millis(5),
+                            result: Ok(CallToolResult {
+                                content: vec![serde_json::to_value(ContentBlock::Text(
+                                    TextContent::new("rendered widget"),
+                                ))?],
+                                structured_content: None,
+                                is_error: Some(false),
+                                meta: None,
+                            }),
+                        }),
+                    )
+                    .await;
+
+                let notifications = client.notifications.lock().unwrap();
+                assert_eq!(
+                    notifications.len(),
+                    2,
+                    "notifications don't match {notifications:?}"
+                );
+
+                let begin_tool_call = match &notifications[0].update {
+                    SessionUpdate::ToolCall(tool_call) => tool_call,
+                    other => panic!("expected MCP begin tool call, got {other:?}"),
+                };
+                assert!(begin_tool_call.content.iter().any(|content| {
+                    matches!(
+                        content,
+                        ToolCallContent::Content(Content {
+                            content: ContentBlock::ResourceLink(ResourceLink { uri, .. }),
+                            ..
+                        }) if uri == &resource_uri
+                    )
+                }));
+
+                let end_update = match &notifications[1].update {
+                    SessionUpdate::ToolCallUpdate(update) => update,
+                    other => panic!("expected MCP end update, got {other:?}"),
+                };
+                let end_content = end_update
+                    .fields
+                    .content
+                    .as_ref()
+                    .expect("MCP end content missing");
+                assert!(end_content.iter().any(|content| {
+                    matches!(
+                        content,
+                        ToolCallContent::Content(Content {
+                            content: ContentBlock::ResourceLink(ResourceLink { uri, .. }),
+                            ..
+                        }) if uri == &resource_uri
+                    )
+                }));
+                assert!(end_content.iter().any(|content| {
+                    matches!(
+                        content,
+                        ToolCallContent::Content(Content {
+                            content: ContentBlock::Text(TextContent { text, .. }),
+                            ..
+                        }) if text == "rendered widget"
+                    )
+                }));
+
+                anyhow::Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_patch_apply_updated_emits_in_progress_tool_call_update() -> anyhow::Result<()> {
+        LocalSet::new()
+            .run_until(async {
+                let session_id = SessionId::new("test");
+                let client = Arc::new(StubClient::new());
+                let session_client =
+                    SessionClient::with_client(session_id, client.clone(), Arc::default());
+                let thread = Arc::new(StubCodexThread::new());
+                let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+                let (message_tx, _message_rx) = tokio::sync::mpsc::unbounded_channel();
+                let mut prompt_state =
+                    PromptState::new("submission-id".to_string(), thread, message_tx, response_tx);
+                let path = PathBuf::from("src/lib.rs");
+                let begin_diff = "@@ -1 +1 @@\n-old\n+new\n".to_string();
+                let updated_diff = "@@ -1 +1,2 @@\n-old\n+new\n+more\n".to_string();
+
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::PatchApplyBegin(PatchApplyBeginEvent {
+                            call_id: "patch-1".to_string(),
+                            turn_id: "turn-1".to_string(),
+                            auto_approved: false,
+                            changes: std::collections::HashMap::from([(
+                                path.clone(),
+                                FileChange::Update {
+                                    unified_diff: begin_diff,
+                                    move_path: None,
+                                },
+                            )]),
+                        }),
+                    )
+                    .await;
+
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::PatchApplyUpdated(PatchApplyUpdatedEvent {
+                            call_id: "patch-1".to_string(),
+                            changes: std::collections::HashMap::from([(
+                                path.clone(),
+                                FileChange::Update {
+                                    unified_diff: updated_diff.clone(),
+                                    move_path: None,
+                                },
+                            )]),
+                        }),
+                    )
+                    .await;
+
+                let notifications = client.notifications.lock().unwrap();
+                assert_eq!(
+                    notifications.len(),
+                    2,
+                    "notifications don't match {notifications:?}"
+                );
+
+                let update = match &notifications[1].update {
+                    SessionUpdate::ToolCallUpdate(update) => update,
+                    other => panic!("expected patch update, got {other:?}"),
+                };
+                assert_eq!(update.fields.status, Some(ToolCallStatus::InProgress));
+                assert_eq!(update.fields.title.as_deref(), Some("Edit src/lib.rs"));
+                assert_eq!(
+                    update
+                        .fields
+                        .locations
+                        .as_ref()
+                        .expect("patch locations missing"),
+                    &vec![ToolCallLocation::new(path.clone())]
+                );
+                assert_eq!(
+                    update
+                        .fields
+                        .raw_output
+                        .as_ref()
+                        .and_then(|value| value.get("call_id"))
+                        .and_then(serde_json::Value::as_str),
+                    Some("patch-1")
+                );
+                assert!(matches!(
+                    update.fields.content.as_ref().and_then(|content| content.first()),
+                    Some(ToolCallContent::Diff(Diff { path: diff_path, new_text, .. }))
+                        if diff_path == &path && new_text == &updated_diff
+                ));
+
+                anyhow::Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_background_terminal_wait_activity_emits_terminal_activity_updates()
     -> anyhow::Result<()> {
         LocalSet::new()
@@ -6760,7 +7043,7 @@ mod tests {
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
         let models_manager = Arc::new(StubModelsManager);
-        let config = test_config()?;
+        let config = test_config().await?;
         let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
         let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
         let actor = ThreadActor::new(

--- a/docs/journal/2026-04-24-codex-122-upgrade.md
+++ b/docs/journal/2026-04-24-codex-122-upgrade.md
@@ -1,0 +1,78 @@
+## Summary
+
+Upgraded `agenthub-codex-acp` from the official Codex `0.121.0` release commit `d65ed92a5e440972626965d0af9a6345179783bc` to the official `0.122.0` release commit `230dcadee609fa99d6162fe1107457030e5270a7`.
+
+## Why
+
+- AgentHub should stay close to the official `openai/codex` release train instead of accumulating private compatibility drift.
+- The `0.122.x` line changes several app-server, protocol, config, and rollout interfaces that `agenthub-codex-acp` consumes directly.
+- Recording the exact ACP-relevant delta avoids treating the full upstream release body as required follow-up for this repository.
+
+## ACP-Relevant Upstream Delta
+
+The upstream `0.121 -> 0.122` range is broad, but only a narrow subset is immediately relevant to AgentHub ACP:
+
+1. MCP tool-call events now carry `mcp_app_resource_uri`.
+   - `codex-rs/protocol/src/protocol.rs` adds `mcp_app_resource_uri: Option<String>` to both `McpToolCallBeginEvent` and `McpToolCallEndEvent`.
+   - `codex-rs/app-server-protocol/src/protocol/v2.rs` also adds the same optional field to `ThreadItem::McpToolCall`.
+   - Upstream core now derives this URI from MCP tool metadata (`ui`, `openai/outputTemplate`, or `openai/output_template`) and threads it through MCP begin/end events.
+
+2. `apply_patch` now emits incremental structured progress.
+   - `codex-rs/protocol/src/protocol.rs` adds `PatchApplyUpdated(PatchApplyUpdatedEvent)`.
+   - `codex-rs/core/src/tools/handlers/apply_patch.rs` now streams parsed file-change progress while the patch input is still arriving.
+
+3. App-server protocol adds a generic warning channel.
+   - `codex-rs/app-server-protocol/src/protocol/common.rs` adds `ServerNotification::Warning`.
+   - `codex-rs/app-server-protocol/src/protocol/v2.rs` defines `WarningNotification { thread_id, message }`.
+
+4. App-server protocol adds `ExternalAgentConfigImportCompleted`.
+   - This is used by upstream TUI to refresh in-memory config/plugin state after an external config import workflow.
+
+5. MCP server config grows new defaults.
+   - `codex-rs/config/src/mcp_types.rs` adds `experimental_environment` and `default_tools_approval_mode` to `McpServerConfig`.
+
+6. Rollout thread listing now requires explicit sort direction.
+   - `codex-rs/rollout/src/list.rs` adds `SortDirection`.
+   - `codex-rs/rollout/src/recorder.rs` updates `RolloutRecorder::list_threads(...)` to require that direction explicitly.
+
+## AgentHub Changes
+
+- Updated all direct `agenthub-codex-acp` Codex git dependencies to `230dcadee609fa99d6162fe1107457030e5270a7`.
+- Updated Bazel `codex_src` to the same upstream release commit.
+- Refreshed `Cargo.lock` to the `0.122.0` Codex graph.
+- Forwarded `mcp_app_resource_uri` through the app-server translation layer so the adapter no longer drops the new upstream field at the boundary.
+- Surfaced `mcp_app_resource_uri` on ACP MCP tool calls as a `ResourceLink` content block so the app/widget target remains visible from tool-call begin through tool-call completion.
+- Accepted the new generic `warning` server notification and translated it into the existing ACP warning path.
+- Explicitly ignored `ExternalAgentConfigImportCompleted` in the ACP adapter because AgentHub ACP does not currently expose the upstream external-config import workflow or plugin-refresh UI.
+- Added the new `McpServerConfig` fields with `None` defaults when AgentHub maps ACP-provided MCP server specs into Codex config.
+- Updated session listing to pass `SortDirection::Desc` so `RolloutRecorder::list_threads(...)` keeps the existing newest-first behavior.
+- Translated `PatchApplyUpdated` into an in-progress ACP `ToolCallUpdate` carrying refreshed title, locations, diff content, and raw event payload so edit tool calls no longer jump directly from begin to end.
+
+## Behavioral Follow-Up Decision
+
+Decision:
+
+- Keep the `0.122` upgrade narrow, but align the ACP adapter with both new user-visible behaviors now that the required schema surface already exists.
+- Do not add new ACP schema or bespoke UI affordances in this slice; reuse existing `ToolCall.content`, `ToolCall.locations`, and `ToolCallUpdate` fields.
+- This closes the immediate adapter-level follow-up for `mcp_app_resource_uri` and `PatchApplyUpdated`.
+
+## Validation
+
+Executed:
+
+```bash
+cargo check -p agenthub-codex-acp
+cargo check -p agenthub-codex-acp --tests
+cargo test -p agenthub-codex-acp test_mcp_tool_call_update_preserves_mcp_app_resource_uri
+cargo test -p agenthub-codex-acp test_patch_apply_updated_emits_in_progress_tool_call_update
+cargo test -p agenthub-codex-acp
+```
+
+Result:
+
+- `cargo check -p agenthub-codex-acp` passed after the compatibility updates.
+- `cargo check -p agenthub-codex-acp --tests` passed after the behavior-alignment updates.
+- Both focused regression tests passed:
+  - `thread::tests::test_mcp_tool_call_update_preserves_mcp_app_resource_uri`
+  - `thread::tests::test_patch_apply_updated_emits_in_progress_tool_call_update`
+- `cargo test -p agenthub-codex-acp` passed (`87` unit tests, `0` failures).


### PR DESCRIPTION
fix(acp): upgrade Codex to 0.122

## Summary

- bump `agenthub-codex-acp` and Bazel `codex_src` from Codex `0.121.0` (`d65ed92a5e440972626965d0af9a6345179783bc`) to `0.122.0` (`230dcadee609fa99d6162fe1107457030e5270a7`)
- align the ACP adapter with the upstream `0.122` protocol and app-server deltas: `mcp_app_resource_uri`, generic `warning` notifications, `McpServerConfig` defaults, and rollout `SortDirection`
- surface the new optional behaviors on the existing ACP tool-call surface by preserving MCP app resource links and streaming `PatchApplyUpdated` as in-progress edit updates
- record the upgrade notes and validation in `docs/journal/2026-04-24-codex-122-upgrade.md`

## Testing

- `cargo check -p agenthub-codex-acp`
- `cargo check -p agenthub-codex-acp --tests`
- `cargo test -p agenthub-codex-acp`
