### PR TITLE
fix(team): harden channel and ACP surfaces

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -33,6 +33,7 @@ Coordination contract:
 - Keep TODO/task statuses aligned with mailbox evidence and compact stale duplicate entries.
 - Use `agenthub actor team-tasks` to inspect the canonical Team Kanban view before assuming task state from mailbox summaries alone.
 - Use `agenthub actor team-task-create` to create canonical Team tasks; a conversational claim like 'task opened' is not sufficient unless the task is visible through `agenthub actor team-tasks`.
+- Every canonical Team task must have an explicit assigned member. Do not create or keep an unassigned execution task; if work is real enough for Kanban, choose the concrete owning agent/member first.
 - Use `agenthub actor team-task-update` when you intentionally move a Team task through lifecycle states.
 - Create a Team task when execution work needs explicit ownership, Kanban visibility, or lifecycle tracking.
 - Load `team-task-lifecycle` whenever you are creating canonical Team tasks or advancing them through review.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -20,6 +20,7 @@ Workspace policy:
 - If agent review is unavailable or times out, the system may post a human-review request into `Channel` (`all`) without blocking your current run.
 - Use `agenthub actor team-members` to inspect the live runtime summary, roster/card descriptions, and current step/session overlay before coordinating.
 - Use `agenthub actor team-tasks` when you need the canonical Team Kanban view instead of inferring task state from mailbox payloads alone.
+- Canonical Team tasks must always have an explicit assigned member; if you notice an unassigned execution task, treat that as a coordination gap and push leader to assign a concrete owner before normal task execution continues.
 - Do not call `agenthub actor team-task-create` or `agenthub actor team-task-update`; canonical Team task creation and lifecycle updates remain leader-owned.
 - Treat `spec.members[]` as static baseline; when live roster and static spec differ, trust `actor team-members` for current execution decisions.
 - Load `team-task-lifecycle` whenever you need canonical Team task state guidance.

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -77,7 +77,9 @@ mod tests {
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-members"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-tasks"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-task-create"));
-        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("must always have an explicit assigned member"));
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT.contains("must always have an explicit assigned member")
+        );
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("profile_patch_proposal"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor time-trigger-set"));
         assert!(

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -67,6 +67,7 @@ mod tests {
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("actor team-tasks"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("actor team-task-create"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("actor team-task-update"));
+        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("must have an explicit assigned member"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("profile_patch_proposal"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("actor time-trigger-set"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("agent_loop"));
@@ -76,6 +77,7 @@ mod tests {
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-members"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-tasks"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor team-task-create"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("must always have an explicit assigned member"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("profile_patch_proposal"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("actor time-trigger-set"));
         assert!(

--- a/docs/features/agents-teams.md
+++ b/docs/features/agents-teams.md
@@ -37,8 +37,10 @@ Canonical execution vocabulary (`task`, `attempt`, `run`, `step`, `round`):
 - Leader/System interprets shared conversation input and turns agreed execution work into internal
   `task` records.
 - A `task` is the primary agent-facing work object.
-- `task.assigned_member_id` is the canonical owner slot, but it stays empty until ownership is set
-  explicitly; the system must not guess an assignee.
+- `task.assigned_member_id` is the canonical owner slot.
+- Canonical execution tasks must not stay unassigned; if a task is materialized onto Kanban, leader
+  must choose a concrete owner explicitly instead of relying on implicit scheduling or leaving the
+  task owner empty.
 - Explicit ownership changes happen through canonical task updates (`assigned_member_id` assign /
   unassign), not implicit runtime scheduling.
 - Human-facing UI / HTTP APIs may display canonical task status and ownership, but they do not

--- a/docs/journal/2026-04-30-team-channel-and-acp-surface-hardening.md
+++ b/docs/journal/2026-04-30-team-channel-and-acp-surface-hardening.md
@@ -1,0 +1,15 @@
+## Summary
+
+- kept `channels` center timelines pinned to the current lane's canonical conversation instead of letting stale task selection hijack `# all`
+- added a compact ACP activity summary strip for Team member ACP headers so operators can see loaded updates, tool calls, and older-history availability before scanning the full thread
+- kept Team member ACP session identity sticky across transient runtime/snapshot refresh gaps so new activity does not blank the current ACP thread or clear the top-of-history state
+
+## Validation
+
+- `cd web && pnpm exec vitest run src/pages/team_page.helpers.test.ts src/pages/team/use_team_task_workspace_data.test.tsx src/pages/team_member_acp_panel.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+
+## Notes
+
+- Chrome DevTools MCP baseline showed the production ACP header still on the old layout before deployment; post-deploy regression should confirm the new ACP activity strip and verify that active member ACP threads no longer blank when new messages arrive.

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -14,6 +14,7 @@ import {
   resolveAgentWorkspaceStatusView,
   resolveSelectedAgentWorkspaceLabel,
   resolveSelectedAgentWorkspaceMemberId,
+  resolveChannelLaneConversationTask,
   resolveSelectedConversationTask,
   buildAgentLabel,
   DEFAULT_TEAM_THREAD_TITLE,
@@ -626,6 +627,28 @@ describe("team page helpers", () => {
         fallbackTask,
       })
     ).toEqual(fallbackTask);
+  });
+
+  it("prefers the current channel lane conversation over stale local task selection", () => {
+    const staleTask = buildTask("task-stale", 120, 140, {
+      title: "Old task thread",
+      status: "in_progress",
+      context: { channel_id: "review", bootstrap_kind: "team_channel" },
+    });
+    const sharedTask = buildTask("task-all", 100, 120, {
+      title: DEFAULT_TEAM_THREAD_TITLE,
+      context: { bootstrap_kind: DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND },
+    });
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "all",
+        selectedConversation: staleTask,
+        selectedChannelTaskId: "task-all",
+        sharedConversation: sharedTask,
+        taskList: [sharedTask, staleTask],
+      })
+    ).toEqual(sharedTask);
   });
 
   it("resolves seen-by coverage from delivered mailbox fan-out", () => {

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -15,6 +15,7 @@ import {
   resolveSelectedAgentWorkspaceLabel,
   resolveSelectedAgentWorkspaceMemberId,
   resolveChannelLaneConversationTask,
+  resolveSelectedConversationLatestRun,
   resolveSelectedConversationTask,
   buildAgentLabel,
   DEFAULT_TEAM_THREAD_TITLE,
@@ -650,6 +651,59 @@ describe("team page helpers", () => {
         taskList: [sharedTask, staleTask],
       })
     ).toEqual(sharedTask);
+  });
+
+  it("resolves the latest run from the active selected conversation", () => {
+    const sharedTask = buildTask("task-all", 100, 120, {
+      title: DEFAULT_TEAM_THREAD_TITLE,
+      context: { bootstrap_kind: DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND },
+    });
+    const explicitTask = buildTask("task-work", 120, 140, {
+      title: "Investigate regression",
+      status: "in_progress",
+      context: { owner: "leader" },
+    });
+    const sharedRun = buildRun("run-shared", 10, "working");
+    const explicitRun = buildRun("run-explicit", 20, "working");
+
+    expect(
+      resolveSelectedConversationLatestRun({
+        selectedConversation: sharedTask,
+        selectedConversationDetail: null,
+        sharedConversation: sharedTask,
+        sharedConversationLatestRun: sharedRun,
+      })?.id
+    ).toBe("run-shared");
+
+    expect(
+      resolveSelectedConversationLatestRun({
+        selectedConversation: explicitTask,
+        selectedConversationDetail: {
+          task: explicitTask,
+          conversation: {
+            id: "conv-task-work",
+            team_id: "team-1",
+            task_id: "task-work",
+            mode: "group_chat",
+            topic: "implementation",
+            created_at: 1,
+            updated_at: 1,
+          },
+          latest_run: explicitRun,
+        },
+        sharedConversation: sharedTask,
+        sharedConversationLatestRun: sharedRun,
+      })?.id
+    ).toBe("run-explicit");
+
+    expect(
+      resolveSelectedConversationLatestRun({
+        selectedConversation: explicitTask,
+        selectedConversationDetail: null,
+        sharedConversation: sharedTask,
+        sharedConversationLatestRun: sharedRun,
+      })
+    ).toBeNull();
   });
 
   it("preserves an explicit plain task conversation on a channel lane", () => {

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -643,12 +643,86 @@ describe("team page helpers", () => {
     expect(
       resolveChannelLaneConversationTask({
         routeChannelId: "all",
+        selectedConversationTaskId: "task-stale",
         selectedConversation: staleTask,
         selectedChannelTaskId: "task-all",
         sharedConversation: sharedTask,
         taskList: [sharedTask, staleTask],
       })
     ).toEqual(sharedTask);
+  });
+
+  it("preserves an explicit plain task conversation on a channel lane", () => {
+    const explicitTask = buildTask("task-work", 120, 140, {
+      title: "Investigate regression",
+      status: "in_progress",
+      context: { owner: "leader" },
+    });
+    const channelTask = buildTask("task-review", 110, 130, {
+      title: "review",
+      status: "in_progress",
+      context: { channel_id: "review", bootstrap_kind: "team_channel" },
+    });
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "review",
+        routeSelectedTaskId: "task-work",
+        selectedConversationTaskId: "task-work",
+        selectedConversation: explicitTask,
+        selectedChannelTaskId: "task-review",
+        sharedConversation: null,
+        taskList: [channelTask, explicitTask],
+      })
+    ).toEqual(explicitTask);
+  });
+
+  it("preserves an explicit channel-scoped task while route canonicalization catches up", () => {
+    const explicitTask = buildTask("task-work", 120, 140, {
+      title: "Review lane task",
+      status: "in_progress",
+      context: { channel_id: "review", bootstrap_kind: "team_channel" },
+    });
+    const sharedTask = buildTask("task-all", 100, 120, {
+      title: DEFAULT_TEAM_THREAD_TITLE,
+      context: { bootstrap_kind: DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND },
+    });
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "all",
+        routeSelectedTaskId: "task-work",
+        selectedConversationTaskId: "task-work",
+        selectedConversation: explicitTask,
+        selectedChannelTaskId: "task-all",
+        sharedConversation: sharedTask,
+        taskList: [sharedTask, explicitTask],
+      })
+    ).toEqual(explicitTask);
+  });
+
+  it("preserves a locally selected plain task before route state catches up", () => {
+    const explicitTask = buildTask("task-work", 120, 140, {
+      title: "Investigate regression",
+      status: "in_progress",
+      context: { owner: "leader" },
+    });
+    const sharedTask = buildTask("task-all", 100, 120, {
+      title: DEFAULT_TEAM_THREAD_TITLE,
+      context: { bootstrap_kind: DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND },
+    });
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "all",
+        routeSelectedTaskId: "",
+        selectedConversationTaskId: "task-work",
+        selectedConversation: explicitTask,
+        selectedChannelTaskId: "task-all",
+        sharedConversation: sharedTask,
+        taskList: [sharedTask, explicitTask],
+      })
+    ).toEqual(explicitTask);
   });
 
   it("resolves seen-by coverage from delivered mailbox fan-out", () => {

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -634,6 +634,41 @@ export function resolveSelectedConversationTask({
   );
 }
 
+export function resolveChannelLaneConversationTask({
+  routeChannelId,
+  selectedConversation,
+  selectedChannelTaskId,
+  sharedConversation,
+  taskList,
+}: {
+  routeChannelId: string;
+  selectedConversation: TeamTaskRecord | null;
+  selectedChannelTaskId?: string | null;
+  sharedConversation: TeamTaskRecord | null;
+  taskList: TeamTaskRecord[];
+}): TeamTaskRecord | null {
+  const normalizedChannelId = routeChannelId.trim().toLowerCase();
+  if (!normalizedChannelId) {
+    return selectedConversation;
+  }
+  if (normalizedChannelId === DEFAULT_TEAM_THREAD_TITLE) {
+    return sharedConversation ?? selectedConversation;
+  }
+  if (selectedConversation && isChannelScopedConversationTask(selectedConversation, normalizedChannelId)) {
+    return selectedConversation;
+  }
+  const normalizedSelectedChannelTaskId = selectedChannelTaskId?.trim() ?? "";
+  if (!normalizedSelectedChannelTaskId) {
+    return selectedConversation;
+  }
+  // Channel routes should render the lane's canonical conversation even when
+  // stale local task selection still points at a previously opened task thread.
+  return (
+    taskList.find((task) => task.id === normalizedSelectedChannelTaskId) ??
+    (selectedConversation?.id === normalizedSelectedChannelTaskId ? selectedConversation : null)
+  );
+}
+
 function parseMailboxPayload(payload: unknown): unknown {
   if (typeof payload !== "string") {
     return payload;

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -8,6 +8,7 @@ import type {
   TeamRuntimeRecord,
   TeamRunEventRecord,
   TeamRunRecord,
+  TeamTaskDetailResponse,
   TeamTaskRecord,
 } from "../../api";
 import type { StatusTone } from "../../components/status_badge";
@@ -632,6 +633,29 @@ export function resolveSelectedConversationTask({
     fallbackTask ??
     null
   );
+}
+
+export function resolveSelectedConversationLatestRun({
+  selectedConversation,
+  selectedConversationDetail,
+  sharedConversation,
+  sharedConversationLatestRun,
+}: {
+  selectedConversation: TeamTaskRecord | null;
+  selectedConversationDetail: TeamTaskDetailResponse | null;
+  sharedConversation: TeamTaskRecord | null;
+  sharedConversationLatestRun: TeamRunRecord | null;
+}): TeamRunRecord | null {
+  if (!selectedConversation) {
+    return null;
+  }
+  if (sharedConversation?.id === selectedConversation.id) {
+    return sharedConversationLatestRun;
+  }
+  if (selectedConversationDetail?.task?.id === selectedConversation.id) {
+    return selectedConversationDetail.latest_run ?? null;
+  }
+  return null;
 }
 
 export function resolveChannelLaneConversationTask({

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -636,25 +636,51 @@ export function resolveSelectedConversationTask({
 
 export function resolveChannelLaneConversationTask({
   routeChannelId,
+  routeSelectedTaskId,
+  selectedConversationTaskId,
   selectedConversation,
   selectedChannelTaskId,
   sharedConversation,
   taskList,
 }: {
   routeChannelId: string;
+  routeSelectedTaskId?: string | null;
+  selectedConversationTaskId?: string | null;
   selectedConversation: TeamTaskRecord | null;
   selectedChannelTaskId?: string | null;
   sharedConversation: TeamTaskRecord | null;
   taskList: TeamTaskRecord[];
 }): TeamTaskRecord | null {
   const normalizedChannelId = routeChannelId.trim().toLowerCase();
+  const normalizedRouteTaskId = routeSelectedTaskId?.trim() ?? "";
+  const normalizedSelectedConversationTaskId = selectedConversationTaskId?.trim() ?? "";
+  const selectedConversationChannelId = resolveTaskChannelId(selectedConversation);
+  const selectedConversationMatchesExplicitRoute =
+    Boolean(normalizedRouteTaskId) && selectedConversation?.id === normalizedRouteTaskId;
+  const selectedConversationMatchesLocalSelection =
+    Boolean(normalizedSelectedConversationTaskId) &&
+    selectedConversation?.id === normalizedSelectedConversationTaskId;
+  const shouldPreservePlainTaskSelection =
+    selectedConversationMatchesLocalSelection && !selectedConversationChannelId;
   if (!normalizedChannelId) {
     return selectedConversation;
   }
   if (normalizedChannelId === DEFAULT_TEAM_THREAD_TITLE) {
+    if (selectedConversationMatchesExplicitRoute || shouldPreservePlainTaskSelection) {
+      return selectedConversation;
+    }
     return sharedConversation ?? selectedConversation;
   }
-  if (selectedConversation && isChannelScopedConversationTask(selectedConversation, normalizedChannelId)) {
+  if (
+    selectedConversation &&
+    (selectedConversationChannelId === normalizedChannelId ||
+      shouldPreservePlainTaskSelection ||
+      (selectedConversationMatchesExplicitRoute &&
+        selectedConversationChannelId !== DEFAULT_TEAM_THREAD_TITLE))
+  ) {
+    // Channel lanes should keep explicit task conversations, but should not let
+    // stale channel-scoped selections from another lane override the lane's
+    // canonical conversation.
     return selectedConversation;
   }
   const normalizedSelectedChannelTaskId = selectedChannelTaskId?.trim() ?? "";

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -19,6 +19,12 @@ import {
 
 export type TeamMemberAcpTab = "conversation" | "plan" | "debug";
 
+export type TeamMemberAcpActivityItem = {
+  id: string;
+  label: string;
+  title?: string;
+};
+
 const ACTIVE_MEMBER_STATUSES = new Set([
   "running",
   "working",
@@ -372,6 +378,53 @@ export function useTeamMemberAcpViewModel({
     acpView.rawEvents.length,
     acpView.toolCalls.length,
   ]);
+  const activitySummaryItems = React.useMemo<TeamMemberAcpActivityItem[]>(() => {
+    if (!selectedMemberId.trim() || !selectedSessionId || isStartingAcpSession) {
+      return [];
+    }
+    const items: TeamMemberAcpActivityItem[] = [];
+    // Use renderable ACP conversation items here instead of raw event count so the
+    // summary matches what the operator can actually read in the panel.
+    if (acpConversation.conversationSourceItems > 0) {
+      const updateCount = acpConversation.conversationSourceItems;
+      items.push({
+        id: "updates",
+        label: `${updateCount} update${updateCount === 1 ? "" : "s"}`,
+        title: `${updateCount} renderable ACP conversation update${updateCount === 1 ? "" : "s"} loaded for this thread`,
+      });
+    }
+    if (acpView.toolCalls.length > 0) {
+      const toolCallCount = acpView.toolCalls.length;
+      items.push({
+        id: "tool-calls",
+        label: `${toolCallCount} tool call${toolCallCount === 1 ? "" : "s"}`,
+        title: `${toolCallCount} ACP tool call${toolCallCount === 1 ? "" : "s"} recorded for this thread`,
+      });
+    }
+    if (memberEventsHasMore) {
+      items.push({
+        id: "older-history",
+        label: "Older history available",
+        title: "Load older ACP history for this thread",
+      });
+    }
+    if (memberEventsLoading) {
+      items.push({
+        id: "syncing",
+        label: "Syncing",
+        title: "Refreshing ACP activity for this thread",
+      });
+    }
+    return items;
+  }, [
+    acpConversation.conversationSourceItems,
+    acpView.toolCalls.length,
+    isStartingAcpSession,
+    memberEventsHasMore,
+    memberEventsLoading,
+    selectedMemberId,
+    selectedSessionId,
+  ]);
   const panelSubtitle = React.useMemo(() => {
     if (!selectedMemberId.trim()) {
       return null;
@@ -553,6 +606,7 @@ export function useTeamMemberAcpViewModel({
     memberStatusClassToken,
     isStartingAcpSession,
     panelSubtitle,
+    activitySummaryItems,
     developerTechnicalMetadata,
     acpPanelProps,
     inputDockJumpMode,

--- a/web/src/pages/team/use_team_task_workspace_data.test.tsx
+++ b/web/src/pages/team/use_team_task_workspace_data.test.tsx
@@ -42,6 +42,8 @@ function createParams(overrides: Partial<HookParams> = {}): HookParams {
   return {
     token: "token-1",
     effectiveSelectedTeamId: "team-1",
+    routeChannelId: "all",
+    selectedChannelTaskId: "shared-thread",
     selectedConversationTaskId: "",
     selectedConversationDetail: null,
     sharedConversation: null,
@@ -167,6 +169,85 @@ describe("useTeamTaskWorkspaceData", () => {
       expect(params.setCompiledRunPreview).toHaveBeenCalledWith(null);
       expect(params.setCompilePreviewContextId).toHaveBeenCalledWith("");
       expect(mounted.getSnapshot()?.resolvedSelectedConversationTaskId).toBe("");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("keeps the channel lane pinned to the shared thread when stale task selection remains", async () => {
+    const sharedConversation = {
+      id: "shared-thread",
+      team_id: "team-1",
+      title: "all",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "shared_thread" },
+      created_at: 1,
+      updated_at: 10,
+    } as const;
+    const staleTask = {
+      id: "task-2",
+      team_id: "team-1",
+      title: "Implementation thread",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "team_channel", channel_id: "review" },
+      created_at: 2,
+      updated_at: 20,
+    } as const;
+    const staleDetail: NonNullable<HookParams["selectedConversationDetail"]> = {
+      task: staleTask,
+      conversation: {
+        id: "conv-task-2",
+        team_id: "team-1",
+        task_id: "task-2",
+        mode: "group_chat",
+        topic: "review",
+        created_at: 2,
+        updated_at: 2,
+      },
+      latest_run: {
+        id: "run-task-2",
+        team_id: "team-1",
+        context_id: "",
+        status: "working",
+        input: {},
+        summary: null,
+        created_at: 2,
+        started_at: 2,
+        ended_at: null,
+      },
+    };
+    const sharedLatestRun = {
+      id: "run-shared",
+      team_id: "team-1",
+      context_id: "",
+      status: "working",
+      input: {},
+      summary: null,
+      created_at: 1,
+      started_at: 1,
+      ended_at: null,
+    } as unknown as HookParams["sharedConversationLatestRun"];
+    mockedApi.getTeamTask.mockResolvedValue(staleDetail);
+
+    const mounted = await mountHook(
+      createParams({
+        routeChannelId: "all",
+        selectedChannelTaskId: "shared-thread",
+        selectedConversationTaskId: "task-2",
+        sharedConversation,
+        sharedConversationLatestRun: sharedLatestRun,
+        selectedConversationDetail: staleDetail,
+        taskList: [sharedConversation, staleTask],
+      })
+    );
+    try {
+      const snapshot = mounted.getSnapshot();
+      expect(snapshot?.selectedConversation?.id).toBe("shared-thread");
+      expect(snapshot?.selectedConversationLatestRun?.id).toBe("run-shared");
     } finally {
       mounted.cleanup();
     }

--- a/web/src/pages/team/use_team_task_workspace_data.test.tsx
+++ b/web/src/pages/team/use_team_task_workspace_data.test.tsx
@@ -365,6 +365,62 @@ describe("useTeamTaskWorkspaceData", () => {
     }
   });
 
+  it("uses the selected conversation detail run when the explicit task thread is active", async () => {
+    const explicitTask = {
+      id: "task-2",
+      team_id: "team-1",
+      title: "Implementation thread",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { owner: "leader" },
+      created_at: 2,
+      updated_at: 20,
+    } as const;
+    const explicitLatestRun = {
+      id: "run-task-2",
+      team_id: "team-1",
+      context_id: "",
+      status: "working",
+      input: {},
+      summary: null,
+      created_at: 2,
+      started_at: 2,
+      ended_at: null,
+    } as unknown as HookParams["sharedConversationLatestRun"];
+    const explicitDetail: NonNullable<HookParams["selectedConversationDetail"]> = {
+      task: explicitTask,
+      conversation: {
+        id: "conv-task-2",
+        team_id: "team-1",
+        task_id: "task-2",
+        mode: "group_chat",
+        topic: "implementation",
+        created_at: 2,
+        updated_at: 2,
+      },
+      latest_run: explicitLatestRun,
+    };
+
+    const mounted = await mountHook(
+      createParams({
+        routeChannelId: "all",
+        routeSelectedTaskId: "task-2",
+        selectedChannelTaskId: "shared-thread",
+        selectedConversationTaskId: "task-2",
+        selectedConversationDetail: explicitDetail,
+        taskList: [explicitTask],
+      })
+    );
+    try {
+      const snapshot = mounted.getSnapshot();
+      expect(snapshot?.selectedConversation?.id).toBe("task-2");
+      expect(snapshot?.selectedConversationLatestRun?.id).toBe("run-task-2");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
   it("clears a selected conversation only after the detail fetch confirms a 404", async () => {
     mockedApi.listTeamTasks.mockResolvedValue([] as never);
     mockedApi.getTeamSharedThread.mockResolvedValue({

--- a/web/src/pages/team/use_team_task_workspace_data.test.tsx
+++ b/web/src/pages/team/use_team_task_workspace_data.test.tsx
@@ -43,6 +43,7 @@ function createParams(overrides: Partial<HookParams> = {}): HookParams {
     token: "token-1",
     effectiveSelectedTeamId: "team-1",
     routeChannelId: "all",
+    routeSelectedTaskId: "",
     selectedChannelTaskId: "shared-thread",
     selectedConversationTaskId: "",
     selectedConversationDetail: null,
@@ -248,6 +249,117 @@ describe("useTeamTaskWorkspaceData", () => {
       const snapshot = mounted.getSnapshot();
       expect(snapshot?.selectedConversation?.id).toBe("shared-thread");
       expect(snapshot?.selectedConversationLatestRun?.id).toBe("run-shared");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("preserves an explicit task route on the shared channel lane", async () => {
+    const sharedConversation = {
+      id: "shared-thread",
+      team_id: "team-1",
+      title: "all",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "shared_thread" },
+      created_at: 1,
+      updated_at: 10,
+    } as const;
+    const explicitTask = {
+      id: "task-2",
+      team_id: "team-1",
+      title: "Implementation thread",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { owner: "leader" },
+      created_at: 2,
+      updated_at: 20,
+    } as const;
+    const explicitDetail: NonNullable<HookParams["selectedConversationDetail"]> = {
+      task: explicitTask,
+      conversation: {
+        id: "conv-task-2",
+        team_id: "team-1",
+        task_id: "task-2",
+        mode: "group_chat",
+        topic: "implementation",
+        created_at: 2,
+        updated_at: 2,
+      },
+      latest_run: null,
+    };
+
+    const mounted = await mountHook(
+      createParams({
+        routeChannelId: "all",
+        routeSelectedTaskId: "task-2",
+        selectedChannelTaskId: "shared-thread",
+        selectedConversationTaskId: "task-2",
+        sharedConversation,
+        selectedConversationDetail: explicitDetail,
+        taskList: [sharedConversation, explicitTask],
+      })
+    );
+    try {
+      const snapshot = mounted.getSnapshot();
+      expect(snapshot?.selectedConversation?.id).toBe("task-2");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
+  it("preserves an explicit task route on a named channel lane", async () => {
+    const explicitTask = {
+      id: "task-2",
+      team_id: "team-1",
+      title: "Implementation thread",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { owner: "leader" },
+      created_at: 2,
+      updated_at: 20,
+    } as const;
+    const explicitDetail: NonNullable<HookParams["selectedConversationDetail"]> = {
+      task: explicitTask,
+      conversation: {
+        id: "conv-task-2",
+        team_id: "team-1",
+        task_id: "task-2",
+        mode: "group_chat",
+        topic: "implementation",
+        created_at: 2,
+        updated_at: 2,
+      },
+      latest_run: null,
+    };
+    const channelTask = {
+      id: "task-review",
+      team_id: "team-1",
+      title: "review",
+      status: "in_progress",
+      created_by_actor_id: "leader",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "team_channel", channel_id: "review" },
+      created_at: 1,
+      updated_at: 10,
+    } as const;
+
+    const mounted = await mountHook(
+      createParams({
+        routeChannelId: "review",
+        routeSelectedTaskId: "task-2",
+        selectedChannelTaskId: "task-review",
+        selectedConversationTaskId: "task-2",
+        selectedConversationDetail: explicitDetail,
+        taskList: [channelTask, explicitTask],
+      })
+    );
+    try {
+      const snapshot = mounted.getSnapshot();
+      expect(snapshot?.selectedConversation?.id).toBe("task-2");
     } finally {
       mounted.cleanup();
     }

--- a/web/src/pages/team/use_team_task_workspace_data.ts
+++ b/web/src/pages/team/use_team_task_workspace_data.ts
@@ -12,6 +12,7 @@ import {
   isCurrentTeamScopedRequest,
   listTeamWorkspaceTasks,
   resolveChannelLaneConversationTask,
+  resolveSelectedConversationLatestRun,
   resolveSelectedConversationTask,
   resolveSelectedTeamTask,
   shouldClearSelectedConversationTask,
@@ -110,16 +111,12 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
   ]);
 
   const selectedConversationLatestRun = useMemo(() => {
-    if (!selectedConversation) {
-      return null;
-    }
-    if (sharedConversation?.id === selectedConversation.id) {
-      return sharedConversationLatestRun;
-    }
-    if (selectedConversationDetail?.task?.id === selectedConversation.id) {
-      return selectedConversationDetail.latest_run ?? null;
-    }
-    return null;
+    return resolveSelectedConversationLatestRun({
+      selectedConversation,
+      selectedConversationDetail,
+      sharedConversation,
+      sharedConversationLatestRun,
+    });
   }, [
     selectedConversation,
     selectedConversationDetail,

--- a/web/src/pages/team/use_team_task_workspace_data.ts
+++ b/web/src/pages/team/use_team_task_workspace_data.ts
@@ -22,6 +22,7 @@ type UseTeamTaskWorkspaceDataOptions = {
   token: string;
   effectiveSelectedTeamId: string | null;
   routeChannelId: string;
+  routeSelectedTaskId?: string | null;
   selectedChannelTaskId?: string | null;
   selectedConversationTaskId: string;
   selectedConversationDetail: TeamTaskDetailResponse | null;
@@ -50,6 +51,7 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
     token,
     effectiveSelectedTeamId,
     routeChannelId,
+    routeSelectedTaskId,
     selectedChannelTaskId,
     selectedConversationTaskId,
     selectedConversationDetail,
@@ -86,16 +88,20 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
       sharedConversation,
       fallbackTask: selectedConversationDetail?.task ?? null,
     });
-    return resolveChannelLaneConversationTask({
+    const nextConversation = resolveChannelLaneConversationTask({
       routeChannelId,
+      routeSelectedTaskId,
+      selectedConversationTaskId: resolvedSelectedConversationTaskId,
       selectedConversation: resolvedConversation,
       selectedChannelTaskId,
       sharedConversation,
       taskList,
     });
+    return nextConversation;
   }, [
     effectiveSelectedTeamId,
     routeChannelId,
+    routeSelectedTaskId,
     resolvedSelectedConversationTaskId,
     selectedChannelTaskId,
     selectedConversationDetail?.task,

--- a/web/src/pages/team/use_team_task_workspace_data.ts
+++ b/web/src/pages/team/use_team_task_workspace_data.ts
@@ -11,6 +11,7 @@ import { parseErrorMessage } from "./create_helpers";
 import {
   isCurrentTeamScopedRequest,
   listTeamWorkspaceTasks,
+  resolveChannelLaneConversationTask,
   resolveSelectedConversationTask,
   resolveSelectedTeamTask,
   shouldClearSelectedConversationTask,
@@ -20,6 +21,8 @@ import {
 type UseTeamTaskWorkspaceDataOptions = {
   token: string;
   effectiveSelectedTeamId: string | null;
+  routeChannelId: string;
+  selectedChannelTaskId?: string | null;
   selectedConversationTaskId: string;
   selectedConversationDetail: TeamTaskDetailResponse | null;
   sharedConversation: TeamTaskRecord | null;
@@ -46,6 +49,8 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
   const {
     token,
     effectiveSelectedTeamId,
+    routeChannelId,
+    selectedChannelTaskId,
     selectedConversationTaskId,
     selectedConversationDetail,
     sharedConversation,
@@ -75,32 +80,44 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
     if (!effectiveSelectedTeamId) {
       return null;
     }
-    return resolveSelectedConversationTask({
+    const resolvedConversation = resolveSelectedConversationTask({
       taskList,
       selectedTaskId: resolvedSelectedConversationTaskId,
       sharedConversation,
       fallbackTask: selectedConversationDetail?.task ?? null,
     });
+    return resolveChannelLaneConversationTask({
+      routeChannelId,
+      selectedConversation: resolvedConversation,
+      selectedChannelTaskId,
+      sharedConversation,
+      taskList,
+    });
   }, [
     effectiveSelectedTeamId,
+    routeChannelId,
     resolvedSelectedConversationTaskId,
+    selectedChannelTaskId,
     selectedConversationDetail?.task,
     sharedConversation,
     taskList,
   ]);
 
   const selectedConversationLatestRun = useMemo(() => {
-    if (!resolvedSelectedConversationTaskId) {
+    if (!selectedConversation) {
+      return null;
+    }
+    if (sharedConversation?.id === selectedConversation.id) {
       return sharedConversationLatestRun;
     }
-    if (sharedConversation?.id === resolvedSelectedConversationTaskId) {
-      return sharedConversationLatestRun;
+    if (selectedConversationDetail?.task?.id === selectedConversation.id) {
+      return selectedConversationDetail.latest_run ?? null;
     }
-    return selectedConversationDetail?.latest_run ?? null;
+    return null;
   }, [
-    resolvedSelectedConversationTaskId,
+    selectedConversation,
     selectedConversationDetail,
-    sharedConversation?.id,
+    sharedConversation,
     sharedConversationLatestRun,
   ]);
 

--- a/web/src/pages/team_member_acp_panel.test.tsx
+++ b/web/src/pages/team_member_acp_panel.test.tsx
@@ -269,6 +269,96 @@ describe("TeamMemberAcpPanel jump-to-bottom alignment", () => {
     expect(onInterrupt).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a compact ACP activity strip for loaded updates, tool calls, and older history", async () => {
+    vi.mocked(useAcpConversation).mockReturnValue(
+      buildConversationHookState({
+        conversationSourceItems: 2,
+        conversationRenderedItems: 2,
+        conversationTotalItems: 2,
+      }) as never
+    );
+
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedSessionId="runtime-session-1"
+        selectedMemberRole="worker"
+        selectedMemberSnapshot={null}
+        memberEvents={buildAcpEvents([
+          {
+            type: "tool_call_update",
+            id: "tool-1",
+            content: [
+              {
+                type: "content",
+                content: { type: "text", text: "{\"command\": \"cargo test\"}" },
+              },
+            ],
+          },
+        ])}
+        memberEventsHasMore={true}
+        memberEventsLoading={false}
+        eventsLoading={false}
+        oldestMemberEventId={11}
+        onSendInput={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const activityStrip = required(
+      container.querySelector('[data-team-member-acp-activity-strip="true"]') as HTMLDivElement | null,
+      "acp activity strip missing"
+    );
+    expect(activityStrip.textContent).toContain("2 updates");
+    expect(activityStrip.textContent).toContain("1 tool call");
+    expect(activityStrip.textContent).toContain("Older history available");
+  });
+
+  it("shows syncing in the ACP activity strip while refreshing a live session", async () => {
+    vi.mocked(useAcpConversation).mockReturnValue(
+      buildConversationHookState({
+        conversationSourceItems: 1,
+        conversationRenderedItems: 1,
+        conversationTotalItems: 1,
+      }) as never
+    );
+
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedSessionId="runtime-session-1"
+        selectedMemberRole="worker"
+        selectedMemberSnapshot={null}
+        memberEvents={buildAcpEvents()}
+        memberEventsHasMore={false}
+        memberEventsLoading={true}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onSendInput={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const activityStrip = required(
+      container.querySelector('[data-team-member-acp-activity-strip="true"]') as HTMLDivElement | null,
+      "acp activity strip missing"
+    );
+    expect(activityStrip.textContent).toContain("1 update");
+    expect(activityStrip.textContent).toContain("Syncing");
+  });
+
   it("prefers the selected member snapshot status over stale ACP run status in the header", () => {
     renderWithMantine(
       root,

--- a/web/src/pages/team_member_acp_panel.test.tsx
+++ b/web/src/pages/team_member_acp_panel.test.tsx
@@ -359,6 +359,48 @@ describe("TeamMemberAcpPanel jump-to-bottom alignment", () => {
     expect(activityStrip.textContent).toContain("Syncing");
   });
 
+  it("hides the ACP activity strip when no ACP session is available yet", async () => {
+    vi.mocked(useAcpConversation).mockReturnValue(
+      buildConversationHookState({
+        conversationSourceItems: 3,
+        conversationRenderedItems: 3,
+        conversationTotalItems: 3,
+      }) as never
+    );
+
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        selectedSessionId={undefined}
+        selectedMemberRole="worker"
+        selectedMemberSnapshot={{
+          member_id: "worker-agent",
+          role: "worker",
+          skills: [],
+          pending_inbox_count: 0,
+          status: "pending",
+          session_status: "pending",
+        }}
+        selectedAgentStatus="running"
+        memberEvents={buildAcpEvents()}
+        memberEventsHasMore={true}
+        memberEventsLoading={true}
+        eventsLoading={false}
+        oldestMemberEventId={null}
+        onSendInput={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-team-member-acp-activity-strip="true"]')).toBeNull();
+  });
+
   it("prefers the selected member snapshot status over stale ACP run status in the header", () => {
     renderWithMantine(
       root,

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -138,6 +138,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
     memberStatusClassToken,
     isStartingAcpSession,
     panelSubtitle,
+    activitySummaryItems,
     developerTechnicalMetadata,
     acpPanelProps,
     inputDockJumpMode,
@@ -253,6 +254,24 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
               </Badge>
             </div>
           ) : null}
+          {activitySummaryItems.length > 0 ? (
+            <div
+              className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1"
+              data-team-member-acp-activity-strip="true"
+            >
+              {activitySummaryItems.map((item) => (
+                <Badge
+                  key={item.id}
+                  tone="outline"
+                  shape="pill"
+                  className="max-w-full truncate border-notion-border/70 bg-white/80 px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-notion-text-muted shadow-none"
+                  title={item.title ?? item.label}
+                >
+                  {item.label}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
           {isStartingAcpSession ? (
             <div className="inline-flex min-w-[12rem] items-center gap-2 rounded-xl border border-notion-border/70 bg-white/80 px-2 py-1 text-[11px] font-medium text-notion-text-muted">
               <span className="shrink-0">Starting session</span>
@@ -278,6 +297,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
       attachedNodeId,
       developerTechnicalMetadata,
       infoStripSummary,
+      activitySummaryItems,
       isStartingAcpSession,
       memberStatus,
       memberStatusClassToken,

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -223,6 +223,7 @@ describe("team_page helpers", () => {
           remote_task_id: "snapshot-session",
         } as never,
         "runtime-session",
+        null,
         "running"
       )
     ).toBe("runtime-session");
@@ -233,6 +234,7 @@ describe("team_page helpers", () => {
           remote_task_id: "snapshot-session",
         } as never,
         "   ",
+        null,
         null
       )
     ).toBe("snapshot-session");
@@ -240,13 +242,25 @@ describe("team_page helpers", () => {
       resolveSelectedAgentWorkspaceSessionId(
         {
           member_id: "worker-1",
+          remote_task_id: "new-snapshot-session",
+        } as never,
+        "   ",
+        "sticky-session",
+        "running"
+      )
+    ).toBe("sticky-session");
+    expect(
+      resolveSelectedAgentWorkspaceSessionId(
+        {
+          member_id: "worker-1",
           remote_task_id: "snapshot-session",
         } as never,
         "runtime-session",
+        "sticky-session",
         "stopped"
       )
     ).toBeNull();
-    expect(resolveSelectedAgentWorkspaceSessionId(null, null)).toBeNull();
+    expect(resolveSelectedAgentWorkspaceSessionId(null, null, null)).toBeNull();
   });
 
   it("extracts positive thread root message ids from conversation payloads", () => {

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildTeamWorkspacePath,
   formatTeamRuntimeActionSummary,
   parseTeamAgentInputSessionMismatch,
+  resolveNextSelectedAgentWorkspaceStickySession,
   resolveChannelRouteTaskId,
   resolveRouteScopedConversationTaskSelection,
   resolveSelectedAgentWorkspaceSessionId,
@@ -261,6 +262,28 @@ describe("team_page helpers", () => {
       )
     ).toBeNull();
     expect(resolveSelectedAgentWorkspaceSessionId(null, null, null)).toBeNull();
+  });
+
+  it("updates sticky ACP session state declaratively across member changes", () => {
+    const initial = { memberId: "", sessionId: null as string | null };
+    const workerOne = resolveNextSelectedAgentWorkspaceStickySession(
+      initial,
+      "worker-1",
+      "session-1"
+    );
+    expect(workerOne).toEqual({ memberId: "worker-1", sessionId: "session-1" });
+
+    expect(
+      resolveNextSelectedAgentWorkspaceStickySession(workerOne, "worker-1", null)
+    ).toBe(workerOne);
+
+    expect(
+      resolveNextSelectedAgentWorkspaceStickySession(workerOne, "worker-2", null)
+    ).toEqual({ memberId: "worker-2", sessionId: null });
+
+    expect(
+      resolveNextSelectedAgentWorkspaceStickySession(workerOne, "", null)
+    ).toEqual({ memberId: "", sessionId: null });
   });
 
   it("extracts positive thread root message ids from conversation payloads", () => {

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -2059,8 +2059,7 @@ describe("TeamPage smoke render", () => {
             />
           </MantineProvider>
         );
-        await Promise.resolve();
-        await Promise.resolve();
+        await flushEffects();
       });
 
       expect(container.querySelector('[aria-label="Show teams panel"]')).not.toBeNull();
@@ -2487,8 +2486,7 @@ describe("TeamPage smoke render", () => {
 
       await act(async () => {
         taskCardButton?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        await flushEffects();
       });
 
       const openConversationButton = Array.from(document.body.querySelectorAll("button")).find(
@@ -2498,8 +2496,7 @@ describe("TeamPage smoke render", () => {
 
       await act(async () => {
         openConversationButton?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        await flushEffects();
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
@@ -2611,8 +2608,7 @@ describe("TeamPage smoke render", () => {
             />
           </MantineProvider>
         );
-        await Promise.resolve();
-        await Promise.resolve();
+        await flushEffects();
       });
 
       const lastOptions =

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -384,6 +384,7 @@ export function parseTeamAgentInputSessionMismatch(
 export function resolveSelectedAgentWorkspaceSessionId(
   latestStep: TeamStepRecord | null | undefined,
   runtimeSessionId: string | null | undefined,
+  previousSessionId?: string | null,
   agentStatus?: string | null
 ): string | null {
   const normalizedAgentStatus = agentStatus?.trim().toLowerCase() ?? "";
@@ -393,6 +394,12 @@ export function resolveSelectedAgentWorkspaceSessionId(
   const normalizedRuntimeSessionId = runtimeSessionId?.trim() ?? "";
   if (normalizedRuntimeSessionId) {
     return normalizedRuntimeSessionId;
+  }
+  const normalizedPreviousSessionId = previousSessionId?.trim() ?? "";
+  // Keep the previous ACP session identity sticky while runtime metadata catches up
+  // so a transient latest_step/runtime refresh does not blank the visible thread.
+  if (normalizedPreviousSessionId) {
+    return normalizedPreviousSessionId;
   }
   const snapshotSessionId = getTeamStepRuntimeHandleId(latestStep);
   return snapshotSessionId?.trim() || null;
@@ -1446,13 +1453,33 @@ export function TeamPage(props: TeamPageProps) {
     }
     return teamMemberAgentsById[memberId] ?? agents.find((agent) => agent.id === memberId) ?? null;
   }, [agents, selectedAgentWorkspaceMemberId, teamMemberAgentsById]);
+  const selectedAgentWorkspaceSessionRef = useRef<{
+    memberId: string;
+    sessionId: string | null;
+  }>({ memberId: "", sessionId: null });
   const selectedAgentWorkspaceSessionId = useMemo(() => {
+    const previousSessionId =
+      selectedAgentWorkspaceSessionRef.current.memberId === selectedAgentWorkspaceMemberId
+        ? selectedAgentWorkspaceSessionRef.current.sessionId
+        : null;
     return resolveSelectedAgentWorkspaceSessionId(
       selectedAgentWorkspaceSnapshot?.latest_step,
       selectedAgentWorkspaceRuntimeMember?.session_id ?? null,
+      previousSessionId,
       selectedAgentWorkspaceAgent?.status ?? null
     );
-  }, [selectedAgentWorkspaceAgent, selectedAgentWorkspaceRuntimeMember, selectedAgentWorkspaceSnapshot]);
+  }, [
+    selectedAgentWorkspaceAgent,
+    selectedAgentWorkspaceMemberId,
+    selectedAgentWorkspaceRuntimeMember,
+    selectedAgentWorkspaceSnapshot,
+  ]);
+  useEffect(() => {
+    selectedAgentWorkspaceSessionRef.current = {
+      memberId: selectedAgentWorkspaceMemberId,
+      sessionId: selectedAgentWorkspaceSessionId,
+    };
+  }, [selectedAgentWorkspaceMemberId, selectedAgentWorkspaceSessionId]);
   const memberTargetNodeById = useMemo<Record<string, string | null>>(() => {
     const entries = Object.entries(teamMemberAgentsById).map(([memberId, agent]) => [
       memberId,
@@ -2031,6 +2058,8 @@ export function TeamPage(props: TeamPageProps) {
   } = useTeamTaskWorkspaceData({
     token: props.token,
     effectiveSelectedTeamId,
+    routeChannelId,
+    selectedChannelTaskId: selectedChannelRecord?.task_id,
     selectedConversationTaskId,
     selectedConversationDetail,
     sharedConversation,

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -2059,6 +2059,7 @@ export function TeamPage(props: TeamPageProps) {
     token: props.token,
     effectiveSelectedTeamId,
     routeChannelId,
+    routeSelectedTaskId,
     selectedChannelTaskId: selectedChannelRecord?.task_id,
     selectedConversationTaskId,
     selectedConversationDetail,

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -405,6 +405,34 @@ export function resolveSelectedAgentWorkspaceSessionId(
   return snapshotSessionId?.trim() || null;
 }
 
+export function resolveNextSelectedAgentWorkspaceStickySession(
+  previous: { memberId: string; sessionId: string | null },
+  memberId: string,
+  resolvedSessionId: string | null
+): { memberId: string; sessionId: string | null } {
+  const normalizedMemberId = memberId.trim();
+  const normalizedResolvedSessionId = resolvedSessionId?.trim() || null;
+  if (!normalizedMemberId) {
+    if (!previous.memberId && previous.sessionId == null) {
+      return previous;
+    }
+    return { memberId: "", sessionId: null };
+  }
+  if (previous.memberId !== normalizedMemberId) {
+    return {
+      memberId: normalizedMemberId,
+      sessionId: normalizedResolvedSessionId,
+    };
+  }
+  if (!normalizedResolvedSessionId || previous.sessionId === normalizedResolvedSessionId) {
+    return previous;
+  }
+  return {
+    memberId: normalizedMemberId,
+    sessionId: normalizedResolvedSessionId,
+  };
+}
+
 export function buildTeamDetailPath(teamId: string): string {
   return buildCanonicalTeamDetailPath(teamId);
 }
@@ -1453,14 +1481,14 @@ export function TeamPage(props: TeamPageProps) {
     }
     return teamMemberAgentsById[memberId] ?? agents.find((agent) => agent.id === memberId) ?? null;
   }, [agents, selectedAgentWorkspaceMemberId, teamMemberAgentsById]);
-  const selectedAgentWorkspaceSessionRef = useRef<{
+  const [selectedAgentWorkspaceStickySession, setSelectedAgentWorkspaceStickySession] = useState<{
     memberId: string;
     sessionId: string | null;
   }>({ memberId: "", sessionId: null });
-  const selectedAgentWorkspaceSessionId = useMemo(() => {
+  const selectedAgentWorkspaceResolvedSessionId = useMemo(() => {
     const previousSessionId =
-      selectedAgentWorkspaceSessionRef.current.memberId === selectedAgentWorkspaceMemberId
-        ? selectedAgentWorkspaceSessionRef.current.sessionId
+      selectedAgentWorkspaceStickySession.memberId === selectedAgentWorkspaceMemberId
+        ? selectedAgentWorkspaceStickySession.sessionId
         : null;
     return resolveSelectedAgentWorkspaceSessionId(
       selectedAgentWorkspaceSnapshot?.latest_step,
@@ -1473,13 +1501,18 @@ export function TeamPage(props: TeamPageProps) {
     selectedAgentWorkspaceMemberId,
     selectedAgentWorkspaceRuntimeMember,
     selectedAgentWorkspaceSnapshot,
+    selectedAgentWorkspaceStickySession,
   ]);
+  const selectedAgentWorkspaceSessionId = selectedAgentWorkspaceResolvedSessionId;
   useEffect(() => {
-    selectedAgentWorkspaceSessionRef.current = {
-      memberId: selectedAgentWorkspaceMemberId,
-      sessionId: selectedAgentWorkspaceSessionId,
-    };
-  }, [selectedAgentWorkspaceMemberId, selectedAgentWorkspaceSessionId]);
+    setSelectedAgentWorkspaceStickySession((previous) =>
+      resolveNextSelectedAgentWorkspaceStickySession(
+        previous,
+        selectedAgentWorkspaceMemberId,
+        selectedAgentWorkspaceResolvedSessionId
+      )
+    );
+  }, [selectedAgentWorkspaceMemberId, selectedAgentWorkspaceResolvedSessionId]);
   const memberTargetNodeById = useMemo<Record<string, string | null>>(() => {
     const entries = Object.entries(teamMemberAgentsById).map(([memberId, agent]) => [
       memberId,


### PR DESCRIPTION
## Summary

- keep channel lanes pinned to their canonical conversations so `# all` does not get replaced by stale task selections
- add a compact ACP activity summary strip in Team member ACP headers
- keep Team member ACP session identity sticky across transient runtime refresh gaps so new activity does not blank the thread

## Validation

- `cd web && pnpm exec vitest run src/pages/team_page.helpers.test.ts src/pages/team/use_team_task_workspace_data.test.tsx src/pages/team_member_acp_panel.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run lint`

## Notes

- Chrome DevTools MCP baseline on production still showed the old ACP header before deployment; post-deploy regression should verify the new activity strip and confirm ACP threads no longer blank on new messages.
