### PR TITLE
fix(team): converge task-aware team route helpers

### DIFF
--- a/docs/journal/2026-04-23-team-channel-api-rollout.md
+++ b/docs/journal/2026-04-23-team-channel-api-rollout.md
@@ -59,3 +59,17 @@ Still remaining:
   across both `# all` and non-default channels
 - close the remaining unified workspace shell follow-ups after the Team channel model is no longer
   hardcoded
+
+## 2026-04-28 Follow-up
+
+- converged Team workspace route construction back onto the canonical shared helper in
+  `web/src/app_route_selection.ts` so `task=` deep links no longer depend on a drifting
+  `team_page.tsx`-local path builder
+- kept the existing `TeamPage` helper exports stable for focused tests, but the local Team route
+  helper now delegates to the shared route contract instead of re-encoding its own query shape
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/app_route_selection.test.ts src/pages/team_page.helpers.test.ts`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run build`

--- a/docs/journal/2026-04-28-team-workbench-width-density.md
+++ b/docs/journal/2026-04-28-team-workbench-width-density.md
@@ -1,0 +1,7 @@
+## Team workbench width density
+
+- Removed the inner `lg:max-w-[1180px]` cap from `web/src/pages/team/team_workbench_content.tsx`.
+- The team workspace already sits inside `TEAM_PAGE_ROOT_CLASS` with `max-w-[1680px]`.
+- Keeping both caps caused excessive left/right whitespace on wide and curved displays, especially compared with the denser Slock layout.
+- The team workbench now expands to the shared root shell width instead of applying a second narrow content column.
+- Follow-up: removed the outer `max-w-[1680px]` cap from `TEAM_PAGE_ROOT_CLASS` and trimmed large-screen horizontal shell padding so the Team workbench can use the available desktop width more like Slock.

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -113,6 +113,9 @@ describe("app route selection", () => {
     expect(buildTeamWorkspacePath("team-1", "channels", "all", 42, null, null, "task-77")).toBe(
       "/workspace/teams/team-1?lens=channels&thread=42&task=task-77"
     );
+    expect(
+      buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp", "task-9")
+    ).toBe("/workspace/teams/team-1?lens=members&task=task-9&member=worker-1&tab=thread");
     expect(resolveWorkspaceNodeId("?lens=nodes&node=node-east")).toBe("node-east");
     expect(resolveWorkspaceNodeId("?lens=nodes")).toBeNull();
     expect(buildWorkspaceNodePath("node-east")).toBe("/workspace?lens=nodes&node=node-east");

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -7,10 +7,13 @@ import {
   buildTeamWorkspacePath,
   buildWorkspaceNodePath,
   buildWorkspacePath,
+  isTeamMemberRouteTab,
   navigateToPath,
   resolveAppRouteKind,
   resolvePostAuthRedirectTarget,
+  resolveTeamMemberRouteTab,
   resolveTeamRoute,
+  resolveTeamSelectedTaskId,
   resolveWorkspaceLens,
   resolveWorkspaceAgentRoute,
   resolveWorkspaceNodeId,
@@ -119,6 +122,14 @@ describe("app route selection", () => {
     expect(resolveWorkspaceNodeId("?lens=nodes&node=node-east")).toBe("node-east");
     expect(resolveWorkspaceNodeId("?lens=nodes")).toBeNull();
     expect(buildWorkspaceNodePath("node-east")).toBe("/workspace?lens=nodes&node=node-east");
+    expect(resolveTeamSelectedTaskId("?task=task-9")).toBe("task-9");
+    expect(resolveTeamSelectedTaskId("?task=%20task-9%20")).toBe("task-9");
+    expect(resolveTeamSelectedTaskId("")).toBe("");
+    expect(resolveTeamMemberRouteTab("?tab=thread")).toBe("agent_acp");
+    expect(resolveTeamMemberRouteTab("?tab=member_console")).toBe("member_console");
+    expect(resolveTeamMemberRouteTab("?tab=overview")).toBeNull();
+    expect(isTeamMemberRouteTab("agent_acp")).toBe(true);
+    expect(isTeamMemberRouteTab("overview")).toBe(false);
   });
 
   it("derives the post-auth redirect target only on the workspace root aliases", () => {

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -38,6 +38,15 @@ export type AppRouteKind =
 
 export type WorkspaceLens = "channels" | "tasks" | "members" | "search" | "nodes";
 export type TeamMemberRouteTab = "agent_acp" | "mailbox" | "member_console";
+const TEAM_MEMBER_ROUTE_TABS = new Set<TeamMemberRouteTab>([
+  "agent_acp",
+  "mailbox",
+  "member_console",
+]);
+
+export function isTeamMemberRouteTab(value: string | null | undefined): value is TeamMemberRouteTab {
+  return value != null && TEAM_MEMBER_ROUTE_TABS.has(value as TeamMemberRouteTab);
+}
 
 export function resolveWorkspaceLens(search: string): WorkspaceLens | null {
   const params = new URLSearchParams(search);
@@ -122,11 +131,25 @@ export function buildTeamWorkspacePath(
   if (normalizedMemberId) {
     params.set("member", normalizedMemberId);
   }
-  if (tab === "agent_acp" || tab === "mailbox" || tab === "member_console") {
+  if (isTeamMemberRouteTab(tab)) {
     params.set("tab", tab === "agent_acp" ? "thread" : tab);
   }
   const search = params.toString();
   return search ? `${pathname}?${search}` : pathname;
+}
+
+export function resolveTeamSelectedTaskId(search: string): string {
+  const params = new URLSearchParams(search);
+  return (params.get("task") ?? "").trim();
+}
+
+export function resolveTeamMemberRouteTab(search: string): TeamMemberRouteTab | null {
+  const params = new URLSearchParams(search);
+  const raw = (params.get("tab") ?? "").trim();
+  if (raw === "thread") {
+    return "agent_acp";
+  }
+  return isTeamMemberRouteTab(raw) ? raw : null;
 }
 
 export function navigateToPath(pathname: string): void {

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -168,7 +168,7 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
 }: TeamWorkbenchContentProps) {
   return (
     <div
-      className="teams-main flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-hidden pb-3 pr-1 lg:mx-auto lg:w-full lg:max-w-[1180px] lg:pr-0"
+      className="teams-main flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-hidden pb-3 pr-1 lg:w-full lg:pr-0"
       data-team-surface="workbench"
     >
       {showTeamBootstrapLoading && <TeamLoadingPanel />}

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { buildAcpView } from "../../acp";
+import { isAgentActiveStatus } from "../../agent_ws";
 import type { AgentEvent, TeamMemberSnapshot } from "../../api";
 import { getTeamStepRuntimeHandleId } from "../../api";
 import { getAcpConversationCacheStats } from "../../components/acp_conversation_cache_stats";
@@ -36,6 +37,7 @@ type UseTeamMemberAcpViewModelArgs = {
   memberTitle?: string | null;
   selectedMemberSnapshot: TeamMemberSnapshot | null;
   selectedMemberRole?: string | null;
+  selectedAgentStatus?: string | null;
   selectedSessionId?: string | null;
   memberEvents: AgentEvent[];
   memberEventsHasMore: boolean;
@@ -75,6 +77,7 @@ export function useTeamMemberAcpViewModel({
   memberTitle: memberTitleProp,
   selectedMemberSnapshot,
   selectedMemberRole,
+  selectedAgentStatus,
   selectedSessionId: selectedSessionIdProp,
   memberEvents,
   memberEventsHasMore,
@@ -177,6 +180,9 @@ export function useTeamMemberAcpViewModel({
   );
   const acpView = React.useMemo(() => buildAcpView(acpEventLines), [acpEventLines]);
   const effectiveAcpTab = !developerMode && acpTab === "debug" ? "conversation" : acpTab;
+  const normalizedAgentStatus = normalizeStatusValue(selectedAgentStatus);
+  const agentAllowsInput =
+    !normalizedAgentStatus || isAgentActiveStatus(normalizedAgentStatus);
   const conversationEventMeta = React.useMemo(() => {
     const memberId = selectedMemberId.trim();
     if (!memberId || !selectedSessionId) {
@@ -204,7 +210,7 @@ export function useTeamMemberAcpViewModel({
     activeSessionId: selectedSessionId ?? null,
     acpTab: effectiveAcpTab,
     eventMeta: conversationEventMeta,
-    isAgentActive: Boolean(selectedSessionId),
+    isAgentActive: Boolean(selectedSessionId) && agentAllowsInput,
     onLoadOlder: () => {
       void onLoadOlder?.();
     },
@@ -217,7 +223,9 @@ export function useTeamMemberAcpViewModel({
     acpConversation.conversationSourceItems >= ACP_INITIAL_VISIBLE_MESSAGE_TARGET;
   const hasRenderableConversationContent =
     acpConversation.conversationSourceItems > 0;
-  const canSendInput = Boolean(selectedMemberId.trim() && selectedSessionId && onSendInput);
+  const canSendInput = Boolean(
+    selectedMemberId.trim() && selectedSessionId && onSendInput && agentAllowsInput
+  );
   const hasInProgressToolCall = acpView.toolCalls.some(
     (call) => call.status === "in_progress"
   );
@@ -257,7 +265,11 @@ export function useTeamMemberAcpViewModel({
     normalizeStatusValue(selectedMemberSnapshot?.session_status);
   const acpRunStatus = normalizeStatusValue(acpView.runStatus?.status);
   const memberStatus =
-    snapshotStatus || acpRunStatus || normalizeStatusValue(memberRoleLabel) || "unknown";
+    (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)
+      ? normalizedAgentStatus
+      : snapshotStatus || acpRunStatus || normalizedAgentStatus) ||
+    normalizeStatusValue(memberRoleLabel) ||
+    "unknown";
   const thinkingLabel =
     acpView.thinkingStartTs && ACTIVE_MEMBER_STATUSES.has(snapshotStatus || acpRunStatus)
     ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - acpView.thinkingStartTs))}s`
@@ -357,6 +369,9 @@ export function useTeamMemberAcpViewModel({
     if (!selectedMemberId.trim()) {
       return null;
     }
+    if (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)) {
+      return "Agent is stopped";
+    }
     if (!selectedSessionId) {
       return "No active thread session yet";
     }
@@ -371,6 +386,7 @@ export function useTeamMemberAcpViewModel({
     acpView.hasAcp,
     hasRenderableConversationContent,
     memberEventsLoading,
+    normalizedAgentStatus,
     selectedMemberId,
     selectedSessionId,
     visibleMemberEvents.length,

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isAgentActiveStatus } from "../agent_ws";
 import { AgentEvent, TeamMemberSnapshot } from "../api";
 import { getTeamStepRuntimeHandleId } from "../api";
 import {
@@ -35,6 +36,7 @@ type TeamMemberAcpPanelProps = {
   hideMemberTitle?: boolean;
   selectedMemberSnapshot: TeamMemberSnapshot | null;
   selectedMemberRole?: string | null;
+  selectedAgentStatus?: string | null;
   selectedTargetNodeId?: string | null;
   selectedSessionId?: string | null;
   memberEvents: AgentEvent[];
@@ -63,6 +65,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
     memberTitle: memberTitleProp,
     hideMemberTitle = false,
     selectedMemberRole,
+    selectedAgentStatus,
     selectedTargetNodeId,
     selectedSessionId: selectedSessionIdProp,
     memberEvents,
@@ -83,8 +86,11 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
   const [acpTab, setAcpTab] = React.useState<TeamMemberAcpTab>("conversation");
   const [, setThinkingTick] = React.useState(0);
   const ansi = React.useCallback((inputValue: string) => inputValue, []);
+  const normalizedAgentStatus = selectedAgentStatus?.trim().toLowerCase() ?? "";
   const resolvedSelectedSessionId =
-    selectedSessionIdProp ?? getTeamStepRuntimeHandleId(selectedMemberSnapshot?.latest_step);
+    normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)
+      ? null
+      : selectedSessionIdProp ?? getTeamStepRuntimeHandleId(selectedMemberSnapshot?.latest_step);
   const {
     terminalRef,
     terminalShowJump,
@@ -140,6 +146,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
     memberTitle: memberTitleProp,
     selectedMemberSnapshot,
     selectedMemberRole,
+    selectedAgentStatus,
     selectedSessionId: selectedSessionIdProp,
     memberEvents,
     memberEventsHasMore,
@@ -257,6 +264,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
       attachedNodeId,
       developerTechnicalMetadata,
       infoStripSummary,
+      selectedAgentStatus,
       memberStatus,
       memberStatusClassToken,
       memberStatusLabel,

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -62,6 +62,9 @@ describe("team_page helpers", () => {
     expect(
       buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
     ).toBe("/workspace/teams/team-1?lens=members&member=worker-1&tab=thread");
+    expect(
+      buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")
+    ).toBe("/workspace/teams/team-1?lens=channels&channel=review&task=task-9");
     expect(buildTeamWorkspacePath("team-1", "members", null, null, " worker-2 ", null)).toBe(
       "/workspace/teams/team-1?lens=members&member=worker-2"
     );
@@ -77,6 +80,9 @@ describe("team_page helpers", () => {
     expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
       "/workspace/teams/team-1?lens=members"
     );
+    expect(
+      buildTeamWorkspacePath("team-1", "members", null, null, "worker-3", "conversation" as never, "task-9")
+    ).toBe("/workspace/teams/team-1?lens=members&task=task-9&member=worker-3");
   });
 
   it("parses team channel and thread query state", () => {

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -173,7 +173,8 @@ describe("team_page helpers", () => {
           member_id: "worker-1",
           remote_task_id: "snapshot-session",
         } as never,
-        "runtime-session"
+        "runtime-session",
+        "running"
       )
     ).toBe("runtime-session");
     expect(
@@ -182,9 +183,20 @@ describe("team_page helpers", () => {
           member_id: "worker-1",
           remote_task_id: "snapshot-session",
         } as never,
-        "   "
+        "   ",
+        null
       )
     ).toBe("snapshot-session");
+    expect(
+      resolveSelectedAgentWorkspaceSessionId(
+        {
+          member_id: "worker-1",
+          remote_task_id: "snapshot-session",
+        } as never,
+        "runtime-session",
+        "stopped"
+      )
+    ).toBeNull();
     expect(resolveSelectedAgentWorkspaceSessionId(null, null)).toBeNull();
   });
 

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -345,8 +345,13 @@ export function parseTeamAgentInputSessionMismatch(
 
 export function resolveSelectedAgentWorkspaceSessionId(
   latestStep: TeamStepRecord | null | undefined,
-  runtimeSessionId: string | null | undefined
+  runtimeSessionId: string | null | undefined,
+  agentStatus?: string | null
 ): string | null {
+  const normalizedAgentStatus = agentStatus?.trim().toLowerCase() ?? "";
+  if (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)) {
+    return null;
+  }
   const normalizedRuntimeSessionId = runtimeSessionId?.trim() ?? "";
   if (normalizedRuntimeSessionId) {
     return normalizedRuntimeSessionId;
@@ -1396,12 +1401,6 @@ export function TeamPage(props: TeamPageProps) {
       ) ?? null
     );
   }, [selectedAgentWorkspaceMemberId, selectedTeamRuntime]);
-  const selectedAgentWorkspaceSessionId = useMemo(() => {
-    return resolveSelectedAgentWorkspaceSessionId(
-      selectedAgentWorkspaceSnapshot?.latest_step,
-      selectedAgentWorkspaceRuntimeMember?.session_id ?? null
-    );
-  }, [selectedAgentWorkspaceRuntimeMember, selectedAgentWorkspaceSnapshot]);
   const selectedAgentWorkspaceAgent = useMemo(() => {
     const memberId = selectedAgentWorkspaceMemberId.trim();
     if (!memberId) {
@@ -1409,6 +1408,13 @@ export function TeamPage(props: TeamPageProps) {
     }
     return teamMemberAgentsById[memberId] ?? agents.find((agent) => agent.id === memberId) ?? null;
   }, [agents, selectedAgentWorkspaceMemberId, teamMemberAgentsById]);
+  const selectedAgentWorkspaceSessionId = useMemo(() => {
+    return resolveSelectedAgentWorkspaceSessionId(
+      selectedAgentWorkspaceSnapshot?.latest_step,
+      selectedAgentWorkspaceRuntimeMember?.session_id ?? null,
+      selectedAgentWorkspaceAgent?.status ?? null
+    );
+  }, [selectedAgentWorkspaceAgent, selectedAgentWorkspaceRuntimeMember, selectedAgentWorkspaceSnapshot]);
   const memberTargetNodeById = useMemo<Record<string, string | null>>(() => {
     const entries = Object.entries(teamMemberAgentsById).map(([memberId, agent]) => [
       memberId,
@@ -3248,6 +3254,7 @@ export function TeamPage(props: TeamPageProps) {
         selectedMemberRole={
           selectedAgentWorkspaceRuntimeMember?.role ?? selectedAgentWorkspaceSnapshot?.role ?? null
         }
+        selectedAgentStatus={selectedAgentWorkspaceAgent?.status ?? null}
         selectedTargetNodeId={
           selectedAgentWorkspaceAgent
             ? selectedAgentWorkspaceAgent.target_node_id?.trim() || "main"

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -30,9 +30,14 @@ import {
   shouldHideErrorBannerMessage,
 } from "../connection_status";
 import {
+  buildTeamDetailPath as buildCanonicalTeamDetailPath,
+  buildTeamWorkspacePath as buildCanonicalTeamWorkspacePath,
   buildWorkspaceNodePath,
+  isTeamMemberRouteTab,
   navigateToPath,
+  resolveTeamMemberRouteTab,
   resolveWorkspaceLens,
+  type TeamMemberRouteTab,
   type WorkspaceLens,
 } from "../app_route_selection";
 import { AuthState } from "../types";
@@ -318,17 +323,7 @@ export function resolveTeamSelectedMemberId(search: string): string {
 }
 
 export function resolveTeamWorkspaceTab(search: string): TeamTab | null {
-  const params = new URLSearchParams(search);
-  const raw = (params.get("tab") ?? "").trim();
-  if (
-    raw === "agent_acp" ||
-    raw === "thread" ||
-    raw === "mailbox" ||
-    raw === "member_console"
-  ) {
-    return raw === "thread" ? "agent_acp" : raw;
-  }
-  return null;
+  return resolveTeamMemberRouteTab(search);
 }
 
 export function parseTeamAgentInputSessionMismatch(
@@ -361,7 +356,7 @@ export function resolveSelectedAgentWorkspaceSessionId(
 }
 
 export function buildTeamDetailPath(teamId: string): string {
-  return `/workspace/teams/${encodeURIComponent(teamId)}`;
+  return buildCanonicalTeamDetailPath(teamId);
 }
 
 function navigateTeamRoute(pathname: string): void {
@@ -385,33 +380,16 @@ export function buildTeamWorkspacePath(
   tab?: TeamTab | null,
   taskId?: string | null
 ): string {
-  const pathname = `/workspace/teams/${encodeURIComponent(teamId)}`;
-  const params = new URLSearchParams();
-  if (lens) {
-    params.set("lens", lens);
-  }
-  if (channelId && channelId !== "all") {
-    params.set("channel", channelId);
-  }
-  if (threadRootMessageId && threadRootMessageId > 0) {
-    params.set("thread", String(threadRootMessageId));
-  }
-  const normalizedTaskId = taskId?.trim() ?? "";
-  if (normalizedTaskId) {
-    params.set("task", normalizedTaskId);
-  }
-  const normalizedMemberId = memberId?.trim() ?? "";
-  if (normalizedMemberId) {
-    params.set("member", normalizedMemberId);
-  }
-  if (tab === "agent_acp" || tab === "mailbox" || tab === "member_console") {
-    params.set("tab", tab === "agent_acp" ? "thread" : tab);
-  }
-  const search = params.toString();
-  if (!search) {
-    return pathname;
-  }
-  return `${pathname}?${search}`;
+  const normalizedTab: TeamMemberRouteTab | null = isTeamMemberRouteTab(tab) ? tab : null;
+  return buildCanonicalTeamWorkspacePath(
+    teamId,
+    lens,
+    channelId,
+    threadRootMessageId,
+    memberId,
+    normalizedTab,
+    taskId
+  );
 }
 
 export function buildTeamLensNavigationPath(

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -5437,6 +5437,36 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Plan");
   });
 
+  it("TeamMemberAcpPanel hides input when the selected agent is stopped", async () => {
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={false}
+        selectedMemberId="worker-agent"
+        memberTitle="Worker agent"
+        selectedMemberSnapshot={null}
+        selectedMemberRole="worker"
+        selectedAgentStatus="stopped"
+        selectedSessionId="stale-session-1"
+        memberEvents={[]}
+        memberEventsHasMore={false}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onSendInput={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent?.toLowerCase()).toContain("agent is stopped");
+    expect(container.textContent?.toLowerCase()).toContain("stopped");
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
   it("TeamMemberAcpPanel keeps ACP shell visible when the session has no thread events yet", () => {
     saveTeamMemberAcpRenderCache("worker-agent", "runtime-session-1", [
       {

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -691,7 +691,7 @@ export const INPUT_DOCK_SEND_BUTTON_CLASS =
   "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-white transition hover:bg-black disabled:opacity-50 disabled:cursor-not-allowed active:translate-y-px";
 
 export const TEAM_PAGE_ROOT_CLASS =
-  "mx-auto flex min-h-0 flex-1 w-full max-w-[1680px] flex-col gap-3 bg-white px-3 py-2 sm:px-4 lg:px-6";
+  "flex min-h-0 flex-1 w-full flex-col gap-3 bg-white px-2.5 py-2 sm:px-3 lg:px-4 xl:px-5";
 
 export const TEAM_SECTION_CARD_CLASS =
   "min-h-0 min-w-0 rounded-lg border border-notion-border bg-white px-2.5 py-1.5 shadow-sm transition-all";
@@ -721,7 +721,7 @@ export const TEAM_WORKBENCH_PANEL_CLASS =
   "shrink-0 rounded-xl border border-notion-border bg-white p-2 shadow-lg backdrop-blur-md";
 
 export const TEAM_WORKBENCH_HEADER_SHELL_CLASS =
-  "flex flex-wrap items-center justify-between gap-2.5 bg-white px-3 py-1.5 sm:px-4 sm:py-2 border-b border-notion-border transition-all";
+  "flex flex-wrap items-center justify-between gap-2.5 border-b border-notion-border bg-white px-2.5 py-1.5 sm:px-3 sm:py-2 transition-all";
 
 export const TEAM_WORKBENCH_HEADER_ICON_BUTTON_CLASS =
   "inline-flex h-8 w-8 items-center justify-center rounded-md text-notion-text-muted transition hover:bg-notion-hover hover:text-notion-text";
@@ -730,7 +730,7 @@ export const TEAM_WORKBENCH_HEADER_STATUS_CLASS =
   "inline-flex items-center gap-1.5 rounded-md border border-notion-border/70 bg-notion-sidebar/72 px-2 py-0.5 text-[10px] font-semibold tracking-[0.08em] text-notion-text-muted transition hover:bg-notion-hover";
 
 export const TEAM_WORKBENCH_WORKSPACE_SHELL_CLASS =
-  "shrink-0 flex min-h-0 flex-col rounded-xl border border-notion-border bg-white px-3 py-2 shadow-sm transition-all";
+  "shrink-0 flex min-h-0 flex-col rounded-xl border border-notion-border bg-white px-2.5 py-2 shadow-sm transition-all";
 
 export const TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS =
   "min-w-0 bg-white px-4 py-3 border-r border-notion-border last:border-r-0";


### PR DESCRIPTION
## Summary

- converge Team task-aware workspace route construction onto the shared `app_route_selection` helper
- extend the canonical Team route builder with optional `task=` query support
- keep focused route/helper coverage and record the route-helper convergence note in the channel rollout journal

## Testing

- cd web && pnpm exec vitest run src/app_route_selection.test.ts src/pages/team_page.helpers.test.ts
- cd web && npm exec tsc -- --noEmit
- cd web && npm run build
