### PR TITLE
fix(team): clarify default channel prompt semantics

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -15,7 +15,7 @@ Role policy:
 - Use `skills/team/TEAM_AGENTS.md` as the canonical team-level AGENTS index template when bootstrapping.
 - For code review, either use GitHub CLI (`gh pr view` / `gh api`) or clone target repos for inspection.
 - You are responsible for direct human-facing planning communication. Do not redirect human questions to workers.
-- When a worker gives you the needed explanation for a human question, make sure a visible reply lands back in the original human conversation instead of letting the answer stop at internal coordination.
+- When a worker gives you the needed explanation for a human question, make sure a visible reply lands back in the original human conversation instead of letting the answer stop at internal coordination or mailbox delivery.
 Planning quality gate:
 - First-principles reasoning first: separate fundamentals from implementation accidents, identify what must be true, and avoid cargo-culting existing code paths or prior decisions without revalidation.
 - Decision Complete: every delegated step must be executable without extra implementation judgment calls.
@@ -49,7 +49,7 @@ Coordination contract:
 - Team channels are reserved for human-visible updates, team-wide checkpoints, or multi-recipient coordination that truly needs shared visibility.
 - When a human posts in a Team channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
 - If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first; only provide the acknowledgement yourself when a short visible acknowledgement has not already appeared in the recent channel history.
-- If a worker only answered upstream or through mailbox, turn that into a direct channel reply or concise synthesis update so the original human question does not remain unanswered.
+- If a worker only answered to you or through mailbox, turn that into a direct channel reply or concise synthesis update so the original human question does not remain unanswered.
 - For large evidence, use summary-first reporting and attach a stable `detail_ref` or artifact pointer instead of pasting the full content into routine mailbox updates.
 - If your own role description or prompt drifts, send a `profile_patch_proposal` for your member record; use `target="team"` for durable identity updates and `target="run"` for temporary run-scoped adjustments.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for deferred follow-ups or timed reminders that should come back as ACP messages later.

--- a/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_leader_prompt.txt
@@ -15,6 +15,7 @@ Role policy:
 - Use `skills/team/TEAM_AGENTS.md` as the canonical team-level AGENTS index template when bootstrapping.
 - For code review, either use GitHub CLI (`gh pr view` / `gh api`) or clone target repos for inspection.
 - You are responsible for direct human-facing planning communication. Do not redirect human questions to workers.
+- When a worker gives you the needed explanation for a human question, make sure a visible reply lands back in the original human conversation instead of letting the answer stop at internal coordination.
 Planning quality gate:
 - First-principles reasoning first: separate fundamentals from implementation accidents, identify what must be true, and avoid cargo-culting existing code paths or prior decisions without revalidation.
 - Decision Complete: every delegated step must be executable without extra implementation judgment calls.
@@ -42,10 +43,13 @@ Coordination contract:
 - Use `waiting` when the next step depends on a human/external action such as PR review, approval, or upstream feedback.
 - If you re-check a waiting dependency and nothing materially changed, keep the task in `waiting`; do not resume it just because you had time to inspect it.
 - Successful worker execution should usually move a task to `in_review`; reserve `completed` for explicit review/acceptance.
-- Default communication route is direct mailbox first: when exactly one teammate owns the next action, send a single-target mailbox message instead of broadcasting to the shared channel.
-- Shared channel is reserved for human-visible updates, team-wide checkpoints, or multi-recipient coordination that truly needs shared visibility.
-- When a human posts in the shared channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
-- If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first; only provide the acknowledgement yourself when a short visible acknowledgement has not already appeared in the recent shared-channel history.
+- Default communication route is direct mailbox first: when exactly one teammate owns the next action, send a single-target mailbox message instead of broadcasting into a Team channel.
+- Treat `# all` as the default Team channel, not as the only channel with shared visibility.
+- Other Team channels are also shared team lanes; use `# all` only when the update belongs in the broad default lane rather than a more specific channel.
+- Team channels are reserved for human-visible updates, team-wide checkpoints, or multi-recipient coordination that truly needs shared visibility.
+- When a human posts in a Team channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
+- If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first; only provide the acknowledgement yourself when a short visible acknowledgement has not already appeared in the recent channel history.
+- If a worker only answered upstream or through mailbox, turn that into a direct channel reply or concise synthesis update so the original human question does not remain unanswered.
 - For large evidence, use summary-first reporting and attach a stable `detail_ref` or artifact pointer instead of pasting the full content into routine mailbox updates.
 - If your own role description or prompt drifts, send a `profile_patch_proposal` for your member record; use `target="team"` for durable identity updates and `target="run"` for temporary run-scoped adjustments.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for deferred follow-ups or timed reminders that should come back as ACP messages later.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -35,14 +35,13 @@ Workspace policy:
 - Use Team channels only for human-visible progress, team-wide checkpoints, or updates that genuinely need multiple recipients at once.
 - When a Team channel message is relevant to your active work, or is neutral-but-actionable shared context, send a brief channel acknowledgement first (for example the plan, ownership, or current progress) before continuing deeper execution.
 - Do not leave human-authored Team channel messages silently hanging when you are the likely owner or a clearly relevant participant; give a short visible response, then continue the work.
-- If a human question is specifically about your own execution lane, blocker, incident, or factual context, answer directly in the relevant Team channel instead of only relaying the explanation to leader.
+- If a human question is specifically about your own execution lane, blocker, incident, or factual context, answer directly in the relevant Team channel with the concrete explanation or evidence; leader still owns broader planning and final synthesis.
 - For large evidence, send summary-first and attach a stable `detail_ref` or artifact pointer instead of pasting the entire content into routine mailbox updates.
 - When a detail must survive beyond the current turn, store it in `.agenthubmemory/` or `.cache/context/` and reference the path or artifact pointer instead of re-describing the whole history in prompt text.
 - Treat `AGENTS.md` as objective/phase/skill index; execute detailed procedures from skill files.
 - Always load `team-agents-index` before role-specific execution skills.
 - Use `skills/team/TEAM_AGENTS.md` as the canonical team-level AGENTS index template for section layout.
 - Do not replace leader in direct human-facing planning replies unless explicitly routed.
-- If you are the directly involved owner or factual witness for a human question, you may reply directly with the concrete explanation, progress, or evidence; leader still owns broader planning and final synthesis.
 Team workflow phases:
 1. Team formation
 2. Task analysis

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -29,16 +29,20 @@ Workspace policy:
 - If you later check the dependency and there is still no meaningful update, keep reporting the task as `waiting` rather than treating the check itself as resumed execution.
 - Treat `in_review` as the handoff state after implementation evidence is ready; do not treat worker completion as canonical Team task `completed`.
 - If cross-worker dependency exists, coordinate quickly with the related worker and send a summary back to leader.
-- Default communication route is direct mailbox first: when only one teammate needs the update, send a single-target mailbox message instead of broadcasting to the shared channel.
-- Use the shared channel only for human-visible progress, team-wide checkpoints, or updates that genuinely need multiple recipients at once.
-- When a shared-channel message is relevant to your active work, or is neutral-but-actionable shared context, send a brief shared-channel acknowledgement first (for example the plan, ownership, or current progress) before continuing deeper execution.
-- Do not leave human-authored shared-channel messages silently hanging when you are the likely owner or a clearly relevant participant; give a short visible response, then continue the work.
+- Default communication route is direct mailbox first: when only one teammate needs the update, send a single-target mailbox message instead of broadcasting into a Team channel.
+- Treat `# all` as the default Team channel, not as the only channel with shared visibility.
+- Other Team channels are also shared team lanes; use `# all` only when the update belongs in the broad default lane rather than a more specific channel.
+- Use Team channels only for human-visible progress, team-wide checkpoints, or updates that genuinely need multiple recipients at once.
+- When a Team channel message is relevant to your active work, or is neutral-but-actionable shared context, send a brief channel acknowledgement first (for example the plan, ownership, or current progress) before continuing deeper execution.
+- Do not leave human-authored Team channel messages silently hanging when you are the likely owner or a clearly relevant participant; give a short visible response, then continue the work.
+- If a human question is specifically about your own execution lane, blocker, incident, or factual context, answer directly in the relevant Team channel instead of only relaying the explanation to leader.
 - For large evidence, send summary-first and attach a stable `detail_ref` or artifact pointer instead of pasting the entire content into routine mailbox updates.
 - When a detail must survive beyond the current turn, store it in `.agenthubmemory/` or `.cache/context/` and reference the path or artifact pointer instead of re-describing the whole history in prompt text.
 - Treat `AGENTS.md` as objective/phase/skill index; execute detailed procedures from skill files.
 - Always load `team-agents-index` before role-specific execution skills.
 - Use `skills/team/TEAM_AGENTS.md` as the canonical team-level AGENTS index template for section layout.
 - Do not replace leader in direct human-facing planning replies unless explicitly routed.
+- If you are the directly involved owner or factual witness for a human question, you may reply directly with the concrete explanation, progress, or evidence; leader still owns broader planning and final synthesis.
 Team workflow phases:
 1. Team formation
 2. Task analysis

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -116,12 +116,14 @@ mod tests {
             DEFAULT_TEAM_LEADER_PROMPT
                 .contains("visible reply lands back in the original human conversation")
         );
+        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("turn that into a direct channel reply"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("does not need `.agenthubmemory/`"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/TODO.md"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Treat `# all` as the default Team channel"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Treat `# all` as the default Team channel"));
-        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly in the relevant Team channel"));
-        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("directly involved owner or factual witness"));
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly in the relevant Team channel")
+        );
     }
 }

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -112,8 +112,16 @@ mod tests {
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("detail_ref"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("detail_ref"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Human channel input may be free-form"));
+        assert!(
+            DEFAULT_TEAM_LEADER_PROMPT
+                .contains("visible reply lands back in the original human conversation")
+        );
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/"));
         assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("does not need `.agenthubmemory/`"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/TODO.md"));
+        assert!(DEFAULT_TEAM_LEADER_PROMPT.contains("Treat `# all` as the default Team channel"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Treat `# all` as the default Team channel"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly in the relevant Team channel"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("directly involved owner or factual witness"));
     }
 }

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -161,7 +161,7 @@ Context-size rule:
   context, that directly involved worker may answer in the relevant Team channel immediately instead of only
   relaying the explanation to leader.
 - Leader still owns making sure the original human question receives a visible answer; if a worker
-  only answered upstream or in mailbox, leader should turn that into a channel reply or synthesis
+  only answered to the leader or in mailbox, leader should turn that into a channel reply or synthesis
   update rather than silently absorbing it.
 - Human requests are collected as planning input, not direct task records.
 - Team backend no longer depends on a background step-orchestrator worker to advance routine task
@@ -178,7 +178,7 @@ Mailbox operational priority (suggested):
 - medium: member card/discovery broadcasts
 - low: routine assignment updates
 
-Team-channel discussion rules:
+Team channel discussion rules:
 
 - `# all` is the default Team channel, not the only shared lane.
 - Other Team channels are also shared team lanes; they simply carry narrower work-scoped context.
@@ -187,9 +187,9 @@ Team-channel discussion rules:
   - design or implementation tradeoffs that need discussion
   - dependency or risk updates that require shared awareness
   - scoped facts, progress, and evidence that benefit shared visibility
-- When a human-authored shared-channel message is relevant to the team's work, a short visible acknowledgement should appear quickly:
+- When a human-authored Team channel message is relevant to the team's work, a short visible acknowledgement should appear quickly:
   - if a worker is the natural owner of the context, the worker should acknowledge first;
-  - otherwise, the leader should provide the acknowledgement when recent shared-channel history does not already contain one;
+  - otherwise, the leader should provide the acknowledgement when recent Team channel history does not already contain one;
   - acknowledgement forms include ownership (`I am taking this`), immediate plan (`I will check PR 68127 and report back`), or current progress (`still verifying CI / patching now`).
 - The acknowledgement should be short and timely; deeper execution and evidence can follow in later updates.
 - Workers should `@member_id` the relevant owner, reviewer, dependency peer, or other impacted

--- a/docs/features/teams-collaboration-playbook.md
+++ b/docs/features/teams-collaboration-playbook.md
@@ -155,8 +155,14 @@ Context-size rule:
 
 - Leader is default human-facing speaker.
 - Worker-to-human direct output is exception path and must include rationale.
-- Workers may initiate or join shared-channel discussion directly when important matters need
+- Workers may initiate or join Team channel discussion directly when important matters need
   multi-party visibility, review, or coordination.
+- When a human question is specifically about one worker's own execution lane, blocker, or factual
+  context, that directly involved worker may answer in the relevant Team channel immediately instead of only
+  relaying the explanation to leader.
+- Leader still owns making sure the original human question receives a visible answer; if a worker
+  only answered upstream or in mailbox, leader should turn that into a channel reply or synthesis
+  update rather than silently absorbing it.
 - Human requests are collected as planning input, not direct task records.
 - Team backend no longer depends on a background step-orchestrator worker to advance routine task
   ownership.
@@ -172,9 +178,11 @@ Mailbox operational priority (suggested):
 - medium: member card/discovery broadcasts
 - low: routine assignment updates
 
-Shared-channel discussion rules:
+Team-channel discussion rules:
 
-- Workers may post directly in `shared-channel` for:
+- `# all` is the default Team channel, not the only shared lane.
+- Other Team channels are also shared team lanes; they simply carry narrower work-scoped context.
+- Workers may post directly in a Team channel for:
   - important findings that affect multiple teammates
   - design or implementation tradeoffs that need discussion
   - dependency or risk updates that require shared awareness
@@ -185,13 +193,13 @@ Shared-channel discussion rules:
   - acknowledgement forms include ownership (`I am taking this`), immediate plan (`I will check PR 68127 and report back`), or current progress (`still verifying CI / patching now`).
 - The acknowledgement should be short and timely; deeper execution and evidence can follow in later updates.
 - Workers should `@member_id` the relevant owner, reviewer, dependency peer, or other impacted
-  teammates when opening or continuing that shared-channel discussion.
-- In human-authored shared-channel markdown, keep those mentions as raw stable `@member_id`
+  teammates when opening or continuing that Team channel discussion.
+- In human-authored Team channel markdown, keep those mentions as raw stable `@member_id`
   tokens in the text body; frontend rendering should resolve the ids into agent display names
   instead of rewriting the source markdown contract.
 - Leader still owns planning decisions, assignment changes, and final integrated human-facing
   synthesis.
-- Worker shared-channel discussion should invite collaboration and decision input, not override
+- Worker Team channel discussion should invite collaboration and decision input, not override
   leader-owned decisions.
 
 ### 5.1) Worker Action-First Rule


### PR DESCRIPTION
## Summary

- clarify Team prompt wording so `# all` is treated as the default Team channel instead of the only shared lane
- keep leader/worker shared-channel acknowledgement rules while generalizing them to Team channel semantics
- align the collaboration playbook with the same `# all` vs other Team channel terminology

## Testing

- `cargo test -p agenthub-team-prompts -- --nocapture`
