### PR TITLE
chore(team): align team panels with shared primitives

### DIFF
--- a/docs/journal/2026-04-04-ui-primitives-bootstrap.md
+++ b/docs/journal/2026-04-04-ui-primitives-bootstrap.md
@@ -57,6 +57,7 @@ surface/header/button patterns stop drifting independently across Agents and Tea
     - selector header and filter row now use `ToolbarRow`
     - create action now uses shared `ActionButton`
     - team rows now use `SelectableListItem`
+    - follow-up cleanup re-aligned the implementation with this contract after a later chrome-only iteration drifted back to a raw `<button>`
   - `web/src/pages/team/team_debug_panels.tsx`
     - debug header and run forms now use `SurfaceCard`
     - debug tab switcher and run actions now use shared `ActionButton`

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -3,6 +3,8 @@ import { TextInput } from "@mantine/core";
 import {
   ActionButton,
   IconButton,
+  SelectableListItem,
+  ToolbarRow,
 } from "../../ui/primitives";
 
 export type TeamSelectorItem = {
@@ -38,8 +40,9 @@ const TeamSelectorEntry = React.memo(function TeamSelectorEntry({
   onSelectTeam: (teamId: string) => void;
 }) {
   return (
-    <button
+    <SelectableListItem
       type="button"
+      layout="row"
       className="flex w-full min-w-0 items-start justify-between gap-3 rounded-md bg-transparent px-2 py-1.5 text-left transition hover:bg-[rgba(55,53,47,0.05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
       data-team-selector-entry="true"
       data-team-id={team.id}
@@ -59,7 +62,7 @@ const TeamSelectorEntry = React.memo(function TeamSelectorEntry({
           <span className="shrink-0 capitalize">{team.runtimeLabel}</span>
         </div>
       </div>
-    </button>
+    </SelectableListItem>
   );
 });
 
@@ -79,7 +82,7 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
   return (
     <div className="flex min-h-0 flex-1 justify-center">
       <section className="flex min-h-0 w-full max-w-[680px] flex-col">
-        <div className="mb-1 mt-3 flex items-center justify-between px-2">
+        <ToolbarRow className="mb-1 mt-3 px-2">
           <div className="min-w-0 flex-1">
             <h2 className="text-[14px] font-medium tracking-tight text-notion-text-muted">Teams</h2>
           </div>
@@ -92,10 +95,10 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
           >
             New Team
           </ActionButton>
-        </div>
+        </ToolbarRow>
 
         {!loading && hasTeams && (
-          <div className="mt-1 flex items-center gap-2 px-2">
+          <ToolbarRow className="mt-1 gap-2 px-2">
             <TextInput
               className="flex-1"
               radius="md"
@@ -119,7 +122,7 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
             >
               <i className="bi bi-arrow-clockwise" aria-hidden="true" />
             </IconButton>
-          </div>
+          </ToolbarRow>
         )}
 
         <div className="mt-2 flex-1 overflow-y-auto">

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -43,7 +43,7 @@ const TeamSelectorEntry = React.memo(function TeamSelectorEntry({
     <SelectableListItem
       type="button"
       layout="row"
-      className="flex w-full min-w-0 items-start justify-between gap-3 rounded-md bg-transparent px-2 py-1.5 text-left transition hover:bg-[rgba(55,53,47,0.05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+      className="w-full min-w-0 items-start justify-between gap-3 text-left"
       data-team-selector-entry="true"
       data-team-id={team.id}
       data-team-name={team.name}

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -139,7 +139,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 {resolveThreadAvatarLabel(rootAuthorLabel)}
               </div>
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
-                <ToolbarRow className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
+                <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                   <span className="font-semibold text-notion-text">
                     {rootAuthorLabel ?? "Unknown"}
                   </span>
@@ -152,7 +152,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   >
                     Original
                   </Badge>
-                </ToolbarRow>
+                </div>
                 <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                   {rootText ? (
                     <TeamThreadRichText
@@ -182,13 +182,13 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                       {resolveThreadAvatarLabel(reply.authorLabel)}
                     </div>
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
-                      <ToolbarRow className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
+                      <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                         <span className="font-semibold text-notion-text">
                           {reply.authorLabel ?? "Unknown"}
                         </span>
                         <span>{formatTs(reply.createdAt)}</span>
                         <span>{`#${reply.messageId}`}</span>
-                      </ToolbarRow>
+                      </div>
                       <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                         <TeamThreadRichText
                           className="text-[13px] leading-6 text-notion-text"

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -6,6 +6,7 @@ import {
   ConversationBubble,
   EmptyState,
   SurfaceCard,
+  ToolbarRow,
 } from "../../ui/primitives";
 import { TeamThreadRichText } from "./team_thread_rich_text";
 import {
@@ -84,7 +85,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
       className="flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80"
       data-team-surface="thread-pane"
     >
-      <div className="flex items-start justify-between gap-2 border-b border-notion-border/70 px-2.5 py-2">
+      <ToolbarRow className="items-start gap-2 border-b border-notion-border/70 px-2.5 py-2">
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
@@ -121,7 +122,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             Close thread
           </CompactButton>
         </div>
-      </div>
+      </ToolbarRow>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2.5 py-2">
         {!hasSelectedRoot ? (
@@ -138,7 +139,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 {resolveThreadAvatarLabel(rootAuthorLabel)}
               </div>
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
-                <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
+                <ToolbarRow className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                   <span className="font-semibold text-notion-text">
                     {rootAuthorLabel ?? "Unknown"}
                   </span>
@@ -151,7 +152,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   >
                     Original
                   </Badge>
-                </div>
+                </ToolbarRow>
                 <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                   {rootText ? (
                     <TeamThreadRichText
@@ -181,13 +182,13 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                       {resolveThreadAvatarLabel(reply.authorLabel)}
                     </div>
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
-                      <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
+                      <ToolbarRow className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                         <span className="font-semibold text-notion-text">
                           {reply.authorLabel ?? "Unknown"}
                         </span>
                         <span>{formatTs(reply.createdAt)}</span>
                         <span>{`#${reply.messageId}`}</span>
-                      </div>
+                      </ToolbarRow>
                       <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                         <TeamThreadRichText
                           className="text-[13px] leading-6 text-notion-text"
@@ -225,11 +226,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 {replyBusy ? "Replying..." : "Reply"}
               </ActionButton>
             </div>
-            <div className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
+            <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
               <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>
                 Reply stays scoped to this thread
               </span>
-            </div>
+            </ToolbarRow>
           </div>
         </div>
       ) : null}

--- a/web/src/pages/team_setup_panel.tsx
+++ b/web/src/pages/team_setup_panel.tsx
@@ -1,4 +1,4 @@
-import { ActionButton } from "../ui/primitives";
+import { ActionButton, PanelHeader } from "../ui/primitives";
 import {
   TEAM_CREATE_PANEL_CARD_CLASS,
   TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS,
@@ -25,25 +25,30 @@ export function TeamSetupPanel({
 }: TeamSetupPanelProps) {
   return (
     <div className={`${TEAM_CREATE_PANEL_CARD_CLASS} ${TEAM_WORKBENCH_PANEL_CLASS}`}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <span className={TEAM_WORKBENCH_BADGE_CLASS}>Team Setup</span>
-          <h3 className="mt-2 text-[18px] font-semibold tracking-tight text-black">
-            No agents have joined this team yet.
-          </h3>
-          <p className="mt-2 max-w-2xl text-[13px] leading-5 text-ui-text-secondary">
-            The team goal is saved, but runtime and runs stay blocked until you add the
-            first agent.
-          </p>
-        </div>
-        <ActionButton
-          className={TEAM_WORKBENCH_ACCENT_BUTTON_CLASS}
-          onClick={onForge}
-        >
-          <i className="bi bi-person-plus" aria-hidden="true" />
-          <span>{forgeLabel}</span>
-        </ActionButton>
-      </div>
+      <PanelHeader
+        title={
+          <div className="min-w-0">
+            <span className={`${TEAM_WORKBENCH_BADGE_CLASS} inline-flex`}>Team Setup</span>
+            <h3 className="mt-2 text-[18px] font-semibold tracking-tight text-black">
+              No agents have joined this team yet.
+            </h3>
+          </div>
+        }
+        subtitle="The team goal is saved, but runtime and runs stay blocked until you add the first agent."
+        className="border-b-0 pb-0"
+        titleClassName="text-base font-normal"
+        subtitleClassName="max-w-2xl text-[13px] leading-5 text-ui-text-secondary"
+        contentClassName="gap-0"
+        actions={
+          <ActionButton
+            className={TEAM_WORKBENCH_ACCENT_BUTTON_CLASS}
+            onClick={onForge}
+          >
+            <i className="bi bi-person-plus" aria-hidden="true" />
+            <span>{forgeLabel}</span>
+          </ActionButton>
+        }
+      />
       <div className={`${TEAM_WORKBENCH_SETUP_CHECKLIST_CLASS} mt-4`}>
         <div className={TEAM_WORKBENCH_INFO_STRIP_GRID_CLASS}>
           <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>


### PR DESCRIPTION
## Summary

- align `TeamSelectorPanel` team rows and toolbar rows with shared UI primitives
- align `TeamThreadPane` header and meta/helper rows with shared toolbar primitives
- align `TeamSetupPanel` header with `PanelHeader`
- update the UI primitives rollout journal to match the current implementation

## Validation

- `cd web && pnpm exec vitest run src/pages/team/team_selector_panel.test.tsx src/pages/team_panels.test.tsx`
- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx src/pages/team_panels.test.tsx`
- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run build`
