### PR TITLE
fix(team): project task attempt counts

### DIFF
--- a/docs/journal/2026-04-28-team-attempt-projection.md
+++ b/docs/journal/2026-04-28-team-attempt-projection.md
@@ -1,0 +1,39 @@
+# Team Attempt Projection
+
+## Summary
+
+- added a narrow backend projection for Team task execution attempts without changing database
+  schema
+- linked task status transitions now maintain `task.context.execution.attempt_number` as the
+  canonical 1-based attempt counter
+
+## Scope
+
+- `src/team/manager.rs`
+- `src/team/manager/tests.rs`
+
+## What Changed
+
+- centralized attempt tracking in `sync_linked_task_status_tx(...)` instead of scattering it across
+  individual run/step lifecycle entry points
+- increment `task.context.execution.attempt_number` only when a linked task enters
+  `in_progress` from a non-`in_progress` state
+- preserve the current attempt number when the task leaves active execution for `waiting`,
+  `in_review`, `completed`, or `canceled`
+- keep the same attempt number when a run rotates or restarts while the linked task is still part
+  of the same active execution push
+
+## Why
+
+- `docs/features/team-execution-vocabulary.md` defines `attempt` as the semantic boundary for one
+  bounded active execution try, but runtime state previously exposed only task status and run
+  status
+- adding an additive projection in task context lets API and UI surfaces adopt the new vocabulary
+  incrementally without forcing an immediate schema migration
+
+## Validation
+
+- `cargo fmt --all --check`
+- `cargo test -p agenthub linked_run_create_sets_first_attempt_number -- --nocapture`
+- `cargo test -p agenthub linked_run_input_required_and_resume_sync_task_waiting_transitions -- --nocapture`
+- `cargo test -p agenthub restart_run_keeps_linked_task_on_same_attempt_when_already_in_progress -- --nocapture`

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -5037,10 +5037,7 @@ fn compute_next_task_execution_context(
 
     let mut next_context = current_context.clone();
     let next_attempt_number = current_context
-        .as_object()
-        .and_then(|context| context.get("execution"))
-        .and_then(Value::as_object)
-        .and_then(|execution| execution.get("attempt_number"))
+        .pointer("/execution/attempt_number")
         .and_then(Value::as_i64)
         .unwrap_or(0)
         + 1;
@@ -5134,12 +5131,9 @@ async fn sync_linked_task_status_tx(
         first = false;
     }
     if let Some(next_context) = next_context.as_ref() {
-        if !first {
-            builder.push(", ");
-        }
+        builder.push(", ");
         builder.push("context_json = ");
         builder.push_bind(next_context.to_string());
-        first = false;
     }
     if !first {
         builder.push(", ");

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -5026,6 +5026,41 @@ fn extract_linked_task_id_from_run_input(input: &Value) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
+fn compute_next_task_execution_context(
+    current_status: &TeamTaskStatus,
+    current_context: &Value,
+    next_status: &TeamTaskStatus,
+) -> Option<Value> {
+    if *next_status != TeamTaskStatus::InProgress || *current_status == TeamTaskStatus::InProgress {
+        return None;
+    }
+
+    let mut next_context = current_context.clone();
+    let next_attempt_number = current_context
+        .as_object()
+        .and_then(|context| context.get("execution"))
+        .and_then(Value::as_object)
+        .and_then(|execution| execution.get("attempt_number"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + 1;
+
+    let context_obj = next_context
+        .as_object_mut()
+        .expect("team task context should always be a JSON object");
+    let execution = context_obj
+        .entry("execution".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let execution_obj = execution
+        .as_object_mut()
+        .expect("task execution context should always be a JSON object");
+    execution_obj.insert(
+        "attempt_number".to_string(),
+        Value::Number(next_attempt_number.into()),
+    );
+    Some(next_context)
+}
+
 async fn load_run_status_sync_meta_tx(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     run_id: &str,
@@ -5059,27 +5094,63 @@ async fn sync_linked_task_status_tx(
         return Ok(());
     };
 
-    let status_raw = team_task_status_to_str(&status);
-    let query = if preserve_waiting {
+    let current_row = sqlx::query(
         r#"
-        UPDATE team_tasks
-        SET status = ?3, updated_at = ?4
-        WHERE id = ?1 AND team_id = ?2 AND status <> ?3 AND status <> 'waiting'
-        "#
-    } else {
-        r#"
-        UPDATE team_tasks
-        SET status = ?3, updated_at = ?4
-        WHERE id = ?1 AND team_id = ?2 AND status <> ?3
-        "#
+        SELECT status, context_json
+        FROM team_tasks
+        WHERE id = ?1 AND team_id = ?2
+        "#,
+    )
+    .bind(task_id)
+    .bind(team_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    let Some(current_row) = current_row else {
+        return Ok(());
     };
-    sqlx::query(query)
-        .bind(task_id)
-        .bind(team_id)
-        .bind(status_raw)
-        .bind(now)
-        .execute(&mut **tx)
-        .await?;
+
+    let current_status_raw: String = current_row.get("status");
+    let current_status = codec::team_task_status_from_str(&current_status_raw);
+    let current_context_json: String = current_row.get("context_json");
+    let current_context: Value =
+        serde_json::from_str(&current_context_json).unwrap_or_else(|_| serde_json::json!({}));
+
+    let effective_status = if preserve_waiting && current_status == TeamTaskStatus::Waiting {
+        current_status.clone()
+    } else {
+        status
+    };
+    let next_context =
+        compute_next_task_execution_context(&current_status, &current_context, &effective_status);
+    if current_status == effective_status && next_context.is_none() {
+        return Ok(());
+    }
+
+    let mut builder = QueryBuilder::<Sqlite>::new("UPDATE team_tasks SET ");
+    let mut first = true;
+    if current_status != effective_status {
+        builder.push("status = ");
+        builder.push_bind(team_task_status_to_str(&effective_status));
+        first = false;
+    }
+    if let Some(next_context) = next_context.as_ref() {
+        if !first {
+            builder.push(", ");
+        }
+        builder.push("context_json = ");
+        builder.push_bind(next_context.to_string());
+        first = false;
+    }
+    if !first {
+        builder.push(", ");
+    }
+    builder.push("updated_at = ");
+    builder.push_bind(now);
+    builder.push(" WHERE id = ");
+    builder.push_bind(task_id);
+    builder.push(" AND team_id = ");
+    builder.push_bind(team_id);
+    builder.build().execute(&mut **tx).await?;
     Ok(())
 }
 

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -392,6 +392,13 @@ async fn setup_test_db() -> SqlitePool {
     pool
 }
 
+fn task_attempt_number(task: &crate::team::TeamTaskRecord) -> Option<i64> {
+    task.context
+        .get("execution")
+        .and_then(|value| value.get("attempt_number"))
+        .and_then(Value::as_i64)
+}
+
 async fn insert_team_conversation_message(
     db: &SqlitePool,
     conversation_id: &str,
@@ -2498,6 +2505,7 @@ async fn linked_run_input_required_and_resume_sync_task_waiting_transitions() {
         .await
         .expect("reload after start");
     assert_eq!(after_start.status, TeamTaskStatus::InProgress);
+    assert_eq!(task_attempt_number(&after_start), Some(1));
 
     let _ = manager
         .set_step_input_required(
@@ -2512,6 +2520,7 @@ async fn linked_run_input_required_and_resume_sync_task_waiting_transitions() {
         .await
         .expect("reload after input required");
     assert_eq!(after_input_required.status, TeamTaskStatus::Waiting);
+    assert_eq!(task_attempt_number(&after_input_required), Some(1));
 
     let _ = manager
         .resume_step(&step.id, Some(json!({"answer":"approved"})))
@@ -2522,6 +2531,7 @@ async fn linked_run_input_required_and_resume_sync_task_waiting_transitions() {
         .await
         .expect("reload after resume");
     assert_eq!(after_resume.status, TeamTaskStatus::InProgress);
+    assert_eq!(task_attempt_number(&after_resume), Some(2));
 
     let _ = manager
         .complete_step(&step.id, Some(json!({"result":"done"})))
@@ -2532,6 +2542,7 @@ async fn linked_run_input_required_and_resume_sync_task_waiting_transitions() {
         .await
         .expect("reload after complete");
     assert_eq!(after_complete.status, TeamTaskStatus::InReview);
+    assert_eq!(task_attempt_number(&after_complete), Some(2));
 }
 
 #[tokio::test]
@@ -2577,6 +2588,48 @@ async fn cancel_run_preserves_waiting_task() {
 
     let reloaded = manager.get_task(&task.id).await.expect("reload task");
     assert_eq!(reloaded.status, TeamTaskStatus::Waiting);
+    assert_eq!(task_attempt_number(&reloaded), None);
+}
+
+#[tokio::test]
+async fn linked_run_create_sets_first_attempt_number() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "linked-task-attempt-create-team".to_string(),
+            description: Some("team with linked task attempt projection".to_string()),
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        })
+        .await
+        .expect("create team");
+
+    let (task, _) = manager
+        .create_task(
+            &team.id,
+            "Attempt-number task",
+            "user",
+            json!({"source":"ui"}),
+            "group_chat",
+            Some("attempt-create"),
+        )
+        .await
+        .expect("create task");
+    assert_eq!(task_attempt_number(&task), None);
+
+    let _ = manager
+        .create_run(
+            &team.id,
+            Some(&task.id),
+            json!({"task_id": task.id, "prompt":"start linked execution"}),
+        )
+        .await
+        .expect("create linked run");
+
+    let reloaded = manager.get_task(&task.id).await.expect("reload task");
+    assert_eq!(reloaded.status, TeamTaskStatus::InProgress);
+    assert_eq!(task_attempt_number(&reloaded), Some(1));
 }
 
 #[tokio::test]
@@ -7140,6 +7193,57 @@ async fn restart_run_creates_new_submission_with_same_context_and_input() {
         .expect("list restarted run events");
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].event_type, "run_submitted");
+}
+
+#[tokio::test]
+async fn restart_run_keeps_linked_task_on_same_attempt_when_already_in_progress() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db);
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "restart-run-attempt-team".to_string(),
+            description: Some("team to verify restart keeps attempt projection".to_string()),
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner"}]}),
+        })
+        .await
+        .expect("create team");
+
+    let (task, _) = manager
+        .create_task(
+            &team.id,
+            "Restart-safe attempt projection",
+            "user",
+            json!({"source":"ui"}),
+            "group_chat",
+            Some("restart-attempt"),
+        )
+        .await
+        .expect("create task");
+
+    let run = manager
+        .create_run(
+            &team.id,
+            Some(&task.id),
+            json!({"task_id": task.id, "prompt":"active execution push"}),
+        )
+        .await
+        .expect("create linked run");
+    let after_create = manager
+        .get_task(&task.id)
+        .await
+        .expect("reload after create");
+    assert_eq!(after_create.status, TeamTaskStatus::InProgress);
+    assert_eq!(task_attempt_number(&after_create), Some(1));
+
+    let _ = manager.restart_run(&run.id).await.expect("restart run");
+
+    let after_restart = manager
+        .get_task(&task.id)
+        .await
+        .expect("reload after restart");
+    assert_eq!(after_restart.status, TeamTaskStatus::InProgress);
+    assert_eq!(task_attempt_number(&after_restart), Some(1));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- project a task-scoped `attempt_number` into `task.context.execution` without changing schema
- increment the attempt counter only when a linked task re-enters `in_progress` from a non-active state
- keep the same attempt number across run restarts while the task remains in the same active execution push

## Validation

- `cargo fmt --all --check`
- `cargo test -p agenthub linked_run_create_sets_first_attempt_number -- --nocapture`
- `cargo test -p agenthub linked_run_input_required_and_resume_sync_task_waiting_transitions -- --nocapture`
- `cargo test -p agenthub restart_run_keeps_linked_task_on_same_attempt_when_already_in_progress -- --nocapture`
