### PR TITLE
fix(acp): tighten event history queries

### DIFF
--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -221,7 +221,33 @@ fn aborted_call_output() -> FunctionCallOutputPayload {
     FunctionCallOutputPayload::from_text("aborted".to_string())
 }
 
-fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct HistoryRepairStats {
+    inserted_function_call_outputs: usize,
+    inserted_custom_tool_call_outputs: usize,
+    dropped_orphan_function_call_outputs: usize,
+    dropped_orphan_custom_tool_call_outputs: usize,
+}
+
+impl HistoryRepairStats {
+    fn total(self) -> usize {
+        self.inserted_function_call_outputs
+            + self.inserted_custom_tool_call_outputs
+            + self.dropped_orphan_function_call_outputs
+            + self.dropped_orphan_custom_tool_call_outputs
+    }
+}
+
+impl std::ops::AddAssign for HistoryRepairStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.inserted_function_call_outputs += rhs.inserted_function_call_outputs;
+        self.inserted_custom_tool_call_outputs += rhs.inserted_custom_tool_call_outputs;
+        self.dropped_orphan_function_call_outputs += rhs.dropped_orphan_function_call_outputs;
+        self.dropped_orphan_custom_tool_call_outputs += rhs.dropped_orphan_custom_tool_call_outputs;
+    }
+}
+
+fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -247,17 +273,25 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
         })
         .collect::<HashSet<_>>();
 
-    let before_len = items.len();
+    let mut repaired = HistoryRepairStats::default();
     items.retain(|item| match item {
         ResponseItem::FunctionCallOutput { call_id, .. } => {
-            function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id)
+            let keep =
+                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_function_call_outputs += 1;
+            }
+            keep
         }
         ResponseItem::CustomToolCallOutput { call_id, .. } => {
-            custom_tool_call_ids.contains(call_id)
+            let keep = custom_tool_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_custom_tool_call_outputs += 1;
+            }
+            keep
         }
         _ => true,
     });
-    let mut repaired = before_len - items.len();
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -279,6 +313,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
             ResponseItem::FunctionCall { call_id, .. }
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -290,6 +325,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
             ResponseItem::CustomToolCall { call_id, .. }
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::CustomToolCallOutput {
@@ -303,6 +339,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
                 call_id: Some(call_id),
                 ..
             } if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
@@ -315,14 +352,13 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> usize {
         }
     }
 
-    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
+fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
@@ -352,7 +388,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
         })
         .collect::<HashSet<_>>();
 
-    let mut repaired = 0usize;
+    let mut repaired = HistoryRepairStats::default();
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
@@ -362,7 +398,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                         ResponseItem::FunctionCallOutput { call_id, output },
                     ));
                 } else {
-                    repaired += 1;
+                    repaired.dropped_orphan_function_call_outputs += 1;
                 }
             }
             RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -379,7 +415,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                         },
                     ));
                 } else {
-                    repaired += 1;
+                    repaired.dropped_orphan_custom_tool_call_outputs += 1;
                 }
             }
             RolloutItem::Compacted(mut compacted) => {
@@ -417,6 +453,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
             RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. })
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -428,6 +465,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
             RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. })
                 if custom_output_call_ids.insert(call_id.clone()) =>
             {
+                repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
@@ -441,6 +479,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
                 call_id: Some(call_id),
                 ..
             }) if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
@@ -453,17 +492,16 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> usize {
         }
     }
 
-    repaired += synthetic_outputs.len();
     for (idx, output) in synthetic_outputs.into_iter().rev() {
         items.insert(idx + 1, output);
     }
     repaired
 }
 
-fn repair_initial_history(history: InitialHistory) -> (InitialHistory, usize) {
+fn repair_initial_history(history: InitialHistory) -> (InitialHistory, HistoryRepairStats) {
     match history {
-        InitialHistory::New => (InitialHistory::New, 0),
-        InitialHistory::Cleared => (InitialHistory::Cleared, 0),
+        InitialHistory::New => (InitialHistory::New, HistoryRepairStats::default()),
+        InitialHistory::Cleared => (InitialHistory::Cleared, HistoryRepairStats::default()),
         InitialHistory::Forked(mut items) => {
             let repaired = repair_rollout_items(&mut items);
             (InitialHistory::Forked(items), repaired)
@@ -661,11 +699,15 @@ impl Agent for CodexAgent {
         let history = RolloutRecorder::get_rollout_history(&rollout_path)
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
-        let (history, repaired_items) = repair_initial_history(history);
-        if repaired_items > 0 {
+        let (history, repaired_stats) = repair_initial_history(history);
+        if repaired_stats.total() > 0 {
             warn!(
                 session_id = %session_id,
-                repaired_items,
+                repaired_items = repaired_stats.total(),
+                inserted_function_call_outputs = repaired_stats.inserted_function_call_outputs,
+                inserted_custom_tool_call_outputs = repaired_stats.inserted_custom_tool_call_outputs,
+                dropped_orphan_function_call_outputs = repaired_stats.dropped_orphan_function_call_outputs,
+                dropped_orphan_custom_tool_call_outputs = repaired_stats.dropped_orphan_custom_tool_call_outputs,
                 "repaired dirty Codex rollout history before session resume"
             );
         }
@@ -846,7 +888,7 @@ impl Agent for CodexAgent {
 
 #[cfg(test)]
 mod tests {
-    use super::{repair_initial_history, repair_response_item_history};
+    use super::{HistoryRepairStats, repair_initial_history, repair_response_item_history};
     use codex_protocol::{
         ThreadId,
         models::{
@@ -872,8 +914,14 @@ mod tests {
             rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
         });
 
-        let (repaired, repaired_count) = repair_initial_history(history);
-        assert_eq!(repaired_count, 1);
+        let (repaired, repaired_stats) = repair_initial_history(history);
+        assert_eq!(
+            repaired_stats,
+            HistoryRepairStats {
+                inserted_custom_tool_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         let items = repaired.get_rollout_items();
         assert_eq!(items.len(), 2);
         assert!(matches!(
@@ -901,7 +949,14 @@ mod tests {
         ];
 
         let repaired = repair_response_item_history(&mut history);
-        assert_eq!(repaired, 2);
+        assert_eq!(
+            repaired,
+            HistoryRepairStats {
+                inserted_custom_tool_call_outputs: 1,
+                dropped_orphan_custom_tool_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         assert_eq!(history.len(), 2);
         assert!(matches!(
             &history[1],
@@ -928,8 +983,14 @@ mod tests {
             }]),
         })]);
 
-        let (repaired, repaired_count) = repair_initial_history(history);
-        assert_eq!(repaired_count, 1);
+        let (repaired, repaired_stats) = repair_initial_history(history);
+        assert_eq!(
+            repaired_stats,
+            HistoryRepairStats {
+                inserted_function_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
         let items = repaired.get_rollout_items();
         let RolloutItem::Compacted(compacted) = &items[0] else {
             panic!("expected compacted item");

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -468,6 +468,7 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     .await?;
 
     migrate_agent_events_message_column_to_blob(&pool).await?;
+    ensure_main_agent_event_db_indexes(&pool).await?;
 
     sqlx::query(
         r#"
@@ -744,74 +745,6 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     .await
     {
         tracing::warn!("db init: failed to create idx_agent_nodes_name: {}", err);
-    }
-
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_seq
-        ON agent_events(agent_id, seq);
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to create idx_agent_events_agent_seq: {}",
-            err
-        );
-    }
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_session_seq
-        ON agent_events(agent_id, session_id, seq);
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to create idx_agent_events_agent_session_seq: {}",
-            err
-        );
-    }
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_id
-        ON agent_events(agent_id, id);
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to create idx_agent_events_agent_id: {}",
-            err
-        );
-    }
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_session_id
-        ON agent_events(agent_id, session_id, id);
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to create idx_agent_events_agent_session_id: {}",
-            err
-        );
-    }
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_agent_events_ts
-        ON agent_events(ts);
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!("db init: failed to create idx_agent_events_ts: {}", err);
     }
 
     if let Err(err) = sqlx::query(
@@ -1498,6 +1431,12 @@ async fn init_agent_event_db_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     )
     .execute(pool)
     .await?;
+    migrate_per_agent_events_message_column_to_blob(pool).await?;
+    ensure_per_agent_event_db_indexes(pool).await?;
+    Ok(())
+}
+
+async fn ensure_per_agent_event_db_indexes(pool: &SqlitePool) -> anyhow::Result<()> {
     sqlx::query(
         r#"
         CREATE INDEX IF NOT EXISTS idx_agent_events_session_id
@@ -1514,6 +1453,48 @@ async fn init_agent_event_db_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     )
     .execute(pool)
     .await?;
+    ensure_agent_events_ts_index(pool).await?;
+    Ok(())
+}
+
+async fn ensure_main_agent_event_db_indexes(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_seq
+        ON agent_events(agent_id, seq);
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_session_seq
+        ON agent_events(agent_id, session_id, seq);
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_id
+        ON agent_events(agent_id, id);
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_agent_events_agent_session_id
+        ON agent_events(agent_id, session_id, id);
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    ensure_agent_events_ts_index(pool).await?;
+    Ok(())
+}
+
+async fn ensure_agent_events_ts_index(pool: &SqlitePool) -> anyhow::Result<()> {
     sqlx::query(
         r#"
         CREATE INDEX IF NOT EXISTS idx_agent_events_ts
@@ -1577,6 +1558,71 @@ async fn migrate_agent_events_message_column_to_blob(pool: &SqlitePool) -> anyho
         r#"
         INSERT INTO agent_events_migrated (id, agent_id, session_id, seq, ts, stream, message)
         SELECT id, agent_id, session_id, seq, ts, stream, CAST(message AS BLOB)
+        FROM agent_events
+        ORDER BY id ASC
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("DROP TABLE agent_events")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("ALTER TABLE agent_events_migrated RENAME TO agent_events")
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn migrate_per_agent_events_message_column_to_blob(pool: &SqlitePool) -> anyhow::Result<()> {
+    let columns = sqlx::query("PRAGMA table_info(agent_events)")
+        .fetch_all(pool)
+        .await?;
+    if columns.is_empty() {
+        return Ok(());
+    }
+
+    let message_type = columns.iter().find_map(|row| {
+        let name = row.get::<String, _>("name");
+        if name.eq_ignore_ascii_case("message") {
+            Some(row.get::<String, _>("type"))
+        } else {
+            None
+        }
+    });
+
+    if message_type
+        .as_deref()
+        .map(|ty| ty.eq_ignore_ascii_case("BLOB"))
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    tracing::info!(
+        from = ?message_type,
+        "db init: migrating per-agent agent_events.message column to BLOB"
+    );
+
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        r#"
+        CREATE TABLE agent_events_migrated (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            seq TEXT NOT NULL,
+            ts INTEGER NOT NULL,
+            stream TEXT NOT NULL,
+            message BLOB NOT NULL
+        );
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO agent_events_migrated (id, session_id, seq, ts, stream, message)
+        SELECT id, session_id, seq, ts, stream, CAST(message AS BLOB)
         FROM agent_events
         ORDER BY id ASC
         "#,
@@ -2214,6 +2260,146 @@ mod tests {
         assert_eq!(
             stored_message,
             b"{\"type\":\"agent_message\",\"text\":\"legacy\"}".to_vec()
+        );
+
+        let index_names = sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index' AND tbl_name = 'agent_events'
+            ORDER BY name
+            "#,
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("load agent_events indexes");
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_agent_id"),
+            "expected idx_agent_events_agent_id after migration, got {index_names:?}"
+        );
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_agent_seq"),
+            "expected idx_agent_events_agent_seq after migration, got {index_names:?}"
+        );
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_agent_session_id"),
+            "expected idx_agent_events_agent_session_id after migration, got {index_names:?}"
+        );
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_agent_session_seq"),
+            "expected idx_agent_events_agent_session_seq after migration, got {index_names:?}"
+        );
+        assert!(
+            index_names.iter().any(|name| name == "idx_agent_events_ts"),
+            "expected idx_agent_events_ts after migration, got {index_names:?}"
+        );
+
+        pool.close().await;
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn init_agent_event_db_schema_migrates_legacy_per_agent_events() {
+        let dir = unique_temp_dir("db-migrate-per-agent-events");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let db_path = dir.join("agent-events.db");
+        let pool = try_connect(&db_path).await.expect("connect sqlite");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE agent_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                seq TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                stream TEXT NOT NULL,
+                message TEXT NOT NULL
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("create legacy per-agent agent_events");
+
+        sqlx::query(
+            r#"
+            INSERT INTO agent_events (session_id, seq, ts, stream, message)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )
+        .bind("session-legacy")
+        .bind("seq-legacy")
+        .bind(chrono::Utc::now().timestamp())
+        .bind("stdout")
+        .bind("{\"type\":\"agent_message\",\"text\":\"legacy\"}")
+        .execute(&pool)
+        .await
+        .expect("insert legacy per-agent event");
+
+        crate::init_agent_event_db_schema(&pool)
+            .await
+            .expect("migrate per-agent agent_events");
+
+        let message_column_type: String = sqlx::query_scalar(
+            r#"
+            SELECT type
+            FROM pragma_table_info('agent_events')
+            WHERE name = 'message'
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read per-agent message column type");
+        assert!(
+            message_column_type.eq_ignore_ascii_case("BLOB"),
+            "expected per-agent message column type to migrate to BLOB, got {message_column_type}"
+        );
+
+        let message_storage_type: String =
+            sqlx::query_scalar("SELECT typeof(message) FROM agent_events WHERE seq = 'seq-legacy'")
+                .fetch_one(&pool)
+                .await
+                .expect("read per-agent message storage type");
+        assert_eq!(
+            message_storage_type, "blob",
+            "expected migrated per-agent row storage type to be blob"
+        );
+
+        let index_names = sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index' AND tbl_name = 'agent_events'
+            ORDER BY name
+            "#,
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("load per-agent agent_events indexes");
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_session_id"),
+            "expected idx_agent_events_session_id after per-agent migration, got {index_names:?}"
+        );
+        assert!(
+            index_names
+                .iter()
+                .any(|name| name == "idx_agent_events_session_seq"),
+            "expected idx_agent_events_session_seq after per-agent migration, got {index_names:?}"
+        );
+        assert!(
+            index_names.iter().any(|name| name == "idx_agent_events_ts"),
+            "expected idx_agent_events_ts after per-agent migration, got {index_names:?}"
         );
 
         pool.close().await;

--- a/docs/journal/2026-04-25-acp-events-query-performance.md
+++ b/docs/journal/2026-04-25-acp-events-query-performance.md
@@ -1,0 +1,21 @@
+## ACP Events Query Performance
+
+This change tightens ACP event history loading on both sides of the request path.
+
+### Problem
+
+- The Team ACP history prefetch path could raise `limit` up to `240` for chunk-heavy sessions.
+- The `/api/agents/:id/events` query relies on `agent_events(session_id, id)` ordering, but older databases could lose the supporting indexes during the `message` column migration because the migration recreated the table and dropped the old indexes.
+
+### Changes
+
+- Lower the ACP history page-size cap from `240` to `180`.
+- Recreate `agent_events` indexes after the message-column migration.
+- Apply the same index-repair logic to per-agent event databases during schema initialization.
+
+### Validation
+
+- `cargo test -p agenthub-db init_db_migrates_agent_events_message_column_to_blob -- --nocapture`
+- `cargo fmt --all --check`
+- `cd web && pnpm exec vitest run src/pages/team/use_team_actions.test.tsx`
+- `cd web && npm run build`

--- a/web/src/pages/team/acp_history_prefetch.ts
+++ b/web/src/pages/team/acp_history_prefetch.ts
@@ -3,7 +3,7 @@ import type { AgentEvent } from "../../api";
 import { buildConversationMessages } from "../../conversation";
 
 export const ACP_INITIAL_VISIBLE_MESSAGE_TARGET = 1;
-export const ACP_HISTORY_PAGE_LIMIT_MAX = 240;
+export const ACP_HISTORY_PAGE_LIMIT_MAX = 180;
 
 type LeadingAcpMessageChunkState = {
   messageId: string | null;
@@ -211,7 +211,7 @@ export function resolveAdaptiveAcpHistoryPageLimit(
     return Math.max(baseLimit, ACP_HISTORY_PAGE_LIMIT_MAX);
   }
   if (leadingState.chunkIndex >= 96) {
-    return Math.max(baseLimit, 180);
+    return Math.max(baseLimit, ACP_HISTORY_PAGE_LIMIT_MAX);
   }
   if (leadingState.chunkIndex >= 32 || leadingMessageDominatesPage) {
     return Math.max(baseLimit, 120);

--- a/web/src/pages/team/use_team_actions.test.tsx
+++ b/web/src/pages/team/use_team_actions.test.tsx
@@ -551,7 +551,7 @@ describe("useTeamActions", () => {
         2,
         "token-1",
         "worker-agent",
-        240,
+        180,
         "runtime-session-1",
         100
       );
@@ -559,7 +559,7 @@ describe("useTeamActions", () => {
         3,
         "token-1",
         "worker-agent",
-        240,
+        180,
         "runtime-session-1",
         80
       );


### PR DESCRIPTION
## Summary

This PR tightens ACP event history queries on both sides of the path.

- lower ACP history prefetch page-size cap from `240` to `180`
- recreate `agent_events` indexes after the message-column migration
- apply the same index repair to per-agent event DB initialization
- document the production query root cause in the journal

## Why

The production ACP events endpoint was being called with `limit=240`, which is too aggressive for chunk-heavy sessions.

The backend query path also depends on `agent_events(session_id, id)` ordering. During the historical `message`-column migration, the table was recreated, which could drop the supporting indexes on upgraded databases unless they were recreated explicitly.

## Testing

- `cargo test -p agenthub-db init_db_migrates_agent_events_message_column_to_blob -- --nocapture`
- `cargo fmt --all --check`
- `cd web && pnpm exec vitest run src/pages/team/use_team_actions.test.tsx`
- `cd web && npm run build`
