### PR TITLE
docs(docs): add Homebrew install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ output rendering, SQLite-backed persistence, multi-agent Team orchestration,
 and optional remote execution nodes.
 
 Quick links: [Docs Site](https://doc.agenthub.hawkingrei.com/) ·
-[Why AgentHub](#why-agenthub) · [Quick Start](#quick-start) ·
+[Why AgentHub](#why-agenthub) · [Install](#install) · [Quick Start](#quick-start) ·
 [Remote Agent Nodes](#remote-agent-nodes-optional) ·
 [Architecture At A Glance](#architecture-at-a-glance) ·
 [Documentation Map](#documentation-map) · [Development](#development)
@@ -34,6 +34,50 @@ for the operational side of agent workflows:
 - Register remote execution nodes and start agents on those nodes
 - Persist session history and operational records in SQLite
 - Receive completion notifications in the web UI
+
+## Install
+
+### Homebrew
+
+AgentHub publishes Homebrew release binaries through the `linkerdog/homebrew-tap`
+tap.
+
+```bash
+brew tap linkerdog/homebrew-tap
+brew install linkerdog/homebrew-tap/agenthub
+```
+
+This installs:
+
+- `agenthub`
+- `agenthub-codex-acp`
+
+To run AgentHub in the background:
+
+```bash
+brew services start linkerdog/homebrew-tap/agenthub
+```
+
+AgentHub reads config from `~/.agenthub/config.toml`.
+
+Minimal example:
+
+```toml
+[server]
+listen = "0.0.0.0:8080"
+```
+
+Then open `http://localhost:8080`.
+
+Current release binaries are available for:
+
+- macOS Apple Silicon (`darwin-arm64`)
+- Linux `x86_64`
+- Linux `aarch64`
+
+### Build From Source
+
+Use the source workflow below if you are developing AgentHub locally.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Minimal example:
 
 ```toml
 [server]
-listen = "0.0.0.0:8080"
+listen = "127.0.0.1:8080"
 ```
 
 Then open `http://localhost:8080`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ output rendering, SQLite-backed persistence, multi-agent Team orchestration,
 and optional remote execution nodes.
 
 Quick links: [Docs Site](https://doc.agenthub.hawkingrei.com/) ·
-[Why AgentHub](#why-agenthub) · [Install](#install) · [Quick Start](#quick-start) ·
+[Why AgentHub](#why-agenthub) · [Install](#install) · [Developer Guide](docs/developer-setup.md) ·
 [Remote Agent Nodes](#remote-agent-nodes-optional) ·
 [Architecture At A Glance](#architecture-at-a-glance) ·
 [Documentation Map](#documentation-map) · [Development](#development)
@@ -77,60 +77,8 @@ Current release binaries are available for:
 
 ### Build From Source
 
-Use the source workflow below if you are developing AgentHub locally.
-
-## Quick Start
-
-### Requirements
-
-- Rust (stable)
-- Node.js 20+
-- Bazel / Bazelisk (optional, for Bazel-driven checks)
-
-### Start Locally
-
-```bash
-# 1) Install web dependencies
-npm --prefix web ci
-
-# 2) Start AgentHub
-make run
-```
-
-`make run` builds the embedded web UI as part of the normal local startup path.
-
-Open `http://localhost:8080`.
-
-AgentHub stays single-binary. Runtime helpers such as the actor CLI are
-subcommands of the same binary:
-
-```bash
-cargo run -- actor --help
-cargo run -- actor team-members --help
-```
-
-## Minimal Configuration
-
-AgentHub reads config from `~/.agenthub/config.toml`.
-
-```toml
-safe_paths = [
-  "/home/foo",
-  "/home/foo/projects"
-]
-
-[server]
-listen = "0.0.0.0:8080"
-
-[worktree]
-default_root = "~/.agenthub/worktrees"
-
-[history]
-event_retention_days = 5
-vacuum_on_cleanup = false
-```
-
-Runtime state defaults to `~/.agenthub/`.
+For local source development, setup, common commands, and CI expectations, see
+[docs/developer-setup.md](docs/developer-setup.md).
 
 ## Remote Agent Nodes (Optional)
 
@@ -188,6 +136,7 @@ current contract and rollout model.
   - Start with Product Overview, Feature Overview, and Architecture Overview
 - Local user docs source: [userdocs/](userdocs/)
 - Internal docs guide: [docs/README.md](docs/README.md)
+- Developer setup and workflow: [docs/developer-setup.md](docs/developer-setup.md)
 - Project charter and engineering constraints: [AGENTS.md](AGENTS.md)
 - Agent and Team architecture: [docs/features/agents-teams.md](docs/features/agents-teams.md)
 - Frontend/UI architecture: [docs/features/frontend-design.md](docs/features/frontend-design.md)
@@ -199,85 +148,10 @@ current contract and rollout model.
 - Active follow-up backlog: [docs/todo.md](docs/todo.md)
 - API payload naming rules: [docs/api_naming.md](docs/api_naming.md)
 
-For user-facing documentation preview/build:
-
-```bash
-npm --prefix userdocs ci
-npm --prefix userdocs run start
-npm --prefix userdocs run build
-```
-
-## Repository Layout
-
-```text
-agenthub/
-  src/                    # Rust server and runtime wiring
-  crates/                 # Rust domain crates
-  web/                    # Vite + React frontend
-  userdocs/               # Docusaurus user documentation site
-  proto/                  # Protobuf schema
-  tests/                  # Integration and blackbox tests
-  docs/                   # Internal engineering docs and journals
-  skills/                 # Team/agent runtime skill definitions
-  agenthub-codex-acp/     # Codex ACP integration workspace member
-```
-
 ## Development
 
-### Common Commands
-
-```bash
-# Run AgentHub server
-make run
-
-# Rust tests
-cargo test
-
-# Frontend unit tests
-npm --prefix web run test
-
-# Frontend lint
-npm --prefix web run lint
-
-# Frontend build
-npm --prefix web run build
-
-# Playwright E2E
-npm --prefix web run e2e
-
-# Bazel checks
-bazel build //...
-bazel test //...
-bazel coverage --combined_report=lcov --test_output=errors //crates/agenthub-text:agenthub_text_tests # Example for a single crate
-```
-
-### Recommended Pre-PR Checks
-
-```bash
-# Rust + proto guard
-cargo test
-make proto-check
-
-# Web checks
-npm --prefix web run lint
-npm --prefix web run test:coverage
-
-# User docs
-npm --prefix userdocs run build
-
-# Optional: E2E smoke
-npm --prefix web run e2e -- tests/e2e/app.e2e.ts --project=chromium
-```
-
-### CI Pipelines
-
-- `Rust`: cargo check + coverage (`rust-cargo.lcov`) + Codecov upload
-- `Clippy`: `cargo clippy --workspace --all-targets -- -D warnings`
-- `Web`: lint + unit coverage + build + Codecov upload
-- `Web E2E`: Playwright coverage + Codecov upload
-- `Bazel`: split `Bazel Build`, `Bazel Test (Root)`, `Bazel Test (Crates)`, and `Bazel Coverage`
-  jobs, with `bazel.lcov` uploaded to Codecov and an aggregate `Bazel Build and Test` gate
-- `User Docs`: Docusaurus build validation
+Development workflow, repository layout, common commands, and CI expectations
+live in [docs/developer-setup.md](docs/developer-setup.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ contributors.
 - `docs/journal/`: dated implementation checkpoints and compaction notes
 - `docs/todo.md`: active follow-up backlog only
 - `docs/api_naming.md`: payload naming conventions for AgentHub-owned APIs
+- `docs/developer-setup.md`: contributor setup, repository layout, and common commands
 - `userdocs/`: published end-user documentation site (Docusaurus)
 
 ## When You Change Code

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -1,0 +1,139 @@
+# Developer Setup
+
+This guide covers local source development for AgentHub contributors.
+
+## Requirements
+
+- Rust (stable)
+- Node.js 20+
+- Bazel / Bazelisk (optional, for Bazel-driven checks)
+- Git
+
+## Repository Layout
+
+```text
+agenthub/
+  src/                    # Rust server and runtime wiring
+  crates/                 # Rust domain crates
+  web/                    # Vite + React frontend
+  userdocs/               # Docusaurus user documentation site
+  proto/                  # Protobuf schema
+  tests/                  # Integration and blackbox tests
+  docs/                   # Internal engineering docs and journals
+  skills/                 # Team/agent runtime skill definitions
+  agenthub-codex-acp/     # Codex ACP integration workspace member
+```
+
+## Local Startup
+
+### Install Web Dependencies
+
+```bash
+npm --prefix web ci
+```
+
+### Create A Minimal Config
+
+AgentHub reads config from `~/.agenthub/config.toml`.
+
+```toml
+safe_paths = [
+  "/home/foo",
+  "/home/foo/projects"
+]
+
+[server]
+listen = "127.0.0.1:8080"
+
+[worktree]
+default_root = "~/.agenthub/worktrees"
+
+[history]
+event_retention_days = 5
+vacuum_on_cleanup = false
+```
+
+Runtime state defaults to `~/.agenthub/`.
+
+### Start Locally
+
+```bash
+make run
+```
+
+`make run` builds the embedded web UI as part of the normal local startup path.
+
+Open `http://localhost:8080`.
+
+AgentHub stays single-binary. Runtime helpers such as the actor CLI are
+subcommands of the same binary:
+
+```bash
+cargo run -- actor --help
+cargo run -- actor team-members --help
+```
+
+## Common Commands
+
+```bash
+# Run AgentHub server
+make run
+
+# Rust tests
+cargo test
+
+# Frontend unit tests
+npm --prefix web run test
+
+# Frontend lint
+npm --prefix web run lint
+
+# Frontend build
+npm --prefix web run build
+
+# Playwright E2E
+npm --prefix web run e2e
+
+# Bazel checks
+bazel build //...
+bazel test //...
+bazel coverage --combined_report=lcov --test_output=errors //crates/agenthub-text:agenthub_text_tests
+```
+
+## Recommended Pre-PR Checks
+
+```bash
+# Rust + proto guard
+cargo test
+make proto-check
+
+# Web checks
+npm --prefix web run lint
+npm --prefix web run test:coverage
+
+# User docs
+npm --prefix userdocs ci
+npm --prefix userdocs run build
+
+# Optional: E2E smoke
+npm --prefix web run e2e -- tests/e2e/app.e2e.ts --project=chromium
+```
+
+## User Docs Preview
+
+```bash
+npm --prefix userdocs ci
+npm --prefix userdocs run start
+npm --prefix userdocs run build
+```
+
+## CI Pipelines
+
+- `Rust`: cargo check + coverage (`rust-cargo.lcov`) + Codecov upload
+- `Clippy`: `cargo clippy --workspace --all-targets -- -D warnings`
+- `Web`: lint + unit coverage + build + Codecov upload
+- `Web E2E`: Playwright coverage + Codecov upload
+- `Bazel`: split `Bazel Build`, `Bazel Test (Root)`, `Bazel Test (Crates)`, and
+  `Bazel Coverage` jobs, with `bazel.lcov` uploaded to Codecov and an aggregate
+  `Bazel Build and Test` gate
+- `User Docs`: Docusaurus build validation

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -4,7 +4,7 @@ This guide covers local source development for AgentHub contributors.
 
 ## Requirements
 
-- Rust (stable)
+- Rust 1.95.0
 - Node.js 20+
 - Bazel / Bazelisk (optional, for Bazel-driven checks)
 - Git

--- a/docs/journal/2026-04-26-homebrew-install-docs.md
+++ b/docs/journal/2026-04-26-homebrew-install-docs.md
@@ -1,0 +1,24 @@
+# Homebrew Install Docs
+
+## Summary
+
+- added a first-class Homebrew install path to the root `README.md`
+- aligned `userdocs/docs/getting-started/installation.md` with the same tap and
+  `brew services` flow
+- clarified that the source-based `make run` path is the development workflow,
+  not the primary release-binary install path
+
+## Scope
+
+- root `README.md`
+- `userdocs/docs/getting-started/installation.md`
+
+## Notes
+
+- the published tap is `linkerdog/homebrew-tap`
+- the recommended install command uses the fully qualified formula name:
+  `brew install linkerdog/homebrew-tap/agenthub`
+- current published binaries cover:
+  - macOS Apple Silicon
+  - Linux `x86_64`
+  - Linux `aarch64`

--- a/docs/journal/2026-04-26-readme-developer-guide-split.md
+++ b/docs/journal/2026-04-26-readme-developer-guide-split.md
@@ -1,0 +1,19 @@
+# README Developer Guide Split
+
+## Summary
+
+- removed source-development setup and command details from the root `README.md`
+- moved contributor-facing setup and workflow content into `docs/developer-setup.md`
+- kept the root README focused on product overview, install paths, and doc entrypoints
+
+## Scope
+
+- `README.md`
+- `docs/README.md`
+- `docs/developer-setup.md`
+
+## Notes
+
+- the root README now links to one dedicated developer guide instead of
+  carrying detailed contributor commands inline
+- user-facing install guidance stays in the README and `userdocs`

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -4,6 +4,46 @@ sidebar_position: 1
 
 # Installation and Startup
 
+## Install Release Binaries With Homebrew
+
+AgentHub publishes Homebrew release binaries through the `linkerdog/homebrew-tap`
+tap.
+
+```bash
+brew tap linkerdog/homebrew-tap
+brew install linkerdog/homebrew-tap/agenthub
+```
+
+This installs:
+
+- `agenthub`
+- `agenthub-codex-acp`
+
+To run AgentHub as a background service:
+
+```bash
+brew services start linkerdog/homebrew-tap/agenthub
+```
+
+AgentHub reads configuration from `~/.agenthub/config.toml`.
+
+Minimal example:
+
+```toml
+[server]
+listen = "0.0.0.0:8080"
+```
+
+Then open `http://localhost:8080`.
+
+Current release binaries are available for:
+
+- macOS Apple Silicon (`darwin-arm64`)
+- Linux `x86_64`
+- Linux `aarch64`
+
+## Build From Source
+
 ## Prerequisites
 
 - Rust `1.95.0` (stable toolchain baseline)

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Minimal example:
 
 ```toml
 [server]
-listen = "0.0.0.0:8080"
+listen = "127.0.0.1:8080"
 ```
 
 Then open `http://localhost:8080`.
@@ -44,19 +44,19 @@ Current release binaries are available for:
 
 ## Build From Source
 
-## Prerequisites
+### Prerequisites
 
 - Rust `1.95.0` (stable toolchain baseline)
 - Node.js 20+
 - Git
 
-## Install Web Dependencies
+### Install Web Dependencies
 
 ```bash
 npm --prefix web ci
 ```
 
-## Create A Minimal Config
+### Create A Minimal Config
 
 AgentHub reads configuration from `~/.agenthub/config.toml` by default.
 
@@ -78,7 +78,7 @@ default_root = "/home/you/.agenthub/worktrees"
 `safe_paths` should list the repository roots that users are allowed to use as
 agent workdirs.
 
-## Start AgentHub
+### Start AgentHub
 
 For the standard local workflow:
 
@@ -97,7 +97,7 @@ cargo run -- -c /path/to/config.toml
 
 By default, AgentHub serves the UI at `http://localhost:8080`.
 
-## ACP Provider Baseline
+### ACP Provider Baseline
 
 The default ACP adapter binary is `agenthub-codex-acp`.
 
@@ -105,7 +105,7 @@ The default ACP adapter binary is `agenthub-codex-acp`.
 - If you override `codex_acp.binary`, keep the replacement ACP binary protocol-
   compatible with the same Codex generation
 
-## Optional App Install
+### Optional App Install
 
 On supported browsers, AgentHub can be installed as a standalone web app.
 
@@ -117,7 +117,7 @@ On supported browsers, AgentHub can be installed as a standalone web app.
 For non-localhost deployments, use HTTPS if you want installability and browser
 push to work reliably.
 
-## Runtime Data Location
+### Runtime Data Location
 
 AgentHub stores runtime data under `~/.agenthub/` by default, including:
 
@@ -134,7 +134,7 @@ runtime skills under `~/.agents/skills/agenthub-runtime/...`.
 - Repo-local `.agents/skills` continue to work independently alongside the
   managed AgentHub skill set.
 
-## Smoke Check
+### Smoke Check
 
 After startup:
 


### PR DESCRIPTION
## Summary

- add a first-class Homebrew install path to the root README
- align userdocs installation guidance with the published tap and `brew services`
- clarify that `make run` remains the source-development workflow

## Testing

- `git diff --check`
