### PR TITLE
fix(acp): extend startup timeout and show startup progress

### DIFF
--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -47,11 +47,17 @@ const MCP_CONFIG_FILE: &str = ".agenthub/mcp.json";
 const SKILLS_CONFIG_FILE: &str = ".agenthub/skills.json";
 const ACP_COMMAND_CHANNEL_CAPACITY: usize = 64;
 const ACP_COMMAND_SEND_TIMEOUT: Duration = Duration::from_secs(5);
-const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(30);
+// Team workers may need a long resume/bootstrap window after service restarts,
+// so ACP startup should tolerate late session readiness instead of failing fast.
+const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(300);
 const ACP_PERMISSION_REVIEW_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub const fn acp_permission_review_timeout() -> Duration {
     ACP_PERMISSION_REVIEW_TIMEOUT
+}
+
+pub const fn acp_session_start_timeout() -> Duration {
+    ACP_SESSION_START_TIMEOUT
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcpActorContinuityEnvelope {
@@ -1834,7 +1840,8 @@ mod tests {
     use super::{
         ACP_PERMISSION_REVIEW_TIMEOUT, AcpActorContinuityEnvelope, AcpActorSkillContext,
         AcpCommand, AcpHandle, AcpPermissionRespondResult, AcpPermissionService,
-        AcpPromptDeliveryPolicy, AcpRuntimeLocation, AcpSendError, acp_permission_review_timeout,
+        AcpPromptDeliveryPolicy, AcpRuntimeLocation, AcpSendError,
+        acp_permission_review_timeout, acp_session_start_timeout,
         build_prompt_prefix_blocks, dedupe_skills, format_auth_required_message,
         handle_auth_required_failure, is_auth_required_error, load_mcp_servers_from_path,
         load_skills_from_config, load_workdir_skills, remove_skills_conflicting_with_reserved,
@@ -2574,5 +2581,10 @@ Fallback to the user-level review contract.
             acp_permission_review_timeout(),
             ACP_PERMISSION_REVIEW_TIMEOUT
         );
+    }
+
+    #[test]
+    fn session_start_timeout_defaults_to_five_minutes() {
+        assert_eq!(acp_session_start_timeout(), Duration::from_secs(300));
     }
 }

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -1840,12 +1840,11 @@ mod tests {
     use super::{
         ACP_PERMISSION_REVIEW_TIMEOUT, AcpActorContinuityEnvelope, AcpActorSkillContext,
         AcpCommand, AcpHandle, AcpPermissionRespondResult, AcpPermissionService,
-        AcpPromptDeliveryPolicy, AcpRuntimeLocation, AcpSendError,
-        acp_permission_review_timeout, acp_session_start_timeout,
-        build_prompt_prefix_blocks, dedupe_skills, format_auth_required_message,
-        handle_auth_required_failure, is_auth_required_error, load_mcp_servers_from_path,
-        load_skills_from_config, load_workdir_skills, remove_skills_conflicting_with_reserved,
-        should_queue_while_prompts_active,
+        AcpPromptDeliveryPolicy, AcpRuntimeLocation, AcpSendError, acp_permission_review_timeout,
+        acp_session_start_timeout, build_prompt_prefix_blocks, dedupe_skills,
+        format_auth_required_message, handle_auth_required_failure, is_auth_required_error,
+        load_mcp_servers_from_path, load_skills_from_config, load_workdir_skills,
+        remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
     };
     use agent_client_protocol_legacy::{
         ContentBlock, Error as AcpError, ErrorCode as AcpErrorCode, McpServer,

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -452,6 +452,21 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
 
     sqlx::query(
         r#"
+        CREATE TABLE IF NOT EXISTS agent_persistent_session_failures (
+            agent_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            failure_count INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (agent_id, provider),
+            FOREIGN KEY(agent_id) REFERENCES agents(id)
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
         CREATE TABLE IF NOT EXISTS agent_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             agent_id TEXT NOT NULL,

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -705,6 +705,19 @@ impl AgentManager {
         Ok(count > 0)
     }
 
+    async fn has_agent_persistent_session_failures_table(&self) -> anyhow::Result<bool> {
+        let count: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'agent_persistent_session_failures'
+            "#,
+        )
+        .fetch_one(&self.db)
+        .await?;
+        Ok(count > 0)
+    }
+
     async fn validate_target_node_id(&self, raw: Option<&str>) -> anyhow::Result<Option<String>> {
         let normalized = normalize_target_node_id(raw);
         let Some(node_id) = normalized.as_deref() else {

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -515,6 +515,8 @@ impl AgentManager {
         guard.remove(agent_id);
         drop(guard);
         let has_persistent_sessions_table = self.has_agent_persistent_sessions_table().await?;
+        let has_persistent_session_failures_table =
+            self.has_agent_persistent_session_failures_table().await?;
         let mut tx = self.db.begin().await?;
         sqlx::query("DELETE FROM acp_permission_requests WHERE agent_id = ?1")
             .bind(agent_id)
@@ -529,6 +531,8 @@ impl AgentManager {
                 .bind(agent_id)
                 .execute(&mut *tx)
                 .await?;
+        }
+        if has_persistent_session_failures_table {
             sqlx::query("DELETE FROM agent_persistent_session_failures WHERE agent_id = ?1")
                 .bind(agent_id)
                 .execute(&mut *tx)

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -529,6 +529,10 @@ impl AgentManager {
                 .bind(agent_id)
                 .execute(&mut *tx)
                 .await?;
+            sqlx::query("DELETE FROM agent_persistent_session_failures WHERE agent_id = ?1")
+                .bind(agent_id)
+                .execute(&mut *tx)
+                .await?;
         }
         sqlx::query("DELETE FROM agents WHERE id = ?1")
             .bind(agent_id)

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -23,6 +23,7 @@ use agent_client_protocol_legacy::Implementation;
 
 const RESUMED_ACP_SESSION_GRACE_PERIOD: Duration = Duration::from_secs(2);
 const RESUMED_ACP_SESSION_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY: i64 = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResumedSessionStartupState {
@@ -39,6 +40,10 @@ fn should_retry_resumed_acp_session(
         startup_state,
         ResumedSessionStartupState::Exited { success: false }
     ) && resumed_session_id == Some(actual_session_id)
+}
+
+fn should_force_fresh_session_after_resume_failures(failure_count: i64) -> bool {
+    failure_count >= RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY
 }
 
 async fn observe_resumed_session_startup(
@@ -125,6 +130,16 @@ impl AgentManager {
         .bind(now)
         .execute(&self.db)
         .await?;
+        sqlx::query(
+            r#"
+            DELETE FROM agent_persistent_session_failures
+            WHERE agent_id = ?1 AND provider = ?2
+            "#,
+        )
+        .bind(agent_id)
+        .bind(provider)
+        .execute(&self.db)
+        .await?;
         Ok(())
     }
 
@@ -145,7 +160,52 @@ impl AgentManager {
         .bind(provider)
         .execute(&self.db)
         .await?;
+        sqlx::query(
+            r#"
+            DELETE FROM agent_persistent_session_failures
+            WHERE agent_id = ?1 AND provider = ?2
+            "#,
+        )
+        .bind(agent_id)
+        .bind(provider)
+        .execute(&self.db)
+        .await?;
         Ok(())
+    }
+
+    async fn increment_persistent_session_failure(
+        &self,
+        agent_id: &str,
+        provider: &str,
+    ) -> anyhow::Result<i64> {
+        let now = Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT INTO agent_persistent_session_failures (agent_id, provider, failure_count, updated_at)
+            VALUES (?1, ?2, 1, ?3)
+            ON CONFLICT(agent_id, provider)
+            DO UPDATE SET
+                failure_count = agent_persistent_session_failures.failure_count + 1,
+                updated_at = excluded.updated_at
+            "#,
+        )
+        .bind(agent_id)
+        .bind(provider)
+        .bind(now)
+        .execute(&self.db)
+        .await?;
+        let row = sqlx::query(
+            r#"
+            SELECT failure_count
+            FROM agent_persistent_session_failures
+            WHERE agent_id = ?1 AND provider = ?2
+            "#,
+        )
+        .bind(agent_id)
+        .bind(provider)
+        .fetch_one(&self.db)
+        .await?;
+        Ok(row.get::<i64, _>("failure_count"))
     }
 
     pub async fn live_session_id_for_agent(
@@ -680,8 +740,9 @@ impl AgentManager {
             {
                 Ok(handle) => handle,
                 Err(err) => {
+                    let err_message = err.to_string();
                     if let Err(record_err) = self
-                        .record_failed_session(&agent.id, &session_id, &err.to_string())
+                        .record_failed_session(&agent.id, &session_id, &err_message)
                         .await
                     {
                         tracing::error!(
@@ -819,12 +880,32 @@ impl AgentManager {
             )
             .await;
             if should_retry_resumed_acp_session(Some(resume_id), acp_session_id, startup_state) {
+                let failure_count = self
+                    .increment_persistent_session_failure(&agent.id, provider_id)
+                    .await
+                    .unwrap_or(RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY);
                 tracing::warn!(
                     agent_id = %agent.id,
                     session_id = %session_id,
                     acp_session_id = %acp_session_id,
                     resumed_session_id = %resume_id,
-                    "resumed acp session exited during startup; clearing persistent session and retrying with a new session"
+                    failure_count,
+                    "resumed acp session exited during startup"
+                );
+                if !should_force_fresh_session_after_resume_failures(failure_count) {
+                    return Err(anyhow::anyhow!(
+                        "resumed acp session exited during startup (attempt {}/{})",
+                        failure_count,
+                        RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY
+                    ));
+                }
+                tracing::warn!(
+                    agent_id = %agent.id,
+                    session_id = %session_id,
+                    acp_session_id = %acp_session_id,
+                    resumed_session_id = %resume_id,
+                    failure_count,
+                    "resumed acp session exited during startup repeatedly; clearing persistent session and retrying with a new session"
                 );
                 Self::finalize_process_exit(
                     &self.db,
@@ -976,6 +1057,26 @@ impl AgentManager {
                 "failed to persist failed agent session row"
             );
         }
+        if let Err(err) = sqlx::query(
+            r#"
+            UPDATE agent_sessions
+            SET status = 'failed', ended_at = ?1
+            WHERE id = ?2 AND agent_id = ?3
+            "#,
+        )
+        .bind(now)
+        .bind(session_id)
+        .bind(agent_id)
+        .execute(&self.db)
+        .await
+        {
+            tracing::warn!(
+                agent_id = %agent_id,
+                session_id = %session_id,
+                error = %err,
+                "failed to update failed agent session row"
+            );
+        }
 
         let failure_message = format!("start failed: {}", message);
         if let Err(err) = persist_agent_event(
@@ -1005,8 +1106,9 @@ impl AgentManager {
 #[cfg(test)]
 mod tests {
     use super::{
-        RESUMED_ACP_SESSION_GRACE_PERIOD, RESUMED_ACP_SESSION_POLL_INTERVAL,
-        ResumedSessionStartupState, observe_resumed_session_startup,
+        RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY, RESUMED_ACP_SESSION_GRACE_PERIOD,
+        RESUMED_ACP_SESSION_POLL_INTERVAL, ResumedSessionStartupState,
+        observe_resumed_session_startup, should_force_fresh_session_after_resume_failures,
         should_retry_resumed_acp_session,
     };
     use std::sync::Arc;
@@ -1040,6 +1142,20 @@ mod tests {
             Some("resume-1"),
             "resume-1",
             ResumedSessionStartupState::Running,
+        ));
+    }
+
+    #[test]
+    fn fresh_session_retry_only_triggers_after_three_resume_failures() {
+        assert!(!should_force_fresh_session_after_resume_failures(1));
+        assert!(!should_force_fresh_session_after_resume_failures(
+            RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY - 1
+        ));
+        assert!(should_force_fresh_session_after_resume_failures(
+            RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY
+        ));
+        assert!(should_force_fresh_session_after_resume_failures(
+            RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY + 1
         ));
     }
 

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -130,11 +130,7 @@ impl AgentManager {
         .bind(now)
         .execute(&self.db)
         .await?;
-        if !self
-            .has_agent_persistent_session_failures_table()
-            .await
-            .unwrap_or(false)
-        {
+        if !self.has_agent_persistent_session_failures_table().await? {
             return Ok(());
         }
         sqlx::query(
@@ -189,7 +185,9 @@ impl AgentManager {
         provider: &str,
     ) -> anyhow::Result<i64> {
         if !self.has_agent_persistent_session_failures_table().await? {
-            return Ok(0);
+            anyhow::bail!(
+                "agent_persistent_session_failures table is unavailable; cannot track resume failures for fresh-session fallback"
+            );
         }
         let now = Utc::now().timestamp();
         sqlx::query(

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -130,6 +130,13 @@ impl AgentManager {
         .bind(now)
         .execute(&self.db)
         .await?;
+        if !self
+            .has_agent_persistent_session_failures_table()
+            .await
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
         sqlx::query(
             r#"
             DELETE FROM agent_persistent_session_failures
@@ -160,6 +167,9 @@ impl AgentManager {
         .bind(provider)
         .execute(&self.db)
         .await?;
+        if !self.has_agent_persistent_session_failures_table().await? {
+            return Ok(());
+        }
         sqlx::query(
             r#"
             DELETE FROM agent_persistent_session_failures
@@ -178,6 +188,9 @@ impl AgentManager {
         agent_id: &str,
         provider: &str,
     ) -> anyhow::Result<i64> {
+        if !self.has_agent_persistent_session_failures_table().await? {
+            return Ok(0);
+        }
         let now = Utc::now().timestamp();
         sqlx::query(
             r#"

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -893,10 +893,25 @@ impl AgentManager {
             )
             .await;
             if should_retry_resumed_acp_session(Some(resume_id), acp_session_id, startup_state) {
-                let failure_count = self
+                let failure_count = match self
                     .increment_persistent_session_failure(&agent.id, provider_id)
                     .await
-                    .unwrap_or(RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY);
+                {
+                    Ok(failure_count) => failure_count,
+                    Err(err) => {
+                        let fallback_failure_count =
+                            RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY;
+                        tracing::warn!(
+                            agent_id = %agent.id,
+                            provider = %provider_id,
+                            resumed_session_id = %resume_id,
+                            error = %err,
+                            fallback_failure_count,
+                            "failed to persist resumed acp session failure count; using fallback"
+                        );
+                        fallback_failure_count
+                    }
+                };
                 tracing::warn!(
                     agent_id = %agent.id,
                     session_id = %session_id,

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -267,15 +267,15 @@ export function useTeamMemberAcpViewModel({
       : snapshotStatus || acpRunStatus || normalizedAgentStatus) ||
     normalizeStatusValue(memberRoleLabel) ||
     "unknown";
-  // Keep "session is starting" narrow to members that already report an active
-  // runtime-like status; an entirely idle member should still render the old
-  // empty-shell copy instead of a misleading progress state.
+  // Prefer authoritative snapshot/runtime status for startup gating so stale
+  // ACP stream state does not keep the UI in a misleading "starting" mode.
   const isStartingAcpSession = Boolean(
     selectedMemberId.trim() &&
       !selectedSessionId &&
-      [normalizedAgentStatus, snapshotStatus, acpRunStatus].some(
-        (status) => status && isAgentActiveStatus(status)
-      )
+      ((snapshotStatus && isAgentActiveStatus(snapshotStatus)) ||
+        (!snapshotStatus &&
+          normalizedAgentStatus &&
+          isAgentActiveStatus(normalizedAgentStatus)))
   );
   const thinkingLabel =
     acpView.thinkingStartTs && ACTIVE_MEMBER_STATUSES.has(snapshotStatus || acpRunStatus)

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -267,6 +267,16 @@ export function useTeamMemberAcpViewModel({
       : snapshotStatus || acpRunStatus || normalizedAgentStatus) ||
     normalizeStatusValue(memberRoleLabel) ||
     "unknown";
+  // Keep "session is starting" narrow to members that already report an active
+  // runtime-like status; an entirely idle member should still render the old
+  // empty-shell copy instead of a misleading progress state.
+  const isStartingAcpSession = Boolean(
+    selectedMemberId.trim() &&
+      !selectedSessionId &&
+      [normalizedAgentStatus, snapshotStatus, acpRunStatus].some(
+        (status) => status && isAgentActiveStatus(status)
+      )
+  );
   const thinkingLabel =
     acpView.thinkingStartTs && ACTIVE_MEMBER_STATUSES.has(snapshotStatus || acpRunStatus)
     ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - acpView.thinkingStartTs))}s`
@@ -369,6 +379,9 @@ export function useTeamMemberAcpViewModel({
     if (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)) {
       return "Agent is stopped";
     }
+    if (isStartingAcpSession) {
+      return "Starting ACP session...";
+    }
     if (!selectedSessionId) {
       return "No active thread session yet";
     }
@@ -384,6 +397,7 @@ export function useTeamMemberAcpViewModel({
     hasRenderableConversationContent,
     memberEventsLoading,
     normalizedAgentStatus,
+    isStartingAcpSession,
     selectedMemberId,
     selectedSessionId,
     visibleMemberEvents.length,
@@ -537,6 +551,7 @@ export function useTeamMemberAcpViewModel({
     memberStatus,
     memberStatusLabel,
     memberStatusClassToken,
+    isStartingAcpSession,
     panelSubtitle,
     developerTechnicalMetadata,
     acpPanelProps,

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -136,6 +136,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
     memberStatus,
     memberStatusLabel,
     memberStatusClassToken,
+    isStartingAcpSession,
     panelSubtitle,
     developerTechnicalMetadata,
     acpPanelProps,
@@ -252,6 +253,19 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
               </Badge>
             </div>
           ) : null}
+          {isStartingAcpSession ? (
+            <div className="inline-flex min-w-[12rem] items-center gap-2 rounded-xl border border-notion-border/70 bg-white/80 px-2 py-1 text-[11px] font-medium text-notion-text-muted">
+              <span className="shrink-0">Starting session</span>
+              <span
+                role="progressbar"
+                aria-label="Starting ACP session"
+                aria-valuetext="Starting ACP session"
+                className="relative h-1.5 min-w-[6rem] flex-1 overflow-hidden rounded-full bg-notion-hover/80"
+              >
+                <span className="absolute inset-y-0 left-0 w-2/5 animate-pulse rounded-full bg-notion-accent/75" />
+              </span>
+            </div>
+          ) : null}
           <OutputHeaderDetails
             items={developerTechnicalMetadata}
             summaryClassName="inline-flex cursor-pointer list-none items-center rounded-xl border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-notion-text-muted/70 transition hover:bg-white/70 hover:text-notion-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent/10"
@@ -264,6 +278,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
       attachedNodeId,
       developerTechnicalMetadata,
       infoStripSummary,
+      isStartingAcpSession,
       memberStatus,
       memberStatusClassToken,
       memberStatusLabel,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -5786,11 +5786,11 @@ describe("team panels interactions", () => {
           developerMode={false}
           selectedMemberId="worker-agent"
           memberTitle="Worker agent"
-          selectedMemberSnapshot={{
-            id: "worker-agent",
+          selectedMemberSnapshot={buildMemberSnapshot({
+            member_id: "worker-agent",
             role: "worker",
             status: "running",
-          } as never}
+          })}
           selectedMemberRole="worker"
           selectedAgentStatus="running"
           memberEvents={[]}
@@ -5798,6 +5798,7 @@ describe("team panels interactions", () => {
           memberEventsLoading={false}
           eventsLoading={false}
           oldestMemberEventId={null}
+          onSendInput={vi.fn()}
           onLoadOlder={vi.fn()}
         />
     );

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -5779,6 +5779,37 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Plan");
   });
 
+  it("TeamMemberAcpPanel shows startup progress when the member is active but has no ACP session yet", () => {
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+          developerMode={false}
+          selectedMemberId="worker-agent"
+          memberTitle="Worker agent"
+          selectedMemberSnapshot={{
+            id: "worker-agent",
+            role: "worker",
+            status: "running",
+          } as never}
+          selectedMemberRole="worker"
+          selectedAgentStatus="running"
+          memberEvents={[]}
+          memberEventsHasMore={false}
+          memberEventsLoading={false}
+          eventsLoading={false}
+          oldestMemberEventId={null}
+          onLoadOlder={vi.fn()}
+        />
+    );
+
+    expect(container.textContent).toContain("Starting ACP session...");
+    expect(container.textContent).toContain("Starting session");
+    expect(
+      container.querySelector('[role="progressbar"][aria-label="Starting ACP session"]')
+    ).not.toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
   it("TeamMemberAcpPanel hides input when the selected agent is stopped", async () => {
     renderWithMantine(
       root,


### PR DESCRIPTION
fix(acp): extend startup timeout and show startup progress

## Summary

- increase `ACP_SESSION_START_TIMEOUT` from `30s` to `5min`
- keep Team member ACP shell visible with an explicit startup-progress state when the member is active but the ACP session is not ready yet
- preserve continuity by default, and only fall back to a fresh Codex session after repeated resumed-session startup exits

## Why

Team workers can resume ACP sessions late after service restarts or slower bootstrap paths. The old `30s` timeout could mark startup as failed even when ACP became ready shortly afterwards. On the frontend that same window looked like a passive empty state instead of an in-progress startup.

Separately, some resumed Codex sessions can exit very early during the startup grace window even though the persistent session id itself is not obviously invalid. We want to avoid clearing continuity on the first transient failure, but also avoid getting stuck retrying the same broken continuity forever.

## Changes

- backend
  - update `crates/agenthub-acp/src/lib.rs` to use a `5min` ACP session startup timeout
  - add a focused unit test for the timeout default
  - track resumed-session startup failures for persisted Codex continuity
  - clear the persisted Codex session and retry with a fresh session only after `3` consecutive resumed-session startup exits
  - add compatibility guards so older/manual test databases that do not yet have the new failure-tracking table still behave correctly
- frontend
  - add a narrow `Starting ACP session...` state in `use_team_member_acp_view_model.ts`
  - render a lightweight startup progress bar in `team_member_acp_panel.tsx`
  - keep `No active thread session yet` for idle members and `Agent is stopped` for stopped members
  - add a focused panel regression covering the startup-progress state

## Validation

- `cargo test -p agenthub-acp session_start_timeout_defaults_to_five_minutes -- --nocapture`
- `cargo test should_retry_resumed_acp_session_only_on_failed_matching_resume -- --nocapture`
- `cargo test fresh_session_retry_only_triggers_after_three_resume_failures -- --nocapture`
- `cargo test delete_agent_keeps_local_cleanup_when_remote_client_is_unavailable -- --nocapture`
- `cargo test delete_agent_removes_related_rows -- --nocapture`
- `cargo test delete_agent_prunes_team_member_references_from_team_specs -- --nocapture`
- `cargo test delete_agent_returns_ok_when_team_prune_follow_up_fails -- --nocapture`
- `cargo test force_new_session_restarts_member_runtime_with_new_session_id -- --nocapture`
- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run lint`
