### PR TITLE
fix(team): acknowledge relevant shared-channel messages

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -45,7 +45,7 @@ Coordination contract:
 - Default communication route is direct mailbox first: when exactly one teammate owns the next action, send a single-target mailbox message instead of broadcasting to the shared channel.
 - Shared channel is reserved for human-visible updates, team-wide checkpoints, or multi-recipient coordination that truly needs shared visibility.
 - When a human posts in the shared channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
-- If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first and continue execution; otherwise provide the acknowledgement yourself before deeper coordination continues.
+- If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first; only provide the acknowledgement yourself when a short visible acknowledgement has not already appeared in the recent shared-channel history.
 - For large evidence, use summary-first reporting and attach a stable `detail_ref` or artifact pointer instead of pasting the full content into routine mailbox updates.
 - If your own role description or prompt drifts, send a `profile_patch_proposal` for your member record; use `target="team"` for durable identity updates and `target="run"` for temporary run-scoped adjustments.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for deferred follow-ups or timed reminders that should come back as ACP messages later.

--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -44,6 +44,8 @@ Coordination contract:
 - Successful worker execution should usually move a task to `in_review`; reserve `completed` for explicit review/acceptance.
 - Default communication route is direct mailbox first: when exactly one teammate owns the next action, send a single-target mailbox message instead of broadcasting to the shared channel.
 - Shared channel is reserved for human-visible updates, team-wide checkpoints, or multi-recipient coordination that truly needs shared visibility.
+- When a human posts in the shared channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
+- If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first and continue execution; otherwise provide the acknowledgement yourself before deeper coordination continues.
 - For large evidence, use summary-first reporting and attach a stable `detail_ref` or artifact pointer instead of pasting the full content into routine mailbox updates.
 - If your own role description or prompt drifts, send a `profile_patch_proposal` for your member record; use `target="team"` for durable identity updates and `target="run"` for temporary run-scoped adjustments.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for deferred follow-ups or timed reminders that should come back as ACP messages later.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -31,6 +31,8 @@ Workspace policy:
 - If cross-worker dependency exists, coordinate quickly with the related worker and send a summary back to leader.
 - Default communication route is direct mailbox first: when only one teammate needs the update, send a single-target mailbox message instead of broadcasting to the shared channel.
 - Use the shared channel only for human-visible progress, team-wide checkpoints, or updates that genuinely need multiple recipients at once.
+- When a shared-channel message is relevant to your active work, or is neutral-but-actionable shared context, send a brief shared-channel acknowledgement first (for example the plan, ownership, or current progress) before continuing deeper execution.
+- Do not leave human-authored shared-channel messages silently hanging when you are the likely owner or a clearly relevant participant; give a short visible response, then continue the work.
 - For large evidence, send summary-first and attach a stable `detail_ref` or artifact pointer instead of pasting the entire content into routine mailbox updates.
 - When a detail must survive beyond the current turn, store it in `.agenthubmemory/` or `.cache/context/` and reference the path or artifact pointer instead of re-describing the whole history in prompt text.
 - Treat `AGENTS.md` as objective/phase/skill index; execute detailed procedures from skill files.

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -179,6 +179,11 @@ Shared-channel discussion rules:
   - design or implementation tradeoffs that need discussion
   - dependency or risk updates that require shared awareness
   - scoped facts, progress, and evidence that benefit shared visibility
+- When a human-authored shared-channel message is relevant to a worker's active work, or is neutral-but-actionable context for that worker, the worker should send a short visible acknowledgement first:
+  - ownership (`I am taking this`)
+  - immediate plan (`I will check PR 68127 and report back`)
+  - current progress (`still verifying CI / patching now`)
+- The acknowledgement should be short and timely; deeper execution and evidence can follow in later updates.
 - Workers should `@member_id` the relevant owner, reviewer, dependency peer, or other impacted
   teammates when opening or continuing that shared-channel discussion.
 - In human-authored shared-channel markdown, keep those mentions as raw stable `@member_id`
@@ -257,6 +262,7 @@ Team collaboration should run with the canonical actor CLI mailbox path as the p
 - Default routing should be direct mailbox first:
   - use a single-target mailbox message when exactly one teammate owns the next action
   - reserve shared-channel for human-visible or genuinely multi-recipient updates
+  - when a human shared-channel message is relevant to active work, emit a short in-channel acknowledgement before falling back to deeper mailbox-only execution
 - Turn loop should stay deterministic:
   - pull inbox -> process -> ack -> send/report -> next pull.
 - Team prompt dynamic tail should include an explicit `Allowed actions` block to deny bypass paths.

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -179,10 +179,10 @@ Shared-channel discussion rules:
   - design or implementation tradeoffs that need discussion
   - dependency or risk updates that require shared awareness
   - scoped facts, progress, and evidence that benefit shared visibility
-- When a human-authored shared-channel message is relevant to a worker's active work, or is neutral-but-actionable context for that worker, the worker should send a short visible acknowledgement first:
-  - ownership (`I am taking this`)
-  - immediate plan (`I will check PR 68127 and report back`)
-  - current progress (`still verifying CI / patching now`)
+- When a human-authored shared-channel message is relevant to the team's work, a short visible acknowledgement should appear quickly:
+  - if a worker is the natural owner of the context, the worker should acknowledge first;
+  - otherwise, the leader should provide the acknowledgement when recent shared-channel history does not already contain one;
+  - acknowledgement forms include ownership (`I am taking this`), immediate plan (`I will check PR 68127 and report back`), or current progress (`still verifying CI / patching now`).
 - The acknowledgement should be short and timely; deeper execution and evidence can follow in later updates.
 - Workers should `@member_id` the relevant owner, reviewer, dependency peer, or other impacted
   teammates when opening or continuing that shared-channel discussion.

--- a/docs/journal/2026-04-30-team-shared-channel-acknowledgement.md
+++ b/docs/journal/2026-04-30-team-shared-channel-acknowledgement.md
@@ -1,0 +1,32 @@
+# Team Shared-Channel Acknowledgement
+
+## Scope
+
+Refine Team role prompts so human-authored shared-channel messages do not disappear into silent
+background execution when a worker or leader is clearly engaged with the request.
+
+## Decision
+
+- Keep direct mailbox as the default execution path.
+- Preserve shared-channel as the human-visible coordination surface.
+- When a shared-channel message is relevant to an active worker, or is neutral-but-actionable shared
+  context, require a short visible acknowledgement before deeper execution continues.
+- Acceptable acknowledgement forms:
+  - ownership
+  - immediate plan
+  - current progress
+
+## Prompt Update
+
+- Worker prompt now tells workers to reply briefly in shared-channel before continuing when they are
+  the likely owner or a clearly relevant participant.
+- Leader prompt now tells leader to ensure the team emits a quick visible acknowledgement instead of
+  letting human channel input sit silently while coordination continues off-screen.
+
+## Validation
+
+- Prompt text review in:
+  - `crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt`
+  - `crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt`
+- Collaboration contract update in:
+  - `docs/features/teams-collaboration-playbook.md`


### PR DESCRIPTION
## Summary

- update Team leader and worker prompts so relevant shared-channel messages get a short visible acknowledgement before deeper execution continues
- document the same acknowledgement rule in the Team collaboration playbook
- add a journal note for the prompt-level behavior change

## Testing

- 
running 2 tests
test tests::default_prompt_resolves_by_role ... ok
test tests::prompt_templates_keep_required_contract_lines ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s