### PR TITLE
fix(team): align mailbox inbox HTTP response

### DIFF
--- a/docs/journal/2026-04-02-actor-receive-readonly-inbox.md
+++ b/docs/journal/2026-04-02-actor-receive-readonly-inbox.md
@@ -23,3 +23,16 @@
 - `cargo test -p agenthub actor_output_preference_contract_covers_all_command_variants -- --nocapture`
 - `cargo test -p agenthub teams_router_http_contract -- --nocapture`
 - `cargo test -p agenthub-team-actor send_and_ack_emit_expected_events -- --nocapture`
+
+## 2026-04-26 Follow-up
+
+- aligned `GET /api/teams/runs/:run_id/messages/inbox` with the mailbox inbox
+  envelope instead of returning a bare message array
+- the HTTP inbox route now preserves:
+  - `messages`
+  - `next_cursor`
+  - `pending_count`
+- this keeps the Team HTTP path consistent with the CLI/runtime mailbox
+  contract:
+  - `actor inbox` remains read-only and exposes unread count
+  - `actor receive` remains the accept-and-consume path

--- a/src/api/openapi/spec.rs
+++ b/src/api/openapi/spec.rs
@@ -855,8 +855,22 @@ pub(super) fn openapi_spec() -> Value {
                 "content": {
                   "application/json": {
                     "schema": {
-                      "type": "array",
-                      "items": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+                      "type": "object",
+                      "required": ["messages", "pending_count"],
+                      "properties": {
+                        "messages": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/TeamActorMessageRecord" }
+                        },
+                        "next_cursor": {
+                          "type": ["integer", "null"],
+                          "format": "int64"
+                        },
+                        "pending_count": {
+                          "type": "integer",
+                          "format": "int64"
+                        }
+                      }
                     }
                   }
                 }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1712,7 +1712,6 @@ async fn list_team_run_inbox(
     let service = state.teams.actor_mailbox_service();
     let mut messages = Vec::new();
     let mut pending_count = 0_i64;
-    let mut next_cursor: Option<i64> = None;
     for actor_id in actor_ids {
         let response = service
             .actor_inbox(ActorInboxRequest {
@@ -1725,11 +1724,6 @@ async fn list_team_run_inbox(
             .await
             .map_err(map_actor_service_api_error)?;
         pending_count += response.pending_count;
-        next_cursor = match (next_cursor, response.next_cursor) {
-            (Some(existing), Some(candidate)) => Some(existing.min(candidate)),
-            (None, candidate) => candidate,
-            (existing, None) => existing,
-        };
         messages.extend(response.messages);
     }
     messages.sort_by_key(|message| message.message_id);
@@ -1737,6 +1731,7 @@ async fn list_team_run_inbox(
     if messages.len() > limit as usize {
         messages.truncate(limit as usize);
     }
+    let next_cursor = messages.last().map(|message| message.message_id);
     Ok(Json(TeamRunInboxResponse {
         messages,
         next_cursor,

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -296,6 +296,13 @@ pub struct ListTeamRunInboxQuery {
     pub include_delivered: Option<bool>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct TeamRunInboxResponse {
+    pub messages: Vec<TeamActorMessageRecord>,
+    pub next_cursor: Option<i64>,
+    pub pending_count: i64,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct FlushTeamRunContextRequest {
     pub member_id: String,
@@ -1687,7 +1694,7 @@ async fn list_team_run_inbox(
     headers: HeaderMap,
     Path(run_id): Path<String>,
     Query(query): Query<ListTeamRunInboxQuery>,
-) -> Result<Json<Vec<TeamActorMessageRecord>>, ApiError> {
+) -> Result<Json<TeamRunInboxResponse>, ApiError> {
     let user = require_user(&headers, &state).await?;
     let (_run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
     let actor_ids =
@@ -1704,8 +1711,10 @@ async fn list_team_run_inbox(
     };
     let service = state.teams.actor_mailbox_service();
     let mut messages = Vec::new();
+    let mut pending_count = 0_i64;
+    let mut next_cursor: Option<i64> = None;
     for actor_id in actor_ids {
-        let actor_messages = service
+        let response = service
             .actor_inbox(ActorInboxRequest {
                 run_id: run_id.clone(),
                 actor_id,
@@ -1714,16 +1723,25 @@ async fn list_team_run_inbox(
                 states: states.clone(),
             })
             .await
-            .map_err(map_actor_service_api_error)?
-            .messages;
-        messages.extend(actor_messages);
+            .map_err(map_actor_service_api_error)?;
+        pending_count += response.pending_count;
+        next_cursor = match (next_cursor, response.next_cursor) {
+            (Some(existing), Some(candidate)) => Some(existing.min(candidate)),
+            (None, candidate) => candidate,
+            (existing, None) => existing,
+        };
+        messages.extend(response.messages);
     }
     messages.sort_by_key(|message| message.message_id);
     messages.dedup_by_key(|message| message.message_id);
     if messages.len() > limit as usize {
         messages.truncate(limit as usize);
     }
-    Ok(Json(messages))
+    Ok(Json(TeamRunInboxResponse {
+        messages,
+        next_cursor,
+        pending_count,
+    }))
 }
 
 async fn ack_team_run_message(

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -3184,8 +3184,9 @@ async fn team_run_messages_api_supports_actor_mailbox_flow() {
     )
     .await
     .expect("list inbox");
-    assert_eq!(inbox.len(), 1);
-    assert_eq!(inbox[0].message_id, local_message.message_id);
+    assert_eq!(inbox.pending_count, 1);
+    assert_eq!(inbox.messages.len(), 1);
+    assert_eq!(inbox.messages[0].message_id, local_message.message_id);
 
     let Json(acked) = ack_team_run_message(
         State(state.clone()),
@@ -3212,7 +3213,8 @@ async fn team_run_messages_api_supports_actor_mailbox_flow() {
     )
     .await
     .expect("list pending after ack");
-    assert!(pending_after_ack.is_empty());
+    assert_eq!(pending_after_ack.pending_count, 0);
+    assert!(pending_after_ack.messages.is_empty());
 
     let Json(inbox_with_delivered) = list_team_run_inbox(
         State(state.clone()),
@@ -3227,9 +3229,10 @@ async fn team_run_messages_api_supports_actor_mailbox_flow() {
     )
     .await
     .expect("list inbox include delivered");
-    assert_eq!(inbox_with_delivered.len(), 1);
+    assert_eq!(inbox_with_delivered.pending_count, 0);
+    assert_eq!(inbox_with_delivered.messages.len(), 1);
     assert_eq!(
-        inbox_with_delivered[0].status,
+        inbox_with_delivered.messages[0].status,
         crate::team::TeamActorMessageStatus::Delivered
     );
 
@@ -3373,9 +3376,10 @@ async fn team_run_messages_api_supports_human_actor_list_and_ack_fallback() {
     )
     .await
     .expect("list inbox by user alias");
-    assert_eq!(inbox_by_alias.len(), 2);
-    assert_eq!(inbox_by_alias[0].message_id, alias_message_id);
-    assert_eq!(inbox_by_alias[1].message_id, canonical_message_id);
+    assert_eq!(inbox_by_alias.pending_count, 2);
+    assert_eq!(inbox_by_alias.messages.len(), 2);
+    assert_eq!(inbox_by_alias.messages[0].message_id, alias_message_id);
+    assert_eq!(inbox_by_alias.messages[1].message_id, canonical_message_id);
 
     let Json(inbox_by_canonical) = list_team_run_inbox(
         State(state.clone()),
@@ -3390,9 +3394,11 @@ async fn team_run_messages_api_supports_human_actor_list_and_ack_fallback() {
     )
     .await
     .expect("list inbox by canonical user actor id");
-    assert_eq!(inbox_by_canonical.len(), 2);
+    assert_eq!(inbox_by_canonical.pending_count, 2);
+    assert_eq!(inbox_by_canonical.messages.len(), 2);
     assert!(
         inbox_by_canonical
+            .messages
             .iter()
             .all(|message| message.status == crate::team::TeamActorMessageStatus::Pending)
     );
@@ -3440,9 +3446,11 @@ async fn team_run_messages_api_supports_human_actor_list_and_ack_fallback() {
     )
     .await
     .expect("list delivered by alias actor id");
-    assert_eq!(inbox_with_delivered.len(), 2);
+    assert_eq!(inbox_with_delivered.pending_count, 0);
+    assert_eq!(inbox_with_delivered.messages.len(), 2);
     assert!(
         inbox_with_delivered
+            .messages
             .iter()
             .all(|message| message.status == crate::team::TeamActorMessageStatus::Delivered)
     );

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -969,6 +969,53 @@ async fn teams_router_http_contract() {
     assert!(message_ids.contains(&local_message_id));
     assert!(message_ids.contains(&idempotent_message_id));
 
+    let paged_inbox_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!("/runs/{message_run_id}/messages/inbox?actor_id=planner&limit=1"),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("list paged actor inbox via router");
+    assert_eq!(paged_inbox_resp.status(), StatusCode::OK);
+    let paged_inbox = decode_json_body(paged_inbox_resp).await;
+    let paged_messages = paged_inbox["messages"]
+        .as_array()
+        .expect("paged inbox messages array");
+    assert_eq!(paged_messages.len(), 1);
+    assert_eq!(
+        paged_inbox["next_cursor"],
+        paged_messages[0]["message_id"],
+        "next_cursor should track the last returned message after truncation"
+    );
+
+    let paged_after_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::GET,
+            &format!(
+                "/runs/{message_run_id}/messages/inbox?actor_id=planner&limit=1&after_id={}",
+                paged_inbox["next_cursor"].as_i64().expect("paged cursor")
+            ),
+            Some(&token),
+            None,
+        ))
+        .await
+        .expect("list paged actor inbox after cursor via router");
+    assert_eq!(paged_after_resp.status(), StatusCode::OK);
+    let paged_after = decode_json_body(paged_after_resp).await;
+    let paged_after_messages = paged_after["messages"]
+        .as_array()
+        .expect("paged inbox messages array after cursor");
+    assert_eq!(paged_after_messages.len(), 1);
+    assert_ne!(
+        paged_after_messages[0]["message_id"],
+        paged_messages[0]["message_id"],
+        "cursor follow-up should not skip to an empty page or repeat the same message"
+    );
+
     let ack_local_message_resp = app
         .clone()
         .oneshot(build_json_request(

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -956,9 +956,10 @@ async fn teams_router_http_contract() {
         .expect("list actor inbox via router");
     assert_eq!(list_inbox_resp.status(), StatusCode::OK);
     let inbox = decode_json_body(list_inbox_resp).await;
-    let inbox = inbox.as_array().expect("inbox array");
+    assert_eq!(inbox["pending_count"], Value::from(2));
+    let inbox = inbox["messages"].as_array().expect("inbox messages array");
     assert_eq!(inbox.len(), 2);
-    for message in inbox.iter() {
+    for message in inbox {
         assert_eq!(message["status"], "pending");
     }
     let message_ids = inbox

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -244,6 +244,12 @@ export type TeamActorMessageTransport = "local" | "remote";
 export type TeamActorMessageStatus = "pending" | "delivered" | "dead_letter";
 export type TeamActorIdentityKind = "agent" | "human";
 
+export type TeamRunInboxRecord = {
+  messages: TeamActorMessageRecord[];
+  next_cursor?: number | null;
+  pending_count: number;
+};
+
 export type TeamDefinitionRecord = {
   id: string;
   name: string;
@@ -1123,7 +1129,7 @@ export const api = {
         payload.include_delivered ? "true" : "false"
       );
     }
-    return apiFetch<TeamActorMessageRecord[]>(
+    return apiFetch<TeamRunInboxRecord>(
       `/api/teams/runs/${encodePathSegment(runId)}/messages/inbox?${params.toString()}`,
       token
     );

--- a/web/src/pages/team/use_team_actions.test.tsx
+++ b/web/src/pages/team/use_team_actions.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
   TeamActorMessageRecord,
+  TeamRunInboxRecord,
   TeamRunEventRecord,
   TeamRunRecord,
   TeamStepRecord,
@@ -268,6 +269,68 @@ describe("useTeamActions", () => {
       expect(rerendered.refreshSnapshot).not.toBe(initial.refreshSnapshot);
       expect(rerendered.onCreateRun).not.toBe(initial.onCreateRun);
     } finally {
+      cleanupHarness(root, container);
+    }
+  });
+
+  it("unwraps inbox messages from the Team inbox envelope", async () => {
+    const captures: TeamActions[] = [];
+    const onCapture = (actions: TeamActions) => {
+      captures.push(actions);
+    };
+    const setInbox = vi.fn<(next: TeamActorMessageRecord[]) => void>();
+    const inboxResponse: TeamRunInboxRecord = {
+      messages: [
+        {
+          message_id: 41,
+          run_id: "run-1",
+          from_actor_id: "leader",
+          from_actor_kind: "agent",
+          from_peer_id: "main",
+          to_actor_id: "worker-1",
+          to_actor_kind: "agent",
+          to_peer_id: "main",
+          channel: "coordination",
+          transport: "local",
+          route: null,
+          payload: { text: "please verify" },
+          status: "pending",
+          created_at: 1,
+          delivered_at: null,
+        },
+      ],
+      next_cursor: 41,
+      pending_count: 1,
+    };
+    const listInboxSpy = vi
+      .spyOn(api, "listTeamRunInbox")
+      .mockResolvedValue(inboxResponse);
+
+    const options = createBaseOptions({
+      token: "token-1",
+      activeRunIdForSelectedTeam: "run-1",
+      inboxActorId: "worker-1",
+      setInbox,
+    });
+
+    const { root, container } = await mountHarness(options, onCapture);
+    try {
+      const actions = captures[captures.length - 1];
+      expect(actions).toBeDefined();
+
+      await act(async () => {
+        await actions.loadInbox();
+      });
+
+      expect(listInboxSpy).toHaveBeenCalledWith("token-1", "run-1", {
+        actor_id: "worker-1",
+        limit: 50,
+        after_id: undefined,
+        include_delivered: false,
+      });
+      expect(setInbox).toHaveBeenCalledWith(inboxResponse.messages);
+    } finally {
+      listInboxSpy.mockRestore();
       cleanupHarness(root, container);
     }
   });

--- a/web/src/pages/team/use_team_actions.ts
+++ b/web/src/pages/team/use_team_actions.ts
@@ -14,6 +14,7 @@ import {
   type TeamActorMessageRecord,
   type TeamDefinitionRecord,
   type TeamMemberSnapshot,
+  type TeamRunInboxRecord,
   type TeamRunEventRecord,
   type TeamRunRecord,
   type TeamRunSnapshotRecord,
@@ -125,7 +126,7 @@ type TeamApiClient = {
       after_id?: number;
       include_delivered?: boolean;
     }
-  ) => Promise<TeamActorMessageRecord[]>;
+  ) => Promise<TeamRunInboxRecord>;
   listAgentEvents: (
     memberAgentId: string,
     limit: number,
@@ -409,13 +410,13 @@ export function useTeamActions(options: UseTeamActionsOptions) {
       }
       const limit = parseOptionalInteger(currentInboxLimit, "Inbox limit") ?? 100;
       const afterId = parseOptionalInteger(currentInboxAfterId, "Inbox after_id");
-      const list = await teamApi.listTeamRunInbox(runId, {
+      const inbox = await teamApi.listTeamRunInbox(runId, {
         actor_id: actorId,
         limit,
         after_id: afterId,
         include_delivered: includeDelivered,
       });
-      setInbox(list);
+      setInbox(inbox.messages);
     },
     [setInbox, teamApi]
   );


### PR DESCRIPTION
## Summary

- align the Team HTTP inbox API with the mailbox inbox envelope
- preserve `pending_count` and `next_cursor` on the read-only HTTP path
- keep `actor receive` as the accept-and-consume boundary while `actor inbox` stays read-only

## What changed

- `src/api/teams.rs`
  - return a structured inbox response instead of a bare message array
  - aggregate `pending_count` and `next_cursor` across the resolved actor ids
- `src/api/teams/tests_core.rs`
  - lock read-only inbox behavior and alias/canonical human actor handling under the new envelope
- `src/api/teams/tests_router.rs`
  - update router contract coverage for the inbox response shape
- `src/api/openapi/spec.rs`
  - document the structured inbox response in OpenAPI
- `docs/journal/2026-04-02-actor-receive-readonly-inbox.md`
  - record the follow-up contract alignment

## Validation

- `cargo fmt --all --check`
- `cargo check -p agenthub`
- `cargo test -p agenthub teams_router_http_contract -- --nocapture`
- `cargo test -p agenthub team_run_messages_api_supports_actor_mailbox_flow -- --nocapture`
- `cargo test -p agenthub team_run_messages_api_supports_human_actor_list_and_ack_fallback -- --nocapture`

## Notes

- This PR intentionally keeps the semantic split narrow:
  - `actor inbox` / `GET .../messages/inbox` are read-only inspection paths
  - `actor receive` remains the accept-and-consume path
