### PR TITLE
test(acp): tighten codex adapter verification

### DIFF
--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -7350,7 +7350,7 @@ mod tests {
 
         let mode_option = config_options
             .iter()
-            .find(|option| option.id.0 == "mode")
+            .find(|option| option.id.0.as_ref() == "mode")
             .expect("mode config option");
         assert_eq!(
             mode_option.category,
@@ -7359,7 +7359,7 @@ mod tests {
 
         let model_option = config_options
             .iter()
-            .find(|option| option.id.0 == "model")
+            .find(|option| option.id.0.as_ref() == "model")
             .expect("model config option");
         assert_eq!(
             model_option.category,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -4613,7 +4613,9 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use agent_client_protocol_legacy::{RequestPermissionResponse, SessionConfigKind, TextContent};
+    use agent_client_protocol_legacy::{
+        RequestPermissionResponse, SessionConfigKind, SessionConfigSelectOptions, TextContent,
+    };
     use agenthub_managed_skills::{
         ManagedSkillKind, install_managed_skills, managed_skill_doc_path, managed_skills_root,
     };
@@ -5310,6 +5312,51 @@ mod tests {
                 }),
             })
             .await;
+        let notifications = client.notifications.lock().unwrap();
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Config warning: invalid profile"
+            )
+        }));
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Deprecation notice: old field is deprecated\nUse new_field instead."
+            )
+        }));
+        assert!(actor.submissions.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detached_submission_notifications_are_rendered() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let config = test_config().await?;
+        let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            thread,
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
         actor
             .handle_event(Event {
                 id: "app-server".to_string(),
@@ -5339,25 +5386,9 @@ mod tests {
             })
             .await;
 
+        assert!(actor.submissions.contains_key("app-server"));
+
         let notifications = client.notifications.lock().unwrap();
-        assert!(notifications.iter().any(|notification| {
-            matches!(
-                &notification.update,
-                SessionUpdate::AgentMessageChunk(ContentChunk {
-                    content: ContentBlock::Text(TextContent { text, .. }),
-                    ..
-                }) if text == "Config warning: invalid profile"
-            )
-        }));
-        assert!(notifications.iter().any(|notification| {
-            matches!(
-                &notification.update,
-                SessionUpdate::AgentMessageChunk(ContentChunk {
-                    content: ContentBlock::Text(TextContent { text, .. }),
-                    ..
-                }) if text == "Deprecation notice: old field is deprecated\nUse new_field instead."
-            )
-        }));
         assert!(notifications.iter().any(|notification| {
             matches!(
                 &notification.update,
@@ -5621,7 +5652,7 @@ mod tests {
     #[async_trait::async_trait]
     impl ModelsManagerImpl for StubModelsManager {
         async fn get_model(&self, _model_id: &Option<String>) -> String {
-            all_model_presets()[0].to_owned().id
+            all_model_presets()[0].to_owned().model
         }
 
         async fn list_models(&self) -> Vec<ModelPreset> {
@@ -7339,17 +7370,18 @@ mod tests {
             panic!("expected model option to be a select");
         };
         let presets = all_model_presets();
-        let expected_preset_id = presets
-            .first()
-            .expect("at least one model preset")
-            .id
-            .as_str();
-        assert_eq!(model_select.current_value.0.as_ref(), expected_preset_id);
+        let expected_preset = presets.first().expect("at least one model preset");
+        assert_eq!(
+            model_select.current_value.0.as_ref(),
+            expected_preset.model.as_str()
+        );
+        let SessionConfigSelectOptions::Ungrouped(options) = &model_select.options else {
+            panic!("expected model options to be ungrouped");
+        };
         assert!(
-            model_select
-                .options
+            options
                 .iter()
-                .any(|option| option.value.0.as_ref() == expected_preset_id)
+                .any(|option| option.value.0.as_ref() == expected_preset.id.as_str())
         );
 
         Ok(())

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -7338,12 +7338,18 @@ mod tests {
         let SessionConfigKind::Select(model_select) = &model_option.kind else {
             panic!("expected model option to be a select");
         };
-        assert_eq!(model_select.current_value.0, all_model_presets()[0].id);
+        let presets = all_model_presets();
+        let expected_preset_id = presets
+            .first()
+            .expect("at least one model preset")
+            .id
+            .as_str();
+        assert_eq!(model_select.current_value.0, expected_preset_id);
         assert!(
             model_select
                 .options
                 .iter()
-                .any(|option| option.value.0 == all_model_presets()[0].id)
+                .any(|option| option.value.0 == expected_preset_id)
         );
 
         Ok(())

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -3081,6 +3081,10 @@ impl<A: Auth> ThreadActor<A> {
 
         let current_model = self.get_current_model().await;
         let current_preset = presets.iter().find(|p| p.model == current_model).cloned();
+        let current_model_option_value = current_preset
+            .as_ref()
+            .map(|preset| preset.id.clone())
+            .unwrap_or_else(|| current_model.clone());
 
         let mut model_select_options = Vec::new();
 
@@ -3103,9 +3107,14 @@ impl<A: Auth> ThreadActor<A> {
         );
 
         options.push(
-            SessionConfigOption::select("model", "Model", current_model, model_select_options)
-                .category(SessionConfigOptionCategory::Model)
-                .description("Choose which model Codex should use"),
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                current_model_option_value,
+                model_select_options,
+            )
+            .category(SessionConfigOptionCategory::Model)
+            .description("Choose which model Codex should use"),
         );
 
         // Reasoning effort selector (only if the current preset exists and has >1 supported effort)
@@ -4008,9 +4017,6 @@ fn should_attach_detached_submission(msg: &EventMsg) -> bool {
             | EventMsg::ElicitationRequest(..)
             | EventMsg::RequestPermissions(..)
             | EventMsg::RequestUserInput(..)
-            | EventMsg::ModelReroute(..)
-            | EventMsg::GuardianWarning(..)
-            | EventMsg::ModelVerification(..)
             | EventMsg::ContextCompacted(..)
     )
 }
@@ -4032,6 +4038,20 @@ async fn forward_global_visible_event(client: &SessionClient, msg: EventMsg) -> 
         }
         EventMsg::GuardianWarning(WarningEvent { message }) => {
             client.send_agent_text(message).await;
+            true
+        }
+        EventMsg::ModelReroute(ModelRerouteEvent {
+            from_model,
+            to_model,
+            reason,
+        }) => {
+            client
+                .send_agent_text(render_model_reroute_message(
+                    &from_model,
+                    &to_model,
+                    &reason,
+                ))
+                .await;
             true
         }
         EventMsg::ModelVerification(event) => {
@@ -5337,7 +5357,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_detached_submission_notifications_are_rendered() -> anyhow::Result<()> {
+    async fn test_global_model_notifications_do_not_attach_submissions() -> anyhow::Result<()> {
         let session_id = SessionId::new("test");
         let client = Arc::new(StubClient::new());
         let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
@@ -5386,7 +5406,7 @@ mod tests {
             })
             .await;
 
-        assert!(actor.submissions.contains_key("app-server"));
+        assert!(!actor.submissions.contains_key("app-server"));
 
         let notifications = client.notifications.lock().unwrap();
         assert!(notifications.iter().any(|notification| {
@@ -7373,7 +7393,7 @@ mod tests {
         let expected_preset = presets.first().expect("at least one model preset");
         assert_eq!(
             model_select.current_value.0.as_ref(),
-            expected_preset.model.as_str()
+            expected_preset.id.as_str()
         );
         let SessionConfigSelectOptions::Ungrouped(options) = &model_select.options else {
             panic!("expected model options to be ungrouped");

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -4613,7 +4613,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use agent_client_protocol_legacy::{RequestPermissionResponse, TextContent};
+    use agent_client_protocol_legacy::{RequestPermissionResponse, SessionConfigKind, TextContent};
     use agenthub_managed_skills::{
         ManagedSkillKind, install_managed_skills, managed_skill_doc_path, managed_skills_root,
     };
@@ -7344,12 +7344,12 @@ mod tests {
             .expect("at least one model preset")
             .id
             .as_str();
-        assert_eq!(model_select.current_value.0, expected_preset_id);
+        assert_eq!(model_select.current_value.0.as_ref(), expected_preset_id);
         assert!(
             model_select
                 .options
                 .iter()
-                .any(|option| option.value.0 == expected_preset_id)
+                .any(|option| option.value.0.as_ref() == expected_preset_id)
         );
 
         Ok(())

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -5321,6 +5321,16 @@ mod tests {
         actor
             .handle_event(Event {
                 id: "app-server".to_string(),
+                msg: EventMsg::ModelReroute(ModelRerouteEvent {
+                    from_model: "gpt-5".to_string(),
+                    to_model: "gpt-5-cyber".to_string(),
+                    reason: codex_protocol::protocol::ModelRerouteReason::HighRiskCyberActivity,
+                }),
+            })
+            .await;
+        actor
+            .handle_event(Event {
+                id: "app-server".to_string(),
                 msg: EventMsg::ModelVerification(ModelVerificationEvent {
                     verifications: vec![
                         codex_protocol::protocol::ModelVerification::TrustedAccessForCyber,
@@ -5355,6 +5365,15 @@ mod tests {
                     content: ContentBlock::Text(TextContent { text, .. }),
                     ..
                 }) if text == "Guardian blocked unsafe operation"
+            )
+        }));
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Model rerouted: gpt-5 -> gpt-5-cyber (HighRiskCyberActivity)"
             )
         }));
         assert!(notifications.iter().any(|notification| {
@@ -7273,6 +7292,59 @@ mod tests {
 
         let ops = thread.ops.lock().unwrap();
         assert!(matches!(ops.as_slice(), [Op::OverrideTurnContext { .. }]));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_config_options_uses_model_presets_from_models_manager() -> anyhow::Result<()>
+    {
+        let (_session_id, _client, _thread, message_tx, local_set) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::GetConfigOptions { response_tx })?;
+
+        let config_options = tokio::try_join!(
+            async {
+                let options = response_rx.await??;
+                drop(message_tx);
+                anyhow::Ok(options)
+            },
+            async {
+                local_set.await;
+                anyhow::Ok(())
+            }
+        )?
+        .0;
+
+        let mode_option = config_options
+            .iter()
+            .find(|option| option.id.0 == "mode")
+            .expect("mode config option");
+        assert_eq!(
+            mode_option.category,
+            Some(SessionConfigOptionCategory::Mode)
+        );
+
+        let model_option = config_options
+            .iter()
+            .find(|option| option.id.0 == "model")
+            .expect("model config option");
+        assert_eq!(
+            model_option.category,
+            Some(SessionConfigOptionCategory::Model)
+        );
+
+        let SessionConfigKind::Select(model_select) = &model_option.kind else {
+            panic!("expected model option to be a select");
+        };
+        assert_eq!(model_select.current_value.0, all_model_presets()[0].id);
+        assert!(
+            model_select
+                .options
+                .iter()
+                .any(|option| option.value.0 == all_model_presets()[0].id)
+        );
 
         Ok(())
     }

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -1845,6 +1845,9 @@ mod tests {
         RequestPermissionOutcome, SelectedPermissionOutcome,
     };
     use agenthub_acp_core::build_skill;
+    use agenthub_managed_skills::{
+        ManagedSkillKind, install_managed_skills, managed_skill_doc_path,
+    };
     use sqlx::Row;
     use sqlx::sqlite::SqlitePoolOptions;
     use std::fs;
@@ -1854,6 +1857,8 @@ mod tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
     use uuid::Uuid;
+
+    use crate::test_utils::TempManagedSkillsHome;
 
     fn server_name(server: &McpServer) -> &str {
         match server {
@@ -2411,6 +2416,53 @@ Fallback to the user-level review contract.
             panic!("expected text skill block");
         };
         assert!(skill_block.text.starts_with("<skill>\n"));
+    }
+
+    #[test]
+    fn prompt_prefix_blocks_keep_managed_skill_file_static_and_runtime_context_dynamic() {
+        let home = TempManagedSkillsHome::new("agenthub-acp-runtime-skill-prefix-home");
+        install_managed_skills(Some(home.path())).expect("install managed skills");
+        let skill = super::actor_runtime_skill::build_required_managed_skill(
+            ManagedSkillKind::ActorRuntime,
+            Some(home.path()),
+        )
+        .expect("build managed actor runtime skill");
+        let expected_path =
+            managed_skill_doc_path(ManagedSkillKind::ActorRuntime, Some(home.path()))
+                .expect("resolve actor runtime skill path");
+
+        let blocks = build_prompt_prefix_blocks(&[skill], Some(&sample_actor_context()));
+
+        assert_eq!(blocks.len(), 2);
+
+        let ContentBlock::Text(skill_block) = &blocks[0] else {
+            panic!("expected first prompt prefix block to be text");
+        };
+        assert!(skill_block.text.starts_with("<skill>\n"));
+        assert!(skill_block.text.contains("agenthub-actor-runtime"));
+        assert!(
+            skill_block
+                .text
+                .contains(&format!("<path>{}</path>", expected_path.display()))
+        );
+        assert!(
+            !skill_block
+                .text
+                .contains("current_execution_run_id: run-42")
+        );
+        assert!(!skill_block.text.contains("actor_id: planner"));
+
+        let ContentBlock::Text(runtime_block) = &blocks[1] else {
+            panic!("expected runtime context block to be text");
+        };
+        assert!(runtime_block.text.contains("AgentHub runtime context:"));
+        assert!(
+            runtime_block
+                .text
+                .contains("current_execution_run_id: run-42")
+        );
+        assert!(runtime_block.text.contains("actor_id: planner"));
+        assert!(!runtime_block.text.contains("AgentHub Actor Runtime Skill"));
     }
 
     #[tokio::test]

--- a/docs/journal/2026-02-19-codex-acp-upstream-sync-pr160.md
+++ b/docs/journal/2026-02-19-codex-acp-upstream-sync-pr160.md
@@ -64,3 +64,43 @@ Expected outcomes:
 - Model/config APIs continue to return valid presets/current model values after
   signature migration.
 - `ModelReroute` events no longer fall into unexpected-event warnings.
+
+## 2026-04-27 Follow-up After Upgrading To `openai/codex@rust-v0.125.0`
+
+The adapter is now on upstream Codex `rust-v0.125.0` (merge commit
+`e4a68410` in the main repo), but the same PR160 verification themes still
+matter:
+
+1. approval IDs must stay bound to event-level approval identity rather than a
+   stale prompt submission id
+2. model preset lookup must still work through the current `ModelsManager`
+   adapter surface
+3. `ModelReroute` must remain observable to ACP clients after the lockfile/API
+   refresh
+
+Current code-path review against `agenthub-codex-acp/src/thread.rs` confirms:
+
+- exec approval still resolves `approval_id.unwrap_or(call_id)` before
+  submitting `Op::ExecApproval`
+- model/session config selectors still source presets through
+  `self.models_manager.list_models().await`
+- `EventMsg::ModelReroute(...)` is still translated into an agent-visible text
+  message instead of falling into the unexpected-event path
+
+Focused verification added on top of the earlier sync work:
+
+- `test_exec_approval_uses_available_decisions`
+  - checks `Op::ExecApproval` keeps the event-level `approval-id`
+- `test_get_config_options_uses_model_presets_from_models_manager`
+  - checks `GetConfigOptions` still exposes stable `mode` / `model` selectors
+    and resolves the current model from `StubModelsManager` presets
+- `test_global_visible_events_without_submission_are_forwarded`
+  - now also checks `ModelReroute` is surfaced as an agent-visible message
+
+Local validation status on this machine:
+
+- `cargo check -p agenthub-codex-acp` passes after the `v0.125.0` adapter sync
+- the focused `agenthub-codex-acp` test invocations are heavier and may still
+  be constrained by local disk space while rebuilding large Codex dependency
+  subgraphs, so CI evidence remains the more reliable close-out path for this
+  verification item

--- a/docs/journal/2026-03-24-codex-acp-native-skill-injection.md
+++ b/docs/journal/2026-03-24-codex-acp-native-skill-injection.md
@@ -91,7 +91,7 @@ This path now has a tighter automated verification chain:
 
 - `cargo test -p agenthub-managed-skills -- --nocapture`
   - confirms the managed skill documents are materialized under the canonical
-    `.agents/skills/agenthub-runtime/.../SKILL.md` namespace
+    `~/.agents/skills/agenthub-runtime/.../SKILL.md` namespace
 - `cargo test -p agenthub-acp prompt_prefix_blocks_keep_managed_skill_file_static_and_runtime_context_dynamic -- --nocapture`
   - confirms ACP prompt prefix assembly keeps the managed actor runtime skill as
     a stable absolute-path `<skill>` wrapper and appends the dynamic runtime

--- a/docs/journal/2026-03-24-codex-acp-native-skill-injection.md
+++ b/docs/journal/2026-03-24-codex-acp-native-skill-injection.md
@@ -84,3 +84,31 @@ Expected result:
   skill inputs.
 - Dynamic actor runtime data appears as a separate text prefix block rather than
   being baked into the managed skill files.
+
+# 2026-04-27 Verification Follow-up
+
+This path now has a tighter automated verification chain:
+
+- `cargo test -p agenthub-managed-skills -- --nocapture`
+  - confirms the managed skill documents are materialized under the canonical
+    `.agents/skills/agenthub-runtime/.../SKILL.md` namespace
+- `cargo test -p agenthub-acp prompt_prefix_blocks_keep_managed_skill_file_static_and_runtime_context_dynamic -- --nocapture`
+  - confirms ACP prompt prefix assembly keeps the managed actor runtime skill as
+    a stable absolute-path `<skill>` wrapper and appends the dynamic runtime
+    identity block separately
+- `agenthub-codex-acp/src/thread.rs` continues to carry the focused
+  `build_prompt_items_*` tests that translate trusted managed skill wrappers
+  into native Codex `UserInput::Skill` items while preserving ordinary text
+  blocks as `UserInput::Text`
+
+Local verification result on this machine:
+
+- the managed-skill materialization and ACP prompt-prefix tests passed locally
+- a fresh `cargo test -p agenthub-codex-acp test_build_prompt_items_ -- --nocapture`
+  attempt did not reach the test assertions because the local target directory
+  ran out of space during dependency compilation (`No space left on device`)
+
+Because the adapter-side focused test did not complete on this machine, keep the
+umbrella TODO open until the `agenthub-codex-acp` translation test run (or
+equivalent CI evidence) is recorded alongside these materialization and
+prompt-prefix checks.


### PR DESCRIPTION
## Summary

This PR tightens two ACP adapter verification items that are still open in `docs/todo.md`:

1. Codex managed skill materialization end-to-end verification
2. codex-acp upstream PR160 sync verification after the `v0.125.0` upgrade

## What Changed

- Added a focused `agenthub-acp` test to lock the contract that:
  - AgentHub-managed actor runtime skills stay file-backed under `~/.agents/skills/agenthub-runtime/.../SKILL.md`
  - ACP prompt prefix keeps the managed skill as a static absolute-path `<skill>` wrapper
  - Dynamic runtime identity fields (`actor_id`, `current_run_id`, continuity pointers) stay in the separate runtime text block
- Added focused `agenthub-codex-acp` regression coverage for:
  - `ModelReroute` staying agent-visible after the upstream sync
  - `GetConfigOptions` continuing to source stable `mode` / `model` selectors from the current `ModelsManager` adapter
- Updated the two relevant journals with the current `v0.125.0` verification notes and remaining validation gap

## Validation

Passed locally:

- `cargo test -p agenthub-managed-skills -- --nocapture`
- `cargo test -p agenthub-acp prompt_prefix_blocks_keep_managed_skill_file_static_and_runtime_context_dynamic -- --nocapture`
- `cargo fmt --all --check`

Also verified earlier in this worktree before the focused test additions:

- `cargo check -p agenthub-codex-acp`

Known local limitation:

- Fresh focused `cargo test -p agenthub-codex-acp ...` runs on this machine currently hit `No space left on device` while rebuilding large Codex dependency subgraphs, so adapter-side closeout should rely on CI evidence for the remaining `agenthub-codex-acp` test coverage.
