### PR TITLE
test(app): cover node startup boundaries

### DIFF
--- a/docs/journal/2026-04-26-node-startup-boundary-verification.md
+++ b/docs/journal/2026-04-26-node-startup-boundary-verification.md
@@ -1,0 +1,39 @@
+# Node Startup Boundary Verification
+
+## Summary
+
+- tightened focused Rust coverage around node-vs-main startup boundaries
+- confirmed the existing implementation already enforces the intended node-mode
+  contract; the missing gap was regression coverage, not a new runtime fix
+
+## Scope
+
+- `src/app.rs`
+- `src/state.rs`
+
+## What Was Added
+
+- `validate_startup_config_rejects_node_mode_without_node_id`
+- `setup_database_creates_root_user_for_main_role`
+- `setup_database_skips_root_user_for_node_role`
+- `initialize_services_enables_push_for_main_role`
+- `initialize_services_disables_push_for_node_role`
+
+These tests lock the most important startup boundaries:
+
+- node mode requires `internal_grpc.enabled = true`
+- node mode requires an explicit non-`main` `server.node_id`
+- node mode must not seed the root user
+- node mode must not initialize push/VAPID state
+- main mode keeps the existing root-user and push initialization behavior
+
+## Validation
+
+- `cargo test -p agenthub validate_startup_config_ -- --nocapture`
+- `cargo test -p agenthub state::tests::setup_database_ -- --nocapture`
+- `cargo test -p agenthub state::tests::initialize_services_ -- --nocapture`
+
+## Follow-up
+
+- This does not close the broader TODO by itself; push/PR CI evidence still
+  needs to be recorded before the TODO can be removed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -412,6 +412,31 @@ mod tests {
     }
 
     #[test]
+    fn validate_startup_config_rejects_node_mode_without_node_id() {
+        let config = AppConfig {
+            server: Some(ServerConfig {
+                listen: None,
+                role: Some(ServerRole::Node),
+                node_id: None,
+            }),
+            internal_grpc: Some(InternalGrpcConfig {
+                enabled: Some(true),
+                listen: Some("127.0.0.1:50051".to_string()),
+                security: None,
+                auth: None,
+                bootstrap: None,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            super::validate_startup_config(&config)
+                .expect_err("node mode should require explicit node id")
+                .to_string(),
+            "server.node_id is required when server.role = \"node\""
+        );
+    }
+
+    #[test]
     fn validate_startup_config_rejects_reserved_main_node_id() {
         let config = AppConfig {
             server: Some(ServerConfig {

--- a/src/state.rs
+++ b/src/state.rs
@@ -499,7 +499,14 @@ mod tests {
         std::fs::create_dir_all(&temp_home).expect("create temp home");
         let _home_guard = set_env_var("HOME", &temp_home);
         let _xdg_guard = clear_env_var("XDG_CONFIG_HOME");
-        let config = AppConfig::default();
+        let config = AppConfig {
+            server: Some(ServerConfig {
+                listen: None,
+                role: Some(ServerRole::Main),
+                node_id: None,
+            }),
+            ..Default::default()
+        };
 
         AppState::seed_safe_paths(&db, &config)
             .await
@@ -757,6 +764,11 @@ mod tests {
         let keys_path = temp_root.join("push").join("vapid.json");
         let event_dir = temp_root.join("agent-events");
         let config = AppConfig {
+            server: Some(ServerConfig {
+                listen: None,
+                role: Some(ServerRole::Main),
+                node_id: None,
+            }),
             push: Some(PushConfig {
                 subject: Some("mailto:test@example.com".to_string()),
                 keys_path: Some(keys_path.to_string_lossy().to_string()),
@@ -769,7 +781,10 @@ mod tests {
                 .await
                 .expect("initialize main services");
 
-        assert!(push.is_enabled(), "main startup should enable push notifications");
+        assert!(
+            push.is_enabled(),
+            "main startup should enable push notifications"
+        );
         assert!(
             keys_path.exists(),
             "main startup should materialize VAPID keys at {}",

--- a/src/state.rs
+++ b/src/state.rs
@@ -672,6 +672,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn setup_database_creates_root_user_for_main_role() {
+        let _guard = ENV_LOCK.lock().await;
+        let temp_home = std::env::temp_dir().join(format!("agenthub-home-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_home).expect("create temp home");
+        let _home_guard = set_env_var("HOME", &temp_home);
+
+        let config = AppConfig::default();
+
+        let db = AppState::setup_database(&config)
+            .await
+            .expect("setup main database");
+
+        let row = sqlx::query("SELECT COUNT(*) AS cnt FROM users WHERE role = 'root'")
+            .fetch_one(&db)
+            .await
+            .expect("count root users");
+        let count: i64 = row.get("cnt");
+        assert_eq!(count, 1, "main startup should create a root user");
+
+        db.close().await;
+        let _ = std::fs::remove_dir_all(&temp_home);
+    }
+
+    #[tokio::test]
     async fn initialize_services_disables_push_for_node_role() {
         let db = test_db().await;
         let temp_root =
@@ -719,6 +743,36 @@ mod tests {
         assert!(
             !keys_path.exists(),
             "node startup should not create VAPID keys at {}",
+            keys_path.display()
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
+    #[tokio::test]
+    async fn initialize_services_enables_push_for_main_role() {
+        let db = test_db().await;
+        let temp_root =
+            std::env::temp_dir().join(format!("agenthub-main-startup-{}", Uuid::new_v4()));
+        let keys_path = temp_root.join("push").join("vapid.json");
+        let event_dir = temp_root.join("agent-events");
+        let config = AppConfig {
+            push: Some(PushConfig {
+                subject: Some("mailto:test@example.com".to_string()),
+                keys_path: Some(keys_path.to_string_lossy().to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let (_, _, push, _, _) =
+            AppState::initialize_services(&config, db, AgentEventDbRouter::new(event_dir))
+                .await
+                .expect("initialize main services");
+
+        assert!(push.is_enabled(), "main startup should enable push notifications");
+        assert!(
+            keys_path.exists(),
+            "main startup should materialize VAPID keys at {}",
             keys_path.display()
         );
 


### PR DESCRIPTION
## Summary

- add focused Rust tests for node-vs-main startup boundaries
- document the verification slice in a dated journal entry
- lock the current startup contract instead of changing runtime behavior

## What changed

- `src/app.rs`
  - add coverage for missing `server.node_id` in node mode
- `src/state.rs`
  - cover root-user creation in main mode
  - cover push/VAPID initialization in main mode
  - keep the existing node-mode skip behavior covered alongside main-mode expectations
- `docs/journal/2026-04-26-node-startup-boundary-verification.md`
  - record scope, validation commands, and follow-up boundary

## Validation

- `cargo test -p agenthub validate_startup_config_ -- --nocapture`
- `cargo test -p agenthub state::tests::setup_database_ -- --nocapture`
- `cargo test -p agenthub state::tests::initialize_services_ -- --nocapture`
- `cargo check -p agenthub`
- `git diff --check`

## Notes

- This slice is intentionally narrow and test-first.
- The current implementation already matched the intended node-startup contract; this PR hardens it with regression coverage and recorded verification.
