### PR TITLE
fix(team): keep selector loading until teams settle

### DIFF
--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -221,7 +221,33 @@ fn aborted_call_output() -> FunctionCallOutputPayload {
     FunctionCallOutputPayload::from_text("aborted".to_string())
 }
 
-fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct HistoryRepairStats {
+    inserted_function_call_outputs: usize,
+    inserted_custom_tool_call_outputs: usize,
+    dropped_orphan_function_call_outputs: usize,
+    dropped_orphan_custom_tool_call_outputs: usize,
+}
+
+impl HistoryRepairStats {
+    fn total(self) -> usize {
+        self.inserted_function_call_outputs
+            + self.inserted_custom_tool_call_outputs
+            + self.dropped_orphan_function_call_outputs
+            + self.dropped_orphan_custom_tool_call_outputs
+    }
+}
+
+impl std::ops::AddAssign for HistoryRepairStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.inserted_function_call_outputs += rhs.inserted_function_call_outputs;
+        self.inserted_custom_tool_call_outputs += rhs.inserted_custom_tool_call_outputs;
+        self.dropped_orphan_function_call_outputs += rhs.dropped_orphan_function_call_outputs;
+        self.dropped_orphan_custom_tool_call_outputs += rhs.dropped_orphan_custom_tool_call_outputs;
+    }
+}
+
+fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -247,17 +273,25 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
         })
         .collect::<HashSet<_>>();
 
-    let before_len = items.len();
+    let mut repaired = HistoryRepairStats::default();
     items.retain(|item| match item {
         ResponseItem::FunctionCallOutput { call_id, .. } => {
-            function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id)
+            let keep =
+                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_function_call_outputs += 1;
+            }
+            keep
         }
         ResponseItem::CustomToolCallOutput { call_id, .. } => {
-            custom_tool_call_ids.contains(call_id)
+            let keep = custom_tool_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_custom_tool_call_outputs += 1;
+            }
+            keep
         }
         _ => true,
     });
-    let mut repaired = before_len - items.len();
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -279,6 +313,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
             ResponseItem::FunctionCall { call_id, .. }
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -290,6 +325,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
             ResponseItem::CustomToolCall { call_id, .. }
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::CustomToolCallOutput {
@@ -303,6 +339,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
                 call_id: Some(call_id),
                 ..
             } if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -315,14 +352,13 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
         }
     }
 
-    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
+fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -352,7 +388,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
         })
         .collect::<HashSet<_>>();
 
-    let mut repaired = 0usize;
+    let mut repaired = HistoryRepairStats::default();
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
@@ -362,7 +398,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                         ResponseItem::FunctionCallOutput { call_id, output },
                     ));
                 } else {
-                    repaired += 1;
+                    repaired.dropped_orphan_function_call_outputs += 1;
                 }
             }
             RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -379,7 +415,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                         },
                     ));
                 } else {
-                    repaired += 1;
+                    repaired.dropped_orphan_custom_tool_call_outputs += 1;
                 }
             }
             RolloutItem::Compacted(mut compacted) => {
@@ -417,6 +453,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
             RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. })
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -428,6 +465,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
             RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. })
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -441,6 +479,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                 call_id: Some(call_id),
                 ..
             }) if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -453,17 +492,16 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
         }
     }
 
-    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_initial_history(history: InitialHistory) -> (InitialHistory, usize) {
+fn repair_initial_history(history: InitialHistory) -> (InitialHistory, HistoryRepairStats) {
     match history {
-        InitialHistory::New => (InitialHistory::New, 0),
-        InitialHistory::Cleared => (InitialHistory::Cleared, 0),
+        InitialHistory::New => (InitialHistory::New, HistoryRepairStats::default()),
+        InitialHistory::Cleared => (InitialHistory::Cleared, HistoryRepairStats::default()),
         InitialHistory::Forked(mut items) => {
             let repaired = repair_rollout_items(&mut items);
             (InitialHistory::Forked(items), repaired)
@@ -661,11 +699,15 @@ impl Agent for CodexAgent {
         let history = RolloutRecorder::get_rollout_history(&rollout_path)
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
-        let (history, repaired_items) = repair_initial_history(history);
-        if repaired_items > 0 {
+        let (history, repaired_stats) = repair_initial_history(history);
+        if repaired_stats.total() > 0 {
             warn!(
                 session_id = %session_id,
-                repaired_items,
+                repaired_items = repaired_stats.total(),
+                inserted_function_call_outputs = repaired_stats.inserted_function_call_outputs,
+                inserted_custom_tool_call_outputs = repaired_stats.inserted_custom_tool_call_outputs,
+                dropped_orphan_function_call_outputs = repaired_stats.dropped_orphan_function_call_outputs,
+                dropped_orphan_custom_tool_call_outputs = repaired_stats.dropped_orphan_custom_tool_call_outputs,
                 "repaired dirty Codex rollout history before session resume"
             );
         }
@@ -846,7 +888,7 @@ impl Agent for CodexAgent {
 
 #[cfg(test)]
 mod tests {
-    use super::{repair_initial_history, repair_response_item_history};
+    use super::{HistoryRepairStats, repair_initial_history, repair_response_item_history};
     use codex_protocol::{
         ThreadId,
         models::{
@@ -872,8 +914,14 @@ mod tests {
             rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
         });
 
-        let (repaired, repaired_count) = repair_initial_history(history);
-        assert_eq!(repaired_count, 1);
+        let (repaired, repaired_stats) = repair_initial_history(history);
+        assert_eq!(
+            repaired_stats,
+            HistoryRepairStats {
+                inserted_custom_tool_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         let items = repaired.get_rollout_items();
         assert_eq!(items.len(), 2);
         assert!(matches!(
@@ -901,7 +949,14 @@ mod tests {
         ];
 
         let repaired = repair_response_item_history(&mut history);
-        assert_eq!(repaired, 2);
+        assert_eq!(
+            repaired,
+            HistoryRepairStats {
+                inserted_custom_tool_call_outputs: 1,
+                dropped_orphan_custom_tool_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         assert_eq!(history.len(), 2);
         assert!(matches!(
             &history[1],
@@ -928,8 +983,14 @@ mod tests {
             }]),
         })]);
 
-        let (repaired, repaired_count) = repair_initial_history(history);
-        assert_eq!(repaired_count, 1);
+        let (repaired, repaired_stats) = repair_initial_history(history);
+        assert_eq!(
+            repaired_stats,
+            HistoryRepairStats {
+                inserted_function_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         let items = repaired.get_rollout_items();
         let RolloutItem::Compacted(compacted) = &items[0] else {
             panic!("expected compacted item");

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -221,33 +221,7 @@ fn aborted_call_output() -> FunctionCallOutputPayload {
     FunctionCallOutputPayload::from_text("aborted".to_string())
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct HistoryRepairStats {
-    inserted_function_call_outputs: usize,
-    inserted_custom_tool_call_outputs: usize,
-    dropped_orphan_function_call_outputs: usize,
-    dropped_orphan_custom_tool_call_outputs: usize,
-}
-
-impl HistoryRepairStats {
-    fn total(self) -> usize {
-        self.inserted_function_call_outputs
-            + self.inserted_custom_tool_call_outputs
-            + self.dropped_orphan_function_call_outputs
-            + self.dropped_orphan_custom_tool_call_outputs
-    }
-}
-
-impl std::ops::AddAssign for HistoryRepairStats {
-    fn add_assign(&mut self, rhs: Self) {
-        self.inserted_function_call_outputs += rhs.inserted_function_call_outputs;
-        self.inserted_custom_tool_call_outputs += rhs.inserted_custom_tool_call_outputs;
-        self.dropped_orphan_function_call_outputs += rhs.dropped_orphan_function_call_outputs;
-        self.dropped_orphan_custom_tool_call_outputs += rhs.dropped_orphan_custom_tool_call_outputs;
-    }
-}
-
-fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairStats {
+fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -273,25 +247,17 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
         })
         .collect::<HashSet<_>>();
 
-    let mut repaired = HistoryRepairStats::default();
+    let before_len = items.len();
     items.retain(|item| match item {
         ResponseItem::FunctionCallOutput { call_id, .. } => {
-            let keep =
-                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
-            if !keep {
-                repaired.dropped_orphan_function_call_outputs += 1;
-            }
-            keep
+            function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id)
         }
         ResponseItem::CustomToolCallOutput { call_id, .. } => {
-            let keep = custom_tool_call_ids.contains(call_id);
-            if !keep {
-                repaired.dropped_orphan_custom_tool_call_outputs += 1;
-            }
-            keep
+            custom_tool_call_ids.contains(call_id)
         }
         _ => true,
     });
+    let mut repaired = before_len - items.len();
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -313,7 +279,6 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
             ResponseItem::FunctionCall { call_id, .. }
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
-                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -325,7 +290,6 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
             ResponseItem::CustomToolCall { call_id, .. }
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
-                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::CustomToolCallOutput {
@@ -339,7 +303,6 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 call_id: Some(call_id),
                 ..
             } if function_output_call_ids.insert(call_id.clone()) => {
-                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -352,13 +315,14 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
         }
     }
 
+    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
+fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -388,7 +352,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
         })
         .collect::<HashSet<_>>();
 
-    let mut repaired = HistoryRepairStats::default();
+    let mut repaired = 0usize;
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
@@ -398,7 +362,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                         ResponseItem::FunctionCallOutput { call_id, output },
                     ));
                 } else {
-                    repaired.dropped_orphan_function_call_outputs += 1;
+                    repaired += 1;
                 }
             }
             RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -415,7 +379,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                         },
                     ));
                 } else {
-                    repaired.dropped_orphan_custom_tool_call_outputs += 1;
+                    repaired += 1;
                 }
             }
             RolloutItem::Compacted(mut compacted) => {
@@ -453,7 +417,6 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
             RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. })
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
-                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -465,7 +428,6 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
             RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. })
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
-                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -479,7 +441,6 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                 call_id: Some(call_id),
                 ..
             }) if function_output_call_ids.insert(call_id.clone()) => {
-                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -492,16 +453,17 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
         }
     }
 
+    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_initial_history(history: InitialHistory) -> (InitialHistory, HistoryRepairStats) {
+fn repair_initial_history(history: InitialHistory) -> (InitialHistory, usize) {
     match history {
-        InitialHistory::New => (InitialHistory::New, HistoryRepairStats::default()),
-        InitialHistory::Cleared => (InitialHistory::Cleared, HistoryRepairStats::default()),
+        InitialHistory::New => (InitialHistory::New, 0),
+        InitialHistory::Cleared => (InitialHistory::Cleared, 0),
         InitialHistory::Forked(mut items) => {
             let repaired = repair_rollout_items(&mut items);
             (InitialHistory::Forked(items), repaired)
@@ -699,15 +661,11 @@ impl Agent for CodexAgent {
         let history = RolloutRecorder::get_rollout_history(&rollout_path)
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
-        let (history, repaired_stats) = repair_initial_history(history);
-        if repaired_stats.total() > 0 {
+        let (history, repaired_items) = repair_initial_history(history);
+        if repaired_items > 0 {
             warn!(
                 session_id = %session_id,
-                repaired_items = repaired_stats.total(),
-                inserted_function_call_outputs = repaired_stats.inserted_function_call_outputs,
-                inserted_custom_tool_call_outputs = repaired_stats.inserted_custom_tool_call_outputs,
-                dropped_orphan_function_call_outputs = repaired_stats.dropped_orphan_function_call_outputs,
-                dropped_orphan_custom_tool_call_outputs = repaired_stats.dropped_orphan_custom_tool_call_outputs,
+                repaired_items,
                 "repaired dirty Codex rollout history before session resume"
             );
         }
@@ -888,7 +846,7 @@ impl Agent for CodexAgent {
 
 #[cfg(test)]
 mod tests {
-    use super::{HistoryRepairStats, repair_initial_history, repair_response_item_history};
+    use super::{repair_initial_history, repair_response_item_history};
     use codex_protocol::{
         ThreadId,
         models::{
@@ -914,14 +872,8 @@ mod tests {
             rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
         });
 
-        let (repaired, repaired_stats) = repair_initial_history(history);
-        assert_eq!(
-            repaired_stats,
-            HistoryRepairStats {
-                inserted_custom_tool_call_outputs: 1,
-                ..HistoryRepairStats::default()
-            }
-        );
+        let (repaired, repaired_count) = repair_initial_history(history);
+        assert_eq!(repaired_count, 1);
         let items = repaired.get_rollout_items();
         assert_eq!(items.len(), 2);
         assert!(matches!(
@@ -949,14 +901,7 @@ mod tests {
         ];
 
         let repaired = repair_response_item_history(&mut history);
-        assert_eq!(
-            repaired,
-            HistoryRepairStats {
-                inserted_custom_tool_call_outputs: 1,
-                dropped_orphan_custom_tool_call_outputs: 1,
-                ..HistoryRepairStats::default()
-            }
-        );
+        assert_eq!(repaired, 2);
         assert_eq!(history.len(), 2);
         assert!(matches!(
             &history[1],
@@ -983,14 +928,8 @@ mod tests {
             }]),
         })]);
 
-        let (repaired, repaired_stats) = repair_initial_history(history);
-        assert_eq!(
-            repaired_stats,
-            HistoryRepairStats {
-                inserted_function_call_outputs: 1,
-                ..HistoryRepairStats::default()
-            }
-        );
+        let (repaired, repaired_count) = repair_initial_history(history);
+        assert_eq!(repaired_count, 1);
         let items = repaired.get_rollout_items();
         let RolloutItem::Compacted(compacted) = &items[0] else {
             panic!("expected compacted item");

--- a/docs/journal/2026-04-25-team-selector-loading-state.md
+++ b/docs/journal/2026-04-25-team-selector-loading-state.md
@@ -1,0 +1,10 @@
+## Team Selector Loading State
+
+- Split Team selector loading from the true empty state so slow `/api/teams` refreshes do not flash `No teams yet` on first load.
+- Preserve the existing Team list while a refresh is in flight; only show the empty-state copy after the refresh settles with zero teams.
+- Added smoke coverage for the selector route loading state and updated the selector panel component tests.
+
+### Validation
+
+- `cd web && pnpm exec vitest run src/pages/team/team_selector_panel.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm run build`

--- a/web/src/pages/team/team_selector_panel.test.tsx
+++ b/web/src/pages/team/team_selector_panel.test.tsx
@@ -4,6 +4,30 @@ import { describe, expect, it, vi } from "vitest";
 import { TeamSelectorPanel } from "./team_selector_panel";
 
 describe("TeamSelectorPanel", () => {
+  it("renders the loading state without the filter controls", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamSelectorPanel
+          busy={null}
+          filter=""
+          loading={true}
+          hasTeams={false}
+          items={[]}
+          bodyTextClassName="body"
+          accentButtonClassName="accent"
+          onFilterChange={vi.fn()}
+          onRefreshTeams={vi.fn()}
+          onCreateTeam={vi.fn()}
+          onSelectTeam={vi.fn()}
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Loading teams...");
+    expect(html).not.toContain("No teams yet. Create one to begin.");
+    expect(html).not.toContain("Search teams");
+  });
+
   it("renders the empty state when no teams are available", () => {
     const html = renderToStaticMarkup(
       <MantineProvider>

--- a/web/src/pages/team/team_selector_panel.test.tsx
+++ b/web/src/pages/team/team_selector_panel.test.tsx
@@ -10,6 +10,7 @@ describe("TeamSelectorPanel", () => {
         <TeamSelectorPanel
           busy={null}
           filter=""
+          loading={false}
           hasTeams={false}
           items={[]}
           bodyTextClassName="body"
@@ -32,6 +33,7 @@ describe("TeamSelectorPanel", () => {
         <TeamSelectorPanel
           busy={null}
           filter="tidb"
+          loading={false}
           hasTeams={true}
           items={[
             {

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -16,6 +16,7 @@ export type TeamSelectorItem = {
 type TeamSelectorPanelProps = {
   busy: string | null;
   filter: string;
+  loading: boolean;
   hasTeams: boolean;
   items: readonly TeamSelectorItem[];
   bodyTextClassName: string;
@@ -65,6 +66,7 @@ const TeamSelectorEntry = React.memo(function TeamSelectorEntry({
 export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
   busy,
   filter,
+  loading,
   hasTeams,
   items,
   bodyTextClassName,
@@ -92,7 +94,7 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
           </ActionButton>
         </div>
 
-        {hasTeams && (
+        {!loading && hasTeams && (
           <div className="mt-1 flex items-center gap-2 px-2">
             <TextInput
               className="flex-1"
@@ -122,12 +124,17 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
 
         <div className="mt-2 flex-1 overflow-y-auto">
           <div className={TEAM_SELECTOR_LIST_CLASS}>
-            {!hasTeams && (
+            {loading && (
+              <p className={`${bodyTextClassName} px-2`} role="status" aria-live="polite">
+                Loading teams...
+              </p>
+            )}
+            {!loading && !hasTeams && (
               <p className={`${bodyTextClassName} px-2`}>
                 No teams yet. Create one to begin.
               </p>
             )}
-            {hasTeams && items.length === 0 && (
+            {!loading && hasTeams && items.length === 0 && (
               <p className={`${bodyTextClassName} px-2`}>No teams match the current filter.</p>
             )}
             {items.map((team) => (

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -43,6 +43,7 @@ const {
   teamPageFixture: {
     teams: [] as Array<Record<string, unknown>>,
     agents: [] as Array<Record<string, unknown>>,
+    settleTeams: true,
   },
 }));
 
@@ -78,6 +79,9 @@ vi.mock("./team/use_team_actions", () => ({
     React.useEffect(() => {
       setTeams(teamPageFixture.teams);
       setAgents(teamPageFixture.agents);
+      if (teamPageFixture.settleTeams) {
+        options.onTeamsRefreshSettled?.();
+      }
     }, [setAgents, setTeams]);
     return {
       refreshAgents: vi.fn().mockResolvedValue(undefined),
@@ -255,6 +259,7 @@ describe("TeamPage smoke render", () => {
     useMediaQueryMock.mockReturnValue(false);
     teamPageFixture.teams = [];
     teamPageFixture.agents = [];
+    teamPageFixture.settleTeams = true;
     window.history.pushState({}, "", "/teams");
   });
 
@@ -284,9 +289,49 @@ describe("TeamPage smoke render", () => {
 
     expect(markup).toContain("Teams");
     expect(markup).toContain("New Team");
-    expect(markup).toContain("No teams yet. Create one to begin.");
+    expect(markup).toContain("Loading teams...");
     expect(markup).not.toContain("Workspace Flow");
     expect(markup).not.toContain("Mission before staffing");
+  });
+
+  it("keeps the selector in loading state until teams refresh settles", async () => {
+    teamPageFixture.settleTeams = false;
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId={null}
+              routeSearch=""
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      expect(container.textContent).toContain("Loading teams...");
+      expect(container.textContent).not.toContain("No teams yet. Create one to begin.");
+      expect(container.querySelector('input[aria-label="Filter teams"]')).toBeNull();
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
   });
 
   it("renders a team detail route without crashing", () => {

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1014,7 +1014,7 @@ export function TeamPage(props: TeamPageProps) {
   const [memberEventsLoading, setMemberEventsLoading] = useState(false);
   const memberEventsRef = useRef<AgentEvent[]>([]);
   const [focusedAgentMemberId, setFocusedAgentMemberId] = useState("");
-  const [teamCatalogSettled, setTeamCatalogSettled] = useState(() => isSelectorRoute);
+  const [teamCatalogSettled, setTeamCatalogSettled] = useState(false);
   const handleTeamsRefreshSettled = useCallback(() => {
     setTeamCatalogSettled(true);
   }, []);
@@ -1024,16 +1024,15 @@ export function TeamPage(props: TeamPageProps) {
     [effectiveSelectedTeamId, teams]
   );
   useEffect(() => {
-    if (isSelectorRoute || teams.length > 0) {
+    if (teams.length > 0) {
       setTeamCatalogSettled(true);
     }
-  }, [isSelectorRoute, teams.length]);
+  }, [teams.length]);
   useEffect(() => {
     setSelectedTeamId(routeTeamId);
   }, [routeTeamId]);
   useEffect(() => {
     if (routeTeamId == null) {
-      setTeamCatalogSettled(true);
       return;
     }
     if (teams.length === 0) {
@@ -3561,6 +3560,7 @@ export function TeamPage(props: TeamPageProps) {
           <TeamSelectorPanel
             busy={busy}
             filter={teamSelectorFilter}
+            loading={!teamCatalogSettled && teams.length === 0}
             hasTeams={teams.length > 0}
             items={selectorTeamItems}
             bodyTextClassName={teamSectionBodyTextClassName}


### PR DESCRIPTION
fix(team): keep selector loading until teams settle

## Summary

- keep the Team selector in an explicit loading state while `/api/teams` is still in flight
- avoid flashing the empty-state copy during slow Team catalog refreshes
- preserve previously loaded Team entries during refresh and only show the empty state after refresh settles with zero teams
- add selector component and smoke coverage for the loading-vs-empty boundary

## Validation

- `cd web && pnpm exec vitest run src/pages/team/team_selector_panel.test.tsx src/pages/team_page.smoke.test.tsx`
- `cd web && npm run build`
