### PR TITLE
chore(ci): run release prebuild post-merge

### DIFF
--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -3,7 +3,6 @@ name: Release Prebuild
 on:
   push:
     branches: ["main"]
-  pull_request:
 
 permissions:
   contents: read

--- a/docs/journal/2026-04-24-release-prebuild-post-merge.md
+++ b/docs/journal/2026-04-24-release-prebuild-post-merge.md
@@ -1,0 +1,27 @@
+# Release Prebuild Post-Merge Only
+
+## Summary
+
+Moved the `Release Prebuild` workflow out of the pull request path so release-target packaging no longer runs on every PR.
+
+## What Changed
+
+- Updated `.github/workflows/release-prebuild.yml`
+- Removed the `pull_request` trigger
+- Kept the `push` trigger on `main`
+
+## Rationale
+
+- PR validation should focus on correctness, unit/integration coverage, and user-facing regressions.
+- Release packaging is slower and more expensive than normal PR feedback loops.
+- Running prebuild only after merge keeps post-merge release confidence without making every PR pay the release matrix cost.
+
+## Validation
+
+- Reviewed workflow triggers locally after the change.
+- No functional code path changed; this is a GitHub Actions trigger-only adjustment.
+
+## Follow-Up
+
+- Confirm after merge that `Release Prebuild` still starts from `push` to `main`.
+- If needed later, consider keeping `workflow_dispatch` for ad-hoc release prebuild verification without restoring PR execution.


### PR DESCRIPTION
## Summary

- remove `pull_request` from `Release Prebuild`
- keep release prebuild running on `push` to `main`
- add a journal note for the CI trigger change

## Why

PR validation should not pay the release packaging matrix cost on every branch update. The real release workflow already runs on tags/manual dispatch, and prebuild can still provide post-merge confidence from `main` pushes.

## Validation

- `git diff --check`
- manually verified `.github/workflows/release-prebuild.yml` triggers after the change

## Notes

- no product/runtime code changed
- this is a GitHub Actions trigger-only adjustment
