### PR TITLE
fix(team): tighten communication shell followups

### DIFF
--- a/docs/features/team-channels-threads.md
+++ b/docs/features/team-channels-threads.md
@@ -267,6 +267,13 @@ Required constraint:
 
 - human chat input must not directly create canonical Team task records
 
+Core product goal:
+
+- let a human mark one outgoing conversation message as "task-oriented intent"
+- keep that intent close to the composer instead of hiding it in Kanban-only workflows
+- preserve the existing Team rule that leader planning/runtime decide whether and how a canonical
+  Team `task` should be materialized
+
 Recommended direction:
 
 - composer may expose a lightweight task affordance such as:
@@ -277,6 +284,165 @@ Recommended direction:
   a canonical Team `task`
 - non-default channels may shape the draft/request context, but must not bypass leader/runtime
   canonicalization
+
+Product interpretation:
+
+- this is a `conversation -> task-intent` affordance
+- it is not a direct `create canonical task now` action
+- the first rollout should optimize clarity of intent, not attempt to expose full task
+  configuration in the composer
+
+#### 7.1 Placement And Surface Rules
+
+The affordance should stay attached to the active Team conversation composer.
+
+Recommended first-rollout placement:
+
+- show the affordance as a compact secondary control adjacent to the send action
+- keep it in the same visual language as other lightweight Team controls
+- do not add a thick horizontal toolbar or a multi-row composer chrome layer
+
+Allowed surfaces:
+
+- channel composer
+- thread reply composer
+
+Disallowed surfaces for the first rollout:
+
+- ACP/agent runtime input docks
+- Kanban canonical task editor
+- global workspace shell header
+
+#### 7.2 Interaction Model
+
+The affordance should behave like a lightweight mode toggle, not a separate form page.
+
+Default state:
+
+- composer behaves like ordinary Team conversation input
+- the task affordance is visible but not active
+
+Armed state:
+
+- after the user activates the affordance, the composer enters a lightweight `task request` mode
+- show a thin context strip above or inside the composer, for example:
+  - `Task request`
+  - `Send as a task-oriented request for leader planning`
+- keep the main text area unchanged
+- allow the user to cancel the mode before sending
+
+Send behavior in armed state:
+
+- sending still creates one conversation message in the current channel/thread context
+- that message carries task-request intent metadata
+- sending does not immediately create a canonical Team task row in Kanban
+
+Exit behavior:
+
+- after successful send, the composer returns to ordinary conversation mode
+- if the user cancels before send, the mode clears without mutating the typed text
+
+#### 7.3 Visual Direction
+
+We should learn from Slock's lightweight "As Task" pattern, but preserve AgentHub's current shell.
+
+Required visual direction:
+
+- compact secondary control
+- minimal additional height
+- one thin context strip when active
+- no modal, no drawer, no expanded inline task form in the first rollout
+
+Explicit anti-goals:
+
+- do not add Slack-like rich composer toolbars
+- do not open a task-configuration side panel from the composer
+- do not ask for assignee, run policy, channel selection, or execution metadata before send
+- do not make the affordance visually heavier than the primary send action
+
+#### 7.4 Semantic Contract
+
+The first rollout should treat the affordance as an intent marker on a conversation message.
+
+Required semantic properties:
+
+- the message remains part of the selected channel/thread conversation history
+- the message is clearly distinguishable to Team planning/runtime as a task-oriented request
+- Team leader/runtime may later:
+  - materialize a canonical Team task
+  - ignore the request
+  - ask for clarification
+  - merge it into an existing task or lane
+
+Important constraint:
+
+- the affordance should not promise that every marked message becomes a task
+- the affordance should only promise that the message is delivered as task-oriented intent
+
+#### 7.5 Relationship To Channel And Thread Context
+
+The affordance should inherit the active communication context rather than invent a separate one.
+
+Rules:
+
+- in a channel composer, the task-request message belongs to that selected channel
+- in a thread composer, the task-request message belongs to that thread context while still
+  remaining subordinate to the parent channel
+- a non-default channel may shape the meaning of the request
+  - for example `# review` implies review-oriented task requests
+  - for example `# research` implies investigation-oriented task requests
+- but channel choice alone must not create or classify canonical Team tasks automatically
+
+#### 7.6 Relationship To Kanban
+
+Kanban remains the canonical task surface.
+
+Still true after this affordance ships:
+
+- Kanban is where canonical tasks live
+- leader planning/runtime own materialization into Kanban
+- composer-level task intent is an upstream signal, not a replacement for Kanban
+
+This means:
+
+- the first rollout should not insert optimistic task cards directly into Kanban on send
+- if later product work wants a stronger link, it should surface as:
+  - `requested task created`
+  - `linked to existing task`
+  - or another explicit follow-up event after canonicalization
+
+#### 7.7 URL And Persistence Guidance
+
+The first rollout should avoid introducing a dedicated URL mode for task-request composer state.
+
+Guidance:
+
+- ordinary `channel` / `thread` route state remains canonical
+- the temporary armed-state of the composer does not need its own query parameter
+- drafts may stay local to the current page session in the first rollout
+
+This keeps the feature lightweight and prevents task-intent UX from overcomplicating shell routing.
+
+#### 7.8 Rollout Slice
+
+The first implementation slice should be intentionally narrow.
+
+Phase 5A:
+
+- add the lightweight composer affordance
+- add the thin active-state strip
+- send one conversation message with task-request intent metadata
+- do not change Kanban materialization semantics yet
+
+Phase 5B:
+
+- surface clearer follow-up feedback when leader/runtime later materialize a task from that request
+- optionally show a compact linkage from the request message to the resulting canonical task
+
+Phase 5C:
+
+- evaluate whether richer task-draft affordances are needed
+- only after the lightweight mode proves useful and does not blur the Team task contract
 
 ### 8) Relationship To Existing Team Semantics
 

--- a/docs/journal/2026-04-04-ui-primitives-bootstrap.md
+++ b/docs/journal/2026-04-04-ui-primitives-bootstrap.md
@@ -44,13 +44,18 @@ surface/header/button patterns stop drifting independently across Agents and Tea
   - `web/src/pages/team_overview_panel.tsx`
     - playbook surface now uses `InsetSurface`
     - member mailbox rows now use `SelectableListItem`
+    - snapshot meta strip now uses `KeyValueList` / `KeyValueItem` instead of a handwritten
+      stats row
   - `web/src/pages/team_run_panel.tsx`
     - run browser body now uses `InsetSurface`
     - list header/footer and run actions use `ToolbarRow`
     - run rows now use `SelectableListItem`
+    - the `Execution Runs` filter/refresh actions now also use `ToolbarRow` instead of a
+      handwritten flex wrapper
   - `web/src/pages/team_active_run_panel.tsx`
     - run action bar now uses `ToolbarRow`
     - refresh/cancel/resume/restart now use shared `ActionButton`
+    - header action cluster now also uses `ToolbarRow` instead of a bare fragment
   - `web/src/pages/team_mailbox_panel.tsx`
     - actor selection rows now use `SelectableListItem`
   - `web/src/pages/team/team_selector_panel.tsx`
@@ -79,8 +84,13 @@ surface/header/button patterns stop drifting independently across Agents and Tea
     - mailbox shell now uses `SurfaceCard`
     - advanced controls shell now uses `InsetSurface`
     - chat composer action row now uses `ToolbarRow`
+    - conversation header accept/jump actions now also use `ToolbarRow` instead of a
+      handwritten flex wrapper
+  - `web/src/pages/team_events_panel.tsx`
+    - run-events header actions now use `ToolbarRow` instead of a handwritten flex wrapper
   - `web/src/pages/team_member_console_panel.tsx`
     - member detail shell now uses `InsetSurface`
+    - header actions now use `ToolbarRow` instead of a handwritten flex wrapper
   - `web/src/use_app_output_cache.ts`, `web/src/use_app_permissions.ts`, `web/src/use_app_sse_events.ts`, `web/src/use_app_acp_ui.ts`
     - cleaned up lingering type imports after the hook extraction so dispatcher/output-cache signatures match actual exports
   - `web/src/components/bubbles/markdown_bubble.tsx`, `web/src/pages/team_task_panel.tsx`, `web/src/pages/team_mailbox_panel.tsx`

--- a/docs/journal/2026-04-18-workspace-shell-phases-1-3-convergence.md
+++ b/docs/journal/2026-04-18-workspace-shell-phases-1-3-convergence.md
@@ -56,3 +56,174 @@ first Agent entity deep-link path.
   shared shell instead of relying on the legacy ACP workbench tab model.
 - Converge the full shared rail so Team selector, Team detail, and Agent workspace all expose one
   compact `Channels / Teams / Agents` directory language.
+
+## 2026-04-29 Follow-up
+
+- extracted the Team-only `Search` placeholder card into a shared workspace-shell component:
+  `WorkspaceLensPlaceholder`
+- Team workbench search now uses shell-level language:
+  - `Shared search is still being wired in`
+  - `...the unified workspace search view is still a shell-level placeholder`
+- this keeps phase-1 shell convergence moving toward shared lens behavior instead of leaving Team
+  to maintain its own temporary search wording and chrome
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/components/workspace_lens_placeholder.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 2
+
+- converged the standard workspace lens-bar item construction into one shared helper:
+  `buildStandardWorkspaceLensItems(...)`
+- root workspace and Team shell now reuse the same canonical lens set and the same `Search`
+  placeholder hint instead of hand-maintaining two parallel arrays
+- this keeps phase-1 shell reuse grounded in shared route/lens vocabulary instead of only sharing
+  the outer header component
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/components/workspace_lens_items.test.ts`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 3
+
+- extended the shared `WorkspaceLensPlaceholder` into the root `/workspace` shell so
+  `?lens=search` no longer keeps a separate root-only fallback surface
+- root workspace and Team shell now use the same shell-level search placeholder copy and card
+  treatment instead of drifting on placeholder wording during phase-1 convergence
+- this keeps the first shell rollout aligned around one temporary `Search` lens contract while
+  shared search behavior is still pending
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/app.route_shell.test.tsx src/components/workspace_lens_placeholder.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 8
+
+- converged the shell-level lazy panel loading chrome into one shared component:
+  `WorkspacePanelLoadingFallback`
+- root workspace workbench fallback and Team lazy panel fallback now use the same shell loading
+  surface instead of keeping separate `Loading...` and `Loading panel...` treatments
+- this keeps phase-1 shell fallback behavior aligned without touching the heavier Team bootstrap
+  loading state
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/agents_route_shell.test.tsx src/pages/team/team_workbench_content.test.tsx src/components/workspace_shell_header.test.tsx src/components/workspace_panel_loading_fallback.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 9
+
+- extended the shared workspace loading fallback into the remaining Team shell loading cards that
+  were still hand-rendering one-off loading copy
+- Team run-context loading and the lazy member ACP loading surface now reuse
+  `WorkspacePanelLoadingFallback`, which keeps shell-level loading chrome aligned without touching
+  the heavier Team bootstrap loading state
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_workbench_content.test.tsx src/components/workspace_panel_loading_fallback.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 10
+
+- converged the remaining Team bootstrap shell states onto the shared workspace shell primitives
+- `TeamLoadingPanel` now renders through `WorkspacePanelLoadingFallback`, and
+  `TeamUnavailablePanel` now renders through `WorkspaceLensPlaceholder` with a `Teams` lens
+  identity instead of keeping a handwritten empty-state block
+- this keeps Team bootstrap loading/unavailable chrome aligned with the rest of phase-1 shell
+  fallback surfaces without changing the heavier bootstrap control flow
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_workspace_state_panel.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 11
+
+- converged the Team selector loading state onto the same shared workspace loading fallback surface
+- the selector no longer shows a bare `Loading teams...` text row; it now renders
+  `WorkspacePanelLoadingFallback` with Team-specific copy while keeping the filter controls hidden
+- this keeps the shell-level team-selection loading chrome aligned with the rest of the phase-1
+  workspace shell surfaces
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_selector_panel.test.tsx src/pages/team_page.smoke.test.tsx -t "Loading teams"`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 12
+
+- converged the root app route lazy fallback onto the shared workspace loading fallback surface
+- `/join`, `/admin`, and `/teams` route-level lazy loading now render the same loading chrome as
+  the rest of the workspace shell instead of a route-local plain text block
+- this keeps root route loading behavior aligned with phase-1 shell fallback language without
+  changing route selection or auth gating behavior
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/app.route_shell.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 5
+
+- converged the `Search` lens hover/title hint onto the same shared shell copy surface as the
+  placeholder card itself
+- `buildStandardWorkspaceLensItems(...)` now reuses the exported shared search hint instead of
+  keeping a second inline string, which removes another small phase-1 wording fork
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/components/workspace_lens_items.test.ts src/components/workspace_lens_placeholder.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 6
+
+- aligned Team shell lens selection with the shared shell contract by resetting hidden Team-local
+  tab state when operators switch back into shell-level lenses
+- `channels` and `search` now restore the conversation baseline, `members` restores the overview
+  baseline, and `tasks` restores the Kanban baseline instead of leaving stale member ACP/mailbox
+  state parked behind the shell placeholder
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/use_team_workspace_view_model.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 7
+
+- converged the root `Machines unavailable` empty state onto the same shared workspace placeholder
+  surface used by other shell-level non-content lenses
+- root shell no longer hand-maintains a one-off empty-state card for the `Machines` lens, which
+  keeps phase-1 shell fallback chrome more uniform across root workspace views
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/app.route_shell.test.tsx src/components/workspace_lens_placeholder.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 4
+
+- converged the shell-level `Search` placeholder copy itself into one shared variant:
+  `WorkspaceSearchLensPlaceholder`
+- root `/workspace` and Team shell no longer each spell out the same temporary search copy by
+  hand, which keeps the phase-1 placeholder contract from drifting as shell work continues
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/app.route_shell.test.tsx src/components/workspace_lens_placeholder.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`

--- a/docs/journal/2026-04-23-team-channel-api-rollout.md
+++ b/docs/journal/2026-04-23-team-channel-api-rollout.md
@@ -93,3 +93,195 @@ Focused validation for this follow-up:
 - `cd web && npm exec tsc -- --noEmit`
 - `cd web && npm run lint`
 - `cd web && npm run build`
+
+## 2026-04-29 Follow-up
+
+- tightened the Kanban/task-surface conversation entry so channel-scoped tasks route back into
+  their owning Team lane instead of inheriting whichever channel the operator last had selected
+- `Open conversation` from Kanban task detail now preserves:
+  - `?lens=channels&channel=review&task=task-work`
+  - instead of incorrectly falling back to `?lens=channels&task=task-work`
+- kept the change narrow by routing only the task-detail CTA through the task-owned channel id;
+  the existing channel-thread and refresh-restore behavior remains unchanged
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/use_team_workspace_view_model.test.tsx src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+- `cd web && npm run build`
+
+Validation note:
+
+- local `vitest` and `vite build` attempts in this pass were blocked by `ENOSPC` while Vite tried
+  to write temporary files under `web/node_modules/.vite-temp`; the new regression coverage is in
+  place, but the final local run needs disk space before it can complete
+
+## 2026-04-29 Follow-up 2
+
+- preserved explicit task conversations when switching away from `Channels` and then returning via
+  the workspace lens bar
+- `onSelectWorkspaceLens("channels")` now keeps the active non-shared task conversation route
+  instead of collapsing back to the selected channel bootstrap lane
+- this keeps `?lens=channels&channel=review&task=task-77` stable across lens hops and finishes one
+  more route-parity gap in multi-channel phase 2
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/use_team_workspace_view_model.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- browser MCP baseline remains blocked in this pass because the saved `agenthub-team-ui` browser
+  session is currently back on the login page
+- `vitest` still shares the same local `ENOSPC` blocker until disk space is recovered
+
+## 2026-04-29 Follow-up 3
+
+- canonicalized legacy `?lens=channels&task=<id>` routes when the selected task actually belongs
+  to a non-default Team channel
+- once the task detail loads, TeamPage now upgrades that route to the canonical lane shape:
+  - `?lens=channels&channel=review&task=task-work`
+- preserved `thread=<message_id>` during the same canonicalization path so older task links can
+  still regain full channel-thread semantics after refresh
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- local `vitest` remains blocked by the same Vite `ENOSPC` temp-file failure until disk space is
+  recovered
+
+## 2026-04-29 Follow-up 4
+
+- tightened the channel timeline thread affordance so it now carries live reply-count context
+  instead of staying a bare `Thread` button
+- channel messages with existing thread replies now render:
+  - `Thread · 1 reply`
+  - `Thread · N replies`
+- this keeps the center timeline closer to the split-view spec: thread access is visible from the
+  parent channel lane without duplicating reply bodies inline
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- focused `vitest` remains blocked by the same local `ENOSPC` condition until disk space is freed
+
+## 2026-04-29 Follow-up 5
+
+- marked the active thread root inside the parent channel timeline when the right-side thread pane
+  is open
+- the center lane now keeps a lightweight focused state on the source message instead of only
+  changing the thread button copy
+- this makes the split-view relationship clearer: the right pane is subordinate to a visible source
+  message in the parent channel, not a detached chat surface
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- local focused `vitest` still depends on recovering disk space from the current `ENOSPC`
+
+## 2026-04-29 Follow-up 6
+
+- added a compact source-message summary strip to the right-side thread pane header
+- thread now makes its parent-context relationship explicit with:
+  - `Source`
+  - `From <author> · #<root_message_id>`
+- this keeps the pane subordinate to the parent channel message without adding heavy debug chrome
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- local focused `vitest` is still blocked by the same `ENOSPC` condition until disk space is freed
+
+## 2026-04-29 Follow-up 7
+
+- expanded the thread-pane source strip into a two-line compact context block
+- the first line still keeps the canonical source identity:
+  - `Source`
+  - `From <author> · #<root_message_id>`
+- the second line now carries a one-line preview of the original root message text when chat text is
+  available
+- this keeps the right pane readable as a focused child context even when the operator no longer
+  has the parent channel root fully in view
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+Validation note:
+
+- local focused `vitest` remains blocked by the same `ENOSPC` condition until disk space is freed
+
+## 2026-04-29 Follow-up 8
+
+- separated `View in channel` from `Close thread` behavior inside split-view
+- `View in channel` now closes the right-side pane and asks the center timeline to scroll the
+  source message back into view
+- the jump stays as local UI state instead of route state so canonical Team URLs remain:
+  - `?channel=<id>`
+  - `?channel=<id>&task=<id>`
+- `Close thread` still just dismisses the pane without forcing a source-message jump
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 9
+
+- tightened the right-side thread-pane hierarchy so it now reads more explicitly as:
+  - `Original`
+  - `Thread replies`
+  - `Reply in thread`
+- replaced the previous generic helper copy with clearer reply-context language:
+  - `Reply stays in this thread, not the parent channel`
+- this keeps the pane acting like a focused child context instead of a second full channel surface
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 10
+
+- canonicalized the task query that rides along channel-thread routes so bootstrap lane tasks no
+  longer leak into thread open/close/view-in-channel URLs as redundant `task=` params
+- explicit task conversations still keep `task=<task_id>` when they differ from the selected
+  channel bootstrap task, but channel bootstrap conversations now return to:
+  - `?lens=channels&channel=review`
+  - instead of the redundant `?lens=channels&channel=review&task=task-review`
+- the route-decision logic now lives in a focused helper with an inline comment describing the
+  canonicalization boundary, so later split-view work does not drift back into local ad-hoc query
+  shaping
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_page.helpers.test.ts src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`

--- a/docs/journal/2026-04-29-team-task-panel-performance.md
+++ b/docs/journal/2026-04-29-team-task-panel-performance.md
@@ -1,0 +1,149 @@
+# Team Task Panel Performance
+
+## 2026-04-29 Follow-up 1
+
+- reduced repeated read-state work in `web/src/pages/team_task_panel.tsx`
+- `SeenProgressState` is now precomputed once per visible activity item instead of rebuilding the
+  same breakdown inside every row render
+- this keeps long channel timelines from paying repeated `seenByMessageId` normalization costs
+  while preserving the existing `Seen X/Y` and pending-receipt UI behavior
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 2
+
+- moved thread-reply counting onto a standalone memo keyed by the full ordered message list
+- viewport-window changes no longer rescan the entire conversation history just to re-derive the
+  `Thread · N replies` affordance for visible rows
+- visible row metadata now layers on top of that precomputed map, which keeps the split-view
+  affordance stable while trimming another hot path in long timelines
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 3
+
+- reduced repeated member-ACP event scanning in
+  `web/src/pages/team/use_team_member_acp_view_model.ts`
+- the view model now projects visible ACP events, ACP line items, and terminal-output rows from a
+  single memoized event projection instead of scattering those traversals across separate memos
+- this keeps the Team member ACP surface on the same performance-hardening track as the channel
+  timeline without changing the visible conversation/debug behavior
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_member_acp_panel.test.tsx src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 4
+
+- reduced repeated mailbox conversation-row work in `web/src/pages/team_mailbox_panel.tsx`
+- mailbox actor rows and visible conversation rows are now projected once so actor labels, unread
+  badges, payload rendering inputs, and acceptability checks are not recomputed inside every row
+  render
+- this keeps long mailbox conversations on the same precomputed-row path as the Team channel
+  timeline and member ACP surfaces
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 5
+
+- pushed more Team channel row display state into the existing `visibleActivityRows` projection in
+  `web/src/pages/team_task_panel.tsx`
+- visible rows now precompute item/content/bubble class names, thread-button labels, and
+  permission-card record state instead of re-deriving those values inside every timeline row render
+- this keeps the render loop closer to a pure view over projected row metadata and trims another
+  layer of repeated `Map` lookups and UI-state branching
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 6
+
+- reduced avoidable thread-transcript rebuilds in `web/src/pages/team/team_thread_pane.tsx`
+- root-message and reply display rows are now memoized so editing the reply draft does not
+  continuously re-derive avatar labels, timestamps, and transcript row props for the whole pane
+- this keeps the split-view reply composer closer to local-state-only updates instead of
+  invalidating the entire visible thread transcript on every keystroke
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 7
+
+- reduced repeated preview-row work in `web/src/pages/team_member_console_panel.tsx`
+- member select options, member event rows, and run preview rows are now memoized so timestamp
+  formatting, actor-label resolution, and JSON payload rendering are not recomputed inside every
+  render pass
+- this keeps the member console aligned with the other ACP-heavy surfaces that now render from
+  projected row data instead of raw event arrays
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx -t "TeamMemberConsolePanel switches preview and member-history views"`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 8
+
+- pushed `TeamMemberConsolePanel` detail and discovery-card field rendering onto projected detail
+  item arrays instead of open-coded field-by-field JSX
+- this keeps the console surface closer to pure data projection across both list and detail areas,
+  and removes another layer of repeated string joining and field branching from the render path
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx -t "TeamMemberConsolePanel switches preview and member-history views"`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 9
+
+- added a lightweight tail render window to `web/src/pages/team_member_console_panel.tsx`
+- loaded member histories now render only the most recent slice of events while keeping `Load Older`
+  behavior intact and surfacing an explicit notice when older loaded rows are being omitted from
+  the current DOM window
+- this is the first structural list-size guard in the member console, beyond the row/detail
+  projections from earlier follow-ups
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx -t "TeamMemberConsolePanel"`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## 2026-04-29 Follow-up 10
+
+- added a lightweight Team run-context SSE invalidation stream in `src/sse.rs`
+- the new `/sse/teams/{team_id}/runs/{run_id}/context` route emits compact refresh hints derived
+  from a server-side run-context fingerprint instead of pushing a second full snapshot contract
+- `web/src/pages/team/use_team_run_lifecycle_effects.ts` now uses that stream as the primary
+  refresh path for run-focused tabs and narrows fallback polling to the minimal tab-specific reads
+- `conversation`, `tasks`, and ACP/member-console surfaces are intentionally excluded from this
+  active-run loop because they already have their own SSE/polling contracts and were the main
+  source of the observed Team page polling storm
+
+Focused validation for this follow-up:
+
+- `cd web && pnpm exec vitest run src/pages/team/use_team_run_lifecycle_effects.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+- `cargo test team_run_context -- --nocapture`

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1171,8 +1171,8 @@ mod tests {
             mailbox_dead_letter: 0,
         };
 
-        let delta = super::build_team_run_context_delta(&previous, &next)
-            .expect("delta should be emitted");
+        let delta =
+            super::build_team_run_context_delta(&previous, &next).expect("delta should be emitted");
         assert!(delta.refresh_run);
         assert!(delta.refresh_events);
         assert!(delta.refresh_snapshot);

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -18,7 +18,9 @@ use tokio::{
 use crate::agent::AgentOutput;
 use crate::api::{ApiError, load_team_for_user};
 use crate::state::AppState;
-use crate::team::TeamConversationStreamEvent;
+use crate::team::{
+    TeamConversationStreamEvent, TeamRunContextFingerprint, TeamRunContextStreamEvent,
+};
 
 #[derive(Debug, serde::Deserialize)]
 struct SseTokenQuery {
@@ -35,6 +37,10 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/agents", get(sse_agents))
         .route("/agents/{id}", get(sse_agent))
+        .route(
+            "/teams/{team_id}/runs/{run_id}/context",
+            get(sse_team_run_context),
+        )
         .route(
             "/teams/{team_id}/tasks/{task_id}/messages",
             get(sse_team_task_messages),
@@ -132,6 +138,27 @@ async fn sse_team_task_messages(
     team_conversation_sse_response(event_rx, team_id, task_id, conversation.id)
 }
 
+async fn sse_team_run_context(
+    State(state): State<AppState>,
+    Path((team_id, run_id)): Path<(String, String)>,
+    Query(query): Query<SseTokenQuery>,
+) -> impl IntoResponse {
+    let user = match state.auth.validate_session(&query.token).await {
+        Ok(user) => user,
+        Err(_) => return (StatusCode::UNAUTHORIZED, "unauthorized").into_response(),
+    };
+    if let Err(error) = load_team_for_user(&state, &team_id, &user).await {
+        return error.into_response();
+    }
+    let run = match state.teams.get_run(&run_id).await {
+        Ok(run) if run.team_id == team_id => run,
+        Ok(_) => return (StatusCode::NOT_FOUND, "run not found").into_response(),
+        Err(error) => return map_sse_not_found_error(error, "run not found").into_response(),
+    };
+    let stream = team_run_context_stream(state, run.team_id, run.id);
+    decorate_sse_response(Sse::new(stream).into_response())
+}
+
 fn map_sse_not_found_error(error: anyhow::Error, msg: &str) -> ApiError {
     if matches!(
         error.downcast_ref::<SqlxError>(),
@@ -190,6 +217,8 @@ const OUTPUT_STREAM_BATCH_MAX_EVENTS: usize = 32;
 const OUTPUT_STREAM_BATCH_MAX_BYTES: usize = 64 * 1024;
 const OUTPUT_STREAM_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(50);
 const TEAM_CONVERSATION_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const TEAM_RUN_CONTEXT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 fn output_stream(
     output_rxs: Vec<broadcast::Receiver<AgentOutput>>,
@@ -484,6 +513,119 @@ fn team_conversation_stream(
     )
 }
 
+#[derive(Debug, serde::Serialize)]
+struct TeamRunContextSseMessage {
+    r#type: String,
+    payload: TeamRunContextStreamEvent,
+}
+
+fn team_run_context_event_to_message(event: TeamRunContextStreamEvent) -> TeamRunContextSseMessage {
+    TeamRunContextSseMessage {
+        r#type: "team_run_context".to_string(),
+        payload: event,
+    }
+}
+
+fn optional_id(id: i64) -> Option<i64> {
+    (id > 0).then_some(id)
+}
+
+fn build_team_run_context_delta(
+    previous: &TeamRunContextFingerprint,
+    next: &TeamRunContextFingerprint,
+) -> Option<TeamRunContextStreamEvent> {
+    let refresh_run = previous.run_status != next.run_status;
+    let refresh_events = previous.latest_event_id != next.latest_event_id;
+    let refresh_mailbox = previous.latest_mailbox_message_id != next.latest_mailbox_message_id
+        || previous.mailbox_pending != next.mailbox_pending
+        || previous.mailbox_delivered != next.mailbox_delivered
+        || previous.mailbox_dead_letter != next.mailbox_dead_letter;
+    let refresh_snapshot = refresh_run || refresh_events || refresh_mailbox;
+    if !(refresh_run || refresh_events || refresh_mailbox) {
+        return None;
+    }
+    Some(TeamRunContextStreamEvent {
+        team_id: next.team_id.clone(),
+        run_id: next.run_id.clone(),
+        refresh_run,
+        refresh_events,
+        refresh_snapshot,
+        refresh_mailbox,
+        latest_event_id: optional_id(next.latest_event_id),
+        latest_mailbox_message_id: optional_id(next.latest_mailbox_message_id),
+        source: "poll_delta".to_string(),
+    })
+}
+
+fn team_run_context_stream(
+    state: AppState,
+    team_id: String,
+    run_id: String,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    futures::stream::unfold(
+        (
+            tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_HEARTBEAT_INTERVAL),
+            tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL),
+            None::<TeamRunContextFingerprint>,
+            state,
+            team_id,
+            run_id,
+        ),
+        |(mut heartbeat, mut poll, mut previous, state, team_id, run_id)| async move {
+            loop {
+                tokio::select! {
+                    _ = heartbeat.tick() => {
+                        return Some((
+                            Ok(Event::default().data("heartbeat")),
+                            (heartbeat, poll, previous, state, team_id, run_id),
+                        ));
+                    }
+                    _ = poll.tick() => {
+                        // The Team workbench still reads snapshots/events over HTTP. This stream
+                        // only ships a compact invalidation fingerprint so one SSE connection can
+                        // replace the old 4s triple-poll loop without introducing a second
+                        // snapshot-format contract to keep in sync.
+                        let next = match state.teams.read_run_context_fingerprint(&run_id).await {
+                            Ok(next) => next,
+                            Err(error) if matches!(error.downcast_ref::<SqlxError>(), Some(SqlxError::RowNotFound)) => {
+                                return None;
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    team_id = %team_id,
+                                    run_id = %run_id,
+                                    error = %error,
+                                    "team run context sse fingerprint refresh failed"
+                                );
+                                continue;
+                            }
+                        };
+                        if next.team_id != team_id {
+                            return None;
+                        }
+                        let event = previous
+                            .as_ref()
+                            .and_then(|prev| build_team_run_context_delta(prev, &next));
+                        previous = Some(next);
+                        if let Some(event) = event {
+                            let text = match serde_json::to_string(
+                                &team_run_context_event_to_message(event),
+                            ) {
+                                Ok(text) => text,
+                                Err(_) => continue,
+                            };
+                            return Some((
+                                Ok(Event::default().data(text)),
+                                (heartbeat, poll, previous, state, team_id, run_id),
+                            ));
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
 fn push_batched_output(state: &mut OutputStreamState, output: AgentOutput) {
     state.batch_bytes = state
         .batch_bytes
@@ -557,7 +699,10 @@ mod tests {
         config::{AppConfig, PushConfig, WebConfig},
         push::PushService,
         state::AppState,
-        team::{TeamConversationStreamEvent, TeamDefinitionConfig, TeamManager},
+        team::{
+            TeamConversationStreamEvent, TeamDefinitionConfig, TeamManager,
+            TeamRunContextFingerprint,
+        },
     };
 
     use super::parse_agent_ids;
@@ -970,6 +1115,70 @@ mod tests {
             .await
             .expect("execute request");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn team_run_context_sse_requires_valid_token() {
+        let state = build_team_test_state().await;
+        let team = state
+            .teams
+            .create_team(TeamDefinitionConfig {
+                name: "sse-team-run-auth".to_string(),
+                description: Some("team run context sse auth".to_string()),
+                spec: serde_json::json!({
+                    "entrypoint":"leader_plan",
+                    "members":[{"member_id":"leader"}]
+                }),
+            })
+            .await
+            .expect("create team");
+        let run = state
+            .teams
+            .create_run(&team.id, Some("ctx-run-auth"), serde_json::json!({}))
+            .await
+            .expect("create run");
+        let app = super::router(state);
+        let response = app
+            .oneshot(build_sse_request(&format!(
+                "/teams/{}/runs/{}/context?token=bad-token",
+                team.id, run.id
+            )))
+            .await
+            .expect("execute request");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn build_team_run_context_delta_marks_expected_refresh_targets() {
+        let previous = TeamRunContextFingerprint {
+            team_id: "team-1".to_string(),
+            run_id: "run-1".to_string(),
+            run_status: "working".to_string(),
+            latest_event_id: 10,
+            latest_mailbox_message_id: 5,
+            mailbox_pending: 1,
+            mailbox_delivered: 2,
+            mailbox_dead_letter: 0,
+        };
+        let next = TeamRunContextFingerprint {
+            team_id: "team-1".to_string(),
+            run_id: "run-1".to_string(),
+            run_status: "completed".to_string(),
+            latest_event_id: 11,
+            latest_mailbox_message_id: 6,
+            mailbox_pending: 0,
+            mailbox_delivered: 3,
+            mailbox_dead_letter: 0,
+        };
+
+        let delta = super::build_team_run_context_delta(&previous, &next)
+            .expect("delta should be emitted");
+        assert!(delta.refresh_run);
+        assert!(delta.refresh_events);
+        assert!(delta.refresh_snapshot);
+        assert!(delta.refresh_mailbox);
+        assert_eq!(delta.latest_event_id, Some(11));
+        assert_eq!(delta.latest_mailbox_message_id, Some(6));
     }
 
     #[tokio::test]

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -218,7 +218,7 @@ const OUTPUT_STREAM_BATCH_MAX_BYTES: usize = 64 * 1024;
 const OUTPUT_STREAM_BATCH_FLUSH_INTERVAL: Duration = Duration::from_millis(50);
 const TEAM_CONVERSATION_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const TEAM_RUN_CONTEXT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
-const TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 fn output_stream(
     output_rxs: Vec<broadcast::Receiver<AgentOutput>>,
@@ -562,10 +562,14 @@ fn team_run_context_stream(
     team_id: String,
     run_id: String,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
+    let mut heartbeat = tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut poll = tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL);
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     futures::stream::unfold(
         (
-            tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_HEARTBEAT_INTERVAL),
-            tokio::time::interval(TEAM_RUN_CONTEXT_STREAM_POLL_INTERVAL),
+            heartbeat,
+            poll,
             None::<TeamRunContextFingerprint>,
             state,
             team_id,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -157,6 +157,31 @@ pub struct TeamConversationStreamEvent {
     pub source: String,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct TeamRunContextStreamEvent {
+    pub team_id: String,
+    pub run_id: String,
+    pub refresh_run: bool,
+    pub refresh_events: bool,
+    pub refresh_snapshot: bool,
+    pub refresh_mailbox: bool,
+    pub latest_event_id: Option<i64>,
+    pub latest_mailbox_message_id: Option<i64>,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamRunContextFingerprint {
+    pub team_id: String,
+    pub run_id: String,
+    pub run_status: String,
+    pub latest_event_id: i64,
+    pub latest_mailbox_message_id: i64,
+    pub mailbox_pending: i64,
+    pub mailbox_delivered: i64,
+    pub mailbox_dead_letter: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct TeamMemoryFlushRequest {
     pub member_id: String,
@@ -3995,6 +4020,57 @@ impl TeamManager {
         .execute(&self.db)
         .await?;
         Ok(())
+    }
+
+    pub async fn read_run_context_fingerprint(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<TeamRunContextFingerprint> {
+        let run_row = sqlx::query(
+            r#"
+            SELECT team_id, status
+            FROM team_runs
+            WHERE id = ?1
+            "#,
+        )
+        .bind(run_id)
+        .fetch_one(&self.db)
+        .await?;
+        let team_id: String = run_row.get("team_id");
+        let run_status: String = run_row.get("status");
+        let latest_event_id = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(id)
+            FROM team_run_events
+            WHERE run_id = ?1
+            "#,
+        )
+        .bind(run_id)
+        .fetch_one(&self.db)
+        .await?
+        .unwrap_or(0);
+        let latest_mailbox_message_id = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(id)
+            FROM team_actor_messages
+            WHERE run_id = ?1
+            "#,
+        )
+        .bind(run_id)
+        .fetch_one(&self.db)
+        .await?
+        .unwrap_or(0);
+        let status_counts = self.list_actor_message_status_counts(run_id).await?;
+        Ok(TeamRunContextFingerprint {
+            team_id,
+            run_id: run_id.to_string(),
+            run_status,
+            latest_event_id,
+            latest_mailbox_message_id,
+            mailbox_pending: status_counts.get("pending").copied().unwrap_or(0),
+            mailbox_delivered: status_counts.get("delivered").copied().unwrap_or(0),
+            mailbox_dead_letter: status_counts.get("dead_letter").copied().unwrap_or(0),
+        })
     }
 
     pub async fn cancel_run(&self, run_id: &str) -> anyhow::Result<TeamRunRecord> {

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -30,8 +30,9 @@ pub(crate) use manager::TEAM_TASK_DETAIL_MESSAGE_LIMIT_MAX;
 #[allow(unused_imports)]
 pub use manager::{
     SendActorMessageInput, TeamContextLookupError, TeamContextRecord, TeamConversationStreamEvent,
-    TeamManager, TeamMemoryFlushRequest, TeamRemoteRelayWorkerSettings, TeamRuntimeRecord,
-    TeamRuntimeStatus, TeamTaskAssignmentUpdate, TeamTaskContextPatch, TeamTaskListQuery,
+    TeamManager, TeamMemoryFlushRequest, TeamRemoteRelayWorkerSettings, TeamRunContextFingerprint,
+    TeamRunContextStreamEvent, TeamRuntimeRecord, TeamRuntimeStatus, TeamTaskAssignmentUpdate,
+    TeamTaskContextPatch, TeamTaskListQuery,
 };
 pub(crate) use permission_review::resolve_team_permission_review_target;
 pub use permission_review::{

--- a/web/src/agents_route_shell.test.tsx
+++ b/web/src/agents_route_shell.test.tsx
@@ -185,7 +185,7 @@ describe("AgentsRouteShell", () => {
   it("renders the lazy workbench fallback when workbench props are present", () => {
     const html = renderRouteShell();
 
-    expect(html).toContain("Loading...");
+    expect(html).toContain("Loading workspace panel...");
     expect(html).toContain(OUTPUT_BODY_ACP_ROOT_CLASS);
   });
 
@@ -194,7 +194,7 @@ describe("AgentsRouteShell", () => {
       workbenchProps: null,
     });
 
-    expect(html).not.toContain("Loading...");
+    expect(html).not.toContain("Loading workspace panel...");
     expect(html).not.toContain(OUTPUT_BODY_ROOT_CLASS);
     expect(html).toContain("No agent selected");
   });

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { __testOnlyApiInternals, api } from "./api";
+import { __testOnlyApiInternals, api, buildTeamRunContextSseUrl } from "./api";
 
 describe("api request headers", () => {
   afterEach(() => {
@@ -179,6 +179,19 @@ describe("api request headers", () => {
     const headers = new Headers(init.headers);
     expect(headers.get("Authorization")).toBe("Bearer token-1");
     expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("builds the team run-context SSE URL with encoded dynamic segments", () => {
+    expect(
+      buildTeamRunContextSseUrl(
+        "https://agenthub.example",
+        "team/one",
+        "run with spaces",
+        "token+value/1"
+      )
+    ).toBe(
+      "https://agenthub.example/sse/teams/team%2Fone/runs/run%20with%20spaces/context?token=token%2Bvalue%2F1"
+    );
   });
 
   it("lists and mutates team channels through the public channel endpoints", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -656,6 +656,17 @@ function encodePathSegment(value: string | number): string {
   return encodeURIComponent(String(value));
 }
 
+export function buildTeamRunContextSseUrl(
+  origin: string,
+  teamId: string,
+  runId: string,
+  token: string
+): string {
+  return `${origin}/sse/teams/${encodePathSegment(teamId)}/runs/${encodePathSegment(
+    runId
+  )}/context?token=${encodeURIComponent(token)}`;
+}
+
 export const api = {
   registerStart: (
     username: string,

--- a/web/src/app.route_shell.test.tsx
+++ b/web/src/app.route_shell.test.tsx
@@ -68,7 +68,7 @@ vi.mock("./webauthn", () => ({
   registerCredentialToJson: vi.fn(() => ({})),
 }));
 
-import { App } from "./app";
+import { App, RouteFallback } from "./app";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -219,6 +219,18 @@ describe("App route shell wiring", () => {
     });
   });
 
+  it("renders the shared route loading fallback chrome", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <RouteFallback label="Loading teams..." />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Loading teams...");
+    expect(html).toContain("loading this workspace route");
+    expect(html).toContain("data-workspace-panel-loading=\"true\"");
+  });
+
   afterEach(() => {
     act(() => {
       root.unmount();
@@ -349,6 +361,40 @@ describe("App route shell wiring", () => {
     );
     expect(rootWorkbenchHtml).toContain("Machines unavailable");
     expect(rootWorkbenchHtml).toContain("do not have permission to manage machines");
+  });
+
+  it("renders the shared workspace search placeholder in the root shell", async () => {
+    globalThis.localStorage.setItem(
+      "agenthub_auth",
+      JSON.stringify({
+        token: "token-root",
+        userId: "user-1",
+        username: "root",
+        role: "root",
+      })
+    );
+    window.history.replaceState({}, "", "/workspace?lens=search");
+
+    act(() => {
+      renderApp(root);
+    });
+    await flushRenderFrames(10);
+
+    const lastCall = agentsRouteShellPropsMock.mock.calls[
+      agentsRouteShellPropsMock.mock.calls.length - 1
+    ]?.[0] as
+      | {
+          rootWorkbenchNode: React.ReactNode;
+        }
+      | undefined;
+
+    expect(lastCall?.rootWorkbenchNode).toBeTruthy();
+    const rootWorkbenchHtml = renderToStaticMarkup(
+      <MantineProvider>{lastCall?.rootWorkbenchNode}</MantineProvider>
+    );
+    expect(rootWorkbenchHtml).toContain("Shared search is still being wired in");
+    expect(rootWorkbenchHtml).toContain("shell-level placeholder");
+    expect(rootWorkbenchHtml).toContain("data-workspace-lens-placeholder=\"search\"");
   });
 
   it("omits the agent output header when the machines lens is active", async () => {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -47,6 +47,11 @@ import {
   buildAgentsWorkbenchProps,
   buildOutputHeaderProps,
 } from "./components/agents_route_shell_props";
+import { buildStandardWorkspaceLensItems } from "./components/workspace_lens_items";
+import {
+  WorkspaceMachinesUnavailablePlaceholder,
+  WorkspaceSearchLensPlaceholder,
+} from "./components/workspace_lens_placeholder";
 import {
   getLocalStorageItemSafe,
   setLocalStorageItemSafe,
@@ -59,10 +64,10 @@ import {
 import {
   AUTH_CARD_BASE_CLASS,
   AUTH_PAGE_CLASS,
-  ROUTE_FALLBACK_SHELL_CLASS,
 } from "./ui/tailwind_classes";
 import { parseSendInputSessionMismatch } from "./app_utils";
 import { resolveDefaultWorktreeRootForTargetNode } from "./worktree_defaults";
+import { WorkspacePanelLoadingFallback } from "./components/workspace_panel_loading_fallback";
 
 import { useAppAuth } from "./use_app_auth";
 import { useAppAgents } from "./use_app_agents";
@@ -160,8 +165,16 @@ function PostLoginRedirect({ target }: { target: string }): null {
   return null;
 }
 
-function RouteFallback({ label }: { label: string }) {
-  return <div className={ROUTE_FALLBACK_SHELL_CLASS}>{label}</div>;
+export function RouteFallback({ label }: { label: string }) {
+  return (
+    <div className="mx-auto flex min-h-[40vh] w-full max-w-3xl items-center justify-center px-6 py-10">
+      <WorkspacePanelLoadingFallback
+        title={label}
+        body="AgentHub is loading this workspace route."
+        className="w-full max-w-md"
+      />
+    </div>
+  );
 }
 
 function AuthGateCard({ title, message }: { title: string; message: string }) {
@@ -432,15 +445,9 @@ export function App() {
 
   const workspaceLensItems = useMemo(
     () =>
-      [
-        { value: "channels", label: "Channels", active: activeWorkspaceLens === "channels" },
-        { value: "tasks", label: "Tasks", active: activeWorkspaceLens === "tasks" },
-        { value: "members", label: "Members", active: activeWorkspaceLens === "members" },
-        { value: "search", label: "Search", active: activeWorkspaceLens === "search" },
-        ...(canManageAgentNodes(auth)
-          ? [{ value: "nodes", label: "Machines", active: activeWorkspaceLens === "nodes" }]
-          : []),
-      ],
+      buildStandardWorkspaceLensItems(activeWorkspaceLens, {
+        includeNodes: canManageAgentNodes(auth),
+      }),
     [activeWorkspaceLens, auth]
   );
 
@@ -1045,15 +1052,11 @@ export function App() {
             />
           )
           : (
-            <div className="flex h-full items-center justify-center p-6 text-center">
-              <div className="max-w-md space-y-2">
-                <h2 className="text-lg font-semibold text-notion-text">Machines unavailable</h2>
-                <p className="text-sm text-notion-text-muted">
-                  You do not have permission to manage machines. Select another workspace view to
-                  continue.
-                </p>
-              </div>
-            </div>
+            <WorkspaceMachinesUnavailablePlaceholder className="m-6 text-center" />
+          )
+        : activeWorkspaceLens === "search"
+          ? (
+            <WorkspaceSearchLensPlaceholder className="m-4" />
           )
         : null,
     [

--- a/web/src/components/agents_route_shell.tsx
+++ b/web/src/components/agents_route_shell.tsx
@@ -12,6 +12,7 @@ import {
   OUTPUT_BODY_LOADING_CLASS,
   OUTPUT_BODY_ROOT_CLASS,
 } from "../ui/tailwind_classes";
+import { WorkspacePanelLoadingFallback } from "./workspace_panel_loading_fallback";
 
 const LazyAgentsWorkbench = React.lazy(async () => {
   const module = await import("./agents_workbench");
@@ -22,8 +23,7 @@ function WorkbenchBodyFallback({ hasAcp }: { hasAcp: boolean }) {
   return (
     <div className={hasAcp ? OUTPUT_BODY_ACP_ROOT_CLASS : OUTPUT_BODY_ROOT_CLASS}>
       <div className={OUTPUT_BODY_LOADING_CLASS}>
-        <i className="bi bi-hourglass-split spinner" aria-hidden="true" />
-        <div className="label">Loading...</div>
+        <WorkspacePanelLoadingFallback className="w-full max-w-md" />
       </div>
     </div>
   );

--- a/web/src/components/workspace_lens_items.test.ts
+++ b/web/src/components/workspace_lens_items.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildStandardWorkspaceLensItems } from "./workspace_lens_items";
+import { SHARED_WORKSPACE_SEARCH_LENS_HINT } from "./workspace_lens_placeholder";
+
+describe("buildStandardWorkspaceLensItems", () => {
+  it("builds the shared workspace lens set with a search placeholder hint", () => {
+    const items = buildStandardWorkspaceLensItems("tasks");
+
+    expect(items.map((item) => item.value)).toEqual([
+      "channels",
+      "tasks",
+      "members",
+      "search",
+    ]);
+    expect(items.find((item) => item.value === "tasks")?.active).toBe(true);
+    expect(items.find((item) => item.value === "search")?.title).toBe(
+      SHARED_WORKSPACE_SEARCH_LENS_HINT
+    );
+  });
+
+  it("optionally appends Machines and wires prefetch callbacks", () => {
+    const onPrefetch = vi.fn();
+    const items = buildStandardWorkspaceLensItems("nodes", {
+      includeNodes: true,
+      onPrefetch,
+    });
+
+    expect(items.map((item) => item.value)).toEqual([
+      "channels",
+      "tasks",
+      "members",
+      "search",
+      "nodes",
+    ]);
+    items.find((item) => item.value === "members")?.onPrefetch?.();
+    expect(onPrefetch).toHaveBeenCalledWith("members");
+    expect(items.find((item) => item.value === "nodes")?.active).toBe(true);
+  });
+});

--- a/web/src/components/workspace_lens_items.ts
+++ b/web/src/components/workspace_lens_items.ts
@@ -1,0 +1,50 @@
+import type { WorkspaceLens } from "../app_route_selection";
+import type { WorkspaceShellLensItem } from "./workspace_shell_header";
+import { SHARED_WORKSPACE_SEARCH_LENS_HINT } from "./workspace_lens_placeholder";
+
+type BuildStandardWorkspaceLensItemsOptions = {
+  includeNodes?: boolean;
+  onPrefetch?: (lens: WorkspaceLens) => void;
+};
+
+export function buildStandardWorkspaceLensItems(
+  activeLens: WorkspaceLens,
+  options: BuildStandardWorkspaceLensItemsOptions = {}
+): WorkspaceShellLensItem[] {
+  const { includeNodes = false, onPrefetch } = options;
+  const items: WorkspaceShellLensItem[] = [
+    {
+      value: "channels",
+      label: "Channels",
+      active: activeLens === "channels",
+      onPrefetch: onPrefetch ? () => onPrefetch("channels") : undefined,
+    },
+    {
+      value: "tasks",
+      label: "Tasks",
+      active: activeLens === "tasks",
+      onPrefetch: onPrefetch ? () => onPrefetch("tasks") : undefined,
+    },
+    {
+      value: "members",
+      label: "Members",
+      active: activeLens === "members",
+      onPrefetch: onPrefetch ? () => onPrefetch("members") : undefined,
+    },
+    {
+      value: "search",
+      label: "Search",
+      active: activeLens === "search",
+      title: SHARED_WORKSPACE_SEARCH_LENS_HINT,
+      onPrefetch: onPrefetch ? () => onPrefetch("search") : undefined,
+    },
+  ];
+  if (includeNodes) {
+    items.push({
+      value: "nodes",
+      label: "Machines",
+      active: activeLens === "nodes",
+    });
+  }
+  return items;
+}

--- a/web/src/components/workspace_lens_placeholder.test.tsx
+++ b/web/src/components/workspace_lens_placeholder.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import {
+  WorkspaceMachinesUnavailablePlaceholder,
+  WorkspaceLensPlaceholder,
+  WorkspaceSearchLensPlaceholder,
+} from "./workspace_lens_placeholder";
+
+describe("WorkspaceLensPlaceholder", () => {
+  it("renders a shared shell placeholder with lens identity and body copy", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceLensPlaceholder
+          lensLabel="Search"
+          title="Shared search is still being wired in"
+          body="Use Channels, Tasks, or Members while the unified workspace search view is still a shell-level placeholder."
+          className="shell-card"
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Search");
+    expect(html).toContain("Shared search is still being wired in");
+    expect(html).toContain("shell-level placeholder");
+    expect(html).toContain("data-workspace-lens-placeholder=\"search\"");
+    expect(html).toContain("shell-card");
+  });
+
+  it("renders the shared workspace search placeholder variant", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceSearchLensPlaceholder className="shared-search-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Search");
+    expect(html).toContain("Shared search is still being wired in");
+    expect(html).toContain("shell-level placeholder");
+    expect(html).toContain("shared-search-card");
+  });
+
+  it("renders the shared machines unavailable placeholder variant", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceMachinesUnavailablePlaceholder className="machines-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Machines");
+    expect(html).toContain("Machines unavailable");
+    expect(html).toContain("permission to manage machines");
+    expect(html).toContain("machines-card");
+    expect(html).toContain("data-workspace-lens-placeholder=\"machines\"");
+  });
+});

--- a/web/src/components/workspace_lens_placeholder.tsx
+++ b/web/src/components/workspace_lens_placeholder.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { EmptyState, SurfaceCard } from "../ui/primitives";
+
+export const SHARED_WORKSPACE_SEARCH_PLACEHOLDER_TITLE =
+  "Shared search is still being wired in";
+export const SHARED_WORKSPACE_SEARCH_PLACEHOLDER_BODY =
+  "Use Channels, Tasks, or Members while the unified workspace search view is still a shell-level placeholder.";
+export const SHARED_WORKSPACE_SEARCH_LENS_HINT =
+  "Shared search is still being wired in across the unified workspace shell.";
+export const WORKSPACE_MACHINES_UNAVAILABLE_TITLE = "Machines unavailable";
+export const WORKSPACE_MACHINES_UNAVAILABLE_BODY =
+  "You do not have permission to manage machines. Select another workspace view to continue.";
+
+type WorkspaceLensPlaceholderProps = {
+  lensLabel: string;
+  title: string;
+  body: string;
+  className?: string;
+};
+
+export const WorkspaceLensPlaceholder = React.memo(function WorkspaceLensPlaceholder({
+  lensLabel,
+  title,
+  body,
+  className = "",
+}: WorkspaceLensPlaceholderProps) {
+  return (
+    <SurfaceCard className={className} data-workspace-lens-placeholder={lensLabel.toLowerCase()}>
+      <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
+        {lensLabel}
+      </div>
+      <EmptyState className="mt-2 border-0 bg-transparent px-0 py-0" title={title} body={body} />
+    </SurfaceCard>
+  );
+});
+
+type WorkspaceSearchLensPlaceholderProps = {
+  className?: string;
+};
+
+export function WorkspaceSearchLensPlaceholder({
+  className = "",
+}: WorkspaceSearchLensPlaceholderProps) {
+  return (
+    <WorkspaceLensPlaceholder
+      lensLabel="Search"
+      title={SHARED_WORKSPACE_SEARCH_PLACEHOLDER_TITLE}
+      body={SHARED_WORKSPACE_SEARCH_PLACEHOLDER_BODY}
+      className={className}
+    />
+  );
+}
+
+type WorkspaceMachinesUnavailablePlaceholderProps = {
+  className?: string;
+};
+
+export function WorkspaceMachinesUnavailablePlaceholder({
+  className = "",
+}: WorkspaceMachinesUnavailablePlaceholderProps) {
+  return (
+    <WorkspaceLensPlaceholder
+      lensLabel="Machines"
+      title={WORKSPACE_MACHINES_UNAVAILABLE_TITLE}
+      body={WORKSPACE_MACHINES_UNAVAILABLE_BODY}
+      className={className}
+    />
+  );
+}

--- a/web/src/components/workspace_panel_loading_fallback.test.tsx
+++ b/web/src/components/workspace_panel_loading_fallback.test.tsx
@@ -14,6 +14,9 @@ describe("WorkspacePanelLoadingFallback", () => {
     expect(html).toContain("Loading workspace panel...");
     expect(html).toContain("loading this workspace surface");
     expect(html).toContain("data-workspace-panel-loading=\"true\"");
+    expect(html).toContain("role=\"status\"");
+    expect(html).toContain("aria-live=\"polite\"");
+    expect(html).toContain("aria-busy=\"true\"");
     expect(html).toContain("loading-shell-card");
   });
 });

--- a/web/src/components/workspace_panel_loading_fallback.test.tsx
+++ b/web/src/components/workspace_panel_loading_fallback.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { WorkspacePanelLoadingFallback } from "./workspace_panel_loading_fallback";
+
+describe("WorkspacePanelLoadingFallback", () => {
+  it("renders the shared shell loading chrome", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspacePanelLoadingFallback className="loading-shell-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Loading workspace panel...");
+    expect(html).toContain("loading this workspace surface");
+    expect(html).toContain("data-workspace-panel-loading=\"true\"");
+    expect(html).toContain("loading-shell-card");
+  });
+});

--- a/web/src/components/workspace_panel_loading_fallback.tsx
+++ b/web/src/components/workspace_panel_loading_fallback.tsx
@@ -1,0 +1,21 @@
+type WorkspacePanelLoadingFallbackProps = {
+  className?: string;
+  title?: string;
+  body?: string;
+};
+
+export function WorkspacePanelLoadingFallback({
+  className = "",
+  title = "Loading workspace panel...",
+  body = "AgentHub is loading this workspace surface.",
+}: WorkspacePanelLoadingFallbackProps) {
+  return (
+    <div
+      className={`rounded-2xl border border-notion-border bg-white/88 px-4 py-6 text-sm text-ui-text-muted shadow-sm ${className}`.trim()}
+      data-workspace-panel-loading="true"
+    >
+      <p className="font-medium text-notion-text">{title}</p>
+      <p className="mt-1 text-ui-text-muted">{body}</p>
+    </div>
+  );
+}

--- a/web/src/components/workspace_panel_loading_fallback.tsx
+++ b/web/src/components/workspace_panel_loading_fallback.tsx
@@ -13,6 +13,9 @@ export function WorkspacePanelLoadingFallback({
     <div
       className={`rounded-2xl border border-notion-border bg-white/88 px-4 py-6 text-sm text-ui-text-muted shadow-sm ${className}`.trim()}
       data-workspace-panel-loading="true"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
     >
       <p className="font-medium text-notion-text">{title}</p>
       <p className="mt-1 text-ui-text-muted">{body}</p>

--- a/web/src/components/workspace_shell_header.test.tsx
+++ b/web/src/components/workspace_shell_header.test.tsx
@@ -95,6 +95,6 @@ describe("WorkspaceShellHeader", () => {
         <TeamPanelLoadingFallback />
       </MantineProvider>
     );
-    expect(html).toContain("Loading panel...");
+    expect(html).toContain("Loading workspace panel...");
   });
 });

--- a/web/src/pages/team/team_selector_panel.test.tsx
+++ b/web/src/pages/team/team_selector_panel.test.tsx
@@ -24,6 +24,8 @@ describe("TeamSelectorPanel", () => {
     );
 
     expect(html).toContain("Loading teams...");
+    expect(html).toContain("available team workspaces");
+    expect(html).toContain("data-workspace-panel-loading=\"true\"");
     expect(html).not.toContain("No teams yet. Create one to begin.");
     expect(html).not.toContain("Search teams");
   });

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -6,6 +6,7 @@ import {
   SelectableListItem,
   ToolbarRow,
 } from "../../ui/primitives";
+import { WorkspacePanelLoadingFallback } from "../../components/workspace_panel_loading_fallback";
 
 export type TeamSelectorItem = {
   id: string;
@@ -128,9 +129,11 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
         <div className="mt-2 flex-1 overflow-y-auto">
           <div className={TEAM_SELECTOR_LIST_CLASS}>
             {loading && (
-              <p className={`${bodyTextClassName} px-2`} role="status" aria-live="polite">
-                Loading teams...
-              </p>
+              <WorkspacePanelLoadingFallback
+                title="Loading teams..."
+                body="AgentHub is loading the available team workspaces."
+                className="mx-2"
+              />
             )}
             {!loading && !hasTeams && (
               <p className={`${bodyTextClassName} px-2`}>

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -1,9 +1,50 @@
+// @vitest-environment jsdom
 import { MantineProvider } from "@mantine/core";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamThreadPane } from "./team_thread_pane";
 
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+}
+
 describe("TeamThreadPane", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const originalWidth = window.innerWidth;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: originalWidth,
+    });
+  });
+
   it("renders the thread shell around the selected root message", () => {
     const html = renderToStaticMarkup(
       <MantineProvider>
@@ -36,19 +77,25 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("# all");
     expect(html).toContain("1 reply");
     expect(html).toContain("Focused replies stay anchored to the source message.");
+    expect(html).toContain("Source");
+    expect(html).toContain("From leader · #42");
+    expect(html).toContain("Investigate the regression in a focused thread.");
     expect(html).toContain("View in channel");
     expect(html).toContain("Close thread");
     expect(html).toContain("Original");
+    expect(html).toContain("Thread replies");
     expect(html).toContain("leader");
     expect(html).toContain(">L<");
     expect(html).toContain("#42");
     expect(html).toContain("Investigate the regression in a focused thread.");
-    expect(html).toContain("Replies stay scoped to this thread.");
+    expect(html).toContain("Thread replies");
     expect(html).toContain("worker-agent");
     expect(html).toContain(">W<");
     expect(html).toContain("#43");
     expect(html).toContain("I can take the follow-up from here.");
     expect(html).toContain("Draft follow-up");
+    expect(html).toContain("Reply in thread · # all");
+    expect(html).toContain("Reply stays in this thread · Enter to reply");
     expect(html).toContain("Reply");
     expect(html).toContain("max-w-[360px]");
     expect(html).toContain("rounded-full");
@@ -78,8 +125,39 @@ describe("TeamThreadPane", () => {
 
     expect(html).toContain("Original content is not available in chat text form.");
     expect(html).toContain("0 replies");
-    expect(html).toContain("Reply in # review");
+    expect(html).toContain("Reply in thread · # review");
     expect(html).toContain("Reply");
+  });
+
+  it("truncates long source previews without changing the root thread content", () => {
+    const longRootText =
+      "This is a long source message that should stay fully visible in the original root bubble while the compact source strip only carries a short preview for context.";
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamThreadPane
+          channelLabel="# review"
+          rootMessageId={88}
+          rootAuthorLabel="leader"
+          rootCreatedAt={1713480000000}
+          rootText={longRootText}
+          replies={[]}
+          replyDraft=""
+          onReplyDraftChange={vi.fn()}
+          onSendReply={vi.fn()}
+          replyBusy={false}
+          formatTs={() => "2026/4/19 00:00:00"}
+          onViewInChannel={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("From leader · #88");
+    expect(html).toContain("Thread replies");
+    expect(html).toContain(
+      "This is a long source message that should stay fully visible in the original root bubble while the compact source str..."
+    );
+    expect(html).toContain(longRootText);
   });
 
   it("shows the empty state when no thread root is selected", () => {
@@ -105,6 +183,93 @@ describe("TeamThreadPane", () => {
 
     expect(html).toContain("Select a channel message");
     expect(html).toContain("Thread roots open from existing channel messages.");
-    expect(html).not.toContain("Reply in # review");
+    expect(html).not.toContain("Reply in thread · # review");
+  });
+
+  it("sends reply on Enter for desktop-sized viewports", () => {
+    const onSendReply = vi.fn();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1440,
+    });
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={88}
+            rootAuthorLabel="leader"
+            rootCreatedAt={1713480000000}
+            rootText="Discuss here."
+            replies={[]}
+            replyDraft="Ready to reply"
+            onReplyDraftChange={vi.fn()}
+            onSendReply={onSendReply}
+            replyBusy={false}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    act(() => {
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onSendReply).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Reply stays in this thread · Enter to reply");
+  });
+
+  it("keeps Enter as newline on mobile-sized viewports", () => {
+    const onSendReply = vi.fn();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 480,
+    });
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={88}
+            rootAuthorLabel="leader"
+            rootCreatedAt={1713480000000}
+            rootText="Discuss here."
+            replies={[]}
+            replyDraft="Ready to reply"
+            onReplyDraftChange={vi.fn()}
+            onSendReply={onSendReply}
+            replyBusy={false}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    act(() => {
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onSendReply).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Reply stays in this thread · Enter adds a new line");
   });
 });

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -18,11 +18,20 @@ import {
   TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
   TEAM_PANEL_TEXTAREA_CLASS,
 } from "../../ui/tailwind_classes";
+import { isMobileInputViewport } from "../../components/input_dock";
 
 type TeamThreadReplyItem = {
   messageId: number;
   authorLabel: string | null;
   createdAt?: number | null;
+  text: string;
+};
+
+type TeamThreadRenderMessage = {
+  messageId: number;
+  authorLabel: string;
+  avatarLabel: string;
+  createdAtLabel: string;
   text: string;
 };
 
@@ -51,8 +60,16 @@ const TEAM_THREAD_MESSAGE_META_ROW_CLASS =
 const TEAM_THREAD_MESSAGE_CONTENT_CLASS = "min-w-0 flex flex-1 flex-col gap-1";
 const TEAM_THREAD_MESSAGE_BUBBLE_CLASS =
   "w-full rounded-[12px] border border-black/6 bg-white/96 px-2 py-[5px] shadow-none [&_.md-blockquote]:bg-slate-50/92 [&_.md-table-wrap]:bg-white/88 [&_.md-table-wrap]:border-black/6 [&_.md-code-block]:border-slate-900/80";
+const TEAM_THREAD_SECTION_ROW_CLASS =
+  "flex flex-wrap items-center justify-between gap-2 px-2";
 function formatThreadReplyCount(count: number): string {
   return count === 1 ? "1 reply" : `${count} replies`;
+}
+
+function formatThreadComposerHelperText(sendOnEnter: boolean): string {
+  return sendOnEnter
+    ? "Reply stays in this thread · Enter to reply"
+    : "Reply stays in this thread · Enter adds a new line";
 }
 
 function resolveThreadAvatarLabel(authorLabel: string | null): string {
@@ -61,6 +78,28 @@ function resolveThreadAvatarLabel(authorLabel: string | null): string {
     return "?";
   }
   return trimmed.charAt(0).toUpperCase();
+}
+
+function formatThreadSourceSummary(
+  rootAuthorLabel: string | null,
+  rootMessageId: number | null
+): string | null {
+  if (rootMessageId == null) {
+    return null;
+  }
+  const authorLabel = rootAuthorLabel?.trim() || "Unknown";
+  return `From ${authorLabel} · #${rootMessageId}`;
+}
+
+function formatThreadSourcePreview(rootText: string | null): string | null {
+  const normalized = rootText?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 117).trimEnd()}...`;
 }
 
 export const TeamThreadPane = React.memo(function TeamThreadPane({
@@ -79,7 +118,54 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
   onClose,
 }: TeamThreadPaneProps) {
   const hasSelectedRoot = rootMessageId != null;
+  const [sendOnEnter, setSendOnEnter] = React.useState(() =>
+    typeof window === "undefined" ? true : !isMobileInputViewport(window.innerWidth)
+  );
   const replyCountLabel = formatThreadReplyCount(replies.length);
+  const sourceSummary = formatThreadSourceSummary(rootAuthorLabel, rootMessageId);
+  const sourcePreview = formatThreadSourcePreview(rootText);
+  // Keep transcript display data stable while the reply draft changes so
+  // typing in the composer does not rebuild every visible thread row.
+  const rootRenderMessage = React.useMemo<TeamThreadRenderMessage | null>(() => {
+    if (rootMessageId == null) {
+      return null;
+    }
+    const authorLabel = rootAuthorLabel?.trim() || "Unknown";
+    return {
+      messageId: rootMessageId,
+      authorLabel,
+      avatarLabel: resolveThreadAvatarLabel(authorLabel),
+      createdAtLabel: formatTs(rootCreatedAt),
+      text: rootText ?? "",
+    };
+  }, [formatTs, rootAuthorLabel, rootCreatedAt, rootMessageId, rootText]);
+  const replyRenderMessages = React.useMemo<TeamThreadRenderMessage[]>(
+    () =>
+      replies.map((reply) => {
+        const authorLabel = reply.authorLabel?.trim() || "Unknown";
+        return {
+          messageId: reply.messageId,
+          authorLabel,
+          avatarLabel: resolveThreadAvatarLabel(authorLabel),
+          createdAtLabel: formatTs(reply.createdAt),
+          text: reply.text,
+        };
+      }),
+    [formatTs, replies]
+  );
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const syncViewport = () => {
+      setSendOnEnter(!isMobileInputViewport(window.innerWidth));
+    };
+    syncViewport();
+    window.addEventListener("resize", syncViewport);
+    return () => {
+      window.removeEventListener("resize", syncViewport);
+    };
+  }, []);
   return (
     <SurfaceCard
       className="flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80"
@@ -103,6 +189,21 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
           <div className="mt-0.5 text-[11px] text-notion-text-muted">
             Focused replies stay anchored to the source message.
           </div>
+          {sourceSummary ? (
+            <div className="mt-1 flex max-w-full flex-col gap-0.5 rounded-md border border-black/6 bg-white/92 px-2 py-1 text-[10px] font-medium text-notion-text-muted">
+              <div className="inline-flex min-w-0 items-center gap-1.5">
+                <span className="uppercase tracking-[0.08em] text-notion-text-muted/70">
+                  Source
+                </span>
+                <span className="truncate text-notion-text">{sourceSummary}</span>
+              </div>
+              {sourcePreview ? (
+                <div className="truncate text-[11px] font-normal leading-4 text-notion-text-muted/90">
+                  {sourcePreview}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
           <CompactButton
@@ -136,15 +237,15 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
           <div className="flex flex-col gap-3">
             <div className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
               <div className={TEAM_THREAD_MESSAGE_AVATAR_CLASS} aria-hidden="true">
-                {resolveThreadAvatarLabel(rootAuthorLabel)}
+                {rootRenderMessage?.avatarLabel ?? "?"}
               </div>
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                 <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                   <span className="font-semibold text-notion-text">
-                    {rootAuthorLabel ?? "Unknown"}
+                    {rootRenderMessage?.authorLabel ?? "Unknown"}
                   </span>
-                  <span>{formatTs(rootCreatedAt)}</span>
-                  <span>{`#${rootMessageId}`}</span>
+                  <span>{rootRenderMessage?.createdAtLabel ?? ""}</span>
+                  <span>{`#${rootRenderMessage?.messageId ?? rootMessageId}`}</span>
                   <Badge
                     tone="outline"
                     shape="pill"
@@ -154,10 +255,10 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   </Badge>
                 </div>
                 <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
-                  {rootText ? (
+                  {rootRenderMessage?.text ? (
                     <TeamThreadRichText
                       className="text-[13px] leading-6 text-notion-text"
-                      text={rootText}
+                      text={rootRenderMessage.text}
                     />
                   ) : (
                     <div className="text-[12px] italic leading-5 text-notion-text-muted">
@@ -167,8 +268,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 </ConversationBubble>
               </div>
             </div>
-            <div className="px-2 text-[10px] leading-5 text-notion-text-muted">
-              Replies stay scoped to this thread.
+            <div className={TEAM_THREAD_SECTION_ROW_CLASS}>
+              <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
+                Thread replies
+              </div>
+              <span className="text-[10px] text-notion-text-muted">{replyCountLabel}</span>
             </div>
             <div className="flex flex-col gap-2 border-t border-notion-border/70 pt-3">
               {replies.length === 0 ? (
@@ -176,17 +280,15 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   No replies yet.
                 </div>
               ) : (
-                replies.map((reply) => (
+                replyRenderMessages.map((reply) => (
                   <div key={reply.messageId} className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
                     <div className={TEAM_THREAD_MESSAGE_AVATAR_CLASS} aria-hidden="true">
-                      {resolveThreadAvatarLabel(reply.authorLabel)}
+                      {reply.avatarLabel}
                     </div>
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                       <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
-                        <span className="font-semibold text-notion-text">
-                          {reply.authorLabel ?? "Unknown"}
-                        </span>
-                        <span>{formatTs(reply.createdAt)}</span>
+                        <span className="font-semibold text-notion-text">{reply.authorLabel}</span>
+                        <span>{reply.createdAtLabel}</span>
                         <span>{`#${reply.messageId}`}</span>
                       </div>
                       <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
@@ -207,15 +309,30 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         <div className="border-t border-notion-border/55 bg-white/92 px-2.5 py-1.5">
           <div className={TEAM_MESSAGE_COMPOSER_SHELL_CLASS}>
             <div className="px-1 pb-1 text-[10px] leading-5 text-notion-text-muted">
-              Reply in {channelLabel}
+              Reply in thread · {channelLabel}
             </div>
             <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
               <textarea
                 className={`${TEAM_PANEL_TEXTAREA_CLASS} min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0`}
                 rows={2}
-                placeholder={`Reply in ${channelLabel}`}
+                placeholder={`Reply in thread · ${channelLabel}`}
                 value={replyDraft}
                 onChange={(event) => onReplyDraftChange(event.currentTarget.value)}
+                onKeyDown={(event) => {
+                  if (
+                    event.key === "Enter" &&
+                    !event.shiftKey &&
+                    !event.altKey &&
+                    !event.metaKey &&
+                    !event.ctrlKey &&
+                    sendOnEnter &&
+                    !replyBusy &&
+                    replyDraft.trim().length > 0
+                  ) {
+                    event.preventDefault();
+                    void onSendReply();
+                  }
+                }}
               />
               <ActionButton
                 type="button"
@@ -228,7 +345,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             </div>
             <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
               <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>
-                Reply stays scoped to this thread
+                {formatThreadComposerHelperText(sendOnEnter)}
               </span>
             </ToolbarRow>
           </div>

--- a/web/src/pages/team/team_workbench_content.test.tsx
+++ b/web/src/pages/team/team_workbench_content.test.tsx
@@ -32,7 +32,7 @@ describe("team_workbench_content", () => {
       root.render(<TeamPanelLoadingFallback />);
     });
 
-    expect(container.textContent).toContain("Loading panel...");
+    expect(container.textContent).toContain("Loading workspace panel...");
     expect(container.firstElementChild?.className).toContain("rounded-2xl");
   });
 

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { WorkspaceLens } from "../../app_route_selection";
 import type { TeamDefinitionRecord } from "../../api";
+import { WorkspaceSearchLensPlaceholder } from "../../components/workspace_lens_placeholder";
+import { WorkspacePanelLoadingFallback } from "../../components/workspace_panel_loading_fallback";
 import { ActionButton } from "../../ui/primitives";
 import {
   TeamLoadingPanel,
@@ -82,11 +84,7 @@ export function prefetchTeamSetupSurface(): void {
 }
 
 export function TeamPanelLoadingFallback() {
-  return (
-    <div className="rounded-2xl border border-notion-border bg-white/88 px-4 py-6 text-sm text-ui-text-muted shadow-sm">
-      Loading panel...
-    </div>
-  );
+  return <WorkspacePanelLoadingFallback />;
 }
 
 type TeamWorkbenchContentProps = {
@@ -96,10 +94,8 @@ type TeamWorkbenchContentProps = {
   selectedTeam: TeamDefinitionRecord | null;
   isAgentWorkspace: boolean;
   teamSectionCardClassName: string;
-  teamSectionHeadingClassName: string;
   teamSectionTitleClassName: string;
   teamSectionBodyTextClassName: string;
-  teamSectionHintTextClassName: string;
   panelSecondaryButtonClassName: string;
   teamWorkbenchWorkspaceShellClassName: string;
   workspaceHeaderProps: React.ComponentProps<typeof TeamWorkspaceHeader>;
@@ -135,10 +131,8 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
   selectedTeam,
   isAgentWorkspace,
   teamSectionCardClassName,
-  teamSectionHeadingClassName,
   teamSectionTitleClassName,
   teamSectionBodyTextClassName,
-  teamSectionHintTextClassName,
   panelSecondaryButtonClassName,
   teamWorkbenchWorkspaceShellClassName,
   workspaceHeaderProps,
@@ -206,11 +200,11 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
           )}
 
           {showRunContextLoading && (
-            <div className={teamSectionCardClassName}>
-              <p className="text-sm text-ui-text-muted">
-                Loading run context for selected team...
-              </p>
-            </div>
+            <WorkspacePanelLoadingFallback
+              className={teamSectionCardClassName}
+              title="Loading run context..."
+              body="AgentHub is loading the selected team's execution context."
+            />
           )}
 
           {showNoActiveRunNotice && (
@@ -240,13 +234,7 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
               }`}
             >
               {activeWorkspaceLens === "search" && (
-                <div className={teamSectionCardClassName}>
-                  <div className={teamSectionHeadingClassName}>Search</div>
-                  <h3 className={teamSectionTitleClassName}>Search is still workspace-local</h3>
-                  <p className={teamSectionHintTextClassName}>
-                    Use Channels, Tasks, or Members while shared search rollup is being wired in.
-                  </p>
-                </div>
+                <WorkspaceSearchLensPlaceholder className={teamSectionCardClassName} />
               )}
 
               {activeWorkspaceLens !== "search" && tab === "conversation" && (

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -158,26 +158,27 @@ export function useTeamMemberAcpViewModel({
     saveTeamMemberAcpRenderCache(selectedMemberId, selectedSessionId, scopedMemberEvents);
   }, [scopedMemberEvents, selectedMemberId, selectedSessionId]);
 
-  const visibleMemberEvents = React.useMemo(
-    () =>
-      omitIncompleteLeadingAcpMessageEvents(
-        effectiveMemberEvents,
-        selectedSessionId ?? null
-      ),
-    [effectiveMemberEvents, selectedSessionId]
-  );
-  const acpEventLines = React.useMemo(
-    () =>
-      visibleMemberEvents.map((event) => ({
-        ts: event.ts,
-        seq: event.seq,
-        event_id: event.event_id,
-        stream: event.stream,
-        message: event.message,
-        session_id: event.session_id,
-      })),
-    [visibleMemberEvents]
-  );
+  const memberEventProjection = React.useMemo(() => {
+    const visible = omitIncompleteLeadingAcpMessageEvents(
+      effectiveMemberEvents,
+      selectedSessionId ?? null
+    );
+    const acpEventLines = visible.map((event) => ({
+      ts: event.ts,
+      seq: event.seq,
+      event_id: event.event_id,
+      stream: event.stream,
+      message: event.message,
+      session_id: event.session_id,
+    }));
+    const terminalOutputs = effectiveMemberEvents.filter((event) => event.stream !== "acp");
+    return {
+      visibleMemberEvents: visible,
+      acpEventLines,
+      terminalOutputs,
+    };
+  }, [effectiveMemberEvents, selectedSessionId]);
+  const { visibleMemberEvents, acpEventLines, terminalOutputs } = memberEventProjection;
   const acpView = React.useMemo(() => buildAcpView(acpEventLines), [acpEventLines]);
   const effectiveAcpTab = !developerMode && acpTab === "debug" ? "conversation" : acpTab;
   const normalizedAgentStatus = normalizeStatusValue(selectedAgentStatus);
@@ -215,10 +216,6 @@ export function useTeamMemberAcpViewModel({
       void onLoadOlder?.();
     },
   });
-  const terminalOutputs = React.useMemo(
-    () => effectiveMemberEvents.filter((event) => event.stream !== "acp"),
-    [effectiveMemberEvents]
-  );
   const hasVisibleConversationItems =
     acpConversation.conversationSourceItems >= ACP_INITIAL_VISIBLE_MESSAGE_TARGET;
   const hasRenderableConversationContent =

--- a/web/src/pages/team/use_team_member_backfill_effect.test.tsx
+++ b/web/src/pages/team/use_team_member_backfill_effect.test.tsx
@@ -420,4 +420,45 @@ describe("useTeamMemberBackfillEffect", () => {
 
     expect(getAgentSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("expires shared resolved buckets after the retention window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-29T00:00:00Z"));
+    const getAgentSpy = vi.spyOn(api, "getAgent").mockImplementation(async (_token, agentId) => {
+      if (agentId === "missing-a") {
+        return makeAgent("missing-a");
+      }
+      throw makeApiError(404, "not-found");
+    });
+
+    let params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: vi.fn(),
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-04-29T00:11:00Z"));
+    params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: params.setTeamMemberAgentsById,
+    });
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web/src/pages/team/use_team_member_backfill_effect.test.tsx
+++ b/web/src/pages/team/use_team_member_backfill_effect.test.tsx
@@ -341,6 +341,35 @@ describe("useTeamMemberBackfillEffect", () => {
     expect(getAgentSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps shared backfill caches isolated per auth token", async () => {
+    const getAgentSpy = vi.spyOn(api, "getAgent").mockImplementation(async (_token, agentId) => {
+      if (agentId === "missing-a") {
+        return makeAgent("missing-a");
+      }
+      throw makeApiError(404, "not-found");
+    });
+
+    const left = createParams({
+      token: "token-1",
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+    });
+    const right = createParams({
+      token: "token-2",
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+    });
+
+    act(() => {
+      root.render(<DualHookHarness left={left} right={right} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(2);
+    expect(getAgentSpy.mock.calls.map(([token]) => token)).toEqual(["token-1", "token-2"]);
+  });
+
   it("retains shared cooldown entries when members temporarily leave and rejoin the team spec", async () => {
     const getAgentSpy = vi.spyOn(api, "getAgent").mockRejectedValue(
       makeApiError(404, "not-found")

--- a/web/src/pages/team/use_team_member_backfill_effect.test.tsx
+++ b/web/src/pages/team/use_team_member_backfill_effect.test.tsx
@@ -3,7 +3,10 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, type AgentRecord } from "../../api";
-import { useTeamMemberBackfillEffect } from "./use_team_member_backfill_effect";
+import {
+  resetTeamMemberBackfillCachesForTest,
+  useTeamMemberBackfillEffect,
+} from "./use_team_member_backfill_effect";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -45,11 +48,18 @@ function HookHarness({ params }: { params: HookParams }) {
   return null;
 }
 
+function DualHookHarness({ left, right }: { left: HookParams; right: HookParams }) {
+  useTeamMemberBackfillEffect(left);
+  useTeamMemberBackfillEffect(right);
+  return null;
+}
+
 describe("useTeamMemberBackfillEffect", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
+    resetTeamMemberBackfillCachesForTest();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -224,7 +234,114 @@ describe("useTeamMemberBackfillEffect", () => {
     expect(getAgentSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("prunes stale cooldown entries when members leave the team spec", async () => {
+  it("coalesces in-flight backfill requests across rerenders before state catches up", async () => {
+    let resolveMissingA: ((agent: AgentRecord) => void) | null = null;
+    const getAgentSpy = vi.spyOn(api, "getAgent").mockImplementation(
+      (_token, agentId) =>
+        new Promise((resolve, reject) => {
+          if (agentId === "missing-a") {
+            resolveMissingA = resolve;
+            return;
+          }
+          reject(makeApiError(404, "not-found"));
+        })
+    );
+
+    const setById = vi.fn();
+    let params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: setById,
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: setById,
+    });
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveMissingA?.(makeAgent("missing-a"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it("does not immediately refetch after a shared backfill resolves before cache props catch up", async () => {
+    const getAgentSpy = vi.spyOn(api, "getAgent").mockImplementation(async (_token, agentId) => {
+      if (agentId === "missing-a") {
+        return makeAgent("missing-a");
+      }
+      throw makeApiError(404, "not-found");
+    });
+
+    const setById = vi.fn();
+    let params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: setById,
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
+
+    params = createParams({
+      teamSpecMemberIds: ["listed-agent", "missing-a"],
+      setTeamMemberAgentsById: setById,
+    });
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces shared backfill requests across multiple hook instances", async () => {
+    const getAgentSpy = vi.spyOn(api, "getAgent").mockImplementation(async (_token, agentId) => {
+      if (agentId === "missing-a") {
+        return makeAgent("missing-a");
+      }
+      throw makeApiError(404, "not-found");
+    });
+
+    const left = createParams({ teamSpecMemberIds: ["listed-agent", "missing-a"] });
+    const right = createParams({ teamSpecMemberIds: ["listed-agent", "missing-a"] });
+
+    act(() => {
+      root.render(<DualHookHarness left={left} right={right} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains shared cooldown entries when members temporarily leave and rejoin the team spec", async () => {
     const getAgentSpy = vi.spyOn(api, "getAgent").mockRejectedValue(
       makeApiError(404, "not-found")
     );
@@ -272,6 +389,6 @@ describe("useTeamMemberBackfillEffect", () => {
       await Promise.resolve();
     });
 
-    expect(getAgentSpy).toHaveBeenCalledTimes(2);
+    expect(getAgentSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/pages/team/use_team_member_backfill_effect.ts
+++ b/web/src/pages/team/use_team_member_backfill_effect.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { AgentRecord } from "../../api";
 import { api, getApiErrorStatus } from "../../api";
@@ -19,6 +19,56 @@ type ResolvedTeamMemberAgent = {
 };
 
 const TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS = 60_000;
+const teamMemberLastResolvedAt = new Map<string, number>();
+const teamMemberInFlightRequests = new Map<string, Promise<ResolvedTeamMemberAgent>>();
+
+function buildTeamMemberBackfillKey(token: string, memberId: string): string {
+  return `${token}\u0000${memberId}`;
+}
+
+// Shared caches keep duplicate Team shell instances from immediately re-fetching the
+// same hidden member record before the first backfill result has propagated into state.
+function getSharedResolvedAt(token: string, memberId: string): number | undefined {
+  return teamMemberLastResolvedAt.get(buildTeamMemberBackfillKey(token, memberId));
+}
+
+function setSharedResolvedAt(token: string, memberId: string, resolvedAt: number): void {
+  teamMemberLastResolvedAt.set(buildTeamMemberBackfillKey(token, memberId), resolvedAt);
+}
+
+function hasSharedInFlightRequest(token: string, memberId: string): boolean {
+  return teamMemberInFlightRequests.has(buildTeamMemberBackfillKey(token, memberId));
+}
+
+function loadSharedMemberAgent(
+  token: string,
+  memberId: string
+): Promise<ResolvedTeamMemberAgent> {
+  const cacheKey = buildTeamMemberBackfillKey(token, memberId);
+  const existing = teamMemberInFlightRequests.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+  const request = api
+    .getAgent(token, memberId)
+    .then((agent) => ({ memberId, agent }))
+    .catch((err) => {
+      if (getApiErrorStatus(err) === 404) {
+        return { memberId, agent: null };
+      }
+      return { memberId };
+    })
+    .finally(() => {
+      teamMemberInFlightRequests.delete(cacheKey);
+    });
+  teamMemberInFlightRequests.set(cacheKey, request);
+  return request;
+}
+
+export function resetTeamMemberBackfillCachesForTest(): void {
+  teamMemberLastResolvedAt.clear();
+  teamMemberInFlightRequests.clear();
+}
 
 function stableSerializeRecord(value: unknown): string {
   return JSON.stringify(sortRecordValue(value));
@@ -58,17 +108,7 @@ export function useTeamMemberBackfillEffect({
   teamMemberAgentsById,
   setTeamMemberAgentsById,
 }: UseTeamMemberBackfillEffectParams) {
-  const lastResolvedAtRef = useRef<Map<string, number>>(new Map());
-
   useEffect(() => {
-    const memberIdSet = new Set(teamSpecMemberIds);
-    if (lastResolvedAtRef.current.size > 0) {
-      for (const memberId of lastResolvedAtRef.current.keys()) {
-        if (!memberIdSet.has(memberId)) {
-          lastResolvedAtRef.current.delete(memberId);
-        }
-      }
-    }
     if (!token || teamSpecMemberIds.length === 0) {
       return;
     }
@@ -78,10 +118,13 @@ export function useTeamMemberBackfillEffect({
       if (listedAgentIds.has(memberId)) {
         return false;
       }
+      const lastResolvedAt = getSharedResolvedAt(token, memberId);
+      const withinSharedCooldown =
+        lastResolvedAt != null &&
+        now - lastResolvedAt < TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS;
       if (!Object.prototype.hasOwnProperty.call(teamMemberAgentsById, memberId)) {
-        return true;
+        return !withinSharedCooldown && !hasSharedInFlightRequest(token, memberId);
       }
-      const lastResolvedAt = lastResolvedAtRef.current.get(memberId);
       return (
         lastResolvedAt == null ||
         now - lastResolvedAt >= TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS
@@ -94,19 +137,7 @@ export function useTeamMemberBackfillEffect({
     let canceled = false;
     const loadMissingMemberAgents = async () => {
       const resolved: ResolvedTeamMemberAgent[] = await Promise.all(
-        unresolvedMemberIds.map(async (memberId) => {
-          try {
-            return {
-              memberId,
-              agent: await api.getAgent(token, memberId),
-            };
-          } catch (err) {
-            if (getApiErrorStatus(err) === 404) {
-              return { memberId, agent: null };
-            }
-            return { memberId };
-          }
-        })
+        unresolvedMemberIds.map((memberId) => loadSharedMemberAgent(token, memberId))
       );
       if (canceled) {
         return;
@@ -117,7 +148,7 @@ export function useTeamMemberBackfillEffect({
       const resolvedAt = Date.now();
       for (const { memberId, agent } of resolved) {
         if (agent !== undefined) {
-          lastResolvedAtRef.current.set(memberId, resolvedAt);
+          setSharedResolvedAt(token, memberId, resolvedAt);
         }
       }
       setTeamMemberAgentsById((prev) => {

--- a/web/src/pages/team/use_team_member_backfill_effect.ts
+++ b/web/src/pages/team/use_team_member_backfill_effect.ts
@@ -19,6 +19,9 @@ type ResolvedTeamMemberAgent = {
 };
 
 const TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS = 60_000;
+const TEAM_MEMBER_BACKFILL_CACHE_RETENTION_MS =
+  TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS * 10;
+const MAX_SHARED_TEAM_MEMBER_TOKEN_BUCKETS = 64;
 const teamMemberLastResolvedAt = new Map<string, Map<string, number>>();
 const teamMemberInFlightRequests = new Map<
   string,
@@ -31,7 +34,12 @@ function getSharedMemberMap<T>(
   createIfMissing: boolean
 ): Map<string, T> | undefined {
   const existing = cache.get(token);
-  if (existing || !createIfMissing) {
+  if (existing) {
+    cache.delete(token);
+    cache.set(token, existing);
+    return existing;
+  }
+  if (!createIfMissing) {
     return existing;
   }
   const next = new Map<string, T>();
@@ -39,14 +47,59 @@ function getSharedMemberMap<T>(
   return next;
 }
 
+function pruneSharedResolvedAt(now: number): void {
+  const expiresBefore = now - TEAM_MEMBER_BACKFILL_CACHE_RETENTION_MS;
+  for (const [token, resolvedAtByMemberId] of teamMemberLastResolvedAt) {
+    for (const [memberId, resolvedAt] of resolvedAtByMemberId) {
+      if (resolvedAt < expiresBefore) {
+        resolvedAtByMemberId.delete(memberId);
+      }
+    }
+    if (
+      resolvedAtByMemberId.size === 0 &&
+      !(teamMemberInFlightRequests.get(token)?.size)
+    ) {
+      teamMemberLastResolvedAt.delete(token);
+    }
+  }
+}
+
+function evictOldestSharedResolvedBuckets(): void {
+  while (teamMemberLastResolvedAt.size > MAX_SHARED_TEAM_MEMBER_TOKEN_BUCKETS) {
+    const oldestToken = teamMemberLastResolvedAt.keys().next().value;
+    if (oldestToken === undefined) {
+      return;
+    }
+    if (teamMemberInFlightRequests.get(oldestToken)?.size) {
+      const activeBucket = teamMemberLastResolvedAt.get(oldestToken);
+      teamMemberLastResolvedAt.delete(oldestToken);
+      if (activeBucket) {
+        teamMemberLastResolvedAt.set(oldestToken, activeBucket);
+      }
+      return;
+    }
+    teamMemberLastResolvedAt.delete(oldestToken);
+  }
+}
+
 // Shared caches keep duplicate Team shell instances from immediately re-fetching the
 // same hidden member record before the first backfill result has propagated into state.
 function getSharedResolvedAt(token: string, memberId: string): number | undefined {
-  return getSharedMemberMap(teamMemberLastResolvedAt, token, false)?.get(memberId);
+  const resolvedAt = getSharedMemberMap(teamMemberLastResolvedAt, token, false)?.get(memberId);
+  if (
+    resolvedAt != null &&
+    resolvedAt >= Date.now() - TEAM_MEMBER_BACKFILL_CACHE_RETENTION_MS
+  ) {
+    return resolvedAt;
+  }
+  getSharedMemberMap(teamMemberLastResolvedAt, token, false)?.delete(memberId);
+  return undefined;
 }
 
 function setSharedResolvedAt(token: string, memberId: string, resolvedAt: number): void {
+  pruneSharedResolvedAt(resolvedAt);
   getSharedMemberMap(teamMemberLastResolvedAt, token, true)?.set(memberId, resolvedAt);
+  evictOldestSharedResolvedBuckets();
 }
 
 function hasSharedInFlightRequest(token: string, memberId: string): boolean {

--- a/web/src/pages/team/use_team_member_backfill_effect.ts
+++ b/web/src/pages/team/use_team_member_backfill_effect.ts
@@ -19,33 +19,46 @@ type ResolvedTeamMemberAgent = {
 };
 
 const TEAM_MEMBER_BACKFILL_REVALIDATE_COOLDOWN_MS = 60_000;
-const teamMemberLastResolvedAt = new Map<string, number>();
-const teamMemberInFlightRequests = new Map<string, Promise<ResolvedTeamMemberAgent>>();
+const teamMemberLastResolvedAt = new Map<string, Map<string, number>>();
+const teamMemberInFlightRequests = new Map<
+  string,
+  Map<string, Promise<ResolvedTeamMemberAgent>>
+>();
 
-function buildTeamMemberBackfillKey(token: string, memberId: string): string {
-  return `${token}\u0000${memberId}`;
+function getSharedMemberMap<T>(
+  cache: Map<string, Map<string, T>>,
+  token: string,
+  createIfMissing: boolean
+): Map<string, T> | undefined {
+  const existing = cache.get(token);
+  if (existing || !createIfMissing) {
+    return existing;
+  }
+  const next = new Map<string, T>();
+  cache.set(token, next);
+  return next;
 }
 
 // Shared caches keep duplicate Team shell instances from immediately re-fetching the
 // same hidden member record before the first backfill result has propagated into state.
 function getSharedResolvedAt(token: string, memberId: string): number | undefined {
-  return teamMemberLastResolvedAt.get(buildTeamMemberBackfillKey(token, memberId));
+  return getSharedMemberMap(teamMemberLastResolvedAt, token, false)?.get(memberId);
 }
 
 function setSharedResolvedAt(token: string, memberId: string, resolvedAt: number): void {
-  teamMemberLastResolvedAt.set(buildTeamMemberBackfillKey(token, memberId), resolvedAt);
+  getSharedMemberMap(teamMemberLastResolvedAt, token, true)?.set(memberId, resolvedAt);
 }
 
 function hasSharedInFlightRequest(token: string, memberId: string): boolean {
-  return teamMemberInFlightRequests.has(buildTeamMemberBackfillKey(token, memberId));
+  return getSharedMemberMap(teamMemberInFlightRequests, token, false)?.has(memberId) ?? false;
 }
 
 function loadSharedMemberAgent(
   token: string,
   memberId: string
 ): Promise<ResolvedTeamMemberAgent> {
-  const cacheKey = buildTeamMemberBackfillKey(token, memberId);
-  const existing = teamMemberInFlightRequests.get(cacheKey);
+  const requestCache = getSharedMemberMap(teamMemberInFlightRequests, token, true)!;
+  const existing = requestCache.get(memberId);
   if (existing) {
     return existing;
   }
@@ -59,9 +72,12 @@ function loadSharedMemberAgent(
       return { memberId };
     })
     .finally(() => {
-      teamMemberInFlightRequests.delete(cacheKey);
+      requestCache.delete(memberId);
+      if (requestCache.size === 0) {
+        teamMemberInFlightRequests.delete(token);
+      }
     });
-  teamMemberInFlightRequests.set(cacheKey, request);
+  requestCache.set(memberId, request);
   return request;
 }
 

--- a/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
@@ -9,6 +9,42 @@ import { useTeamRunLifecycleEffects } from "./use_team_run_lifecycle_effects";
 
 type HookParams = Parameters<typeof useTeamRunLifecycleEffects>[0];
 
+class MockEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  emitOpen() {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  emitMessage(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  emitError() {
+    this.readyState = MockEventSource.CLOSED;
+    this.onerror?.(new Event("error"));
+  }
+
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+}
+
 function makeRun(id: string, teamId: string): TeamRunRecord {
   return {
     id,
@@ -47,6 +83,7 @@ function makeSnapshot(teamId: string): TeamRunSnapshotRecord {
 
 function createParams(overrides: Partial<HookParams> = {}): HookParams {
   return {
+    token: "token-1",
     selectedTeamId: "team-1",
     runStatusFilter: "all",
     runs: [makeRun("run-1", "team-1")],
@@ -59,7 +96,6 @@ function createParams(overrides: Partial<HookParams> = {}): HookParams {
     refreshTeams: vi.fn().mockResolvedValue(undefined),
     refreshTeamRuns: vi.fn().mockResolvedValue(undefined),
     refreshRun: vi.fn().mockResolvedValue(makeRun("run-1", "team-1")),
-    refreshSteps: vi.fn().mockResolvedValue(undefined),
     refreshEvents: vi.fn().mockResolvedValue(undefined),
     refreshSnapshot: vi.fn().mockResolvedValue(makeSnapshot("team-1")),
     loadInbox: vi.fn().mockResolvedValue(undefined),
@@ -90,6 +126,8 @@ describe("useTeamRunLifecycleEffects", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubGlobal("EventSource", undefined);
+    MockEventSource.instances = [];
     Object.defineProperty(document, "visibilityState", {
       configurable: true,
       value: "visible",
@@ -135,7 +173,7 @@ describe("useTeamRunLifecycleEffects", () => {
       await Promise.resolve();
     });
 
-    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase + 1);
+    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase);
     expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase + 1);
     expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase + 1);
 
@@ -144,7 +182,7 @@ describe("useTeamRunLifecycleEffects", () => {
       await Promise.resolve();
     });
 
-    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase + 1);
+    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase);
     expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase + 1);
     expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase + 1);
 
@@ -158,7 +196,7 @@ describe("useTeamRunLifecycleEffects", () => {
       await Promise.resolve();
     });
 
-    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase + 2);
+    expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase);
     expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase + 2);
     expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase + 2);
   });
@@ -190,6 +228,58 @@ describe("useTeamRunLifecycleEffects", () => {
     expect(params.refreshRun).toHaveBeenCalledTimes(refreshRunBase);
     expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase);
     expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase);
+  });
+
+  it("uses team run context SSE instead of interval polling for event-driven tabs", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const params = createParams({
+      tab: "events",
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    const source = MockEventSource.instances[0];
+    act(() => {
+      source.emitOpen();
+    });
+
+    const refreshEventsBase = (params.refreshEvents as ReturnType<typeof vi.fn>).mock.calls.length;
+    const refreshSnapshotBase = (
+      params.refreshSnapshot as ReturnType<typeof vi.fn>
+    ).mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+
+    expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase);
+    expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase);
+
+    await act(async () => {
+      source.emitMessage(
+        JSON.stringify({
+          type: "team_run_context",
+          payload: {
+            team_id: "team-1",
+            run_id: "run-1",
+            refresh_events: true,
+            refresh_snapshot: true,
+          },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase + 1);
+    expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase + 1);
   });
 
   it("polls only snapshot for the mailbox tab", async () => {

--- a/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
@@ -363,6 +363,44 @@ describe("useTeamRunLifecycleEffects", () => {
     expect(params.loadInbox).toHaveBeenCalledTimes(loadInboxBase);
   });
 
+  it("hydrates the steps state from snapshot refreshes on the steps tab", async () => {
+    const nextSteps = [
+      {
+        id: "step-2",
+        run_id: "run-1",
+        step_key: "compile",
+        member_id: "worker-1",
+        status: "working",
+        payload: {},
+        result: null,
+        created_at: 2,
+        updated_at: 2,
+      },
+    ];
+    const params = createParams({
+      tab: "steps",
+      refreshSnapshot: vi.fn().mockResolvedValue({
+        ...makeSnapshot("team-1"),
+        steps: nextSteps,
+      }),
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+
+    expect(params.setSteps).toHaveBeenCalledWith(nextSteps);
+  });
+
   it("hydrates only the active snapshot once for member ACP when snapshot is missing", async () => {
     const params = createParams({
       tab: "agent_acp",

--- a/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.test.tsx
@@ -2,7 +2,11 @@
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TeamRunRecord, TeamRunSnapshotRecord } from "../../api";
+import {
+  buildTeamRunContextSseUrl,
+  type TeamRunRecord,
+  type TeamRunSnapshotRecord,
+} from "../../api";
 import { useTeamRunLifecycleEffects } from "./use_team_run_lifecycle_effects";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -246,6 +250,14 @@ describe("useTeamRunLifecycleEffects", () => {
 
     expect(MockEventSource.instances).toHaveLength(1);
     const source = MockEventSource.instances[0];
+    expect(source?.url).toBe(
+      buildTeamRunContextSseUrl(
+        window.location.origin,
+        params.selectedTeamId ?? "",
+        params.activeRunIdForSelectedTeam ?? "",
+        params.token
+      )
+    );
     act(() => {
       source.emitOpen();
     });
@@ -313,6 +325,42 @@ describe("useTeamRunLifecycleEffects", () => {
     expect(params.refreshEvents).toHaveBeenCalledTimes(refreshEventsBase);
     expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase + 2);
     expect(params.loadInbox).toHaveBeenCalledTimes(loadInboxBase + 2);
+  });
+
+  it("does not interval-poll mailbox context while run-context SSE stays connected", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const params = createParams({
+      tab: "mailbox",
+      chatInboxActorId: "leader-actor",
+      loadInbox: vi.fn().mockResolvedValue(undefined),
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    const source = MockEventSource.instances[0];
+    act(() => {
+      source.emitOpen();
+    });
+
+    const refreshSnapshotBase = (
+      params.refreshSnapshot as ReturnType<typeof vi.fn>
+    ).mock.calls.length;
+    const loadInboxBase = (params.loadInbox as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+
+    expect(params.refreshSnapshot).toHaveBeenCalledTimes(refreshSnapshotBase);
+    expect(params.loadInbox).toHaveBeenCalledTimes(loadInboxBase);
   });
 
   it("hydrates only the active snapshot once for member ACP when snapshot is missing", async () => {

--- a/web/src/pages/team/use_team_run_lifecycle_effects.ts
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.ts
@@ -164,6 +164,11 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
             refreshRun(runId).catch(() => undefined),
             refreshSnapshot(runId).catch(() => undefined),
           ]);
+        } else if (tab === "steps") {
+          const nextSnapshot = await refreshSnapshot(runId).catch(() => undefined);
+          if (nextSnapshot) {
+            setSteps(nextSnapshot.steps);
+          }
         } else {
           await refreshSnapshot(runId).catch(() => undefined);
         }
@@ -187,6 +192,7 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
     refreshEvents,
     refreshRun,
     refreshSnapshot,
+    setSteps,
     tab,
   ]);
 

--- a/web/src/pages/team/use_team_run_lifecycle_effects.ts
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.ts
@@ -13,6 +13,7 @@ import {
   TeamRunRecord,
   TeamRunSnapshotRecord,
   TeamStepRecord,
+  buildTeamRunContextSseUrl,
 } from "../../api";
 import { resolveActiveRunIdForSelectedTeam, type TeamRunStatusFilter } from "./run_helpers";
 import type { TeamTab } from "./state";
@@ -445,11 +446,12 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
       // The SSE payload is only a lightweight invalidation signal. The hook still
       // refreshes the tab-specific minimal read set so the route keeps one source of truth.
       const nextSource = new EventSource(
-        `${location.origin}/sse/teams/${encodeURIComponent(
-          normalizedTeamId
-        )}/runs/${encodeURIComponent(normalizedRunId)}/context?token=${encodeURIComponent(
+        buildTeamRunContextSseUrl(
+          location.origin,
+          normalizedTeamId,
+          normalizedRunId,
           token
-        )}`
+        )
       );
       source = nextSource;
       nextSource.onopen = () => {

--- a/web/src/pages/team/use_team_run_lifecycle_effects.ts
+++ b/web/src/pages/team/use_team_run_lifecycle_effects.ts
@@ -1,4 +1,11 @@
-import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import {
   AgentEvent,
   TeamActorMessageRecord,
@@ -10,11 +17,26 @@ import {
 import { resolveActiveRunIdForSelectedTeam, type TeamRunStatusFilter } from "./run_helpers";
 import type { TeamTab } from "./state";
 
-function shouldPollActiveRunContext(tab: TeamTab): boolean {
-  return tab !== "agent_acp" && tab !== "member_console";
+const TEAM_RUN_CONTEXT_POLL_INTERVAL_MS = 4000;
+
+function supportsLiveRunContext(tab: TeamTab): boolean {
+  // Conversation, task, and ACP-heavy tabs already maintain their own live data paths.
+  // Keep the run-context channel scoped to panes that actually render run snapshot metadata.
+  return (
+    tab === "runs" ||
+    tab === "overview" ||
+    tab === "events" ||
+    tab === "steps" ||
+    tab === "mailbox"
+  );
+}
+
+function isEventDrivenRunContextTab(tab: TeamTab): boolean {
+  return tab === "events" || tab === "steps" || tab === "overview" || tab === "mailbox";
 }
 
 type UseTeamRunLifecycleEffectsOptions = {
+  token: string;
   selectedTeamId: string | null;
   runStatusFilter: TeamRunStatusFilter;
   runs: TeamRunRecord[];
@@ -34,7 +56,6 @@ type UseTeamRunLifecycleEffectsOptions = {
     }
   ) => Promise<unknown>;
   refreshRun: (runId: string) => Promise<TeamRunRecord>;
-  refreshSteps: (runId: string) => Promise<unknown>;
   refreshEvents: (runId: string) => Promise<void>;
   refreshSnapshot: (runId: string) => Promise<TeamRunSnapshotRecord>;
   loadInbox: (actorIdOverride?: string) => Promise<void>;
@@ -54,6 +75,7 @@ type UseTeamRunLifecycleEffectsOptions = {
 
 export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOptions) {
   const {
+    token,
     selectedTeamId,
     runStatusFilter,
     runs,
@@ -66,7 +88,6 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
     refreshTeams,
     refreshTeamRuns,
     refreshRun,
-    refreshSteps,
     refreshEvents,
     refreshSnapshot,
     loadInbox,
@@ -84,11 +105,89 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
     setChatStickToBottom,
   } = options;
   const hasCompletedInitialActiveRunRefreshRef = useRef(false);
-  const activeRunContextPollingEnabled = shouldPollActiveRunContext(tab);
+  const activeRunContextEnabled = supportsLiveRunContext(tab);
+  const refreshInFlightRef = useRef(false);
+  const refreshQueuedRef = useRef(false);
+  const pollFallbackAllowedRef = useRef(false);
+  const sseConnectedRef = useRef(false);
+  const sseConnectingRef = useRef(false);
+  const [pollFallbackEnabled, setPollFallbackEnabled] = useState(false);
 
   useEffect(() => {
     hasCompletedInitialActiveRunRefreshRef.current = false;
   }, [activeRunIdForSelectedTeam, tab, chatInboxActorId]);
+
+  const syncPollFallbackEnabled = useCallback(() => {
+    const nextEnabled =
+      pollFallbackAllowedRef.current &&
+      (typeof EventSource === "undefined" ||
+        (!sseConnectedRef.current && !sseConnectingRef.current));
+    setPollFallbackEnabled((previous) =>
+      previous === nextEnabled ? previous : nextEnabled
+    );
+  }, []);
+
+  const refreshActiveRunContext = useCallback(async () => {
+    const runId = activeRunIdForSelectedTeam?.trim() ?? "";
+    if (!runId || !activeRunContextEnabled) {
+      return;
+    }
+    if (
+      typeof document !== "undefined" &&
+      hasCompletedInitialActiveRunRefreshRef.current &&
+      document.visibilityState !== "visible"
+    ) {
+      return;
+    }
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true;
+      return;
+    }
+    refreshInFlightRef.current = true;
+    try {
+      for (;;) {
+        refreshQueuedRef.current = false;
+        if (tab === "mailbox") {
+          await refreshSnapshot(runId).catch(() => undefined);
+          const actorId = chatInboxActorId.trim();
+          if (actorId) {
+            await loadInbox(actorId).catch(() => undefined);
+          }
+        } else if (tab === "events") {
+          await Promise.all([
+            refreshEvents(runId).catch(() => undefined),
+            refreshSnapshot(runId).catch(() => undefined),
+          ]);
+        } else if (tab === "runs") {
+          await Promise.all([
+            refreshRun(runId).catch(() => undefined),
+            refreshSnapshot(runId).catch(() => undefined),
+          ]);
+        } else {
+          await refreshSnapshot(runId).catch(() => undefined);
+        }
+        hasCompletedInitialActiveRunRefreshRef.current = true;
+        if (!refreshQueuedRef.current) {
+          return;
+        }
+      }
+    } finally {
+      refreshInFlightRef.current = false;
+      if (refreshQueuedRef.current) {
+        refreshQueuedRef.current = false;
+        void refreshActiveRunContext().catch(() => undefined);
+      }
+    }
+  }, [
+    activeRunContextEnabled,
+    activeRunIdForSelectedTeam,
+    chatInboxActorId,
+    loadInbox,
+    refreshEvents,
+    refreshRun,
+    refreshSnapshot,
+    tab,
+  ]);
 
   useEffect(() => {
     void refreshTeams();
@@ -177,7 +276,7 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
   const currentSnapshotTeamId = snapshot?.team.id ?? null;
 
   useEffect(() => {
-    if (!activeRunIdForSelectedTeam || activeRunContextPollingEnabled) {
+    if (!activeRunIdForSelectedTeam || activeRunContextEnabled) {
       return;
     }
     if (
@@ -202,7 +301,7 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
       canceled = true;
     };
   }, [
-    activeRunContextPollingEnabled,
+    activeRunContextEnabled,
     activeRunIdForSelectedTeam,
     currentSnapshotRunId,
     currentSnapshotTeamId,
@@ -213,7 +312,7 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
   ]);
 
   useEffect(() => {
-    if (!activeRunIdForSelectedTeam || !activeRunContextPollingEnabled) {
+    if (!activeRunIdForSelectedTeam || !activeRunContextEnabled) {
       return;
     }
     let canceled = false;
@@ -224,20 +323,27 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
           await refreshSnapshot(activeRunIdForSelectedTeam);
           return;
         }
-        const run = await refreshRun(activeRunIdForSelectedTeam);
-        if (canceled) return;
-        if (selectedTeamId && run.team_id !== selectedTeamId) {
-          setError(
-            `Run ${run.id} belongs to team ${run.team_id}. Select that team to view it.`
-          );
-          setActiveRunId((current) => (current === run.id ? null : current));
+        if (tab === "events") {
+          await Promise.all([
+            refreshEvents(activeRunIdForSelectedTeam),
+            refreshSnapshot(activeRunIdForSelectedTeam),
+          ]);
           return;
         }
-        await Promise.all([
-          refreshSteps(activeRunIdForSelectedTeam),
-          refreshEvents(activeRunIdForSelectedTeam),
-          refreshSnapshot(activeRunIdForSelectedTeam),
-        ]);
+        if (tab === "runs") {
+          const run = await refreshRun(activeRunIdForSelectedTeam);
+          if (canceled) return;
+          if (selectedTeamId && run.team_id !== selectedTeamId) {
+            setError(
+              `Run ${run.id} belongs to team ${run.team_id}. Select that team to view it.`
+            );
+            setActiveRunId((current) => (current === run.id ? null : current));
+            return;
+          }
+          await refreshSnapshot(activeRunIdForSelectedTeam);
+          return;
+        }
+        await refreshSnapshot(activeRunIdForSelectedTeam);
       } catch (err) {
         if (!canceled) {
           setError(parseError(err));
@@ -249,13 +355,12 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
       canceled = true;
     };
   }, [
-    activeRunContextPollingEnabled,
+    activeRunContextEnabled,
     activeRunIdForSelectedTeam,
     parseError,
     refreshEvents,
     refreshRun,
     refreshSnapshot,
-    refreshSteps,
     selectedTeamId,
     setActiveRunId,
     setError,
@@ -263,37 +368,138 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
   ]);
 
   useEffect(() => {
+    pollFallbackAllowedRef.current = Boolean(
+      eventsAutoRefresh &&
+        activeRunContextEnabled &&
+        activeRunIdForSelectedTeam?.trim() &&
+        selectedTeamId?.trim()
+    );
+    syncPollFallbackEnabled();
+  }, [
+    activeRunContextEnabled,
+    activeRunIdForSelectedTeam,
+    eventsAutoRefresh,
+    selectedTeamId,
+    syncPollFallbackEnabled,
+  ]);
+
+  useEffect(() => {
+    if (!eventsAutoRefresh || !activeRunContextEnabled || !activeRunIdForSelectedTeam) {
+      sseConnectedRef.current = false;
+      sseConnectingRef.current = false;
+      setPollFallbackEnabled(false);
+      return;
+    }
+    const normalizedTeamId = selectedTeamId?.trim() ?? "";
+    const normalizedRunId = activeRunIdForSelectedTeam.trim();
+    if (!normalizedTeamId) {
+      sseConnectedRef.current = false;
+      sseConnectingRef.current = false;
+      setPollFallbackEnabled(false);
+      return;
+    }
+    if (!isEventDrivenRunContextTab(tab) || typeof EventSource === "undefined" || !token.trim()) {
+      sseConnectedRef.current = false;
+      sseConnectingRef.current = false;
+      syncPollFallbackEnabled();
+      return;
+    }
+    let cancelled = false;
+    let source: EventSource | null = null;
+    let reconnectTimer: number | null = null;
+    let reconnectAttempt = 0;
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimer != null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    };
+
+    const closeSource = () => {
+      sseConnectedRef.current = false;
+      sseConnectingRef.current = false;
+      source?.close();
+      source = null;
+    };
+
+    const scheduleReconnect = () => {
+      if (cancelled) {
+        return;
+      }
+      closeSource();
+      syncPollFallbackEnabled();
+      const delay = Math.min(30_000, 1000 * 2 ** reconnectAttempt);
+      reconnectAttempt = Math.min(reconnectAttempt + 1, 6);
+      reconnectTimer = window.setTimeout(() => {
+        if (!cancelled) {
+          openSource();
+        }
+      }, delay);
+    };
+
+    function openSource() {
+      closeSource();
+      sseConnectingRef.current = true;
+      syncPollFallbackEnabled();
+      // The SSE payload is only a lightweight invalidation signal. The hook still
+      // refreshes the tab-specific minimal read set so the route keeps one source of truth.
+      const nextSource = new EventSource(
+        `${location.origin}/sse/teams/${encodeURIComponent(
+          normalizedTeamId
+        )}/runs/${encodeURIComponent(normalizedRunId)}/context?token=${encodeURIComponent(
+          token
+        )}`
+      );
+      source = nextSource;
+      nextSource.onopen = () => {
+        reconnectAttempt = 0;
+        sseConnectingRef.current = false;
+        sseConnectedRef.current = true;
+        syncPollFallbackEnabled();
+      };
+      nextSource.onmessage = (event) => {
+        if (cancelled || event.data === "heartbeat") {
+          return;
+        }
+        void refreshActiveRunContext().catch(() => undefined);
+      };
+      nextSource.onerror = () => {
+        if (source !== nextSource) {
+          nextSource.close();
+          return;
+        }
+        scheduleReconnect();
+      };
+    }
+
+    openSource();
+    return () => {
+      cancelled = true;
+      clearReconnectTimer();
+      closeSource();
+      setPollFallbackEnabled(false);
+    };
+  }, [
+    activeRunContextEnabled,
+    activeRunIdForSelectedTeam,
+    eventsAutoRefresh,
+    refreshActiveRunContext,
+    selectedTeamId,
+    syncPollFallbackEnabled,
+    tab,
+    token,
+  ]);
+
+  useEffect(() => {
     if (
       !activeRunIdForSelectedTeam ||
       !eventsAutoRefresh ||
-      !activeRunContextPollingEnabled
+      !activeRunContextEnabled ||
+      !pollFallbackEnabled
     ) {
       return;
     }
-    const refreshActiveRunContext = async () => {
-      if (
-        typeof document !== "undefined" &&
-        hasCompletedInitialActiveRunRefreshRef.current &&
-        document.visibilityState !== "visible"
-      ) {
-        return;
-      }
-      if (tab === "mailbox") {
-        await refreshSnapshot(activeRunIdForSelectedTeam).catch(() => undefined);
-        const actorId = chatInboxActorId.trim();
-        if (actorId) {
-          await loadInbox(actorId).catch(() => undefined);
-        }
-        hasCompletedInitialActiveRunRefreshRef.current = true;
-        return;
-      }
-      await Promise.all([
-        refreshRun(activeRunIdForSelectedTeam).catch(() => undefined),
-        refreshEvents(activeRunIdForSelectedTeam).catch(() => undefined),
-        refreshSnapshot(activeRunIdForSelectedTeam).catch(() => undefined),
-      ]);
-      hasCompletedInitialActiveRunRefreshRef.current = true;
-    };
     const handleFocus = () => {
       void refreshActiveRunContext();
     };
@@ -307,7 +513,7 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
     };
     const timer = window.setInterval(() => {
       void refreshActiveRunContext();
-    }, 4000);
+    }, TEAM_RUN_CONTEXT_POLL_INTERVAL_MS);
     window.addEventListener("focus", handleFocus);
     window.addEventListener("online", handleOnline);
     document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -319,13 +525,9 @@ export function useTeamRunLifecycleEffects(options: UseTeamRunLifecycleEffectsOp
     };
   }, [
     activeRunIdForSelectedTeam,
-    activeRunContextPollingEnabled,
-    chatInboxActorId,
+    activeRunContextEnabled,
     eventsAutoRefresh,
-    loadInbox,
-    refreshEvents,
-    refreshRun,
-    refreshSnapshot,
-    tab,
+    pollFallbackEnabled,
+    refreshActiveRunContext,
   ]);
 }

--- a/web/src/pages/team/use_team_workspace_view_model.test.tsx
+++ b/web/src/pages/team/use_team_workspace_view_model.test.tsx
@@ -209,6 +209,8 @@ describe("useTeamWorkspaceViewModel", () => {
       act(() => {
         snapshot?.onSelectWorkspaceLens("search");
       });
+      expect(params.setTab).toHaveBeenCalledWith("conversation");
+      expect(params.setFocusedAgentMemberId).toHaveBeenCalledWith("");
       expect(params.navigateToTeamLens).toHaveBeenCalledWith("team-1", "search");
       act(() => {
         snapshot?.workspaceLensItems[2]?.onPrefetch?.();
@@ -411,11 +413,79 @@ describe("useTeamWorkspaceViewModel", () => {
       act(() => {
         snapshot?.onSelectWorkspaceLens("channels");
       });
+      expect(params.setTab).toHaveBeenLastCalledWith("conversation");
+      expect(params.setFocusedAgentMemberId).toHaveBeenLastCalledWith("");
       expect(params.navigateToTeamLens).toHaveBeenLastCalledWith(
         "team-1",
         "channels",
-        "review"
+        "review",
+        ""
       );
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("preserves the explicit task conversation when returning to channels", async () => {
+    const params = createParams({
+      selectedChannelId: "review",
+      selectedChannelLabel: "# review",
+      selectedChannelDescription: "Focused design and implementation review lane.",
+      selectedConversation: {
+        id: "task-77",
+        team_id: "team-1",
+        title: "Investigate regression",
+        status: "in_progress",
+        created_by_actor_id: "leader",
+        assigned_member_id: "leader",
+        context: {
+          bootstrap_kind: "team_channel",
+          channel_id: "review",
+        },
+        created_at: 1,
+        updated_at: 1,
+      } as HookParams["selectedConversation"],
+    });
+    const mounted = await mountHook(params);
+    try {
+      const snapshot = mounted.getSnapshot();
+      act(() => {
+        snapshot?.onSelectWorkspaceLens("channels");
+      });
+      expect(params.setTab).toHaveBeenCalledWith("conversation");
+      expect(params.navigateToTeamLens).toHaveBeenLastCalledWith(
+        "team-1",
+        "channels",
+        "review",
+        "task-77"
+      );
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("resets hidden member workspace state when switching into shell-level members and tasks lenses", async () => {
+    const params = createParams({
+      tab: "agent_acp",
+      focusedAgentMemberId: "worker-2",
+      selectedMemberId: "worker-2",
+    });
+    const mounted = await mountHook(params);
+    try {
+      const snapshot = mounted.getSnapshot();
+      act(() => {
+        snapshot?.onSelectWorkspaceLens("members");
+      });
+      expect(params.setTab).toHaveBeenCalledWith("overview");
+      expect(params.setFocusedAgentMemberId).toHaveBeenCalledWith("");
+      expect(params.navigateToTeamLens).toHaveBeenCalledWith("team-1", "members");
+
+      act(() => {
+        snapshot?.onSelectWorkspaceLens("tasks");
+      });
+      expect(params.setTab).toHaveBeenCalledWith("tasks");
+      expect(params.setFocusedAgentMemberId).toHaveBeenCalledWith("");
+      expect(params.navigateToTeamLens).toHaveBeenCalledWith("team-1", "tasks");
     } finally {
       mounted.cleanup();
     }
@@ -482,6 +552,30 @@ describe("useTeamWorkspaceViewModel", () => {
       });
       expect(params.setSelectedConversationTaskId).toHaveBeenCalledWith("task-77");
       expect(params.navigateToTeamLens).not.toHaveBeenCalled();
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("routes channel-scoped task conversations back to the task lane", async () => {
+    const params = createParams({
+      selectedChannelId: "all",
+      selectedChannelLabel: "# all",
+      selectedChannelDescription:
+        "Shared coordination lane for requests, updates, and cross-cutting discussion.",
+    });
+    const mounted = await mountHook(params);
+    try {
+      const snapshot = mounted.getSnapshot();
+      act(() => {
+        snapshot?.onSelectConversationSubject("task-77", "review");
+      });
+      expect(params.navigateToTeamLens).toHaveBeenCalledWith(
+        "team-1",
+        "channels",
+        "review",
+        "task-77"
+      );
     } finally {
       mounted.cleanup();
     }

--- a/web/src/pages/team/use_team_workspace_view_model.ts
+++ b/web/src/pages/team/use_team_workspace_view_model.ts
@@ -7,6 +7,7 @@ import type {
   TeamTaskRecord,
 } from "../../api";
 import type { WorkspaceLens } from "../../app_route_selection";
+import { buildStandardWorkspaceLensItems } from "../../components/workspace_lens_items";
 import { createDisplayNameLookup } from "./mailbox_helpers";
 import { describeTeamKanban } from "./channel_metadata";
 import type { TeamMemberLiveState, TeamMemberAgentStatusSummary } from "./member_helpers";
@@ -136,32 +137,10 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
     return "";
   }, [focusedAgentMemberId, selectedAgentWorkspaceMemberId, selectedTeam]);
   const workspaceLensItems = useMemo(
-    () => [
-      {
-        value: "channels",
-        label: "Channels",
-        active: activeWorkspaceLens === "channels",
-        onPrefetch: () => prefetchWorkspaceLens?.("channels"),
-      },
-      {
-        value: "tasks",
-        label: "Tasks",
-        active: activeWorkspaceLens === "tasks",
-        onPrefetch: () => prefetchWorkspaceLens?.("tasks"),
-      },
-      {
-        value: "members",
-        label: "Members",
-        active: activeWorkspaceLens === "members",
-        onPrefetch: () => prefetchWorkspaceLens?.("members"),
-      },
-      {
-        value: "search",
-        label: "Search",
-        active: activeWorkspaceLens === "search",
-        onPrefetch: () => prefetchWorkspaceLens?.("search"),
-      },
-    ],
+    () =>
+      buildStandardWorkspaceLensItems(activeWorkspaceLens, {
+        onPrefetch: prefetchWorkspaceLens,
+      }),
     [activeWorkspaceLens, prefetchWorkspaceLens]
   );
 
@@ -234,6 +213,10 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
   const selectedConversationIsShared = useMemo(
     () => (selectedConversation ? isSharedThreadTask(selectedConversation) : true),
     [selectedConversation]
+  );
+  const selectedConversationRouteTaskId = useMemo(
+    () => (selectedConversation && !selectedConversationIsShared ? selectedConversation.id : ""),
+    [selectedConversation, selectedConversationIsShared]
   );
 
   const currentWorkspaceTabLabel = useMemo(
@@ -438,13 +421,22 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
   );
 
   const onSelectConversationSubject = useCallback(
-    (taskId?: string | null) => {
+    (taskId?: string | null, taskChannelId?: string | null) => {
       const normalizedTaskId = typeof taskId === "string" ? taskId.trim() : "";
+      const normalizedTaskChannelId =
+        typeof taskChannelId === "string" ? taskChannelId.trim() : "";
       setFocusedAgentMemberId("");
       setSelectedConversationTaskId(normalizedTaskId);
       setTab("conversation");
       if (selectedTeamId) {
-        navigateToTeamLens(selectedTeamId, "channels", selectedChannelId, normalizedTaskId);
+        // Channel-scoped task conversations should route back to their owning lane
+        // instead of inheriting whichever channel the operator last had selected.
+        navigateToTeamLens(
+          selectedTeamId,
+          "channels",
+          normalizedTaskChannelId || selectedChannelId,
+          normalizedTaskId
+        );
       }
       if (isCompactWorkbench) {
         setTeamsSidebarCollapsed(true);
@@ -532,11 +524,28 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
         return;
       }
       const lens = value as WorkspaceLens;
-      if (lens === "search") {
+      // Shell-level lens switches should also reset the hidden Team-local tab
+      // state so the URL and the in-memory workspace context stay aligned.
+      if (lens === "tasks") {
+        setTab("tasks");
+      } else if (lens === "members") {
+        setTab("overview");
+      } else {
+        setTab("conversation");
+      }
+      if (lens === "search" || lens === "channels" || lens === "tasks" || lens === "members") {
         setFocusedAgentMemberId("");
       }
       if (lens === "channels") {
-        navigateToTeamLens(selectedTeamId, lens, selectedChannelId);
+        // Preserve the explicit task conversation when the operator leaves and
+        // returns to the channel lane; otherwise channel-scoped tasks collapse
+        // back into the bootstrap lane.
+        navigateToTeamLens(
+          selectedTeamId,
+          lens,
+          selectedChannelId,
+          selectedConversationRouteTaskId
+        );
       } else {
         navigateToTeamLens(selectedTeamId, lens);
       }
@@ -548,8 +557,10 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
       isCompactWorkbench,
       navigateToTeamLens,
       selectedChannelId,
+      selectedConversationRouteTaskId,
       selectedTeamId,
       setFocusedAgentMemberId,
+      setTab,
       setTeamsSidebarCollapsed,
     ]
   );

--- a/web/src/pages/team_active_run_panel.tsx
+++ b/web/src/pages/team_active_run_panel.tsx
@@ -7,6 +7,7 @@ import {
   KeyValueList,
   PanelHeader,
   SurfaceCard,
+  ToolbarRow,
 } from "../ui/primitives";
 
 type TeamActiveRunPanelProps = {
@@ -45,52 +46,52 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
         title="Active Execution Run"
         titleClassName={titleClassName}
         actions={
-          <>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            title="Refresh active execution run"
-            aria-label="Refresh active execution run"
-            onClick={onRefresh}
-          >
-            <i className="bi bi-arrow-clockwise" aria-hidden="true" />
-            <span>Refresh</span>
-          </ActionButton>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={onCancel}
-            disabled={busy === "cancel-run" || run.status === "canceled"}
-          >
-            Cancel Execution Run
-          </ActionButton>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={onResume}
-            disabled={busy === "resume-run" || !canResumeRun}
-            title={
-              canResumeRun
-                ? "Resume a failed/canceled run"
-                : "Resume is available for failed/canceled runs"
-            }
-          >
-            Resume Execution Run
-          </ActionButton>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={onRestart}
-            disabled={busy === "restart-run" || !canRestartRun}
-            title={
-              canRestartRun
-                ? "Create a fresh run from the same context/input"
-                : "Restart is available for completed/failed/canceled runs"
-            }
-          >
-            Restart Execution Run
-          </ActionButton>
-          </>
+          <ToolbarRow className="justify-end gap-2">
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              title="Refresh active execution run"
+              aria-label="Refresh active execution run"
+              onClick={onRefresh}
+            >
+              <i className="bi bi-arrow-clockwise" aria-hidden="true" />
+              <span>Refresh</span>
+            </ActionButton>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={onCancel}
+              disabled={busy === "cancel-run" || run.status === "canceled"}
+            >
+              Cancel Execution Run
+            </ActionButton>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={onResume}
+              disabled={busy === "resume-run" || !canResumeRun}
+              title={
+                canResumeRun
+                  ? "Resume a failed/canceled run"
+                  : "Resume is available for failed/canceled runs"
+              }
+            >
+              Resume Execution Run
+            </ActionButton>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={onRestart}
+              disabled={busy === "restart-run" || !canRestartRun}
+              title={
+                canRestartRun
+                  ? "Create a fresh run from the same context/input"
+                  : "Restart is available for completed/failed/canceled runs"
+              }
+            >
+              Restart Execution Run
+            </ActionButton>
+          </ToolbarRow>
         }
       />
       <KeyValueList className="mt-3 gap-y-2 text-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3">

--- a/web/src/pages/team_conversation_panel.tsx
+++ b/web/src/pages/team_conversation_panel.tsx
@@ -32,6 +32,8 @@ type TeamConversationPanelProps = {
   toPrettyJson: (value: unknown) => string;
   onOpenThread?: (messageId: number) => void;
   activeThreadMessageId?: number | null;
+  jumpToMessageId?: number | null;
+  onJumpToMessageSettled?: () => void;
 };
 
 function TeamConversationPanelImpl(props: TeamConversationPanelProps) {
@@ -76,6 +78,8 @@ function TeamConversationPanelImpl(props: TeamConversationPanelProps) {
         toPrettyJson={props.toPrettyJson}
         onOpenThread={props.onOpenThread}
         activeThreadMessageId={props.activeThreadMessageId}
+        jumpToMessageId={props.jumpToMessageId}
+        onJumpToMessageSettled={props.onJumpToMessageSettled}
       />
     </div>
   );

--- a/web/src/pages/team_events_panel.tsx
+++ b/web/src/pages/team_events_panel.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { TeamRunEventRecord } from "../api";
-import { ActionButton, EmptyState, InlineNotice, PanelHeader, SurfaceCard } from "../ui/primitives";
+import {
+  ActionButton,
+  EmptyState,
+  InlineNotice,
+  PanelHeader,
+  SurfaceCard,
+  ToolbarRow,
+} from "../ui/primitives";
 import {
   TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_PRE_CLASS,
@@ -50,39 +57,39 @@ function TeamEventsPanelImpl(props: TeamEventsPanelProps) {
         title="Run Events"
         titleClassName={TEAM_PANEL_TITLE_CLASS}
         actions={
-          <div className="flex flex-wrap items-center gap-2">
-          <label className={EVENTS_CHECKBOX_LABEL_CLASS}>
-            <input
-              type="checkbox"
-              checked={eventsAutoRefresh}
-              onChange={(event) => onEventsAutoRefreshChange(event.target.checked)}
-            />
-            Auto refresh
-          </label>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={() => {
-              void onRefreshEvents();
-            }}
-            disabled={eventsLoading}
-            title="Refresh events"
-            aria-label="Refresh events"
-          >
-            <i className="bi bi-arrow-clockwise" aria-hidden="true" />
-            <span>Refresh</span>
-          </ActionButton>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={() => {
-              void onLoadOlderEvents();
-            }}
-            disabled={previewMode || eventsLoading || !eventsHasMore || oldestEventId == null}
-          >
-            Load Older
-          </ActionButton>
-          </div>
+          <ToolbarRow className="justify-end gap-2">
+            <label className={EVENTS_CHECKBOX_LABEL_CLASS}>
+              <input
+                type="checkbox"
+                checked={eventsAutoRefresh}
+                onChange={(event) => onEventsAutoRefreshChange(event.target.checked)}
+              />
+              Auto refresh
+            </label>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={() => {
+                void onRefreshEvents();
+              }}
+              disabled={eventsLoading}
+              title="Refresh events"
+              aria-label="Refresh events"
+            >
+              <i className="bi bi-arrow-clockwise" aria-hidden="true" />
+              <span>Refresh</span>
+            </ActionButton>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={() => {
+                void onLoadOlderEvents();
+              }}
+              disabled={previewMode || eventsLoading || !eventsHasMore || oldestEventId == null}
+            >
+              Load Older
+            </ActionButton>
+          </ToolbarRow>
         }
       />
       {previewMode && (

--- a/web/src/pages/team_mailbox_panel.tsx
+++ b/web/src/pages/team_mailbox_panel.tsx
@@ -51,6 +51,26 @@ type MailboxTemplateOption = {
   label: string;
 };
 
+type MailboxActorRow = {
+  memberId: string;
+  role: string;
+  pendingInboxCount: number;
+  status: string;
+  unread: number;
+  isHuman: boolean;
+  label: string;
+};
+
+type MailboxConversationRow = {
+  message: TeamActorMessageRecord;
+  isOutgoing: boolean;
+  htmlPayload: string | null;
+  payload: string;
+  fromLabel: string;
+  toLabel: string;
+  canAccept: boolean;
+};
+
 type TeamMailboxPanelProps = {
   developerMode: boolean;
   mode?: "full" | "advanced_only";
@@ -203,30 +223,96 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
   const showAdvancedControls = mode === "advanced_only";
   const showDeveloperMailboxTools = developerMode && showAdvancedControls;
   const normalizedHumanActorId = humanActorId.trim();
-  const acceptVisibleMessages = conversationMessages.filter((message) =>
-    isMessageAcceptableForInbox(message, chatActors.inboxActorId, normalizedHumanActorId)
-  );
   const humanPendingCount =
     snapshot?.mailbox.recent_messages.filter(
       (message) =>
         message.to_actor_id === normalizedHumanActorId &&
         message.status === "pending"
     ).length ?? 0;
-  const mailboxMembers = snapshot?.members ?? [];
-  const mailboxActors = [
-    ...mailboxMembers,
-    ...(normalizedHumanActorId &&
-    !mailboxMembers.some((member) => member.member_id === normalizedHumanActorId)
-      ? [
-          {
-            member_id: normalizedHumanActorId,
-            role: "human",
-            pending_inbox_count: humanPendingCount,
-            status: "human",
-          },
-        ]
-      : []),
-  ];
+  const mailboxActorRows = React.useMemo<MailboxActorRow[]>(() => {
+    const mailboxMembers = snapshot?.members ?? [];
+    const mailboxActors = [
+      ...mailboxMembers,
+      ...(normalizedHumanActorId &&
+      !mailboxMembers.some((member) => member.member_id === normalizedHumanActorId)
+        ? [
+            {
+              member_id: normalizedHumanActorId,
+              role: "human",
+              pending_inbox_count: humanPendingCount,
+              status: "human",
+            },
+          ]
+        : []),
+    ];
+    return mailboxActors.map((member) => {
+      const isHuman = member.role === "human";
+      return {
+        memberId: member.member_id,
+        role: member.role,
+        pendingInboxCount: member.pending_inbox_count,
+        status: member.status,
+        unread: unreadByMemberId[member.member_id] ?? 0,
+        isHuman,
+        label: resolveMailboxActorLabel(
+          member.member_id,
+          displayNameByActorId,
+          normalizedHumanActorId
+        ),
+      };
+    });
+  }, [
+    displayNameByActorId,
+    humanPendingCount,
+    normalizedHumanActorId,
+    snapshot?.members,
+    unreadByMemberId,
+  ]);
+  const conversationRows = React.useMemo<MailboxConversationRow[]>(() => {
+    // Precompute mailbox row presentation so long conversations do not repeatedly
+    // re-parse payload text and actor labels during every list render.
+    return conversationMessages.map((message) => {
+      const isOutgoing = message.from_actor_id === chatActors.fromActorId;
+      const chatText = resolveVisibleTeamPayloadText(message.payload);
+      const payload = chatText ?? toPrettyJson(message.payload);
+      const htmlPayload =
+        chatText === null
+          ? null
+          : renderPlainTextWithMentions(payload, displayNameByActorId);
+      return {
+        message,
+        isOutgoing,
+        htmlPayload,
+        payload,
+        fromLabel: resolveMailboxActorLabel(
+          message.from_actor_id,
+          displayNameByActorId,
+          normalizedHumanActorId
+        ),
+        toLabel: resolveMailboxActorLabel(
+          message.to_actor_id,
+          displayNameByActorId,
+          normalizedHumanActorId
+        ),
+        canAccept: isMessageAcceptableForInbox(
+          message,
+          chatActors.inboxActorId,
+          normalizedHumanActorId
+        ),
+      };
+    });
+  }, [
+    chatActors.fromActorId,
+    chatActors.inboxActorId,
+    conversationMessages,
+    displayNameByActorId,
+    normalizedHumanActorId,
+    toPrettyJson,
+  ]);
+  const acceptVisibleMessages = React.useMemo(
+    () => conversationRows.filter((row) => row.canAccept).map((row) => row.message),
+    [conversationRows]
+  );
 
   const advancedControls = (
     <div className={MAILBOX_ADVANCED_GRID_CLASS}>
@@ -380,25 +466,18 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
         <div className={MAILBOX_SHELL_CLASS}>
           <div className={MAILBOX_MEMBER_LIST_CLASS}>
             <h4 className={MAILBOX_SECTION_TITLE_CLASS}>Agents</h4>
-            {mailboxActors.map((member) => {
-              const unread = unreadByMemberId[member.member_id] ?? 0;
-              const isHuman = member.role === "human";
+            {mailboxActorRows.map((member) => {
               return (
                 <SelectableListItem
-                  key={member.member_id}
-                  active={selectedMemberId === member.member_id}
-                  onClick={() => onSelectMember(member.member_id)}
+                  key={member.memberId}
+                  active={selectedMemberId === member.memberId}
+                  onClick={() => onSelectMember(member.memberId)}
                 >
                   <div className="flex w-full items-center justify-between gap-2">
                     <span className={`${TEAM_LIST_ITEM_TITLE_CLASS} font-bold`}>
-                      {resolveMailboxActorLabel(
-                        member.member_id,
-                        displayNameByActorId,
-                        normalizedHumanActorId
-                      )}{" "}
-                      ({member.role})
+                      {member.label} ({member.role})
                     </span>
-                    {!isHuman && (
+                    {!member.isHuman && (
                       <StatusBadge
                         label={member.status}
                         tone={resolveTeamRunStatusTone(member.status)}
@@ -409,18 +488,18 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
                   </div>
                   <div className="flex w-full items-center justify-between gap-2 mt-0.5">
                     <span className={TEAM_LIST_ITEM_META_CLASS}>
-                      {isHuman ? "human actor" : `pending=${member.pending_inbox_count}`}
+                      {member.isHuman ? "human actor" : `pending=${member.pendingInboxCount}`}
                     </span>
-                    {unread > 0 && (
+                    {member.unread > 0 && (
                       <span className="teams-member-unread shrink-0 rounded-sm bg-state-warning-bg border border-state-warning-border px-1.5 py-0.5 text-[10px] font-bold text-state-warning-text">
-                        unread={unread}
+                        unread={member.unread}
                       </span>
                     )}
                   </div>
                 </SelectableListItem>
               );
             })}
-            {mailboxActors.length === 0 && (
+            {mailboxActorRows.length === 0 && (
               <EmptyState className={`${TEAM_MUTED_TEXT_CLASS} px-2`} body="No members available." />
             )}
           </div>
@@ -446,7 +525,7 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
                   auto_follow={chatStickToBottom ? "on" : "off"}
                 </div>
               </div>
-              <div className="flex flex-wrap items-center gap-2">
+              <ToolbarRow className="flex-none justify-end">
                 <ActionButton
                   tone="secondary"
                   size="md"
@@ -473,7 +552,7 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
                   <i className="bi bi-chevron-down" aria-hidden="true" />
                   <span>Jump to bottom</span>
                 </ActionButton>
-              </div>
+              </ToolbarRow>
             </ToolbarRow>
 
             <ul
@@ -481,60 +560,42 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
               ref={chatMessagesRef}
               onScroll={() => onConversationScroll()}
             >
-              {conversationMessages.map((message) => {
-                const isOutgoing = message.from_actor_id === chatActors.fromActorId;
-                const chatText = resolveVisibleTeamPayloadText(message.payload);
-                const payload = chatText ?? toPrettyJson(message.payload);
-                const fromLabel = resolveMailboxActorLabel(
-                  message.from_actor_id,
-                  displayNameByActorId,
-                  normalizedHumanActorId
-                );
-                const toLabel = resolveMailboxActorLabel(
-                  message.to_actor_id,
-                  displayNameByActorId,
-                  normalizedHumanActorId
-                );
-
+              {conversationRows.map((row) => {
                 return (
                   <li
-                    key={message.message_id}
-                    className={`${MAILBOX_MESSAGE_ITEM_CLASS} ${isOutgoing ? "items-end" : "items-start"}`}
+                    key={row.message.message_id}
+                    className={`${MAILBOX_MESSAGE_ITEM_CLASS} ${row.isOutgoing ? "items-end" : "items-start"}`}
                   >
-                    <div className={isOutgoing ? MAILBOX_MESSAGE_BUBBLE_OUTGOING_CLASS : MAILBOX_MESSAGE_BUBBLE_INCOMING_CLASS}>
-                      <div className={`${MAILBOX_MESSAGE_HEAD_CLASS} ${isOutgoing ? "justify-end text-right" : "justify-start text-left"}`}>
+                    <div className={row.isOutgoing ? MAILBOX_MESSAGE_BUBBLE_OUTGOING_CLASS : MAILBOX_MESSAGE_BUBBLE_INCOMING_CLASS}>
+                      <div className={`${MAILBOX_MESSAGE_HEAD_CLASS} ${row.isOutgoing ? "justify-end text-right" : "justify-start text-left"}`}>
                         <span className="font-bold">
-                          {fromLabel}
+                          {row.fromLabel}
                         </span>
                         <span className="opacity-60">{" → "}</span>
                         <span className="font-bold">
-                          {toLabel}
+                          {row.toLabel}
                         </span>
                         <span className="opacity-40">{" · "}</span>
-                        <span className="opacity-60">{formatTs(message.created_at)}</span>
+                        <span className="opacity-60">{formatTs(row.message.created_at)}</span>
                       </div>
                       <div className="mt-0.5 text-[14px] leading-6">
-                        {chatText !== null ? (
+                        {row.htmlPayload !== null ? (
                           <div
                             dangerouslySetInnerHTML={{
-                              __html: renderPlainTextWithMentions(payload, displayNameByActorId),
+                              __html: row.htmlPayload,
                             }}
                           />
                         ) : (
-                          <pre className="mono whitespace-pre-wrap rounded border border-black/5 bg-white/40 p-1.5 text-[12px]">{payload}</pre>
+                          <pre className="mono whitespace-pre-wrap rounded border border-black/5 bg-white/40 p-1.5 text-[12px]">{row.payload}</pre>
                         )}
                       </div>
-                      {isMessageAcceptableForInbox(
-                        message,
-                        chatActors.inboxActorId,
-                        normalizedHumanActorId
-                      ) && (
-                        <div className={`mt-2 flex ${isOutgoing ? "justify-end" : "justify-start"}`}>
+                      {row.canAccept && (
+                        <div className={`mt-2 flex ${row.isOutgoing ? "justify-end" : "justify-start"}`}>
                           <ActionButton
                             tone="secondary"
                             size="md"
                             onClick={() => {
-                              void onAcceptMessage(message);
+                              void onAcceptMessage(row.message);
                             }}
                             disabled={busy !== null}
                           >

--- a/web/src/pages/team_member_console_panel.tsx
+++ b/web/src/pages/team_member_console_panel.tsx
@@ -18,6 +18,7 @@ import {
   InsetSurface,
   PanelHeader,
   SurfaceCard,
+  ToolbarRow,
 } from "../ui/primitives";
 import {
   resolveDisplayName,
@@ -28,6 +29,7 @@ import {
   TEAM_PANEL_PRE_CLASS,
   TEAM_PANEL_TITLE_CLASS,
 } from "../ui/tailwind_classes";
+import { windowTeamConversation } from "./team/team_conversation_viewport";
 
 type TeamMemberConsolePanelProps = {
   snapshot: TeamRunSnapshotRecord | null;
@@ -71,6 +73,37 @@ const MEMBER_CONSOLE_EMPTY_TEXT_CLASS = TEAM_MUTED_TEXT_CLASS;
 const MEMBER_CONSOLE_PROMPT_DETAILS_CLASS = "rounded-lg border border-ui-border bg-ui-surface p-2";
 const MEMBER_CONSOLE_PROMPT_SUMMARY_CLASS =
   "cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-ui-text-muted";
+const MEMBER_CONSOLE_EVENT_WINDOW_NOTICE_CLASS =
+  "rounded-lg border border-ui-border bg-ui-surface-soft/70 px-2 py-1 text-[11px] text-ui-text-muted";
+const MEMBER_CONSOLE_EVENT_TAIL_WINDOW_SIZE = 80;
+
+type TeamMemberConsoleSelectOption = {
+  memberId: string;
+  label: string;
+  role: string;
+};
+
+type TeamMemberConsoleMemberEventRow = {
+  eventId: number;
+  stream: string;
+  tsLabel: string;
+  message: string;
+};
+
+type TeamMemberConsoleRunEventRow = {
+  eventId: number;
+  eventType: string;
+  tsLabel: string;
+  payloadText: string;
+};
+
+type TeamMemberConsoleDetailItem = {
+  label: string;
+  value: string;
+  wrap?: boolean;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+};
 
 function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
   const {
@@ -107,6 +140,110 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
     );
   }, [selectedMemberSnapshot?.skills]);
   const attachedNodeId = selectedTargetNodeId?.trim() || null;
+  const memberOptions = React.useMemo<TeamMemberConsoleSelectOption[]>(
+    () =>
+      (snapshot?.members ?? []).map((member) => ({
+        memberId: member.member_id,
+        label: resolveDisplayName(member.member_id, displayNameByActorId, member.member_id),
+        role: member.role,
+      })),
+    [displayNameByActorId, snapshot?.members]
+  );
+  const memberEventRows = React.useMemo<TeamMemberConsoleMemberEventRow[]>(
+    () =>
+      memberEvents.map((event) => ({
+        eventId: event.event_id,
+        stream: event.stream,
+        tsLabel: formatTs(event.ts),
+        message: event.message,
+      })),
+    [formatTs, memberEvents]
+  );
+  const runEventRows = React.useMemo<TeamMemberConsoleRunEventRow[]>(
+    () =>
+      // Precompute preview rows so large member-console histories do not repeat
+      // timestamp formatting and payload JSON rendering during every list render.
+      displayedRunEvents.map((event) => ({
+        eventId: event.event_id,
+        eventType: event.event_type,
+        tsLabel: formatTs(event.ts),
+        payloadText: toPrettyJson(event.payload),
+      })),
+    [displayedRunEvents, formatTs, toPrettyJson]
+  );
+  const memberEventWindow = React.useMemo(
+    () => windowTeamConversation(memberEventRows, true, MEMBER_CONSOLE_EVENT_TAIL_WINDOW_SIZE),
+    [memberEventRows]
+  );
+  const memberDetailItems = React.useMemo<TeamMemberConsoleDetailItem[]>(() => {
+    if (!selectedMemberSnapshot) {
+      return [];
+    }
+    return [
+      { label: "member_id", value: selectedMemberSnapshot.member_id },
+      { label: "role", value: selectedMemberSnapshot.role },
+      { label: "model", value: selectedMemberSnapshot.model ?? "-" },
+      {
+        label: "member_description",
+        value: selectedMemberSnapshot.description ?? "-",
+        wrap: true,
+      },
+      { label: "status", value: selectedMemberSnapshot.status },
+      { label: "session_status", value: selectedMemberSnapshot.session_status ?? "-" },
+      attachedNodeId
+        ? {
+            label: "attached_node",
+            value: attachedNodeId,
+            href: buildWorkspaceNodePath(attachedNodeId),
+            onClick: (event) => {
+              if (!shouldHandleInAppLinkClick(event)) {
+                return;
+              }
+              event.preventDefault();
+              navigateToPath(buildWorkspaceNodePath(attachedNodeId));
+            },
+          }
+        : { label: "attached_node", value: "-" },
+      {
+        label: "runtime_handle_id",
+        value: getTeamStepRuntimeHandleId(selectedMemberSnapshot.latest_step) ?? "-",
+      },
+      {
+        label: "skills",
+        value:
+          selectedMemberSnapshot.skills.length > 0
+            ? selectedMemberSnapshot.skills.join(", ")
+            : "-",
+        wrap: true,
+      },
+      {
+        label: "mcp_skills",
+        value: mcpSkills.length > 0 ? mcpSkills.join(", ") : "-",
+        wrap: true,
+      },
+    ];
+  }, [attachedNodeId, mcpSkills, selectedMemberSnapshot]);
+  const discoveryCardDetailItems = React.useMemo<TeamMemberConsoleDetailItem[]>(() => {
+    if (!memberDiscoveryCard) {
+      return [];
+    }
+    return [
+      { label: "card_id", value: memberDiscoveryCard.card_id },
+      { label: "schema_version", value: memberDiscoveryCard.schema_version },
+      { label: "description", value: memberDiscoveryCard.description, wrap: true },
+      { label: "acp_provider", value: memberDiscoveryCard.runtime.acp_provider ?? "-" },
+      { label: "worktree_mode", value: memberDiscoveryCard.runtime.worktree_mode },
+      { label: "code_mode", value: memberDiscoveryCard.runtime.code_mode ? "true" : "false" },
+      {
+        label: "capability_tags",
+        value:
+          memberDiscoveryCard.capability_tags.length > 0
+            ? memberDiscoveryCard.capability_tags.join(", ")
+            : "-",
+        wrap: true,
+      },
+    ];
+  }, [memberDiscoveryCard]);
 
   return (
     <SurfaceCard className="p-4" data-team-panel="member-console">
@@ -114,36 +251,36 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
         title="Member Console"
         titleClassName={TEAM_PANEL_TITLE_CLASS}
         actions={
-          <div className="flex flex-wrap items-center gap-2">
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={() => {
-              void onRefresh();
-            }}
-            disabled={selectedMemberSnapshot ? memberEventsLoading : eventsLoading}
-            title="Refresh member console"
-            aria-label="Refresh member console"
-          >
-            <i className="bi bi-arrow-clockwise" aria-hidden="true" />
-            <span>Refresh</span>
-          </ActionButton>
-          <ActionButton
-            tone="secondary"
-            size="sm"
-            onClick={() => {
-              void onLoadOlder();
-            }}
-            disabled={
-              !selectedMemberSnapshot ||
-              memberEventsLoading ||
-              !memberEventsHasMore ||
-              oldestMemberEventId == null
-            }
-          >
-            Load Older
-          </ActionButton>
-          </div>
+          <ToolbarRow className="justify-end gap-2">
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={() => {
+                void onRefresh();
+              }}
+              disabled={selectedMemberSnapshot ? memberEventsLoading : eventsLoading}
+              title="Refresh member console"
+              aria-label="Refresh member console"
+            >
+              <i className="bi bi-arrow-clockwise" aria-hidden="true" />
+              <span>Refresh</span>
+            </ActionButton>
+            <ActionButton
+              tone="secondary"
+              size="sm"
+              onClick={() => {
+                void onLoadOlder();
+              }}
+              disabled={
+                !selectedMemberSnapshot ||
+                memberEventsLoading ||
+                !memberEventsHasMore ||
+                oldestMemberEventId == null
+              }
+            >
+              Load Older
+            </ActionButton>
+          </ToolbarRow>
         }
       />
 
@@ -154,10 +291,9 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
           onChange={(event) => onSelectedMemberIdChange(event.target.value)}
         >
           <option value="">Select member</option>
-          {snapshot?.members.map((member) => (
-            <option key={member.member_id} value={member.member_id}>
-              {resolveDisplayName(member.member_id, displayNameByActorId, member.member_id)} (
-              {member.role})
+          {memberOptions.map((member) => (
+            <option key={member.memberId} value={member.memberId}>
+              {member.label} ({member.role})
             </option>
           ))}
         </select>
@@ -166,75 +302,31 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
       {selectedMemberSnapshot && (
         <InsetSurface className={MEMBER_CONSOLE_DETAIL_CLASS}>
           <div className={MEMBER_CONSOLE_DETAIL_GRID_CLASS}>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>member_id</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                {selectedMemberSnapshot.member_id}
-              </span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>role</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>{selectedMemberSnapshot.role}</span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>model</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>{selectedMemberSnapshot.model ?? "-"}</span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>member_description</div>
-              <span className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
-                {selectedMemberSnapshot.description ?? "-"}
-              </span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>status</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>{selectedMemberSnapshot.status}</span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>session_status</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                {selectedMemberSnapshot.session_status ?? "-"}
-              </span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>attached_node</div>
-              {attachedNodeId ? (
-                <a
-                  href={buildWorkspaceNodePath(attachedNodeId)}
-                  className={`${MEMBER_CONSOLE_DETAIL_VALUE_CLASS} text-blue-700 underline decoration-transparent underline-offset-2 transition hover:decoration-current`}
-                  title={`Open node detail for ${attachedNodeId}`}
-                  onClick={(event) => {
-                    if (!shouldHandleInAppLinkClick(event)) {
-                      return;
+            {memberDetailItems.map((item) => (
+              <div key={item.label} className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
+                <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>{item.label}</div>
+                {item.href ? (
+                  <a
+                    href={item.href}
+                    className={`${MEMBER_CONSOLE_DETAIL_VALUE_CLASS} text-blue-700 underline decoration-transparent underline-offset-2 transition hover:decoration-current`}
+                    title={`Open node detail for ${item.value}`}
+                    onClick={item.onClick}
+                  >
+                    {item.value}
+                  </a>
+                ) : (
+                  <span
+                    className={
+                      item.wrap
+                        ? MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS
+                        : MEMBER_CONSOLE_DETAIL_VALUE_CLASS
                     }
-                    event.preventDefault();
-                    navigateToPath(buildWorkspaceNodePath(attachedNodeId));
-                  }}
-                >
-                  {attachedNodeId}
-                </a>
-              ) : (
-                <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>-</span>
-              )}
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>runtime_handle_id</div>
-              <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                {getTeamStepRuntimeHandleId(selectedMemberSnapshot.latest_step) ?? "-"}
-              </span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>skills</div>
-              <span className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
-                {selectedMemberSnapshot.skills.length > 0 ? selectedMemberSnapshot.skills.join(", ") : "-"}
-              </span>
-            </div>
-            <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-              <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>mcp_skills</div>
-              <span className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
-                {mcpSkills.length > 0 ? mcpSkills.join(", ") : "-"}
-              </span>
-            </div>
+                  >
+                    {item.value}
+                  </span>
+                )}
+              </div>
+            ))}
           </div>
           <details className={MEMBER_CONSOLE_PROMPT_DETAILS_CLASS}>
             <summary className={MEMBER_CONSOLE_PROMPT_SUMMARY_CLASS}>
@@ -251,50 +343,20 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
             )}
             {!memberDiscoveryCardLoading && memberDiscoveryCard && (
               <div className={MEMBER_CONSOLE_DETAIL_GRID_CLASS}>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>card_id</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                    {memberDiscoveryCard.card_id}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>schema_version</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                    {memberDiscoveryCard.schema_version}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>description</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
-                    {memberDiscoveryCard.description}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>acp_provider</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                    {memberDiscoveryCard.runtime.acp_provider ?? "-"}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>worktree_mode</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                    {memberDiscoveryCard.runtime.worktree_mode}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>code_mode</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_VALUE_CLASS}>
-                    {memberDiscoveryCard.runtime.code_mode ? "true" : "false"}
-                  </span>
-                </div>
-                <div className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
-                  <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>capability_tags</div>
-                  <span className={MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS}>
-                    {memberDiscoveryCard.capability_tags.length > 0
-                      ? memberDiscoveryCard.capability_tags.join(", ")
-                      : "-"}
-                  </span>
-                </div>
+                {discoveryCardDetailItems.map((item) => (
+                  <div key={item.label} className={MEMBER_CONSOLE_DETAIL_ITEM_CLASS}>
+                    <div className={MEMBER_CONSOLE_DETAIL_LABEL_CLASS}>{item.label}</div>
+                    <span
+                      className={
+                        item.wrap
+                          ? MEMBER_CONSOLE_DETAIL_WRAP_VALUE_CLASS
+                          : MEMBER_CONSOLE_DETAIL_VALUE_CLASS
+                      }
+                    >
+                      {item.value}
+                    </span>
+                  </div>
+                ))}
               </div>
             )}
             {!memberDiscoveryCardLoading && !memberDiscoveryCard && (
@@ -332,12 +394,17 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
 
       {selectedMemberSnapshot && (
         <ul className={MEMBER_CONSOLE_LIST_CLASS}>
-          {memberEvents.map((event) => (
-            <li key={event.event_id} className={MEMBER_CONSOLE_LIST_ITEM_CLASS}>
+          {memberEventWindow.offset > 0 && (
+            <li className={MEMBER_CONSOLE_EVENT_WINDOW_NOTICE_CLASS}>
+              {`Showing latest ${memberEventWindow.items.length} of ${memberEventWindow.total} loaded member events.`}
+            </li>
+          )}
+          {memberEventWindow.items.map((event) => (
+            <li key={event.eventId} className={MEMBER_CONSOLE_LIST_ITEM_CLASS}>
               <div className={MEMBER_CONSOLE_EVENT_HEAD_CLASS}>
-                <span className="mono">#{event.event_id}</span>
+                <span className="mono">#{event.eventId}</span>
                 <span>{event.stream}</span>
-                <span>{formatTs(event.ts)}</span>
+                <span>{event.tsLabel}</span>
               </div>
               <pre className={TEAM_PANEL_PRE_CLASS}>{event.message}</pre>
             </li>
@@ -347,14 +414,14 @@ function TeamMemberConsolePanelImpl(props: TeamMemberConsolePanelProps) {
 
       {!selectedMemberSnapshot && (
         <ul className={MEMBER_CONSOLE_LIST_CLASS}>
-          {displayedRunEvents.map((event) => (
-            <li key={event.event_id} className={MEMBER_CONSOLE_LIST_ITEM_CLASS}>
+          {runEventRows.map((event) => (
+            <li key={event.eventId} className={MEMBER_CONSOLE_LIST_ITEM_CLASS}>
               <div className={MEMBER_CONSOLE_EVENT_HEAD_CLASS}>
-                <span className="mono">#{event.event_id}</span>
-                <span>{event.event_type}</span>
-                <span>{formatTs(event.ts)}</span>
+                <span className="mono">#{event.eventId}</span>
+                <span>{event.eventType}</span>
+                <span>{event.tsLabel}</span>
               </div>
-              <pre className={TEAM_PANEL_PRE_CLASS}>{toPrettyJson(event.payload)}</pre>
+              <pre className={TEAM_PANEL_PRE_CLASS}>{event.payloadText}</pre>
             </li>
           ))}
         </ul>

--- a/web/src/pages/team_overview_panel.tsx
+++ b/web/src/pages/team_overview_panel.tsx
@@ -10,6 +10,8 @@ import {
   ActionButton,
   EmptyState,
   InsetSurface,
+  KeyValueItem,
+  KeyValueList,
   PanelHeader,
   SelectableListItem,
   StatusPill,
@@ -105,34 +107,21 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
 
       {snapshot && (
         <>
-          <div className={`teams-overview-meta ${OVERVIEW_META_CLASS}`}>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Leader</strong>
-              <StatusPill className="mono border-notion-accent/20 text-notion-accent">
-                {snapshot.leader_member_id ?? "-"}
-              </StatusPill>
-            </span>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Members</strong>
-              <span className="font-bold">{snapshot.members.length}</span>
-            </span>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Pending Mailbox</strong>
-              <span className="font-bold">{snapshot.mailbox.pending}</span>
-            </span>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Delivered</strong>
-              <span className="font-bold">{snapshot.mailbox.delivered}</span>
-            </span>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Dead Letter</strong>
-              <span className="font-bold">{snapshot.mailbox.dead_letter}</span>
-            </span>
-            <span>
-              <strong className="text-notion-text-muted font-bold uppercase text-[10px] tracking-widest mr-2">Recent Events</strong>
-              <span className="font-bold">{snapshot.latest_events.length}</span>
-            </span>
-          </div>
+          <KeyValueList className={`teams-overview-meta ${OVERVIEW_META_CLASS}`}>
+            <KeyValueItem
+              label="Leader"
+              value={
+                <StatusPill className="mono border-notion-accent/20 text-notion-accent">
+                  {snapshot.leader_member_id ?? "-"}
+                </StatusPill>
+              }
+            />
+            <KeyValueItem label="Members" value={snapshot.members.length} />
+            <KeyValueItem label="Pending mailbox" value={snapshot.mailbox.pending} />
+            <KeyValueItem label="Delivered" value={snapshot.mailbox.delivered} />
+            <KeyValueItem label="Dead letter" value={snapshot.mailbox.dead_letter} />
+            <KeyValueItem label="Recent events" value={snapshot.latest_events.length} />
+          </KeyValueList>
 
           <div className={OVERVIEW_MEMBER_LIST_CLASS}>
             {snapshot.members.map((member) => {

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildTeamWorkspacePath,
   formatTeamRuntimeActionSummary,
   parseTeamAgentInputSessionMismatch,
+  resolveChannelRouteTaskId,
   resolveRouteScopedConversationTaskSelection,
   resolveSelectedAgentWorkspaceSessionId,
   resolveThreadRootMessageIdFromPayload,
@@ -162,6 +163,54 @@ describe("team_page helpers", () => {
         routeSelectedTaskId: "",
         routeChannelId: "review",
         selectedChannelTaskId: null,
+      })
+    ).toBeNull();
+  });
+
+  it("keeps only explicit task conversations in channel-thread route state", () => {
+    expect(
+      resolveChannelRouteTaskId({
+        routeSelectedTaskId: "task-review",
+        selectedConversationTaskId: "task-review",
+        selectedConversationIsShared: false,
+        selectedConversationMatchesChannelLane: true,
+        selectedChannelTaskId: "task-review",
+      })
+    ).toBeNull();
+    expect(
+      resolveChannelRouteTaskId({
+        routeSelectedTaskId: "task-work",
+        selectedConversationTaskId: "task-work",
+        selectedConversationIsShared: false,
+        selectedConversationMatchesChannelLane: true,
+        selectedChannelTaskId: "task-review",
+      })
+    ).toBe("task-work");
+    expect(
+      resolveChannelRouteTaskId({
+        routeSelectedTaskId: "",
+        selectedConversationTaskId: "task-work",
+        selectedConversationIsShared: false,
+        selectedConversationMatchesChannelLane: true,
+        selectedChannelTaskId: "task-review",
+      })
+    ).toBe("task-work");
+    expect(
+      resolveChannelRouteTaskId({
+        routeSelectedTaskId: "task-review",
+        selectedConversationTaskId: "",
+        selectedConversationIsShared: true,
+        selectedConversationMatchesChannelLane: true,
+        selectedChannelTaskId: "task-review",
+      })
+    ).toBeNull();
+    expect(
+      resolveChannelRouteTaskId({
+        routeSelectedTaskId: "task-review",
+        selectedConversationTaskId: "task-review",
+        selectedConversationIsShared: false,
+        selectedConversationMatchesChannelLane: false,
+        selectedChannelTaskId: "task-review",
       })
     ).toBeNull();
   });

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -17,6 +17,9 @@ const {
   getTeamSharedThread,
   getTeamTask,
   listTeamTasks,
+  replyTeamThread,
+  refreshTaskMessagesSpy,
+  sendTaskMessageSpy,
   teamActionsOptionsSpy,
   teamConversationActionsOptionsSpy,
   teamPageFixture,
@@ -37,6 +40,9 @@ const {
   getTeamSharedThread: vi.fn(),
   getTeamTask: vi.fn(),
   listTeamTasks: vi.fn().mockResolvedValue([]),
+  replyTeamThread: vi.fn().mockResolvedValue(undefined),
+  refreshTaskMessagesSpy: vi.fn().mockResolvedValue(undefined),
+  sendTaskMessageSpy: vi.fn().mockResolvedValue(undefined),
   teamActionsOptionsSpy: vi.fn(),
   teamConversationActionsOptionsSpy: vi.fn(),
   useMediaQueryMock: vi.fn(() => false),
@@ -64,6 +70,7 @@ vi.mock("../api", async () => {
       getTeamSharedThread,
       getTeamTask,
       listTeamTasks,
+      replyTeamThread,
     },
   };
 });
@@ -154,8 +161,8 @@ vi.mock("./team/use_team_conversation_actions", () => ({
       selectedTeamId: options.selectedTeamId,
     });
     return {
-      refreshTaskMessages: vi.fn().mockResolvedValue(undefined),
-      sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+      refreshTaskMessages: refreshTaskMessagesSpy,
+      sendTaskMessage: sendTaskMessageSpy,
     };
   },
 }));
@@ -230,7 +237,10 @@ describe("TeamPage smoke render", () => {
     },
   });
 
-  const changeInputValue = async (element: HTMLInputElement, value: string) => {
+  const changeInputValue = async (
+    element: HTMLInputElement | HTMLTextAreaElement,
+    value: string
+  ) => {
     await act(async () => {
       const prototype = Object.getPrototypeOf(element) as { value?: unknown };
       const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
@@ -254,6 +264,9 @@ describe("TeamPage smoke render", () => {
     getTeamSharedThread.mockClear();
     getTeamTask.mockClear();
     listTeamTasks.mockClear();
+    replyTeamThread.mockClear();
+    refreshTaskMessagesSpy.mockClear();
+    sendTaskMessageSpy.mockClear();
     teamActionsOptionsSpy.mockClear();
     teamConversationActionsOptionsSpy.mockClear();
     useMediaQueryMock.mockReset();
@@ -1189,6 +1202,106 @@ describe("TeamPage smoke render", () => {
     }
   });
 
+  it("drops a redundant bootstrap task query when closing a channel bootstrap thread", async () => {
+    const buildTeam = (id: string, name: string) => ({
+      id,
+      name,
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        leader_member_id: "leader",
+        entrypoint: "leader_plan",
+        steps: [],
+        members: [{ member_id: "leader", role: "leader", prompt: "Plan" }],
+      },
+      created_at: 1,
+      updated_at: 1,
+    });
+
+    teamPageFixture.teams = [buildTeam("team-1", "Team One")];
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "review",
+        task_id: "task-review",
+        conversation_id: "conv-review",
+        description: "Review lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1", "task-all", "run-all"));
+    getTeamTask.mockResolvedValue({
+      task: {
+        id: "task-review",
+        team_id: "team-1",
+        title: "review",
+        status: "open",
+        created_by_actor_id: "user:user-1",
+        assigned_member_id: null,
+        context: { bootstrap_kind: "team_channel", channel_id: "review" },
+        created_at: 1,
+        updated_at: 1,
+      },
+      conversation: {
+        id: "conv-review",
+        team_id: "team-1",
+        task_id: "task-review",
+        mode: "group_chat",
+        topic: "review",
+        created_at: 1,
+        updated_at: 1,
+      },
+      latest_run: null,
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+              routeSearch="?lens=channels&channel=review&task=task-review&thread=17"
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      const closeThreadButton = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Close thread")
+      ) as HTMLButtonElement | undefined;
+      expect(closeThreadButton).toBeDefined();
+
+      await act(async () => {
+        closeThreadButton?.click();
+        await flushEffects();
+      });
+
+      expect(window.location.pathname).toBe("/workspace/teams/team-1");
+      expect(window.location.search).toBe("?lens=channels&channel=review");
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
   it("keeps the active channel when returning from a non-default channel thread to the lane", async () => {
     const buildTeam = (id: string, name: string) => ({
       id,
@@ -1386,6 +1499,199 @@ describe("TeamPage smoke render", () => {
         root.unmount();
       });
       container.remove();
+    }
+  });
+
+  it("does not force a manual task-message refresh after thread reply when EventSource is available", async () => {
+    const originalEventSource = globalThis.EventSource;
+    class MockEventSource {
+      close(): void {}
+    }
+    Object.defineProperty(globalThis, "EventSource", {
+      configurable: true,
+      writable: true,
+      value: MockEventSource,
+    });
+
+    const buildTeam = (id: string, name: string) => ({
+      id,
+      name,
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        leader_member_id: "leader",
+        entrypoint: "leader_plan",
+        steps: [],
+        members: [{ member_id: "leader", role: "leader", prompt: "Plan" }],
+      },
+      created_at: 1,
+      updated_at: 1,
+    });
+
+    teamPageFixture.teams = [buildTeam("team-1", "Team One")];
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "all",
+        task_id: "task-all",
+        conversation_id: "conv-task-all",
+        description: "Shared lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1", "task-all", "run-all"));
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+              routeSearch="?lens=channels&channel=all&thread=17"
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      const textarea = container.querySelector(
+        'textarea[placeholder="Reply in thread · # all"]'
+      ) as HTMLTextAreaElement | null;
+      expect(textarea).not.toBeNull();
+      await changeInputValue(textarea!, "reply from smoke");
+
+      const replyButton = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Reply")
+      ) as HTMLButtonElement | undefined;
+      expect(replyButton).toBeDefined();
+
+      await act(async () => {
+        replyButton?.click();
+        await flushEffects();
+      });
+
+      expect(replyTeamThread).toHaveBeenCalledTimes(1);
+      expect(refreshTaskMessagesSpy).not.toHaveBeenCalled();
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+      Object.defineProperty(globalThis, "EventSource", {
+        configurable: true,
+        writable: true,
+        value: originalEventSource,
+      });
+    }
+  });
+
+  it("keeps the fallback manual task-message refresh after thread reply when EventSource is unavailable", async () => {
+    const originalEventSource = globalThis.EventSource;
+    Object.defineProperty(globalThis, "EventSource", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const buildTeam = (id: string, name: string) => ({
+      id,
+      name,
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        leader_member_id: "leader",
+        entrypoint: "leader_plan",
+        steps: [],
+        members: [{ member_id: "leader", role: "leader", prompt: "Plan" }],
+      },
+      created_at: 1,
+      updated_at: 1,
+    });
+
+    teamPageFixture.teams = [buildTeam("team-1", "Team One")];
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "all",
+        task_id: "task-all",
+        conversation_id: "conv-task-all",
+        description: "Shared lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1", "task-all", "run-all"));
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+              routeSearch="?lens=channels&channel=all&thread=17"
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      const textarea = container.querySelector(
+        'textarea[placeholder="Reply in thread · # all"]'
+      ) as HTMLTextAreaElement | null;
+      expect(textarea).not.toBeNull();
+      await changeInputValue(textarea!, "reply from smoke");
+
+      const replyButton = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Reply")
+      ) as HTMLButtonElement | undefined;
+      expect(replyButton).toBeDefined();
+
+      await act(async () => {
+        replyButton?.click();
+        await flushEffects();
+      });
+
+      expect(replyTeamThread).toHaveBeenCalledTimes(1);
+      expect(refreshTaskMessagesSpy).toHaveBeenCalledWith("task-all");
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+      Object.defineProperty(globalThis, "EventSource", {
+        configurable: true,
+        writable: true,
+        value: originalEventSource,
+      });
     }
   });
 
@@ -2317,6 +2623,255 @@ describe("TeamPage smoke render", () => {
       };
       expect(lastOptions.selectedConversation?.id).toBe("task-work");
       expect(getTeamTask).toHaveBeenCalledWith("token", "team-1", "task-work");
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("canonicalizes a channel-scoped task route that is missing the channel id", async () => {
+    const buildTeam = (id: string, name: string) => ({
+      id,
+      name,
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        leader_member_id: "leader",
+        entrypoint: "leader_plan",
+        steps: [],
+        members: [{ member_id: "leader", role: "leader", prompt: "Plan" }],
+      },
+      created_at: 1,
+      updated_at: 1,
+    });
+
+    teamPageFixture.teams = [buildTeam("team-1", "Team One")];
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "review",
+        task_id: "task-review",
+        conversation_id: "conv-review",
+        description: "Review lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1", "task-all", "run-all"));
+    listTeamTasks.mockResolvedValue([
+      {
+        id: "task-work",
+        team_id: "team-1",
+        title: "Investigate regression",
+        status: "open",
+        created_by_actor_id: "leader",
+        assigned_member_id: "leader",
+        context: {
+          bootstrap_kind: "team_channel",
+          channel_id: "review",
+        },
+        created_at: 1,
+        updated_at: 2,
+      },
+    ]);
+    getTeamTask.mockResolvedValue({
+      task: {
+        id: "task-work",
+        team_id: "team-1",
+        title: "Investigate regression",
+        status: "open",
+        created_by_actor_id: "leader",
+        assigned_member_id: "leader",
+        context: {
+          bootstrap_kind: "team_channel",
+          channel_id: "review",
+        },
+        created_at: 1,
+        updated_at: 2,
+      },
+      conversation: {
+        id: "conv-task-work",
+        team_id: "team-1",
+        task_id: "task-work",
+        mode: "group_chat",
+        topic: "Investigate regression",
+        created_at: 1,
+        updated_at: 2,
+      },
+      latest_run: null,
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+              routeSearch="?lens=channels&task=task-work"
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      expect(window.location.pathname).toBe("/workspace/teams/team-1");
+      expect(window.location.search).toBe("?lens=channels&channel=review&task=task-work");
+
+      const lastOptions =
+        teamConversationActionsOptionsSpy.mock.calls[
+          teamConversationActionsOptionsSpy.mock.calls.length - 1
+        ]?.[0] as {
+          selectedConversation?: { id?: string };
+        };
+      expect(lastOptions.selectedConversation?.id).toBe("task-work");
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("routes a channel-scoped Kanban task back into its owning channel conversation", async () => {
+    const buildTeam = (id: string, name: string) => ({
+      id,
+      name,
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        leader_member_id: "leader",
+        entrypoint: "leader_plan",
+        steps: [],
+        members: [{ member_id: "leader", role: "leader", prompt: "Plan" }],
+      },
+      created_at: 1,
+      updated_at: 1,
+    });
+
+    teamPageFixture.teams = [buildTeam("team-1", "Team One")];
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "review",
+        task_id: "task-review",
+        conversation_id: "conv-review",
+        description: "Review lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1", "task-all", "run-all"));
+    listTeamTasks.mockResolvedValue([
+      {
+        id: "task-work",
+        team_id: "team-1",
+        title: "Investigate regression",
+        status: "open",
+        created_by_actor_id: "leader",
+        assigned_member_id: "leader",
+        context: {
+          bootstrap_kind: "team_channel",
+          channel_id: "review",
+        },
+        created_at: 1,
+        updated_at: 2,
+      },
+    ]);
+    getTeamTask.mockResolvedValue({
+      task: {
+        id: "task-work",
+        team_id: "team-1",
+        title: "Investigate regression",
+        status: "open",
+        created_by_actor_id: "leader",
+        assigned_member_id: "leader",
+        context: {
+          bootstrap_kind: "team_channel",
+          channel_id: "review",
+        },
+        created_at: 1,
+        updated_at: 2,
+      },
+      conversation: {
+        id: "conv-task-work",
+        team_id: "team-1",
+        task_id: "task-work",
+        mode: "group_chat",
+        topic: "Investigate regression",
+        created_at: 1,
+        updated_at: 2,
+      },
+      latest_run: null,
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+              routeSearch="?lens=tasks"
+            />
+          </MantineProvider>
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const taskCardButton = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Investigate regression")
+      );
+      expect(taskCardButton).toBeDefined();
+
+      await act(async () => {
+        taskCardButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const openConversationButton = Array.from(document.body.querySelectorAll("button")).find(
+        (button) => button.textContent?.includes("Open conversation")
+      ) as HTMLButtonElement | undefined;
+      expect(openConversationButton).toBeDefined();
+
+      await act(async () => {
+        openConversationButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(window.location.pathname).toBe("/workspace/teams/team-1");
+      expect(window.location.search).toBe("?lens=channels&channel=review&task=task-work");
     } finally {
       act(() => {
         root.unmount();

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -58,6 +58,7 @@ import { TeamPageHeader } from "./team/team_page_header";
 import { TeamPageShell } from "./team/team_page_shell";
 import { TeamSelectorPanel } from "./team/team_selector_panel";
 import { TeamThreadPane } from "./team/team_thread_pane";
+import { WorkspacePanelLoadingFallback } from "../components/workspace_panel_loading_fallback";
 import {
   TeamPanelLoadingFallback,
   prefetchTeamSetupSurface,
@@ -112,6 +113,7 @@ import {
 import {
   formatTs,
   isChannelScopedConversationTask,
+  resolveTaskChannelId,
   resolveTeamPageNotice,
   resolveSelectedAgentWorkspaceMemberId,
   resolveTaskConversationMemberIds,
@@ -316,6 +318,41 @@ export function resolveRouteScopedConversationTaskSelection(options: {
     return previousTaskId === selectedChannelTaskId ? previousTaskId : selectedChannelTaskId;
   }
   return null;
+}
+
+export function resolveChannelRouteTaskId(options: {
+  routeSelectedTaskId: string | null | undefined;
+  selectedConversationTaskId: string | null | undefined;
+  selectedConversationIsShared: boolean;
+  selectedConversationMatchesChannelLane: boolean;
+  selectedChannelTaskId: string | null | undefined;
+}): string | null {
+  const {
+    routeSelectedTaskId,
+    selectedConversationTaskId,
+    selectedConversationIsShared,
+    selectedConversationMatchesChannelLane,
+    selectedChannelTaskId,
+  } = options;
+  if (!selectedConversationMatchesChannelLane) {
+    return null;
+  }
+  const normalizedChannelTaskId = selectedChannelTaskId?.trim() ?? "";
+  const normalizedConversationTaskId = selectedConversationTaskId?.trim() ?? "";
+  if (
+    !selectedConversationIsShared &&
+    normalizedConversationTaskId &&
+    normalizedConversationTaskId !== normalizedChannelTaskId
+  ) {
+    return normalizedConversationTaskId;
+  }
+  const normalizedRouteTaskId = routeSelectedTaskId?.trim() ?? "";
+  // Drop the channel bootstrap task from thread routes so channel-scoped lanes
+  // only keep `task=` when the operator is looking at an explicit task conversation.
+  if (!normalizedRouteTaskId || normalizedRouteTaskId === normalizedChannelTaskId) {
+    return null;
+  }
+  return normalizedRouteTaskId;
 }
 
 export function resolveTeamSelectedMemberId(search: string): string {
@@ -1909,6 +1946,7 @@ export function TeamPage(props: TeamPageProps) {
   ]);
 
   useTeamRunLifecycleEffects({
+    token: props.token,
     selectedTeamId: effectiveSelectedTeamId,
     runStatusFilter,
     runs,
@@ -1921,7 +1959,6 @@ export function TeamPage(props: TeamPageProps) {
     refreshTeams,
     refreshTeamRuns,
     refreshRun,
-    refreshSteps,
     refreshEvents,
     refreshSnapshot,
     loadInbox,
@@ -2036,6 +2073,40 @@ export function TeamPage(props: TeamPageProps) {
     setConversationMailboxMessages,
     setTaskMessageDraft,
   });
+  useEffect(() => {
+    if (
+      !effectiveSelectedTeamId ||
+      routeWorkspaceLens !== "channels" ||
+      routeChannelId !== DEFAULT_TEAM_CHANNEL_ID ||
+      !routeSelectedTaskId
+    ) {
+      return;
+    }
+    const owningChannelId = resolveTaskChannelId(selectedConversation);
+    if (!owningChannelId) {
+      return;
+    }
+    // Canonicalize old task-only channel routes so channel-scoped conversations
+    // regain their owning lane semantics, including thread-pane behavior.
+    navigateTeamRoute(
+      buildTeamWorkspacePath(
+        effectiveSelectedTeamId,
+        "channels",
+        owningChannelId,
+        routeThreadRootMessageId,
+        null,
+        null,
+        routeSelectedTaskId
+      )
+    );
+  }, [
+    effectiveSelectedTeamId,
+    routeChannelId,
+    routeSelectedTaskId,
+    routeThreadRootMessageId,
+    routeWorkspaceLens,
+    selectedConversation,
+  ]);
 
   useEffect(() => {
     if (!effectiveSelectedTeamId || !routeSelectedTaskId) {
@@ -3019,7 +3090,9 @@ export function TeamPage(props: TeamPageProps) {
         { text }
       );
       setThreadReplyDraft("");
-      await refreshTaskMessages(selectedConversation?.id ?? undefined);
+      if (typeof EventSource === "undefined") {
+        await refreshTaskMessages(selectedConversation?.id ?? undefined);
+      }
     } catch (err) {
       setError(parseErrorMessage(err));
     } finally {
@@ -3049,12 +3122,14 @@ export function TeamPage(props: TeamPageProps) {
       )
   );
   const activeChannelConversationTaskId =
-    selectedConversationMatchesChannelLane &&
-    !selectedConversationIsShared &&
-    selectedConversation &&
-    selectedChannelRecord?.task_id !== selectedConversation.id
-      ? selectedConversation.id
-      : routeSelectedTaskId || null;
+    resolveChannelRouteTaskId({
+      routeSelectedTaskId,
+      selectedConversationTaskId: selectedConversation?.id,
+      selectedConversationIsShared,
+      selectedConversationMatchesChannelLane,
+      selectedChannelTaskId: selectedChannelRecord?.task_id,
+    });
+  const [channelFocusMessageId, setChannelFocusMessageId] = React.useState<number | null>(null);
   const conversationPanel = (
     <TeamConversationPanel
       conversationKey={selectedConversation?.id}
@@ -3081,6 +3156,10 @@ export function TeamPage(props: TeamPageProps) {
       activeThreadMessageId={
         selectedConversationMatchesChannelLane ? routeThreadRootMessageId : null
       }
+      jumpToMessageId={channelFocusMessageId}
+      onJumpToMessageSettled={() => {
+        setChannelFocusMessageId(null);
+      }}
       onOpenThread={
         effectiveSelectedTeamId &&
         selectedConversationMatchesChannelLane
@@ -3157,6 +3236,7 @@ export function TeamPage(props: TeamPageProps) {
       replyBusy={busy === "send-thread-reply"}
       formatTs={formatTs}
       onViewInChannel={() => {
+        setChannelFocusMessageId(routeThreadRootMessageId);
         const nextPath = buildCurrentThreadlessPath();
         if (!nextPath) {
           return;
@@ -3265,9 +3345,11 @@ export function TeamPage(props: TeamPageProps) {
   const agentAcpPanel = (
     <Suspense
       fallback={
-        <div className={teamSectionCardClassName}>
-          <p className={teamSectionBodyTextClassName}>Loading agent ACP...</p>
-        </div>
+        <WorkspacePanelLoadingFallback
+          className={teamSectionCardClassName}
+          title="Loading agent ACP..."
+          body="AgentHub is loading the selected member runtime context."
+        />
       }
     >
       <LazyTeamMemberAcpPanel
@@ -3799,10 +3881,8 @@ export function TeamPage(props: TeamPageProps) {
             selectedTeam={selectedTeam}
             isAgentWorkspace={isAgentWorkspace}
             teamSectionCardClassName={teamSectionCardClassName}
-            teamSectionHeadingClassName={teamSectionHeadingClassName}
             teamSectionTitleClassName={teamSectionTitleClassName}
             teamSectionBodyTextClassName={teamSectionBodyTextClassName}
-            teamSectionHintTextClassName={teamSectionHintTextClassName}
             panelSecondaryButtonClassName={panelSecondaryButtonClassName}
             teamWorkbenchWorkspaceShellClassName={teamWorkbenchWorkspaceShellClassName}
             workspaceHeaderProps={{

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3752,6 +3752,92 @@ describe("team panels interactions", () => {
     }
   });
 
+  it("TeamTaskPanel retries jump-to-message after the tail window expands the target row into view", async () => {
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: scrollIntoView,
+    });
+
+    try {
+      renderWithMantine(
+        root,
+        <TeamTaskPanel
+          developerMode={false}
+          tasksLoading={false}
+          onRefreshTasks={vi.fn()}
+          messageDraft=""
+          onMessageDraftChange={vi.fn()}
+          onSendMessage={vi.fn()}
+          messages={Array.from({ length: 26 }, (_, index) =>
+            buildTaskMessage(index + 1, {
+              from_actor_id: "leader-agent",
+              route: "group_chat",
+              payload: { type: "chat_message", text: `source ${index + 1}` },
+            })
+          )}
+          seenByMessageId={{}}
+          humanActorId="user:u-1"
+          memberLiveStates={[buildMemberLiveState()]}
+          memberIds={["leader-agent", "worker-agent"]}
+          conversationTitle="Shared thread"
+          isChannelConversation={true}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+          jumpToMessageId={1}
+          onJumpToMessageSettled={vi.fn()}
+        />
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      const scrollNode = required(
+        container.querySelector('[data-team-channel-scroll="true"]') as HTMLDivElement | null,
+        "team channel scroll container missing"
+      );
+      Object.defineProperty(scrollNode, "scrollHeight", {
+        configurable: true,
+        value: 640,
+      });
+      Object.defineProperty(scrollNode, "clientHeight", {
+        configurable: true,
+        value: 200,
+      });
+      Object.defineProperty(scrollNode, "scrollTop", {
+        configurable: true,
+        writable: true,
+        value: 640,
+      });
+
+      act(() => {
+        scrollNode.scrollTop = 720;
+        scrollNode.dispatchEvent(new Event("scroll", { bubbles: true }));
+      });
+
+      act(() => {
+        scrollNode.scrollTop = 80;
+        scrollNode.dispatchEvent(new Event("scroll", { bubbles: true }));
+      });
+
+      await waitForCondition(() => scrollIntoView.mock.calls.length > 0);
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", inline: "nearest" });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        writable: true,
+        value: originalScrollIntoView,
+      });
+    }
+  });
+
   it("TeamTaskPanel sticks to bottom by default and shows a jump action after manual upward scroll", async () => {
     const toPrettyJson = vi.fn((value: unknown) => JSON.stringify(value));
     const rafSpy = vi

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2128,6 +2128,58 @@ describe("team panels interactions", () => {
     expect(onLoadOlder).toHaveBeenCalled();
   });
 
+  it("TeamMemberConsolePanel windows long loaded member histories", () => {
+    const memberEvents = Array.from({ length: 90 }, (_, index) => ({
+      event_id: index + 1,
+      agent_id: "agent-1",
+      session_id: "session-1",
+      seq: String(index + 1),
+      ts: 100 + index,
+      stream: "stdout",
+      message: `worker output ${index + 1}`,
+    })) satisfies AgentEvent[];
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamMemberConsolePanel
+            snapshot={buildSnapshot()}
+            selectedMemberId="worker-agent"
+            onSelectedMemberIdChange={() => {}}
+            selectedTargetNodeId="node-east"
+            selectedMemberSnapshot={buildMemberSnapshot({
+              member_id: "worker-agent",
+              role: "worker",
+              latest_step: buildStep({ member_id: "worker-agent", remote_task_id: "task-77" }),
+            })}
+            memberEvents={memberEvents}
+            memberEventsHasMore={true}
+            memberEventsLoading={false}
+            eventsLoading={false}
+            oldestMemberEventId={1}
+            displayedRunEvents={[]}
+            previewLimit={5}
+            onRefresh={() => {}}
+            onLoadOlder={() => {}}
+            toPrettyJson={(value) => JSON.stringify(value)}
+            formatTs={(ts) => `ts-${String(ts)}`}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("Showing latest 80 of 90 loaded member events.");
+    const eventRows = Array.from(
+      container.querySelectorAll('[data-team-panel="member-console"] .teams-event-list > li')
+    );
+    expect(eventRows).toHaveLength(81);
+    expect(eventRows[0]?.textContent).toContain("Showing latest 80 of 90 loaded member events.");
+    expect(eventRows[1]?.textContent).toContain("#11");
+    expect(eventRows[1]?.textContent).toContain("worker output 11");
+    expect(eventRows[eventRows.length - 1]?.textContent).toContain("#90");
+    expect(eventRows[eventRows.length - 1]?.textContent).toContain("worker output 90");
+  });
+
   it("TeamTaskPanel supports create/select/send workflow", () => {
     const onMessageDraftChange = vi.fn();
     const onSendMessage = vi.fn();
@@ -3439,6 +3491,106 @@ describe("team panels interactions", () => {
     expect(queryButtonByText(container, "Details")).toBeNull();
   });
 
+  it("TeamTaskPanel surfaces thread reply counts on the channel timeline affordance", () => {
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        tasksLoading={false}
+        onRefreshTasks={vi.fn()}
+        messageDraft=""
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        messages={[
+          buildTaskMessage(12, {
+            payload: { type: "chat_message", text: "review the rollout note" },
+          }),
+          buildTaskMessage(13, {
+            route: "team_thread_reply",
+            payload: {
+              type: "chat_message",
+              text: "I have one follow-up.",
+              thread_root_message_id: 12,
+            },
+          }),
+          buildTaskMessage(14, {
+            route: "team_thread_reply",
+            payload: {
+              type: "chat_message",
+              text: "Second follow-up stays in the thread pane.",
+              thread_root_message_id: 12,
+            },
+          }),
+        ]}
+        seenByMessageId={{}}
+        humanActorId="user:u-1"
+        memberLiveStates={[buildMemberLiveState()]}
+        memberIds={["leader-agent", "worker-agent"]}
+        conversationTitle="Shared thread"
+        isChannelConversation={true}
+        messagesLoading={false}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+        onOpenThread={vi.fn()}
+        activeThreadMessageId={null}
+      />
+    );
+
+    expect(findButtonByText(container, "Thread · 2 replies")).toBeDefined();
+    expect(container.textContent).not.toContain("I have one follow-up.");
+    expect(container.textContent).not.toContain("Second follow-up stays in the thread pane.");
+  });
+
+  it("TeamTaskPanel marks the active thread root inside the channel timeline", () => {
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        tasksLoading={false}
+        onRefreshTasks={vi.fn()}
+        messageDraft=""
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        messages={[
+          buildTaskMessage(21, {
+            payload: { type: "chat_message", text: "focus this thread root" },
+          }),
+          buildTaskMessage(22, {
+            payload: { type: "chat_message", text: "leave this message idle" },
+          }),
+        ]}
+        seenByMessageId={{}}
+        humanActorId="user:u-1"
+        memberLiveStates={[buildMemberLiveState()]}
+        memberIds={["leader-agent", "worker-agent"]}
+        conversationTitle="Shared thread"
+        isChannelConversation={true}
+        messagesLoading={false}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+        onOpenThread={vi.fn()}
+        activeThreadMessageId={21}
+      />
+    );
+
+    const items = Array.from(
+      container.querySelectorAll("[data-team-channel-item='true']")
+    ) as HTMLElement[];
+    const activeItem = items.find(
+      (item) => item.getAttribute("data-team-thread-root-active") === "true"
+    );
+    const inactiveItem = items.find(
+      (item) => item.getAttribute("data-team-thread-root-active") === "false"
+    );
+
+    expect(activeItem?.textContent).toContain("focus this thread root");
+    expect(activeItem?.className).toContain("ring-1");
+    expect(activeItem?.className).toContain("bg-notion-hover/60");
+    expect(inactiveItem?.textContent).toContain("leave this message idle");
+  });
+
   it("TeamTaskPanel hides thread access for permission review cards", () => {
     renderWithMantine(
       root,
@@ -3546,6 +3698,58 @@ describe("team panels interactions", () => {
       writable: true,
       value: originalScrollIntoView,
     });
+  });
+
+  it("TeamTaskPanel scrolls the requested source message into view when thread focus returns to channel", async () => {
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: scrollIntoView,
+    });
+
+    try {
+      renderWithMantine(
+        root,
+        <TeamTaskPanel
+          developerMode={false}
+          tasksLoading={false}
+          onRefreshTasks={vi.fn()}
+          messageDraft=""
+          onMessageDraftChange={vi.fn()}
+          onSendMessage={vi.fn()}
+          messages={[
+            buildTaskMessage(41, {
+              from_actor_id: "leader-agent",
+              route: "group_chat",
+              payload: { type: "chat_message", text: "source message" },
+            }),
+          ]}
+          seenByMessageId={{}}
+          humanActorId="user:u-1"
+          memberLiveStates={[buildMemberLiveState()]}
+          memberIds={["leader-agent", "worker-agent"]}
+          conversationTitle="Shared thread"
+          isChannelConversation={true}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+          jumpToMessageId={41}
+          onJumpToMessageSettled={vi.fn()}
+        />
+      );
+
+      await waitForCondition(() => scrollIntoView.mock.calls.length > 0);
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", inline: "nearest" });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        writable: true,
+        value: originalScrollIntoView,
+      });
+    }
   });
 
   it("TeamTaskPanel sticks to bottom by default and shows a jump action after manual upward scroll", async () => {
@@ -4281,7 +4485,11 @@ describe("team panels interactions", () => {
                 title: "Prepare rollout",
                 status: "in_progress",
                 assigned_member_id: "worker-1",
-                context: { owner: "leader" },
+                context: {
+                  owner: "leader",
+                  bootstrap_kind: "team_channel",
+                  channel_id: "review",
+                },
                 created_at: 90,
                 updated_at: 220,
               }),
@@ -4399,7 +4607,7 @@ describe("team panels interactions", () => {
 
     expect(document.body.querySelector('[data-team-compile-preview="true"]')).not.toBeNull();
     expect(onSelectedTaskIdChange).toHaveBeenCalledWith("task-1");
-    expect(onOpenConversation).toHaveBeenNthCalledWith(1, "task-2");
+    expect(onOpenConversation).toHaveBeenNthCalledWith(1, "task-2", "review");
     expect(onOpenConversation).toHaveBeenNthCalledWith(2);
     expect(onCompilePreviewContextIdChange).toHaveBeenCalledWith("ctx-next");
     expect(onCompileTaskRunPreview).toHaveBeenCalledTimes(1);
@@ -4418,6 +4626,9 @@ describe("team panels interactions", () => {
       "Kanban is the canonical Team task surface. Human requests and clarifications should go through"
     );
     expect(container.textContent).toContain("# review");
+    expect(document.body.textContent).toContain(
+      "Task conversation stays in # review; Team runtime controls manage lifecycle here."
+    );
     expect(document.body.textContent).toContain("Open conversation");
     expect(container.textContent).toContain("Open # review");
     expect(document.body.textContent).toContain("Latest execution run");

--- a/web/src/pages/team_run_panel.tsx
+++ b/web/src/pages/team_run_panel.tsx
@@ -136,29 +136,31 @@ function TeamRunPanelImpl(props: TeamRunPanelProps) {
           title="Execution Runs"
           titleClassName="text-[13px] font-bold uppercase tracking-tight text-notion-text"
           actions={
-            <div className="actions flex flex-wrap items-center gap-2">
-            <NativeSelect
-              className="w-full sm:w-[164px]"
-              aria-label="Run status filter"
-              value={runStatusFilter}
-              onChange={(event) => onRunStatusFilterChange(event.currentTarget.value as TeamRunStatusFilter)}
-              data={runStatusFilterOptions}
-              size="xs"
-              radius="sm"
-            />
-            <ActionButton
-              tone="secondary"
-              size="md"
-              onClick={() => {
-                void onRefreshRuns();
-              }}
-              disabled={runsLoading}
-              title="Refresh execution runs"
-              aria-label="Refresh execution runs"
-            >
-              <i className="bi bi-arrow-clockwise" aria-hidden="true" />
-            </ActionButton>
-            </div>
+            <ToolbarRow className="justify-end gap-2">
+              <NativeSelect
+                className="w-full sm:w-[164px]"
+                aria-label="Run status filter"
+                value={runStatusFilter}
+                onChange={(event) =>
+                  onRunStatusFilterChange(event.currentTarget.value as TeamRunStatusFilter)
+                }
+                data={runStatusFilterOptions}
+                size="xs"
+                radius="sm"
+              />
+              <ActionButton
+                tone="secondary"
+                size="md"
+                onClick={() => {
+                  void onRefreshRuns();
+                }}
+                disabled={runsLoading}
+                title="Refresh execution runs"
+                aria-label="Refresh execution runs"
+              >
+                <i className="bi bi-arrow-clockwise" aria-hidden="true" />
+              </ActionButton>
+            </ToolbarRow>
           }
         />
 

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -100,6 +100,8 @@ type TeamTaskPanelProps = {
   toPrettyJson: (value: unknown) => string;
   onOpenThread?: (messageId: number) => void;
   activeThreadMessageId?: number | null;
+  jumpToMessageId?: number | null;
+  onJumpToMessageSettled?: () => void;
 };
 
 type VisibleConversationItem = {
@@ -107,6 +109,13 @@ type VisibleConversationItem = {
   permissionCardPayload: PermissionReviewCardPayload | null;
   text: string;
 };
+
+function formatThreadButtonLabel(replyCount: number): string {
+  if (replyCount <= 0) {
+    return "Thread";
+  }
+  return replyCount === 1 ? "Thread · 1 reply" : `Thread · ${replyCount} replies`;
+}
 
 function isThreadReplyMessage(message: TeamConversationMessageRecord): boolean {
   return message.route === "team_thread_reply";
@@ -276,6 +285,17 @@ function canOpenThreadFromMessage(message: TeamConversationMessageRecord): boole
   return !isThreadReplyMessage(message) && resolveMessageText(message) !== null;
 }
 
+function resolveThreadRootMessageIdFromPayload(payload: unknown): number | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const raw = (payload as { thread_root_message_id?: unknown }).thread_root_message_id;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw <= 0) {
+    return null;
+  }
+  return raw;
+}
+
 function resolveThreadAuthorLabel(
   actorId: string,
   humanActorId: string,
@@ -306,11 +326,16 @@ function resolveMentionLabel(
 
 function resolveActivityItemClassName(
   actorId: string,
-  humanActorId: string
+  humanActorId: string,
+  isActiveThreadRoot: boolean
 ): string {
-  return isHumanMailboxActor(actorId, humanActorId)
+  const baseClassName = isHumanMailboxActor(actorId, humanActorId)
     ? TEAM_TASK_ACTIVITY_ITEM_HUMAN_CLASS
     : TEAM_TASK_ACTIVITY_ITEM_AGENT_CLASS;
+  if (!isActiveThreadRoot) {
+    return baseClassName;
+  }
+  return `${baseClassName} rounded-xl bg-notion-hover/60 ring-1 ring-notion-accent/20`;
 }
 
 function resolveActivityContentClassName(
@@ -957,9 +982,11 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     messagesLoading,
     busy,
     formatTs,
-    onOpenThread,
-    activeThreadMessageId = null,
-  } = props;
+  onOpenThread,
+  activeThreadMessageId = null,
+  jumpToMessageId = null,
+  onJumpToMessageSettled,
+} = props;
 
   const messageTextareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const messageDraftComposingRef = React.useRef(false);
@@ -975,6 +1002,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
   const [permissionBusyId, setPermissionBusyId] = React.useState<string | null>(null);
   const [permissionErrorById, setPermissionErrorById] = React.useState<Record<string, string>>({});
   const activityListRef = React.useRef<HTMLDivElement | null>(null);
+  const activityItemRefs = React.useRef(new Map<number, HTMLDivElement>());
   const lastActivityScrollTopRef = React.useRef<number | null>(null);
   const conversationViewportKeyRef = React.useRef("");
   const initialStickResolvedRef = React.useRef(false);
@@ -1288,9 +1316,37 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
           text: item.text,
           permissionCardPayload: item.permissionCardPayload,
           canOpenThread: item.permissionCardPayload == null && canOpenThreadFromMessage(message),
+          threadReplyCount: 0,
         };
       }),
     [activityWindow.items]
+  );
+  const threadReplyCountByRootMessageId = React.useMemo(() => {
+    const replyCountByRootMessageId = new Map<number, number>();
+    // Keep thread reply counting keyed off the full ordered message list so
+    // viewport-window changes do not rescan the entire conversation history.
+    for (const message of orderedMessages) {
+      if (!isThreadReplyMessage(message)) {
+        continue;
+      }
+      const rootMessageId = resolveThreadRootMessageIdFromPayload(message.payload);
+      if (rootMessageId == null) {
+        continue;
+      }
+      replyCountByRootMessageId.set(
+        rootMessageId,
+        (replyCountByRootMessageId.get(rootMessageId) ?? 0) + 1
+      );
+    }
+    return replyCountByRootMessageId;
+  }, [orderedMessages]);
+  const visibleActivityItems = React.useMemo(
+    () =>
+      visibleWaterfallItems.map((item) => ({
+        ...item,
+        threadReplyCount: threadReplyCountByRootMessageId.get(item.sequence) ?? 0,
+      })),
+    [threadReplyCountByRootMessageId, visibleWaterfallItems]
   );
   const hiddenWaterfallCount = activityWindow.offset;
   const shouldDelayInitialConversationRender =
@@ -1311,6 +1367,81 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
       : TEAM_TASK_ACTIVITY_LIST_EMPTY_CLASS;
   const showInitialThreadLoading =
     !shouldDelayInitialConversationRender && messagesLoading && visibleWaterfallItems.length === 0;
+  const seenProgressByMessageId = React.useMemo(() => {
+    const next = new Map<number, SeenProgressState>();
+    // Precompute read-state once per visible item so long channel timelines do not
+    // rebuild the same progress breakdown during every row render.
+    for (const item of visibleActivityItems) {
+      next.set(
+        item.sequence,
+        resolveSeenProgressState(
+          seenByMessageId[item.sequence] ?? [],
+          memberIds,
+          item.fromActorId
+        )
+      );
+    }
+    return next;
+  }, [memberIds, seenByMessageId, visibleActivityItems]);
+  const visibleActivityRows = React.useMemo(
+    () =>
+      visibleActivityItems.map((item) => {
+        const seenActorIds = seenByMessageId[item.sequence] ?? [];
+        const seenProgress =
+          seenProgressByMessageId.get(item.sequence) ??
+          resolveSeenProgressState(seenActorIds, memberIds, item.fromActorId);
+        const isHumanAuthor = isHumanMailboxActor(item.fromActorId, humanActorId);
+        const permissionCardPayload = item.permissionCardPayload;
+        return {
+          item,
+          state: liveStateByMemberId.get(item.fromActorId),
+          isHumanAuthor,
+          isActiveThreadRoot: activeThreadMessageId === item.sequence,
+          authorLabel: resolveThreadAuthorLabel(
+            item.fromActorId,
+            humanActorId,
+            liveStateByMemberId
+          ),
+          seenActorIds,
+          seenProgress,
+          shouldShowSeenMeta: isHumanAuthor || seenProgress.totalCount > 0,
+          itemClassName: resolveActivityItemClassName(
+            item.fromActorId,
+            humanActorId,
+            activeThreadMessageId === item.sequence
+          ),
+          contentClassName: resolveActivityContentClassName(item.fromActorId, humanActorId),
+          bubbleClassName: `${resolveActivityBubbleToneClassName(
+            item.fromActorId,
+            humanActorId
+          )} ${resolveActivityBubbleLayoutClassName(isHumanAuthor || seenProgress.totalCount > 0)}`,
+          threadButtonLabel: formatThreadButtonLabel(item.threadReplyCount),
+          permissionCardPayload,
+          permissionRecord: permissionCardPayload
+            ? permissionRecordsById[permissionCardPayload.permission_id]
+            : undefined,
+          permissionBusy:
+            permissionCardPayload != null &&
+            permissionBusyId === permissionCardPayload.permission_id,
+          permissionErrorText:
+            permissionCardPayload != null
+              ? permissionErrorById[permissionCardPayload.permission_id]
+              : undefined,
+        };
+      }),
+    [
+      activeThreadMessageId,
+      humanActorId,
+      liveStateByMemberId,
+      memberIds,
+      permissionBusyId,
+      permissionErrorById,
+      permissionRecordsById,
+      seenByMessageId,
+      seenProgressByMessageId,
+      visibleActivityItems,
+    ]
+  );
   const latestWaterfallKey =
     visibleWaterfallItems.length > 0
       ? visibleWaterfallItems[visibleWaterfallItems.length - 1]?.key ?? "empty"
@@ -1437,6 +1568,20 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     };
   }, [latestWaterfallKey, messagesLoading, orderedMessages.length, scrollActivityToBottom, stickToBottom]);
 
+  React.useEffect(() => {
+    if (jumpToMessageId == null || messagesLoading) {
+      return;
+    }
+    const target = activityItemRefs.current.get(jumpToMessageId);
+    if (!target) {
+      return;
+    }
+    // Keep this as local UI state instead of route state so `View in channel`
+    // can regain the source message context without polluting canonical Team URLs.
+    target.scrollIntoView({ block: "center", inline: "nearest" });
+    onJumpToMessageSettled?.();
+  }, [jumpToMessageId, messagesLoading, onJumpToMessageSettled]);
+
   const handleActivityScroll = React.useCallback(() => {
     const node = activityListRef.current;
     if (!node) {
@@ -1483,30 +1628,39 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                       style={{ height: hiddenWaterfallSpacerHeight }}
                     />
                   )}
-                  {visibleWaterfallItems.map((item) => {
-                    const state = liveStateByMemberId.get(item.fromActorId);
-                    const isHumanAuthor = isHumanMailboxActor(item.fromActorId, humanActorId);
-                    const authorLabel = resolveThreadAuthorLabel(
-                      item.fromActorId,
-                      humanActorId,
-                      liveStateByMemberId
-                    );
-                    const permissionCardPayload = item.permissionCardPayload;
-                    const seenActorIds = seenByMessageId[item.sequence] ?? [];
-                    const seenProgress = resolveSeenProgressState(
+                  {visibleActivityRows.map((row) => {
+                    const {
+                      item,
+                      state,
+                      isHumanAuthor,
+                      isActiveThreadRoot,
+                      authorLabel,
                       seenActorIds,
-                      memberIds,
-                      item.fromActorId
-                    );
-                    const shouldShowSeenMeta =
-                      isHumanMailboxActor(item.fromActorId, humanActorId) ||
-                      seenProgress.totalCount > 0;
+                      seenProgress,
+                      shouldShowSeenMeta,
+                      itemClassName,
+                      contentClassName,
+                      bubbleClassName,
+                      threadButtonLabel,
+                      permissionCardPayload,
+                      permissionRecord,
+                      permissionBusy,
+                      permissionErrorText,
+                    } = row;
                     return (
                       <div
                         key={item.key}
-                        className={resolveActivityItemClassName(item.fromActorId, humanActorId)}
+                        ref={(node) => {
+                          if (node) {
+                            activityItemRefs.current.set(item.sequence, node);
+                            return;
+                          }
+                          activityItemRefs.current.delete(item.sequence);
+                        }}
+                        className={itemClassName}
                         data-activity-author-kind={isHumanAuthor ? "human" : "agent"}
                         data-team-channel-item="true"
+                        data-team-thread-root-active={isActiveThreadRoot ? "true" : "false"}
                       >
                         <div
                           className={
@@ -1517,7 +1671,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                         >
                           {isHumanAuthor ? "U" : authorLabel.charAt(0).toUpperCase()}
                         </div>
-                        <div className={resolveActivityContentClassName(item.fromActorId, humanActorId)}>
+                        <div className={contentClassName}>
                           <div className={TEAM_TASK_ACTIVITY_HEADER_ROW_CLASS}>
                             <div className={TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS}>
                               <span className={TEAM_TASK_ACTIVITY_AUTHOR_CLASS}>{authorLabel}</span>
@@ -1528,13 +1682,13 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                                 {isChannelConversation && onOpenThread && item.canOpenThread && (
                                   <CompactButton
                                     className={
-                                      activeThreadMessageId === item.sequence
+                                      isActiveThreadRoot
                                         ? `${TEAM_TASK_ACTIVITY_META_BUTTON_CLASS} bg-transparent text-notion-text-muted/82`
                                         : TEAM_TASK_ACTIVITY_META_BUTTON_CLASS
                                     }
                                     onClick={() => onOpenThread(item.sequence)}
                                   >
-                                    Thread
+                                    {threadButtonLabel}
                                   </CompactButton>
                                 )}
                                 {developerMode ? (
@@ -1558,19 +1712,16 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                             <div data-team-channel-bubble="permission" className="mt-1 max-w-full">
                               <PermissionReviewCard
                                 payload={permissionCardPayload}
-                                permissionRecord={permissionRecordsById[permissionCardPayload.permission_id]}
-                                busy={permissionBusyId === permissionCardPayload.permission_id}
-                                errorText={permissionErrorById[permissionCardPayload.permission_id]}
+                                permissionRecord={permissionRecord}
+                                busy={permissionBusy}
+                                errorText={permissionErrorText}
                                 onRespond={onRespondPermission}
                               />
                             </div>
                           ) : (
                             <TeamActivityBubble
                               bubbleKind={isHumanAuthor ? "human" : "agent"}
-                              bubbleClassName={`${resolveActivityBubbleToneClassName(
-                                item.fromActorId,
-                                humanActorId
-                              )} ${resolveActivityBubbleLayoutClassName(shouldShowSeenMeta)}`}
+                              bubbleClassName={bubbleClassName}
                               showSeenMeta={shouldShowSeenMeta}
                               itemKey={item.key}
                               seenActorIds={seenActorIds}

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -1442,6 +1442,10 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
       visibleActivityItems,
     ]
   );
+  const visibleActivitySequenceKey = React.useMemo(
+    () => visibleActivityRows.map((row) => String(row.item.sequence)).join(","),
+    [visibleActivityRows]
+  );
   const latestWaterfallKey =
     visibleWaterfallItems.length > 0
       ? visibleWaterfallItems[visibleWaterfallItems.length - 1]?.key ?? "empty"
@@ -1580,7 +1584,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     // can regain the source message context without polluting canonical Team URLs.
     target.scrollIntoView({ block: "center", inline: "nearest" });
     onJumpToMessageSettled?.();
-  }, [jumpToMessageId, messagesLoading, onJumpToMessageSettled]);
+  }, [jumpToMessageId, messagesLoading, onJumpToMessageSettled, visibleActivitySequenceKey]);
 
   const handleActivityScroll = React.useCallback(() => {
     const node = activityListRef.current;

--- a/web/src/pages/team_tasks_panel.tsx
+++ b/web/src/pages/team_tasks_panel.tsx
@@ -16,6 +16,7 @@ import {
 } from "../ui/primitives";
 import { selectRunsForTask } from "./team/run_helpers";
 import type { TeamMemberLiveState } from "./team/member_helpers";
+import { resolveTaskChannelId } from "./team/page_helpers";
 import {
   NOTION_MODAL_CLASSNAMES,
   NOTION_MODAL_OVERLAY_PROPS,
@@ -46,7 +47,7 @@ type TeamTasksPanelProps = {
   selectedTaskId: string;
   onSelectedTaskIdChange: (taskId: string) => void;
   onRefreshTasks: () => Promise<void> | void;
-  onOpenConversation: (taskId?: string | null) => void;
+  onOpenConversation: (taskId?: string | null, taskChannelId?: string | null) => void;
   busy: string | null;
   runs: TeamRunRecord[];
   onOpenRun: (runId: string) => void;
@@ -267,6 +268,10 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
     () => (selectedTask ? selectRunsForTask(runs, selectedTask.id) : []),
     [runs, selectedTask]
   );
+  const selectedTaskConversationLabel = React.useMemo(() => {
+    const taskChannelId = resolveTaskChannelId(selectedTask);
+    return taskChannelId ? `# ${taskChannelId}` : channelLabel;
+  }, [channelLabel, selectedTask]);
   const latestRun = relatedRuns[0] ?? null;
   const showInitialLoadingState = tasksLoading && tasks.length === 0;
 
@@ -437,14 +442,16 @@ function TeamTasksPanelImpl(props: TeamTasksPanelProps) {
           </div>
 
           <div className="mt-2 rounded-md bg-notion-sidebar/30 px-3 py-2 text-[13px] text-notion-text-muted italic border border-notion-border/50">
-            Task managed through Team runtime controls.
+            {`Task conversation stays in ${selectedTaskConversationLabel}; Team runtime controls manage lifecycle here.`}
           </div>
 
           <div className="mt-4 flex flex-wrap items-center gap-2">
             <ActionButton
               tone="secondary"
               size="md"
-              onClick={() => onOpenConversation(selectedTask.id)}
+              onClick={() =>
+                onOpenConversation(selectedTask.id, resolveTaskChannelId(selectedTask))
+              }
             >
               Open conversation
             </ActionButton>

--- a/web/src/pages/team_workspace_state_panel.test.tsx
+++ b/web/src/pages/team_workspace_state_panel.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { TeamLoadingPanel, TeamUnavailablePanel } from "./team_workspace_state_panel";
+
+describe("team_workspace_state_panel", () => {
+  it("renders the shared loading fallback for team bootstrap state", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamLoadingPanel />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Loading team workspace...");
+    expect(html).toContain("data-workspace-panel-loading=\"true\"");
+    expect(html).toContain("AgentHub is loading the workspace context and team metadata.");
+  });
+
+  it("renders the shared unavailable placeholder and back action", () => {
+    const onBackToSelector = vi.fn();
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamUnavailablePanel onBackToSelector={onBackToSelector} />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Teams");
+    expect(html).toContain("This team is unavailable");
+    expect(html).toContain("Return to the team list and choose another one.");
+    expect(html).toContain("Back to teams");
+    expect(html).toContain("data-workspace-lens-placeholder=\"teams\"");
+  });
+});

--- a/web/src/pages/team_workspace_state_panel.tsx
+++ b/web/src/pages/team_workspace_state_panel.tsx
@@ -1,21 +1,15 @@
-import { Loader } from "@mantine/core";
 import { ActionButton } from "../ui/primitives";
+import { WorkspaceLensPlaceholder } from "../components/workspace_lens_placeholder";
+import { WorkspacePanelLoadingFallback } from "../components/workspace_panel_loading_fallback";
 
 export function TeamLoadingPanel() {
   return (
     <div className="mx-auto flex w-full max-w-[680px] flex-col px-6 py-10" data-team-loading-shell="true">
-      <div className="flex items-center gap-3">
-        <Loader size="sm" color="gray" />
-        <div className="min-w-0">
-          <p className="text-[11px] font-medium tracking-[0.01em] text-black/45">Loading</p>
-          <h2 className="mt-1 text-[20px] font-semibold tracking-tight text-black">
-            Loading team workspace
-          </h2>
-          <p className="mt-2 max-w-xl text-[13px] leading-5 text-black/65">
-            AgentHub is loading the workspace context and team metadata.
-          </p>
-        </div>
-      </div>
+      <WorkspacePanelLoadingFallback
+        title="Loading team workspace..."
+        body="AgentHub is loading the workspace context and team metadata."
+        className="border-notion-border/70 bg-white/92"
+      />
     </div>
   );
 }
@@ -29,13 +23,11 @@ export function TeamUnavailablePanel({
 }: TeamUnavailablePanelProps) {
   return (
     <div className="mx-auto flex w-full max-w-[680px] flex-col px-6 py-10">
-      <p className="text-[11px] font-medium tracking-[0.01em] text-black/45">Unavailable</p>
-      <h2 className="mt-1 text-[20px] font-semibold tracking-tight text-black">
-        This team is unavailable
-      </h2>
-      <p className="mt-2 max-w-xl text-[13px] leading-5 text-black/65">
-        The requested team could not be loaded. Return to the team list and choose another one.
-      </p>
+      <WorkspaceLensPlaceholder
+        lensLabel="Teams"
+        title="This team is unavailable"
+        body="The requested team could not be loaded. Return to the team list and choose another one."
+      />
       <div className="mt-5">
         <ActionButton
           size="sm"

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -1092,8 +1092,8 @@ test("team mailbox IM mode supports conversation focus, unread, auto-follow and 
   const inboxBeforePolling = counters.inbox;
   await page.waitForTimeout(4500);
   expect(counters.events).toBe(eventsBeforePolling);
-  expect(counters.snapshot).toBeGreaterThan(snapshotBeforePolling);
-  expect(counters.inbox).toBeGreaterThan(inboxBeforePolling);
+  expect(counters.snapshot).toBe(snapshotBeforePolling);
+  expect(counters.inbox).toBe(inboxBeforePolling);
 
   await openAdvancedView(page, "Debug");
   await page.getByRole("button", { name: "Mailbox Raw" }).click();


### PR DESCRIPTION
## Summary

This follow-up bundles the next Team communication and shell cleanup slices:

- converge Team shell placeholders, loading fallbacks, and shared lens items
- finish the current Team channel and thread route / split-view follow-ups
- move Team active run refresh onto run-context SSE instead of the old polling storm
- harden Team and ACP-heavy render paths across channel timeline, member ACP, mailbox, thread pane, and member console
- dedupe hidden team member detail backfill so fresh loads stop refetching the same `api/agents/:id` records twice
- align the thread reply composer with channel composer desktop behavior and remove the extra thread-reply refresh when SSE is available

## Validation

- `cd web && pnpm exec vitest run src/pages/team/use_team_run_lifecycle_effects.test.tsx`
- `cd web && pnpm exec vitest run src/pages/team/use_team_member_backfill_effect.test.tsx`
- `cd web && pnpm exec vitest run src/pages/team/team_thread_pane.test.tsx src/pages/team_panels.test.tsx`
- `cd web && pnpm exec vitest run src/pages/team_page.smoke.test.tsx src/pages/team/team_thread_pane.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run lint`
- `cargo test team_run_context -- --nocapture`

## Chrome MCP

Live regression checks on `agenthub.hawkingrei.com` confirmed:

- fresh `Members` and `Channels` loads now fetch each hidden `api/agents/:id` member detail only once
- the new run-context SSE replaces the old Team `run + events + snapshot` polling storm on fresh Team pages
- the thread pane helper text now shows `Reply stays in this thread · Enter to reply`
- desktop `Enter` in the thread composer successfully posts a thread reply
- thread replies now refresh with `POST + one messages GET` instead of the previous duplicate `POST + two identical messages GETs`
