### PR TITLE
fix(acp): upgrade codex to v0.125.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -718,7 +718,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1037,6 +1037,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1102,310 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1417,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1104,7 +1450,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1152,6 +1498,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1347,6 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1379,6 +1736,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytestring"
@@ -1663,6 +2030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,13 +2071,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-agent-identity"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "chrono",
+ "codex-protocol",
+ "crypto_box",
+ "ed25519-dalek",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "codex-analytics"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
  "codex-plugin",
  "codex-protocol",
  "os_info",
@@ -1714,8 +2109,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1743,8 +2138,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1753,6 +2148,7 @@ dependencies = [
  "chrono",
  "clap",
  "codex-analytics",
+ "codex-api",
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-backend-client",
@@ -1761,6 +2157,7 @@ dependencies = [
  "codex-config",
  "codex-core",
  "codex-core-plugins",
+ "codex-device-key",
  "codex-exec-server",
  "codex-features",
  "codex-feedback",
@@ -1768,6 +2165,7 @@ dependencies = [
  "codex-git-utils",
  "codex-login",
  "codex-mcp",
+ "codex-model-provider",
  "codex-models-manager",
  "codex-otel",
  "codex-protocol",
@@ -1778,6 +2176,7 @@ dependencies = [
  "codex-state",
  "codex-thread-store",
  "codex-tools",
+ "codex-uds",
  "codex-utils-absolute-path",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
@@ -1793,11 +2192,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1806,12 +2207,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
  "codex-arg0",
+ "codex-config",
  "codex-core",
  "codex-exec-server",
  "codex-feedback",
@@ -1829,8 +2231,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1853,8 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1868,8 +2270,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1886,8 +2288,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1895,14 +2297,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-aws-auth"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-types",
+ "bytes",
+ "http 1.4.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codex-backend-client"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
+ "codex-api",
  "codex-backend-openapi-models",
  "codex-client",
  "codex-login",
+ "codex-model-provider",
  "codex-protocol",
  "reqwest 0.12.28",
  "serde",
@@ -1911,8 +2329,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1921,17 +2339,17 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "clap",
  "codex-app-server-protocol",
- "codex-config",
  "codex-connectors",
  "codex-core",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
  "codex-utils-cli",
  "serde",
  "tokio",
@@ -1939,8 +2357,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1965,8 +2383,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1989,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2006,15 +2424,16 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 
 [[package]]
 name = "codex-config"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
+ "async-trait",
  "codex-app-server-protocol",
  "codex-execpolicy",
  "codex-features",
@@ -2023,8 +2442,12 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-path",
+ "dns-lookup",
  "futures",
+ "gethostname",
+ "libc",
  "multimap",
+ "prost",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2034,14 +2457,17 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "toml_edit 0.24.1+spec-1.1.0",
+ "tonic",
+ "tonic-prost",
  "tracing",
  "wildmatch",
+ "winapi-util",
 ]
 
 [[package]]
 name = "codex-connectors"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2051,8 +2477,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2078,7 +2504,6 @@ dependencies = [
  "codex-feedback",
  "codex-git-utils",
  "codex-hooks",
- "codex-instructions",
  "codex-login",
  "codex-mcp",
  "codex-model-provider",
@@ -2091,6 +2516,7 @@ dependencies = [
  "codex-response-debug-context",
  "codex-rmcp-client",
  "codex-rollout",
+ "codex-rollout-trace",
  "codex-sandboxing",
  "codex-secrets",
  "codex-shell-command",
@@ -2113,11 +2539,9 @@ dependencies = [
  "codex-utils-template",
  "codex-windows-sandbox",
  "core-foundation 0.9.4",
- "crypto_box",
  "csv",
  "dirs",
  "dunce",
- "ed25519-dalek",
  "env-flags",
  "eventsource-stream",
  "futures",
@@ -2136,11 +2560,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.10.9",
  "shlex",
  "similar",
  "tempfile",
- "test-log",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -2153,13 +2575,12 @@ dependencies = [
  "which 8.0.2",
  "whoami",
  "windows-sys 0.52.0",
- "zip",
 ]
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -2168,6 +2589,8 @@ dependencies = [
  "codex-exec-server",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
+ "codex-otel",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
@@ -2182,20 +2605,21 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
+ "zip",
 ]
 
 [[package]]
 name = "codex-core-skills"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-analytics",
  "codex-app-server-protocol",
  "codex-config",
  "codex-exec-server",
- "codex-instructions",
  "codex-login",
+ "codex-model-provider",
  "codex-otel",
  "codex-protocol",
  "codex-skills",
@@ -2215,33 +2639,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-device-key"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "p256",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "codex-exec-server"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "arc-swap",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "codex-app-server-protocol",
+ "codex-client",
  "codex-config",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
  "codex-utils-pty",
  "futures",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "tokio-util",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2256,8 +2700,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2266,8 +2710,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2279,8 +2723,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -2292,8 +2736,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2307,17 +2751,21 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
+ "anyhow",
+ "chrono",
  "codex-exec-server",
  "codex-protocol",
  "codex-utils-absolute-path",
  "futures",
+ "gix",
  "once_cell",
  "regex",
  "schemars 0.8.22",
  "serde",
+ "similar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2327,8 +2775,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2344,18 +2792,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-instructions"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
-dependencies = [
- "codex-protocol",
- "serde",
-]
-
-[[package]]
 name = "codex-keyring-store"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "keyring",
  "tracing",
@@ -2363,8 +2802,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "cc",
  "clap",
@@ -2383,13 +2822,13 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "codex-agent-identity",
  "codex-app-server-protocol",
  "codex-client",
  "codex-config",
@@ -2399,7 +2838,6 @@ dependencies = [
  "codex-protocol",
  "codex-terminal-detection",
  "codex-utils-template",
- "ed25519-dalek",
  "once_cell",
  "os_info",
  "rand 0.9.4",
@@ -2418,15 +2856,17 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "async-channel",
+ "codex-api",
  "codex-async-utils",
  "codex-config",
  "codex-exec-server",
  "codex-login",
+ "codex-model-provider",
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
@@ -2447,8 +2887,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2473,21 +2913,30 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
+ "codex-agent-identity",
  "codex-api",
+ "codex-aws-auth",
+ "codex-client",
+ "codex-feedback",
  "codex-login",
  "codex-model-provider-info",
+ "codex-models-manager",
+ "codex-otel",
  "codex-protocol",
+ "codex-response-debug-context",
  "http 1.4.0",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2499,24 +2948,18 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
+ "async-trait",
  "chrono",
- "codex-api",
  "codex-app-server-protocol",
  "codex-collaboration-mode-templates",
- "codex-config",
- "codex-feedback",
  "codex-login",
- "codex-model-provider",
- "codex-model-provider-info",
  "codex-otel",
  "codex-protocol",
- "codex-response-debug-context",
  "codex-utils-output-truncation",
  "codex-utils-template",
- "http 1.4.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2525,8 +2968,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2555,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2587,8 +3030,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-plugins",
@@ -2597,8 +3040,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2634,8 +3077,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2645,11 +3088,13 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "axum",
+ "bytes",
+ "codex-api",
  "codex-client",
  "codex-config",
  "codex-exec-server",
@@ -2677,8 +3122,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2700,9 +3145,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-rollout-trace"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
+dependencies = [
+ "anyhow",
+ "codex-code-mode",
+ "codex-protocol",
+ "serde",
+ "serde_json",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "codex-sandboxing"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -2718,8 +3177,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "age",
  "anyhow",
@@ -2737,8 +3196,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -2756,8 +3215,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2776,8 +3235,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -2786,8 +3245,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2808,16 +3267,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2829,14 +3288,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-prost",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
@@ -2851,9 +3312,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-uds"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
+dependencies = [
+ "async-io",
+ "tokio",
+ "tokio-util",
+ "uds_windows",
+]
+
+[[package]]
 name = "codex-utils-absolute-path"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "dirs",
  "dunce",
@@ -2864,16 +3336,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "lru",
  "sha1",
@@ -2882,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -2893,8 +3365,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2902,8 +3374,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2915,8 +3387,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -2924,8 +3396,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2933,8 +3405,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2943,8 +3415,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -2955,8 +3427,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -2971,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -2982,34 +3454,34 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "regex-lite",
 ]
 
 [[package]]
 name = "codex-utils-template"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.122.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8dd355d192ddf148ab2d97c9ba89223739cfdd18#8dd355d192ddf148ab2d97c9ba89223739cfdd18"
+version = "0.125.0"
+source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3161,12 +3633,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -3567,6 +4068,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,7 +4393,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3921,6 +4436,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.6.3",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -4139,27 +4675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfd0e7fc632dec5e6c9396a27bc9f9975b4e039720e1fd3e34021d3ce28c415"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,7 +4716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4260,6 +4775,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,6 +4838,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -4772,6 +5308,861 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "gix"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-blame",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2 0.9.10",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc99523b8bf32561b9abf72c878fbff3854d806ed46c1198e57899f9f3c7f05"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "imara-diff 0.2.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c998bf10447f0797e579567382b5e22a19c22435d2df091e25857728c6d9af8d"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2 0.9.10",
+ "rustix 1.1.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2 0.9.10",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2 0.9.10",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +6229,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4915,6 +6315,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.4.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5075,6 +6485,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -5092,7 +6513,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -5135,7 +6556,7 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -5202,7 +6623,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -5532,6 +6953,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5653,6 +7093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "io_tee"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5695,7 +7145,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5774,6 +7224,47 @@ name = "ixdtf"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -5990,6 +7481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6181,6 +7681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "local-waker"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6326,6 +7832,17 @@ name = "matchit"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "md-5"
@@ -6601,6 +8118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6633,7 +8156,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7190,6 +8713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +9041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7662,6 +9200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,6 +9354,16 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
 
 [[package]]
 name = "pulldown-cmark"
@@ -8124,7 +9681,7 @@ dependencies = [
  "const_format",
  "fnv",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "memchr",
@@ -8506,13 +10063,15 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -8559,7 +10118,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -8645,7 +10204,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "oauth2",
  "pastey 0.2.1",
@@ -8840,7 +10399,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8899,7 +10458,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9537,6 +11096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9714,7 +11283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9955,7 +11524,7 @@ checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
 dependencies = [
  "bytes",
  "futures-util",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
 ]
@@ -10332,7 +11901,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10395,39 +11964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
-dependencies = [
- "env_logger",
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-core"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
-dependencies = [
- "syn 2.0.117",
- "test-log-core",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10814,7 +12351,7 @@ dependencies = [
  "bytes",
  "h2",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -10915,7 +12452,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -11177,7 +12714,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11225,6 +12762,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
@@ -11412,6 +12955,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "waker-fn"
@@ -11813,7 +13362,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12505,6 +14054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12732,6 +14287,12 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -27,23 +27,23 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-config = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-core = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-features = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-login = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "8dd355d192ddf148ab2d97c9ba89223739cfdd18" }
+codex-apply-patch = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-config = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-app-server-client = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-core = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-exec-server = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-features = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-feedback = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-mcp-server = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-login = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-models-manager = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-shell-command = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -24,7 +24,6 @@ use codex_app_server_protocol::{
 use codex_arg0::Arg0DispatchPaths;
 use codex_core::config::Config;
 use codex_core::config_loader::{CloudRequirementsLoader, LoaderOverrides};
-use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::approvals::{
@@ -59,6 +58,7 @@ use codex_shell_command::parse_command::parse_command;
 use tokio::sync::Mutex;
 use tracing::warn;
 
+use crate::build_environment_manager;
 use crate::thread::CodexThreadImpl;
 
 const ACP_CLIENT_NAME: &str = "agenthub-codex-acp";
@@ -916,16 +916,9 @@ impl AppServerCodexThread {
 
                 Ok(Some(Event {
                     id: submission_id,
-                    msg: EventMsg::RequestPermissions(RequestPermissionsEvent {
-                        call_id: params.item_id,
-                        turn_id: params.turn_id,
-                        reason: params.reason,
-                        permissions: RequestPermissionProfile {
-                            network: params.permissions.network.map(Into::into),
-                            file_system: params.permissions.file_system.map(Into::into),
-                        },
-                        cwd: None,
-                    }),
+                    msg: EventMsg::RequestPermissions(permissions_request_event_from_params(
+                        params,
+                    )),
                 }))
             }
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
@@ -1020,9 +1013,24 @@ impl AppServerCodexThread {
                     }),
                 }))
             }
-            ServerNotification::FileChangePatchUpdated(_)
-            | ServerNotification::ModelVerification(_)
-            | ServerNotification::GuardianWarning(_) => Ok(None),
+            ServerNotification::FileChangePatchUpdated(payload) => {
+                let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
+                Ok(submission_id.map(|id| Event {
+                    id,
+                    msg: EventMsg::PatchApplyUpdated(file_change_patch_updated_to_core(payload)),
+                }))
+            }
+            ServerNotification::ModelVerification(payload) => {
+                let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
+                Ok(submission_id.map(|id| Event {
+                    id,
+                    msg: EventMsg::ModelVerification(model_verification_to_core(payload)),
+                }))
+            }
+            ServerNotification::GuardianWarning(payload) => Ok(Some(Event {
+                id: payload.thread_id.clone(),
+                msg: EventMsg::GuardianWarning(guardian_warning_to_core(payload)),
+            })),
             ServerNotification::TurnStarted(payload) => {
                 let (submission_id, interrupt_request) = {
                     let mut state = self.state.lock().await;
@@ -2599,11 +2607,6 @@ fn app_server_web_search_action_to_core(
 }
 
 async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error> {
-    let runtime_paths = ExecServerRuntimePaths::from_optional_paths(
-        std::env::current_exe().ok(),
-        config.codex_linux_sandbox_exe.clone(),
-    )
-    .map_err(|err| Error::internal_error().data(err.to_string()))?;
     InProcessAppServerClient::start(InProcessClientStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
         config: Arc::new(config.clone()),
@@ -2612,9 +2615,7 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
         cloud_requirements: CloudRequirementsLoader::default(),
         feedback: CodexFeedback::new(),
         log_db: None,
-        environment_manager: Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
-            runtime_paths,
-        ))),
+        environment_manager: build_environment_manager(config)?,
         config_warnings: Vec::new(),
         session_source: codex_protocol::protocol::SessionSource::Unknown,
         enable_codex_api_key_env: false,
@@ -2626,6 +2627,86 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
     })
     .await
     .map_err(|err| Error::internal_error().data(err.to_string()))
+}
+
+fn permissions_request_event_from_params(
+    params: codex_app_server_protocol::PermissionsRequestApprovalParams,
+) -> RequestPermissionsEvent {
+    RequestPermissionsEvent {
+        call_id: params.item_id,
+        turn_id: params.turn_id,
+        reason: params.reason,
+        permissions: RequestPermissionProfile {
+            network: params.permissions.network.map(Into::into),
+            file_system: params.permissions.file_system.map(Into::into),
+        },
+        cwd: Some(params.cwd),
+    }
+}
+
+fn file_change_patch_updated_to_core(
+    payload: codex_app_server_protocol::FileChangePatchUpdatedNotification,
+) -> codex_protocol::protocol::PatchApplyUpdatedEvent {
+    codex_protocol::protocol::PatchApplyUpdatedEvent {
+        call_id: payload.item_id,
+        changes: payload
+            .changes
+            .into_iter()
+            .map(|change| {
+                (
+                    PathBuf::from(change.path.clone()),
+                    file_update_change_to_core(change),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn file_update_change_to_core(
+    change: codex_app_server_protocol::FileUpdateChange,
+) -> codex_protocol::protocol::FileChange {
+    match change.kind {
+        codex_app_server_protocol::PatchChangeKind::Add => {
+            codex_protocol::protocol::FileChange::Add {
+                content: change.diff,
+            }
+        }
+        codex_app_server_protocol::PatchChangeKind::Delete => {
+            codex_protocol::protocol::FileChange::Delete {
+                content: change.diff,
+            }
+        }
+        codex_app_server_protocol::PatchChangeKind::Update { move_path } => {
+            codex_protocol::protocol::FileChange::Update {
+                unified_diff: change.diff,
+                move_path,
+            }
+        }
+    }
+}
+
+fn guardian_warning_to_core(
+    payload: codex_app_server_protocol::GuardianWarningNotification,
+) -> codex_protocol::protocol::WarningEvent {
+    codex_protocol::protocol::WarningEvent {
+        message: payload.message,
+    }
+}
+
+fn model_verification_to_core(
+    payload: codex_app_server_protocol::ModelVerificationNotification,
+) -> codex_protocol::protocol::ModelVerificationEvent {
+    codex_protocol::protocol::ModelVerificationEvent {
+        verifications: payload
+            .verifications
+            .into_iter()
+            .map(|verification| match verification {
+                codex_app_server_protocol::ModelVerification::TrustedAccessForCyber => {
+                    codex_protocol::protocol::ModelVerification::TrustedAccessForCyber
+                }
+            })
+            .collect(),
+    }
 }
 
 fn thread_start_params_from_config(config: &Config) -> ThreadStartParams {
@@ -2985,6 +3066,87 @@ mod tests {
                 .expect("question answer")
                 .answers,
             vec!["approved".to_string()]
+        );
+    }
+
+    #[test]
+    fn permissions_request_event_preserves_cwd() {
+        let cwd = AbsolutePathBuf::try_from(std::env::temp_dir()).expect("valid temp dir");
+        let event = permissions_request_event_from_params(
+            codex_app_server_protocol::PermissionsRequestApprovalParams {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                item_id: "call-1".to_string(),
+                cwd: cwd.clone(),
+                reason: Some("need write access".to_string()),
+                permissions: codex_app_server_protocol::RequestPermissionProfile {
+                    network: Some(codex_app_server_protocol::AdditionalNetworkPermissions::Enabled),
+                    file_system: None,
+                },
+            },
+        );
+
+        assert_eq!(event.call_id, "call-1");
+        assert_eq!(event.turn_id, "turn-1");
+        assert_eq!(event.cwd, Some(cwd));
+        assert_eq!(event.reason.as_deref(), Some("need write access"));
+        assert_eq!(
+            event.permissions.network,
+            Some(codex_protocol::config_types::NetworkPermissions::Enabled)
+        );
+    }
+
+    #[test]
+    fn file_change_patch_updated_translation_preserves_call_id_and_changes() {
+        let event = file_change_patch_updated_to_core(
+            codex_app_server_protocol::FileChangePatchUpdatedNotification {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                item_id: "call-1".to_string(),
+                changes: vec![codex_app_server_protocol::FileUpdateChange {
+                    path: "src/main.rs".to_string(),
+                    kind: codex_app_server_protocol::PatchChangeKind::Update { move_path: None },
+                    diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+                }],
+            },
+        );
+
+        assert_eq!(event.call_id, "call-1");
+        assert_eq!(event.changes.len(), 1);
+        assert_eq!(
+            event.changes.get(&PathBuf::from("src/main.rs")),
+            Some(&codex_protocol::protocol::FileChange::Update {
+                unified_diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+                move_path: None,
+            })
+        );
+    }
+
+    #[test]
+    fn guardian_warning_translation_preserves_message() {
+        let event =
+            guardian_warning_to_core(codex_app_server_protocol::GuardianWarningNotification {
+                thread_id: "thread-1".to_string(),
+                message: "unsafe operation blocked".to_string(),
+            });
+
+        assert_eq!(event.message, "unsafe operation blocked");
+    }
+
+    #[test]
+    fn model_verification_translation_preserves_verifications() {
+        let event =
+            model_verification_to_core(codex_app_server_protocol::ModelVerificationNotification {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                verifications: vec![
+                    codex_app_server_protocol::ModelVerification::TrustedAccessForCyber,
+                ],
+            });
+
+        assert_eq!(
+            event.verifications,
+            vec![codex_protocol::protocol::ModelVerification::TrustedAccessForCyber]
         );
     }
 

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -2783,6 +2783,7 @@ fn server_request_id_to_mcp_request_id(request_id: &RequestId) -> McpRequestId {
 mod tests {
     use super::*;
     use codex_core::config::ConfigBuilder;
+    use codex_utils_absolute_path::AbsolutePathBuf;
     use std::fs;
     use uuid::Uuid;
 
@@ -3080,7 +3081,9 @@ mod tests {
                 cwd: cwd.clone(),
                 reason: Some("need write access".to_string()),
                 permissions: codex_app_server_protocol::RequestPermissionProfile {
-                    network: Some(codex_app_server_protocol::AdditionalNetworkPermissions::Enabled),
+                    network: Some(codex_app_server_protocol::AdditionalNetworkPermissions {
+                        enabled: Some(true),
+                    }),
                     file_system: None,
                 },
             },
@@ -3092,7 +3095,9 @@ mod tests {
         assert_eq!(event.reason.as_deref(), Some("need write access"));
         assert_eq!(
             event.permissions.network,
-            Some(codex_protocol::config_types::NetworkPermissions::Enabled)
+            Some(codex_protocol::models::NetworkPermissions {
+                enabled: Some(true),
+            })
         );
     }
 

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -24,7 +24,7 @@ use codex_app_server_protocol::{
 use codex_arg0::Arg0DispatchPaths;
 use codex_core::config::Config;
 use codex_core::config_loader::{CloudRequirementsLoader, LoaderOverrides};
-use codex_exec_server::EnvironmentManager;
+use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::approvals::{
@@ -266,6 +266,7 @@ impl AppServerCodexThread {
                 items,
                 final_output_json_schema,
                 responsesapi_client_metadata,
+                ..
             } => (
                 items.clone(),
                 final_output_json_schema.clone(),
@@ -483,6 +484,7 @@ impl AppServerCodexThread {
                                 last_agent_message: None,
                                 completed_at: None,
                                 duration_ms: None,
+                                time_to_first_token_ms: None,
                             }),
                         });
                         Ok(())
@@ -711,6 +713,7 @@ impl AppServerCodexThread {
                 PermissionGrantScope::Turn => AppPermissionGrantScope::Turn,
                 PermissionGrantScope::Session => AppPermissionGrantScope::Session,
             },
+            strict_auto_review: Some(response.strict_auto_review),
         })
         .map_err(|err| CodexErr::Fatal(err.to_string()))?;
 
@@ -921,6 +924,7 @@ impl AppServerCodexThread {
                             network: params.permissions.network.map(Into::into),
                             file_system: params.permissions.file_system.map(Into::into),
                         },
+                        cwd: None,
                     }),
                 }))
             }
@@ -1016,6 +1020,9 @@ impl AppServerCodexThread {
                     }),
                 }))
             }
+            ServerNotification::FileChangePatchUpdated(_)
+            | ServerNotification::ModelVerification(_)
+            | ServerNotification::GuardianWarning(_) => Ok(None),
             ServerNotification::TurnStarted(payload) => {
                 let (submission_id, interrupt_request) = {
                     let mut state = self.state.lock().await;
@@ -1263,6 +1270,7 @@ impl AppServerCodexThread {
                             turn_id: payload.turn_id,
                             tool,
                             arguments,
+                            namespace: None,
                         }),
                     }),
                     (
@@ -1501,6 +1509,7 @@ impl AppServerCodexThread {
                                 turn_id: payload.turn_id,
                                 tool,
                                 arguments,
+                                namespace: None,
                                 content_items: content_items
                                     .unwrap_or_default()
                                     .into_iter()
@@ -1724,6 +1733,7 @@ impl CodexThreadImpl for AppServerCodexThread {
                 personality,
                 windows_sandbox_level: _,
                 service_tier,
+                permission_profile: _,
             } => {
                 self.override_turn_context(OverrideTurnContextArgs {
                     cwd,
@@ -2078,6 +2088,7 @@ fn prepare_submission_start(
             items,
             final_output_json_schema,
             responsesapi_client_metadata,
+            ..
         } => {
             state.active_turn = Some(ActiveTurn {
                 submission_id: submission_id.to_string(),
@@ -2104,6 +2115,8 @@ fn prepare_submission_start(
                     output_schema: final_output_json_schema.clone(),
                     responsesapi_client_metadata: responsesapi_client_metadata.clone(),
                     collaboration_mode: None,
+                    environments: None,
+                    permission_profile: None,
                 }),
             })
         }
@@ -2509,6 +2522,7 @@ fn turn_completed_event_msg(turn: &Turn, last_agent_message: Option<String>) -> 
             last_agent_message,
             completed_at: turn.completed_at,
             duration_ms: turn.duration_ms,
+            time_to_first_token_ms: None,
         }),
         TurnStatus::Interrupted => EventMsg::TurnAborted(TurnAbortedEvent {
             turn_id: Some(turn.id.clone()),
@@ -2585,6 +2599,11 @@ fn app_server_web_search_action_to_core(
 }
 
 async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error> {
+    let runtime_paths = ExecServerRuntimePaths::from_optional_paths(
+        std::env::current_exe().ok(),
+        config.codex_linux_sandbox_exe.clone(),
+    )
+    .map_err(|err| Error::internal_error().data(err.to_string()))?;
     InProcessAppServerClient::start(InProcessClientStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
         config: Arc::new(config.clone()),
@@ -2593,7 +2612,9 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
         cloud_requirements: CloudRequirementsLoader::default(),
         feedback: CodexFeedback::new(),
         log_db: None,
-        environment_manager: Arc::new(EnvironmentManager::from_env()),
+        environment_manager: Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
+            runtime_paths,
+        ))),
         config_warnings: Vec::new(),
         session_source: codex_protocol::protocol::SessionSource::Unknown,
         enable_codex_api_key_env: false,

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -1021,16 +1021,24 @@ impl AppServerCodexThread {
                 }))
             }
             ServerNotification::ModelVerification(payload) => {
-                let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
-                Ok(submission_id.map(|id| Event {
-                    id,
+                let submission_id = active_submission_id_for_turn(self, &payload.turn_id)
+                    .await
+                    .unwrap_or_else(noop_submission_id);
+                Ok(Some(Event {
+                    id: submission_id,
                     msg: EventMsg::ModelVerification(model_verification_to_core(payload)),
                 }))
             }
-            ServerNotification::GuardianWarning(payload) => Ok(Some(Event {
-                id: payload.thread_id.clone(),
-                msg: EventMsg::GuardianWarning(guardian_warning_to_core(payload)),
-            })),
+            ServerNotification::GuardianWarning(payload) => {
+                let submission_id = {
+                    let state = self.state.lock().await;
+                    active_submission_id(&state).unwrap_or_else(noop_submission_id)
+                };
+                Ok(Some(Event {
+                    id: submission_id,
+                    msg: EventMsg::GuardianWarning(guardian_warning_to_core(payload)),
+                }))
+            }
             ServerNotification::TurnStarted(payload) => {
                 let (submission_id, interrupt_request) = {
                     let mut state = self.state.lock().await;

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -16,7 +16,7 @@ use codex_core::{
     RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
     find_thread_path_by_id_str, parse_cursor,
 };
-use codex_exec_server::EnvironmentManager;
+use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -39,7 +39,7 @@ use tracing::{debug, info, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::app_server_thread;
-use crate::thread::Thread;
+use crate::thread::{Thread, adapt_models_manager};
 
 /// The Codex implementation of the ACP Agent trait.
 ///
@@ -70,6 +70,7 @@ impl CodexAgent {
             config.codex_home.to_path_buf(),
             false,
             config.cli_auth_credentials_store_mode,
+            Some(config.chatgpt_base_url.clone()),
         );
 
         let client_capabilities: Arc<Mutex<ClientCapabilities>> = Arc::default();
@@ -82,7 +83,7 @@ impl CodexAgent {
             CollaborationModesConfig {
                 default_mode_request_user_input: true,
             },
-            Arc::new(EnvironmentManager::from_env()),
+            build_environment_manager(&config),
             None,
         );
         Self {
@@ -214,6 +215,24 @@ impl CodexAgent {
             .map_err(|e| anyhow::anyhow!(e))?;
 
         Ok(config)
+    }
+}
+
+fn build_environment_manager(config: &Config) -> Arc<EnvironmentManager> {
+    match ExecServerRuntimePaths::from_optional_paths(
+        std::env::current_exe().ok(),
+        config.codex_linux_sandbox_exe.clone(),
+    ) {
+        Ok(runtime_paths) => Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
+            runtime_paths,
+        ))),
+        Err(err) => {
+            warn!(
+                error = %err,
+                "failed to resolve exec-server runtime paths; falling back to test environment manager"
+            );
+            Arc::new(EnvironmentManager::default_for_tests())
+        }
     }
 }
 
@@ -657,7 +676,7 @@ impl Agent for CodexAgent {
             session_id.clone(),
             thread_impl,
             self.auth_manager.clone(),
-            self.thread_manager.get_models_manager(),
+            adapt_models_manager(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
             config.clone(),
         ));
@@ -722,7 +741,7 @@ impl Agent for CodexAgent {
             session_id.clone(),
             thread_impl,
             self.auth_manager.clone(),
-            self.thread_manager.get_models_manager(),
+            adapt_models_manager(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
             config.clone(),
         ));
@@ -763,6 +782,7 @@ impl Agent for CodexAgent {
                 SessionSource::VSCode,
                 SessionSource::Unknown,
             ],
+            None,
             None,
             self.config.model_provider_id.as_str(),
             None,

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -16,7 +16,6 @@ use codex_core::{
     RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
     find_thread_path_by_id_str, parse_cursor,
 };
-use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -39,6 +38,7 @@ use tracing::{debug, info, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::app_server_thread;
+use crate::build_environment_manager;
 use crate::thread::{Thread, adapt_models_manager};
 
 /// The Codex implementation of the ACP Agent trait.
@@ -65,7 +65,7 @@ const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
 
 impl CodexAgent {
     /// Create a new `CodexAgent` with the given configuration
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config) -> Result<Self, Error> {
         let auth_manager = AuthManager::shared(
             config.codex_home.to_path_buf(),
             false,
@@ -83,17 +83,17 @@ impl CodexAgent {
             CollaborationModesConfig {
                 default_mode_request_user_input: true,
             },
-            build_environment_manager(&config),
+            build_environment_manager(&config)?,
             None,
         );
-        Self {
+        Ok(Self {
             auth_manager,
             client_capabilities,
             config,
             thread_manager,
             sessions: Rc::default(),
             session_roots,
-        }
+        })
     }
 
     fn get_thread(&self, session_id: &SessionId) -> Result<Rc<Thread>, Error> {
@@ -215,24 +215,6 @@ impl CodexAgent {
             .map_err(|e| anyhow::anyhow!(e))?;
 
         Ok(config)
-    }
-}
-
-fn build_environment_manager(config: &Config) -> Arc<EnvironmentManager> {
-    match ExecServerRuntimePaths::from_optional_paths(
-        std::env::current_exe().ok(),
-        config.codex_linux_sandbox_exe.clone(),
-    ) {
-        Ok(runtime_paths) => Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
-            runtime_paths,
-        ))),
-        Err(err) => {
-            warn!(
-                error = %err,
-                "failed to resolve exec-server runtime paths; falling back to test environment manager"
-            );
-            Arc::new(EnvironmentManager::default_for_tests())
-        }
     }
 }
 

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -4,6 +4,7 @@
 use agent_client_protocol_legacy::AgentSideConnection;
 use codex_core::config::ManagedFeatures;
 use codex_core::config::{Config, ConfigOverrides};
+use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_features::{Feature, Features};
 use codex_utils_cli::CliConfigOverrides;
 use std::fmt;
@@ -32,6 +33,28 @@ mod thread;
 
 pub static ACP_CLIENT: OnceLock<Arc<AgentSideConnection>> = OnceLock::new();
 const AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED_ENV: &str = "AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED";
+
+pub(crate) fn build_environment_manager(
+    config: &Config,
+) -> Result<Arc<EnvironmentManager>, agent_client_protocol_legacy::Error> {
+    let current_exe = std::env::current_exe().map_err(|err| {
+        agent_client_protocol_legacy::Error::internal_error().data(format!(
+            "failed to determine current executable path: {err}"
+        ))
+    })?;
+    let runtime_paths = ExecServerRuntimePaths::from_optional_paths(
+        Some(current_exe),
+        config.codex_linux_sandbox_exe.clone(),
+    )
+    .map_err(|err| {
+        agent_client_protocol_legacy::Error::internal_error().data(format!(
+            "failed to resolve exec-server runtime paths: {err}"
+        ))
+    })?;
+    Ok(Arc::new(EnvironmentManager::new(
+        EnvironmentManagerArgs::from_env(runtime_paths),
+    )))
+}
 
 pub(crate) fn spawn_acp_io_task<F>(
     thread_name: &str,
@@ -312,7 +335,9 @@ pub async fn run_main(
     normalize_responses_websocket_support(&mut config);
 
     // Create our Agent implementation with notification channel
-    let agent = Rc::new(codex_agent::CodexAgent::new(config));
+    let agent = Rc::new(codex_agent::CodexAgent::new(config).map_err(|err| {
+        std::io::Error::other(format!("failed to initialize Codex ACP agent: {err}"))
+    })?);
 
     let stdin = tokio::io::stdin().compat();
     let stdout = tokio::io::stdout().compat_write();

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1138,6 +1138,10 @@ impl PromptState {
                 // informational notices (e.g., the post-compact advisory message).
                 client.send_agent_text(message).await;
             }
+            EventMsg::GuardianWarning(WarningEvent { message }) => {
+                warn!("Guardian warning: {message}");
+                client.send_agent_text(message).await;
+            }
             EventMsg::McpStartupUpdate(McpStartupUpdateEvent { server, status }) => {
                 info!("MCP startup update: server={server}, status={status:?}");
             }
@@ -1164,6 +1168,12 @@ impl PromptState {
                     &reason,
                 ))
                 .await;
+            }
+            EventMsg::ModelVerification(event) => {
+                info!("Model verification: {:?}", event.verifications);
+                client
+                    .send_agent_text(render_model_verification_message(&event.verifications))
+                    .await;
             }
             EventMsg::DeprecationNotice(DeprecationNoticeEvent { summary, details }) => {
                 info!("Deprecation notice: summary={summary}, details={details:?}");
@@ -1220,9 +1230,7 @@ impl PromptState {
             | EventMsg::CollabResumeEnd(..)
             | EventMsg::CollabCloseBegin(..)
             | EventMsg::CollabCloseEnd(..)
-            | EventMsg::PlanDelta(..)
-            | EventMsg::GuardianWarning(..)
-            | EventMsg::ModelVerification(..) => {}
+            | EventMsg::PlanDelta(..) => {}
             EventMsg::GuardianAssessment(..) => {}
             e @ (EventMsg::McpListToolsResponse(..)
             | EventMsg::ListSkillsResponse(..)
@@ -4032,6 +4040,21 @@ fn render_model_reroute_message(
     format!("Model rerouted: {from_model} -> {to_model} ({reason:?})")
 }
 
+fn render_model_verification_message(
+    verifications: &[codex_protocol::protocol::ModelVerification],
+) -> String {
+    let details = verifications
+        .iter()
+        .map(|verification| match verification {
+            codex_protocol::protocol::ModelVerification::TrustedAccessForCyber => {
+                "trusted_access_for_cyber"
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Model verification: {details}")
+}
+
 fn render_deprecation_notice_message(summary: &str, details: Option<&str>) -> String {
     match details.map(str::trim).filter(|details| !details.is_empty()) {
         Some(details) => format!("Deprecation notice: {summary}\n{details}"),
@@ -4591,6 +4614,15 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn render_model_verification_message_lists_verifications() {
+        let message = render_model_verification_message(&[
+            codex_protocol::protocol::ModelVerification::TrustedAccessForCyber,
+        ]);
+
+        assert_eq!(message, "Model verification: trusted_access_for_cyber");
+    }
 
     struct TempManagedSkillsHome {
         home: PathBuf,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -4009,6 +4009,8 @@ fn should_attach_detached_submission(msg: &EventMsg) -> bool {
             | EventMsg::RequestPermissions(..)
             | EventMsg::RequestUserInput(..)
             | EventMsg::ModelReroute(..)
+            | EventMsg::GuardianWarning(..)
+            | EventMsg::ModelVerification(..)
             | EventMsg::ContextCompacted(..)
     )
 }
@@ -4025,6 +4027,16 @@ async fn forward_global_visible_event(client: &SessionClient, msg: EventMsg) -> 
                     &summary,
                     details.as_deref(),
                 ))
+                .await;
+            true
+        }
+        EventMsg::GuardianWarning(WarningEvent { message }) => {
+            client.send_agent_text(message).await;
+            true
+        }
+        EventMsg::ModelVerification(event) => {
+            client
+                .send_agent_text(render_model_verification_message(&event.verifications))
                 .await;
             true
         }
@@ -5297,6 +5309,24 @@ mod tests {
                 }),
             })
             .await;
+        actor
+            .handle_event(Event {
+                id: "app-server".to_string(),
+                msg: EventMsg::GuardianWarning(WarningEvent {
+                    message: "Guardian blocked unsafe operation".to_string(),
+                }),
+            })
+            .await;
+        actor
+            .handle_event(Event {
+                id: "app-server".to_string(),
+                msg: EventMsg::ModelVerification(ModelVerificationEvent {
+                    verifications: vec![
+                        codex_protocol::protocol::ModelVerification::TrustedAccessForCyber,
+                    ],
+                }),
+            })
+            .await;
 
         let notifications = client.notifications.lock().unwrap();
         assert!(notifications.iter().any(|notification| {
@@ -5315,6 +5345,24 @@ mod tests {
                     content: ContentBlock::Text(TextContent { text, .. }),
                     ..
                 }) if text == "Deprecation notice: old field is deprecated\nUse new_field instead."
+            )
+        }));
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Guardian blocked unsafe operation"
+            )
+        }));
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Model verification: trusted_access_for_cyber"
             )
         }));
 

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -35,7 +35,7 @@ use codex_protocol::{
     dynamic_tools::{DynamicToolCallOutputContentItem, DynamicToolCallRequest},
     error::CodexErr,
     mcp::CallToolResult,
-    models::{PermissionProfile, ResponseItem, WebSearchAction},
+    models::{AdditionalPermissionProfile, ResponseItem, WebSearchAction},
     openai_models::{ModelPreset, ReasoningEffort},
     parse_command::ParsedCommand,
     plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs},
@@ -102,7 +102,7 @@ pub trait ModelsManagerImpl {
 }
 
 #[async_trait::async_trait]
-impl ModelsManagerImpl for ModelsManager {
+impl<T: ModelsManager + ?Sized> ModelsManagerImpl for T {
     async fn get_model(&self, model_id: &Option<String>) -> String {
         self.get_default_model(model_id, RefreshStrategy::OnlineIfUncached)
             .await
@@ -111,6 +111,26 @@ impl ModelsManagerImpl for ModelsManager {
     async fn list_models(&self) -> Vec<ModelPreset> {
         self.list_models(RefreshStrategy::OnlineIfUncached).await
     }
+}
+
+#[derive(Debug)]
+struct SharedModelsManagerAdapter(Arc<dyn ModelsManager>);
+
+#[async_trait::async_trait]
+impl ModelsManagerImpl for SharedModelsManagerAdapter {
+    async fn get_model(&self, model_id: &Option<String>) -> String {
+        self.0
+            .get_default_model(model_id, RefreshStrategy::OnlineIfUncached)
+            .await
+    }
+
+    async fn list_models(&self) -> Vec<ModelPreset> {
+        self.0.list_models(RefreshStrategy::OnlineIfUncached).await
+    }
+}
+
+pub fn adapt_models_manager(models_manager: Arc<dyn ModelsManager>) -> Arc<dyn ModelsManagerImpl> {
+    Arc::new(SharedModelsManagerAdapter(models_manager))
 }
 
 pub trait Auth {
@@ -342,7 +362,7 @@ enum PendingPermissionRequest {
     },
     RequestPermissions {
         call_id: String,
-        permissions: PermissionProfile,
+        permissions: codex_protocol::request_permissions::RequestPermissionProfile,
     },
 }
 
@@ -705,21 +725,27 @@ impl PromptState {
                         ..
                     }) => match option_id.0.as_ref() {
                         "approved-for-session" => RequestPermissionsResponse {
-                            permissions: permissions.into(),
+                            permissions: permissions.clone(),
                             scope: PermissionGrantScope::Session,
+                            strict_auto_review: false,
                         },
                         "approved" => RequestPermissionsResponse {
-                            permissions: permissions.into(),
+                            permissions: permissions.clone(),
                             scope: PermissionGrantScope::Turn,
+                            strict_auto_review: false,
                         },
                         _ => RequestPermissionsResponse {
-                            permissions: PermissionProfile::default().into(),
+                            permissions:
+                                codex_protocol::request_permissions::RequestPermissionProfile::default(),
                             scope: PermissionGrantScope::Turn,
+                            strict_auto_review: false,
                         },
                     },
                     RequestPermissionOutcome::Cancelled | _ => RequestPermissionsResponse {
-                        permissions: PermissionProfile::default().into(),
+                        permissions:
+                            codex_protocol::request_permissions::RequestPermissionProfile::default(),
                         scope: PermissionGrantScope::Turn,
+                        strict_auto_review: false,
                     },
                 };
 
@@ -935,7 +961,13 @@ impl PromptState {
                 );
                 self.terminal_interaction(client, event).await;
             }
-            EventMsg::DynamicToolCallRequest(DynamicToolCallRequest { call_id, turn_id, tool, arguments }) => {
+            EventMsg::DynamicToolCallRequest(DynamicToolCallRequest {
+                call_id,
+                turn_id,
+                tool,
+                arguments,
+                ..
+            }) => {
                 info!("Dynamic tool call request: call_id={call_id}, turn_id={turn_id}, tool={tool}");
                 self.start_dynamic_tool_call(client, call_id, tool, arguments).await;
             }
@@ -1017,6 +1049,7 @@ impl PromptState {
                 turn_id,
                 completed_at: _,
                 duration_ms: _,
+                ..
             }) => {
                 info!(
                     "Task {turn_id} completed successfully after {} events. Last agent message: {last_agent_message:?}",
@@ -1187,7 +1220,9 @@ impl PromptState {
             | EventMsg::CollabResumeEnd(..)
             | EventMsg::CollabCloseBegin(..)
             | EventMsg::CollabCloseEnd(..)
-            | EventMsg::PlanDelta(..) => {}
+            | EventMsg::PlanDelta(..)
+            | EventMsg::GuardianWarning(..)
+            | EventMsg::ModelVerification(..) => {}
             EventMsg::GuardianAssessment(..) => {}
             e @ (EventMsg::McpListToolsResponse(..)
             | EventMsg::ListSkillsResponse(..)
@@ -1445,6 +1480,7 @@ impl PromptState {
             success,
             error,
             duration: _,
+            ..
         } = event;
 
         client
@@ -2038,6 +2074,7 @@ impl PromptState {
             turn_id: _,
             reason,
             permissions,
+            ..
         } = event;
 
         // Create a new tool call for the command execution
@@ -2049,16 +2086,23 @@ impl PromptState {
             content.push(reason.clone());
         }
         if let Some(file_system) = permissions.file_system.as_ref() {
-            if let Some(read) = file_system.read.as_ref() {
+            if let Some((read, write)) = file_system.legacy_read_write_roots() {
+                if let Some(read) = read {
+                    content.push(format!(
+                        "File System Read Access: {}",
+                        read.iter().map(|p| p.display()).join(", ")
+                    ));
+                }
+                if let Some(write) = write {
+                    content.push(format!(
+                        "File System Write Access: {}",
+                        write.iter().map(|p| p.display()).join(", ")
+                    ));
+                }
+            } else {
                 content.push(format!(
-                    "File System Read Access: {}",
-                    read.iter().map(|p| p.display()).join(", ")
-                ));
-            }
-            if let Some(write) = file_system.write.as_ref() {
-                content.push(format!(
-                    "File System Write Access: {}",
-                    write.iter().map(|p| p.display()).join(", ")
+                    "File System Access: {}",
+                    serde_json::to_string_pretty(file_system)?
                 ));
             }
         }
@@ -2078,7 +2122,7 @@ impl PromptState {
             permissions_request_key(&call_id),
             PendingPermissionRequest::RequestPermissions {
                 call_id,
-                permissions: permissions.into(),
+                permissions: permissions.clone(),
             },
             ToolCallUpdate::new(
                 tool_call_id,
@@ -2195,7 +2239,7 @@ struct ExecPermissionOption {
 fn build_exec_permission_options(
     available_decisions: &[ReviewDecision],
     network_approval_context: Option<&NetworkApprovalContext>,
-    additional_permissions: Option<&PermissionProfile>,
+    additional_permissions: Option<&AdditionalPermissionProfile>,
 ) -> Vec<ExecPermissionOption> {
     available_decisions
         .iter()
@@ -3180,6 +3224,7 @@ impl<A: Auth> ThreadActor<A> {
                     personality: None,
                     windows_sandbox_level: None,
                     service_tier: None,
+                    permission_profile: None,
                 },
             )
             .await
@@ -3230,6 +3275,7 @@ impl<A: Auth> ThreadActor<A> {
                     personality: None,
                     windows_sandbox_level: None,
                     service_tier: None,
+                    permission_profile: None,
                 },
             )
             .await
@@ -3330,6 +3376,7 @@ impl<A: Auth> ThreadActor<A> {
                         }],
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
+                        environments: None,
                     }
                 }
                 "review" => {
@@ -3381,6 +3428,7 @@ impl<A: Auth> ThreadActor<A> {
                         items,
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
+                        environments: None,
                     }
                 }
             }
@@ -3389,6 +3437,7 @@ impl<A: Auth> ThreadActor<A> {
                 items,
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                environments: None,
             }
         }
 
@@ -3452,6 +3501,7 @@ impl<A: Auth> ThreadActor<A> {
                     personality: None,
                     windows_sandbox_level: None,
                     service_tier: None,
+                    permission_profile: None,
                 },
             )
             .await
@@ -3522,6 +3572,7 @@ impl<A: Auth> ThreadActor<A> {
                     personality: None,
                     windows_sandbox_level: None,
                     service_tier: None,
+                    permission_profile: None,
                 },
             )
             .await
@@ -4751,6 +4802,7 @@ mod tests {
                 }],
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                environments: None,
             }],
             "ops don't match {ops:?}"
         );
@@ -5026,6 +5078,7 @@ mod tests {
                 }],
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                environments: None,
             }],
             "ops don't match {ops:?}"
         );
@@ -5078,6 +5131,7 @@ mod tests {
                     turn_id: "shared-turn".to_string(),
                     completed_at: None,
                     duration_ms: None,
+                    time_to_first_token_ms: None,
                 }));
 
                 assert_eq!(first_stop_rx.await??, StopReason::EndTurn);
@@ -5145,6 +5199,7 @@ mod tests {
                             turn_id: "resumed-turn".to_string(),
                             completed_at: None,
                             duration_ms: None,
+                            time_to_first_token_ms: None,
                         }),
                     })
                     .await;
@@ -5367,6 +5422,7 @@ mod tests {
                     turn_id: "shared-turn".to_string(),
                     completed_at: None,
                     duration_ms: None,
+                    time_to_first_token_ms: None,
                 }));
 
                 assert_eq!(first_stop_rx.await??, StopReason::EndTurn);
@@ -5595,6 +5651,7 @@ mod tests {
                             turn_id,
                             completed_at: None,
                             duration_ms: None,
+                            time_to_first_token_ms: None,
                         }));
                     } else if prompt == "approval-block" {
                         self.op_tx
@@ -5654,6 +5711,7 @@ mod tests {
                                     turn_id: id.to_string(),
                                     completed_at: None,
                                     duration_ms: None,
+                                    time_to_first_token_ms: None,
                                 }),
                             })
                             .unwrap();
@@ -5692,6 +5750,7 @@ mod tests {
                                 turn_id: id.to_string(),
                                 completed_at: None,
                                 duration_ms: None,
+                                time_to_first_token_ms: None,
                             }),
                         })
                         .unwrap();
@@ -5729,6 +5788,7 @@ mod tests {
                                 turn_id: id.to_string(),
                                 completed_at: None,
                                 duration_ms: None,
+                                time_to_first_token_ms: None,
                             }),
                         })
                         .unwrap();
@@ -5767,6 +5827,7 @@ mod tests {
                                 turn_id: id.to_string(),
                                 completed_at: None,
                                 duration_ms: None,
+                                time_to_first_token_ms: None,
                             }),
                         })
                         .unwrap();

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -4619,6 +4619,7 @@ mod tests {
     };
     use codex_core::test_support::all_model_presets;
     use codex_protocol::config_types::ModeKind;
+    use codex_protocol::protocol::ModelVerificationEvent;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use tokio::{
         sync::{Mutex, Notify, mpsc::UnboundedSender},


### PR DESCRIPTION
## Summary

- switch `agenthub-codex-acp` from the local Codex fork to upstream `openai/codex@rust-v0.125.0`
- adapt ACP bridge code to the updated Codex protocol/runtime APIs
- keep `agenthub-codex-acp` compiling against the upstream release while preserving current AgentHub ACP behavior

## What Changed

- update `agenthub-codex-acp/Cargo.toml` and `Cargo.lock` to upstream Codex `v0.125.0`
- align ACP protocol handling with new upstream fields such as:
  - `environments`
  - `permission_profile`
  - `time_to_first_token_ms`
  - `strict_auto_review`
  - `cwd`
  - `namespace`
- adapt permission request bridging to `RequestPermissionProfile`
- replace deprecated `EnvironmentManager::from_env()` usage with `EnvironmentManagerArgs + ExecServerRuntimePaths`
- update `AuthManager::shared(...)` and `RolloutRecorder::list_threads(...)` call sites
- add a small models-manager adapter so `Thread` still consumes the local ACP abstraction cleanly

## Validation

```bash
cargo check -p agenthub-codex-acp
cargo fmt --all --check
```

## Notes

- upstream `rust-v0.125.0` still does not include the local custom-tool-output history-repair semantic change; this PR only handles the ACP/runtime compatibility layer needed to compile against upstream
- `cargo test -p agenthub-codex-acp --lib --no-run` was blocked locally by disk-space exhaustion while compiling the broader dependency graph
