### PR TITLE
fix(team): refine deterministic avatars

### DIFF
--- a/web/src/components/deterministic_avatar.test.tsx
+++ b/web/src/components/deterministic_avatar.test.tsx
@@ -13,9 +13,11 @@ describe("DeterministicAvatar", () => {
 
     expect(first.seed).toBe("Worker Agent::worker-1");
     expect(second.seed).toBe(first.seed);
+    expect(second.variantKey).toBe(first.variantKey);
     expect(second.backgroundColor).toBe(first.backgroundColor);
     expect(second.foregroundColor).toBe(first.foregroundColor);
-    expect(second.cells).toEqual(first.cells);
+    expect(second.borderColor).toBe(first.borderColor);
+    expect(second.accentColor).toBe(first.accentColor);
     expect(resolveDeterministicAvatarSeed("Worker Agent", "worker-1")).toBe(first.seed);
   });
 
@@ -24,10 +26,10 @@ describe("DeterministicAvatar", () => {
     const second = renderDeterministicAvatarModel("Worker Agent", "worker-2");
 
     expect(second.seed).not.toBe(first.seed);
-    expect(second.cells).not.toEqual(first.cells);
+    expect(second.variantKey).not.toBe(first.variantKey);
   });
 
-  it("renders a deterministic SVG avatar shell", () => {
+  it("renders a deterministic object avatar shell", () => {
     const html = renderToStaticMarkup(
       <DeterministicAvatar
         name="Leader"
@@ -37,8 +39,8 @@ describe("DeterministicAvatar", () => {
     );
 
     expect(html).toContain('data-avatar-seed="Leader::leader-agent"');
-    expect(html).toContain("<svg");
+    expect(html).toContain('data-avatar-variant="');
     expect(html).toContain('class="inline-flex shrink-0 overflow-hidden rounded-full h-7 w-7 border border-black/8"');
-    expect(html).toContain('role="presentation"');
+    expect(html).toContain("<svg");
   });
 });

--- a/web/src/components/deterministic_avatar.test.tsx
+++ b/web/src/components/deterministic_avatar.test.tsx
@@ -18,6 +18,8 @@ describe("DeterministicAvatar", () => {
     expect(second.foregroundColor).toBe(first.foregroundColor);
     expect(second.borderColor).toBe(first.borderColor);
     expect(second.accentColor).toBe(first.accentColor);
+    expect(second.shadowColor).toBe(first.shadowColor);
+    expect(second.cells).toEqual(first.cells);
     expect(resolveDeterministicAvatarSeed("Worker Agent", "worker-1")).toBe(first.seed);
   });
 
@@ -41,6 +43,18 @@ describe("DeterministicAvatar", () => {
     expect(html).toContain('data-avatar-seed="Leader::leader-agent"');
     expect(html).toContain('data-avatar-variant="');
     expect(html).toContain('class="inline-flex shrink-0 overflow-hidden rounded-full h-7 w-7 border border-black/8"');
-    expect(html).toContain("<svg");
+    expect(html).toContain("grid-template-columns:repeat(8, 1fr)");
+    expect(html).toContain("image-rendering:pixelated");
+  });
+
+  it("keeps every row horizontally symmetric", () => {
+    const model = renderDeterministicAvatarModel("Leader", "leader-agent");
+    for (let row = 0; row < 8; row += 1) {
+      for (let col = 0; col < 4; col += 1) {
+        const left = model.cells[row * 8 + col];
+        const right = model.cells[row * 8 + (7 - col)];
+        expect(left).toBe(right);
+      }
+    }
   });
 });

--- a/web/src/components/deterministic_avatar.test.tsx
+++ b/web/src/components/deterministic_avatar.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  DeterministicAvatar,
+  renderDeterministicAvatarModel,
+  resolveDeterministicAvatarSeed,
+} from "./deterministic_avatar";
+
+describe("DeterministicAvatar", () => {
+  it("uses the same seed and shape for the same name/id pair", () => {
+    const first = renderDeterministicAvatarModel("Worker Agent", "worker-1");
+    const second = renderDeterministicAvatarModel("Worker Agent", "worker-1");
+
+    expect(first.seed).toBe("Worker Agent::worker-1");
+    expect(second.seed).toBe(first.seed);
+    expect(second.backgroundColor).toBe(first.backgroundColor);
+    expect(second.foregroundColor).toBe(first.foregroundColor);
+    expect(second.cells).toEqual(first.cells);
+    expect(resolveDeterministicAvatarSeed("Worker Agent", "worker-1")).toBe(first.seed);
+  });
+
+  it("changes the generated avatar when the stable id changes", () => {
+    const first = renderDeterministicAvatarModel("Worker Agent", "worker-1");
+    const second = renderDeterministicAvatarModel("Worker Agent", "worker-2");
+
+    expect(second.seed).not.toBe(first.seed);
+    expect(second.cells).not.toEqual(first.cells);
+  });
+
+  it("renders a deterministic SVG avatar shell", () => {
+    const html = renderToStaticMarkup(
+      <DeterministicAvatar
+        name="Leader"
+        stableId="leader-agent"
+        className="h-7 w-7 border border-black/8"
+      />
+    );
+
+    expect(html).toContain('data-avatar-seed="Leader::leader-agent"');
+    expect(html).toContain("<svg");
+    expect(html).toContain('class="inline-flex shrink-0 overflow-hidden rounded-full h-7 w-7 border border-black/8"');
+    expect(html).toContain('role="presentation"');
+  });
+});

--- a/web/src/components/deterministic_avatar.tsx
+++ b/web/src/components/deterministic_avatar.tsx
@@ -114,7 +114,10 @@ export const DeterministicAvatar = React.memo(function DeterministicAvatar({
   title,
   ariaHidden = true,
 }: DeterministicAvatarProps) {
-  const model = buildDeterministicAvatarModel(name, stableId);
+  const model = React.useMemo(
+    () => buildDeterministicAvatarModel(name, stableId),
+    [name, stableId]
+  );
   return (
     <span
       className={`inline-flex shrink-0 overflow-hidden rounded-full ${className}`.trim()}

--- a/web/src/components/deterministic_avatar.tsx
+++ b/web/src/components/deterministic_avatar.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+
+type DeterministicAvatarProps = {
+  name?: string | null;
+  stableId?: string | number | null;
+  className?: string;
+  title?: string;
+  ariaHidden?: boolean;
+};
+
+type DeterministicAvatarModel = {
+  seed: string;
+  backgroundColor: string;
+  foregroundColor: string;
+  cells: readonly boolean[];
+};
+
+function normalizeAvatarSeed(name?: string | null, stableId?: string | number | null): string {
+  const normalizedName = name?.trim() || "unknown";
+  const normalizedId =
+    stableId == null ? "unknown" : String(stableId).trim() || "unknown";
+  return `${normalizedName}::${normalizedId}`;
+}
+
+function hashAvatarSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function buildAvatarCells(hash: number): boolean[] {
+  const cells: boolean[] = [];
+  let state = hash || 0x811c9dc5;
+  for (let row = 0; row < 5; row += 1) {
+    const mirroredRow: boolean[] = [];
+    for (let col = 0; col < 3; col += 1) {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      mirroredRow.push((state & 1) === 0);
+    }
+    cells.push(
+      mirroredRow[0] ?? false,
+      mirroredRow[1] ?? false,
+      mirroredRow[2] ?? false,
+      mirroredRow[1] ?? false,
+      mirroredRow[0] ?? false
+    );
+  }
+  return cells;
+}
+
+function buildDeterministicAvatarModel(
+  name?: string | null,
+  stableId?: string | number | null
+): DeterministicAvatarModel {
+  const seed = normalizeAvatarSeed(name, stableId);
+  const hash = hashAvatarSeed(seed);
+  const hue = hash % 360;
+  const saturation = 56 + ((hash >>> 9) % 18);
+  const backgroundLightness = 92 - ((hash >>> 17) % 8);
+  const foregroundLightness = 34 + ((hash >>> 25) % 12);
+  return {
+    seed,
+    backgroundColor: `hsl(${hue} ${saturation}% ${backgroundLightness}%)`,
+    foregroundColor: `hsl(${hue} ${saturation + 8}% ${foregroundLightness}%)`,
+    cells: buildAvatarCells(hash),
+  };
+}
+
+export function resolveDeterministicAvatarSeed(
+  name?: string | null,
+  stableId?: string | number | null
+): string {
+  return normalizeAvatarSeed(name, stableId);
+}
+
+export function renderDeterministicAvatarModel(
+  name?: string | null,
+  stableId?: string | number | null
+): DeterministicAvatarModel {
+  return buildDeterministicAvatarModel(name, stableId);
+}
+
+export const DeterministicAvatar = React.memo(function DeterministicAvatar({
+  name,
+  stableId,
+  className = "",
+  title,
+  ariaHidden = true,
+}: DeterministicAvatarProps) {
+  const model = buildDeterministicAvatarModel(name, stableId);
+  return (
+    <span
+      className={`inline-flex shrink-0 overflow-hidden rounded-full ${className}`.trim()}
+      data-avatar-seed={model.seed}
+      title={title}
+      aria-hidden={ariaHidden}
+    >
+      <svg
+        viewBox="0 0 48 48"
+        className="h-full w-full"
+        role="presentation"
+        focusable="false"
+      >
+        <rect width="48" height="48" rx="24" fill={model.backgroundColor} />
+        {model.cells.map((filled, index) => {
+          if (!filled) {
+            return null;
+          }
+          const row = Math.floor(index / 5);
+          const col = index % 5;
+          const x = 7 + col * 7;
+          const y = 7 + row * 7;
+          return (
+            <rect
+              key={`${row}-${col}`}
+              x={x}
+              y={y}
+              width="6"
+              height="6"
+              rx="1.5"
+              fill={model.foregroundColor}
+            />
+          );
+        })}
+      </svg>
+    </span>
+  );
+});

--- a/web/src/components/deterministic_avatar.tsx
+++ b/web/src/components/deterministic_avatar.tsx
@@ -8,24 +8,21 @@ type DeterministicAvatarProps = {
   ariaHidden?: boolean;
 };
 
+type PixelTone = "foreground" | "accent" | "shadow";
+
 type DeterministicAvatarModel = {
   seed: string;
   variantKey: number;
   backgroundColor: string;
   foregroundColor: string;
   accentColor: string;
+  shadowColor: string;
   borderColor: string;
-  silhouetteIndex: number;
-  centerIndex: number;
-  topperIndex: number;
-  orbitIndex: number;
-  baseIndex: number;
+  cells: readonly (PixelTone | null)[];
 };
 
-type LayerProps = {
-  foregroundColor: string;
-  accentColor: string;
-};
+const GRID_SIZE = 8;
+const MIRROR_COLUMNS = GRID_SIZE / 2;
 
 function normalizeAvatarSeed(name?: string | null, stableId?: string | number | null): string {
   const normalizedName = name?.trim() || "unknown";
@@ -43,127 +40,36 @@ function hashAvatarSeed(seed: string): number {
   return hash >>> 0;
 }
 
-function decomposeVariantKey(variantKey: number): [number, number, number, number, number] {
-  return [
-    variantKey & 3,
-    (variantKey >>> 2) & 3,
-    (variantKey >>> 4) & 3,
-    (variantKey >>> 6) & 3,
-    (variantKey >>> 8) & 3,
-  ];
+function resolveTone(value: number): PixelTone | null {
+  if (value < 2) {
+    return null;
+  }
+  if (value < 5) {
+    return "foreground";
+  }
+  if (value === 5) {
+    return "accent";
+  }
+  return "shadow";
 }
 
-const SILHOUETTE_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
-  ({ foregroundColor }) => (
-    <g>
-      <circle cx="24" cy="25" r="11.5" fill={foregroundColor} />
-      <rect x="16" y="31" width="16" height="4.5" rx="2.25" fill={foregroundColor} />
-    </g>
-  ),
-  ({ foregroundColor }) => (
-    <g>
-      <rect x="13" y="14" width="22" height="22" rx="7" fill={foregroundColor} />
-      <rect x="18" y="32" width="12" height="4" rx="2" fill={foregroundColor} />
-    </g>
-  ),
-  ({ foregroundColor }) => (
-    <g>
-      <path d="M24 11L35 18V31L24 38L13 31V18L24 11Z" fill={foregroundColor} />
-      <rect x="18" y="31" width="12" height="4" rx="2" fill={foregroundColor} />
-    </g>
-  ),
-  ({ foregroundColor }) => (
-    <g>
-      <path
-        d="M24 12C31.4 12 36.5 17.6 36.5 24.3C36.5 31.3 30.8 36 24 36C17.2 36 11.5 31.3 11.5 24.3C11.5 17.6 16.6 12 24 12Z"
-        fill={foregroundColor}
-      />
-      <rect x="17" y="31.5" width="14" height="3.5" rx="1.75" fill={foregroundColor} />
-    </g>
-  ),
-];
-
-const CENTER_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
-  ({ accentColor }) => (
-    <path
-      d="M24 18.5L25.9 22.4L30.2 22.9L27 25.9L27.8 30.1L24 28.1L20.2 30.1L21 25.9L17.8 22.9L22.1 22.4Z"
-      fill={accentColor}
-    />
-  ),
-  ({ accentColor }) => (
-    <g>
-      <rect x="20" y="19.5" width="8" height="8" rx="2.4" fill={accentColor} />
-      <rect x="18.5" y="28.5" width="11" height="2.4" rx="1.2" fill={accentColor} />
-    </g>
-  ),
-  ({ accentColor }) => (
-    <g>
-      <circle cx="21" cy="22.5" r="2.4" fill={accentColor} />
-      <circle cx="27" cy="22.5" r="2.4" fill={accentColor} />
-      <rect x="20.5" y="27" width="7" height="2.2" rx="1.1" fill={accentColor} />
-    </g>
-  ),
-  ({ accentColor }) => (
-    <path
-      d="M24 18C28.2 18 30.7 20.6 30.7 24.2C30.7 27.9 27.8 30.6 24 30.6C20.2 30.6 17.3 27.9 17.3 24.2C17.3 20.6 19.8 18 24 18ZM24 20.4C21.5 20.4 19.9 22 19.9 24.2C19.9 26.5 21.7 28.1 24 28.1C26.3 28.1 28.1 26.5 28.1 24.2C28.1 22 26.5 20.4 24 20.4Z"
-      fill={accentColor}
-    />
-  ),
-];
-
-const TOPPER_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
-  ({ accentColor }) => (
-    <path d="M24 10L27.8 14H20.2L24 10Z" fill={accentColor} />
-  ),
-  ({ accentColor }) => (
-    <g>
-      <rect x="22.8" y="9.8" width="2.4" height="6.4" rx="1.2" fill={accentColor} />
-      <circle cx="24" cy="9.4" r="1.9" fill={accentColor} />
-    </g>
-  ),
-  ({ accentColor }) => (
-    <path
-      d="M18.5 12.5C19.8 10.7 22 9.8 24 9.8C26 9.8 28.2 10.7 29.5 12.5L27.7 14.1C26.8 12.9 25.4 12.2 24 12.2C22.6 12.2 21.2 12.9 20.3 14.1Z"
-      fill={accentColor}
-    />
-  ),
-  () => null,
-];
-
-const ORBIT_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
-  ({ accentColor }) => (
-    <circle cx="24" cy="24" r="15.5" fill="none" stroke={accentColor} strokeWidth="1.6" strokeDasharray="3.2 2.4" />
-  ),
-  ({ accentColor }) => (
-    <g fill={accentColor}>
-      <circle cx="13" cy="21" r="1.4" />
-      <circle cx="35" cy="19" r="1.5" />
-      <circle cx="33" cy="32" r="1.3" />
-    </g>
-  ),
-  ({ accentColor }) => (
-    <path d="M12 30C16 33.4 20.1 35 24 35C27.9 35 32 33.4 36 30" fill="none" stroke={accentColor} strokeWidth="1.8" strokeLinecap="round" />
-  ),
-  ({ accentColor }) => (
-    <g>
-      <rect x="10.5" y="13" width="4.4" height="4.4" rx="1.5" fill={accentColor} />
-      <rect x="33.1" y="28.4" width="4.4" height="4.4" rx="1.5" fill={accentColor} />
-    </g>
-  ),
-];
-
-const BASE_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
-  ({ foregroundColor }) => (
-    <rect x="15" y="36.2" width="18" height="2.8" rx="1.4" fill={foregroundColor} opacity="0.22" />
-  ),
-  ({ foregroundColor }) => (
-    <path d="M16.5 37.2C19.2 35.9 21.7 35.3 24 35.3C26.3 35.3 28.8 35.9 31.5 37.2" fill="none" stroke={foregroundColor} strokeWidth="2" strokeLinecap="round" opacity="0.22" />
-  ),
-  ({ accentColor }) => (
-    <rect x="18" y="36" width="12" height="2.4" rx="1.2" fill={accentColor} opacity="0.4" />
-  ),
-  () => null,
-];
+function buildSymmetricCells(hash: number): readonly (PixelTone | null)[] {
+  const cells: (PixelTone | null)[] = Array.from({ length: GRID_SIZE * GRID_SIZE }, () => null);
+  let state = hash || 0x811c9dc5;
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    const rowBias = (hash >>> (row % 16)) & 3;
+    for (let col = 0; col < MIRROR_COLUMNS; col += 1) {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      const base = (state >>> ((col % 4) * 3)) & 7;
+      const value = (base + rowBias) & 7;
+      const tone = resolveTone(value);
+      const mirroredCol = GRID_SIZE - 1 - col;
+      cells[row * GRID_SIZE + col] = tone;
+      cells[row * GRID_SIZE + mirroredCol] = tone;
+    }
+  }
+  return cells;
+}
 
 function buildDeterministicAvatarModel(
   name?: string | null,
@@ -171,24 +77,19 @@ function buildDeterministicAvatarModel(
 ): DeterministicAvatarModel {
   const seed = normalizeAvatarSeed(name, stableId);
   const hash = hashAvatarSeed(seed);
-  const variantKey = hash & 1023;
-  const [silhouetteIndex, centerIndex, topperIndex, orbitIndex, baseIndex] =
-    decomposeVariantKey(variantKey);
   const hue = hash % 360;
-  const saturation = 50 + ((hash >>> 10) % 18);
-  const backgroundLightness = 92 - ((hash >>> 18) % 6);
+  const saturation = 24 + ((hash >>> 8) % 12);
+  const backgroundLightness = 86 + ((hash >>> 16) % 7);
+  const variantKey = hash & 1023;
   return {
     seed,
     variantKey,
     backgroundColor: `hsl(${hue} ${saturation}% ${backgroundLightness}%)`,
-    foregroundColor: `hsl(${(hue + 18) % 360} ${Math.max(42, saturation - 6)}% 32%)`,
-    accentColor: `hsl(${(hue + 210) % 360} ${Math.min(84, saturation + 10)}% 52%)`,
-    borderColor: `hsl(${hue} ${Math.max(38, saturation - 10)}% ${backgroundLightness - 11}%)`,
-    silhouetteIndex,
-    centerIndex,
-    topperIndex,
-    orbitIndex,
-    baseIndex,
+    foregroundColor: `hsl(${(hue + 10) % 360} ${Math.max(22, saturation + 2)}% 32%)`,
+    accentColor: `hsl(${(hue + 165) % 360} ${Math.min(48, saturation + 12)}% 52%)`,
+    shadowColor: `hsl(${(hue + 6) % 360} ${Math.max(18, saturation - 2)}% 23%)`,
+    borderColor: `hsl(${hue} ${Math.max(16, saturation - 8)}% ${backgroundLightness - 11}%)`,
+    cells: buildSymmetricCells(hash),
   };
 }
 
@@ -214,10 +115,6 @@ export const DeterministicAvatar = React.memo(function DeterministicAvatar({
   ariaHidden = true,
 }: DeterministicAvatarProps) {
   const model = buildDeterministicAvatarModel(name, stableId);
-  const layerProps = {
-    foregroundColor: model.foregroundColor,
-    accentColor: model.accentColor,
-  };
   return (
     <span
       className={`inline-flex shrink-0 overflow-hidden rounded-full ${className}`.trim()}
@@ -230,19 +127,33 @@ export const DeterministicAvatar = React.memo(function DeterministicAvatar({
         boxShadow: `inset 0 0 0 1px ${model.borderColor}`,
       }}
     >
-      <svg
-        viewBox="0 0 48 48"
-        className="h-full w-full"
+      <span
+        className="grid h-full w-full"
         role="presentation"
-        focusable="false"
+        style={{
+          gridTemplateColumns: `repeat(${GRID_SIZE}, 1fr)`,
+          gridTemplateRows: `repeat(${GRID_SIZE}, 1fr)`,
+          imageRendering: "pixelated",
+        }}
       >
-        <rect width="48" height="48" rx="24" fill={model.backgroundColor} />
-        {ORBIT_LAYERS[model.orbitIndex]?.(layerProps) ?? null}
-        {SILHOUETTE_LAYERS[model.silhouetteIndex]?.(layerProps) ?? null}
-        {CENTER_LAYERS[model.centerIndex]?.(layerProps) ?? null}
-        {TOPPER_LAYERS[model.topperIndex]?.(layerProps) ?? null}
-        {BASE_LAYERS[model.baseIndex]?.(layerProps) ?? null}
-      </svg>
+        {model.cells.map((tone, index) => {
+          const backgroundColor =
+            tone === "foreground"
+              ? model.foregroundColor
+              : tone === "accent"
+                ? model.accentColor
+                : tone === "shadow"
+                  ? model.shadowColor
+                  : "transparent";
+          return (
+            <span
+              key={index}
+              aria-hidden="true"
+              style={{ backgroundColor }}
+            />
+          );
+        })}
+      </span>
     </span>
   );
 });

--- a/web/src/components/deterministic_avatar.tsx
+++ b/web/src/components/deterministic_avatar.tsx
@@ -10,9 +10,21 @@ type DeterministicAvatarProps = {
 
 type DeterministicAvatarModel = {
   seed: string;
+  variantKey: number;
   backgroundColor: string;
   foregroundColor: string;
-  cells: readonly boolean[];
+  accentColor: string;
+  borderColor: string;
+  silhouetteIndex: number;
+  centerIndex: number;
+  topperIndex: number;
+  orbitIndex: number;
+  baseIndex: number;
+};
+
+type LayerProps = {
+  foregroundColor: string;
+  accentColor: string;
 };
 
 function normalizeAvatarSeed(name?: string | null, stableId?: string | number | null): string {
@@ -31,25 +43,127 @@ function hashAvatarSeed(seed: string): number {
   return hash >>> 0;
 }
 
-function buildAvatarCells(hash: number): boolean[] {
-  const cells: boolean[] = [];
-  let state = hash || 0x811c9dc5;
-  for (let row = 0; row < 5; row += 1) {
-    const mirroredRow: boolean[] = [];
-    for (let col = 0; col < 3; col += 1) {
-      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
-      mirroredRow.push((state & 1) === 0);
-    }
-    cells.push(
-      mirroredRow[0] ?? false,
-      mirroredRow[1] ?? false,
-      mirroredRow[2] ?? false,
-      mirroredRow[1] ?? false,
-      mirroredRow[0] ?? false
-    );
-  }
-  return cells;
+function decomposeVariantKey(variantKey: number): [number, number, number, number, number] {
+  return [
+    variantKey & 3,
+    (variantKey >>> 2) & 3,
+    (variantKey >>> 4) & 3,
+    (variantKey >>> 6) & 3,
+    (variantKey >>> 8) & 3,
+  ];
 }
+
+const SILHOUETTE_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
+  ({ foregroundColor }) => (
+    <g>
+      <circle cx="24" cy="25" r="11.5" fill={foregroundColor} />
+      <rect x="16" y="31" width="16" height="4.5" rx="2.25" fill={foregroundColor} />
+    </g>
+  ),
+  ({ foregroundColor }) => (
+    <g>
+      <rect x="13" y="14" width="22" height="22" rx="7" fill={foregroundColor} />
+      <rect x="18" y="32" width="12" height="4" rx="2" fill={foregroundColor} />
+    </g>
+  ),
+  ({ foregroundColor }) => (
+    <g>
+      <path d="M24 11L35 18V31L24 38L13 31V18L24 11Z" fill={foregroundColor} />
+      <rect x="18" y="31" width="12" height="4" rx="2" fill={foregroundColor} />
+    </g>
+  ),
+  ({ foregroundColor }) => (
+    <g>
+      <path
+        d="M24 12C31.4 12 36.5 17.6 36.5 24.3C36.5 31.3 30.8 36 24 36C17.2 36 11.5 31.3 11.5 24.3C11.5 17.6 16.6 12 24 12Z"
+        fill={foregroundColor}
+      />
+      <rect x="17" y="31.5" width="14" height="3.5" rx="1.75" fill={foregroundColor} />
+    </g>
+  ),
+];
+
+const CENTER_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
+  ({ accentColor }) => (
+    <path
+      d="M24 18.5L25.9 22.4L30.2 22.9L27 25.9L27.8 30.1L24 28.1L20.2 30.1L21 25.9L17.8 22.9L22.1 22.4Z"
+      fill={accentColor}
+    />
+  ),
+  ({ accentColor }) => (
+    <g>
+      <rect x="20" y="19.5" width="8" height="8" rx="2.4" fill={accentColor} />
+      <rect x="18.5" y="28.5" width="11" height="2.4" rx="1.2" fill={accentColor} />
+    </g>
+  ),
+  ({ accentColor }) => (
+    <g>
+      <circle cx="21" cy="22.5" r="2.4" fill={accentColor} />
+      <circle cx="27" cy="22.5" r="2.4" fill={accentColor} />
+      <rect x="20.5" y="27" width="7" height="2.2" rx="1.1" fill={accentColor} />
+    </g>
+  ),
+  ({ accentColor }) => (
+    <path
+      d="M24 18C28.2 18 30.7 20.6 30.7 24.2C30.7 27.9 27.8 30.6 24 30.6C20.2 30.6 17.3 27.9 17.3 24.2C17.3 20.6 19.8 18 24 18ZM24 20.4C21.5 20.4 19.9 22 19.9 24.2C19.9 26.5 21.7 28.1 24 28.1C26.3 28.1 28.1 26.5 28.1 24.2C28.1 22 26.5 20.4 24 20.4Z"
+      fill={accentColor}
+    />
+  ),
+];
+
+const TOPPER_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
+  ({ accentColor }) => (
+    <path d="M24 10L27.8 14H20.2L24 10Z" fill={accentColor} />
+  ),
+  ({ accentColor }) => (
+    <g>
+      <rect x="22.8" y="9.8" width="2.4" height="6.4" rx="1.2" fill={accentColor} />
+      <circle cx="24" cy="9.4" r="1.9" fill={accentColor} />
+    </g>
+  ),
+  ({ accentColor }) => (
+    <path
+      d="M18.5 12.5C19.8 10.7 22 9.8 24 9.8C26 9.8 28.2 10.7 29.5 12.5L27.7 14.1C26.8 12.9 25.4 12.2 24 12.2C22.6 12.2 21.2 12.9 20.3 14.1Z"
+      fill={accentColor}
+    />
+  ),
+  () => null,
+];
+
+const ORBIT_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
+  ({ accentColor }) => (
+    <circle cx="24" cy="24" r="15.5" fill="none" stroke={accentColor} strokeWidth="1.6" strokeDasharray="3.2 2.4" />
+  ),
+  ({ accentColor }) => (
+    <g fill={accentColor}>
+      <circle cx="13" cy="21" r="1.4" />
+      <circle cx="35" cy="19" r="1.5" />
+      <circle cx="33" cy="32" r="1.3" />
+    </g>
+  ),
+  ({ accentColor }) => (
+    <path d="M12 30C16 33.4 20.1 35 24 35C27.9 35 32 33.4 36 30" fill="none" stroke={accentColor} strokeWidth="1.8" strokeLinecap="round" />
+  ),
+  ({ accentColor }) => (
+    <g>
+      <rect x="10.5" y="13" width="4.4" height="4.4" rx="1.5" fill={accentColor} />
+      <rect x="33.1" y="28.4" width="4.4" height="4.4" rx="1.5" fill={accentColor} />
+    </g>
+  ),
+];
+
+const BASE_LAYERS: readonly ((props: LayerProps) => React.ReactNode)[] = [
+  ({ foregroundColor }) => (
+    <rect x="15" y="36.2" width="18" height="2.8" rx="1.4" fill={foregroundColor} opacity="0.22" />
+  ),
+  ({ foregroundColor }) => (
+    <path d="M16.5 37.2C19.2 35.9 21.7 35.3 24 35.3C26.3 35.3 28.8 35.9 31.5 37.2" fill="none" stroke={foregroundColor} strokeWidth="2" strokeLinecap="round" opacity="0.22" />
+  ),
+  ({ accentColor }) => (
+    <rect x="18" y="36" width="12" height="2.4" rx="1.2" fill={accentColor} opacity="0.4" />
+  ),
+  () => null,
+];
 
 function buildDeterministicAvatarModel(
   name?: string | null,
@@ -57,15 +171,24 @@ function buildDeterministicAvatarModel(
 ): DeterministicAvatarModel {
   const seed = normalizeAvatarSeed(name, stableId);
   const hash = hashAvatarSeed(seed);
+  const variantKey = hash & 1023;
+  const [silhouetteIndex, centerIndex, topperIndex, orbitIndex, baseIndex] =
+    decomposeVariantKey(variantKey);
   const hue = hash % 360;
-  const saturation = 56 + ((hash >>> 9) % 18);
-  const backgroundLightness = 92 - ((hash >>> 17) % 8);
-  const foregroundLightness = 34 + ((hash >>> 25) % 12);
+  const saturation = 50 + ((hash >>> 10) % 18);
+  const backgroundLightness = 92 - ((hash >>> 18) % 6);
   return {
     seed,
+    variantKey,
     backgroundColor: `hsl(${hue} ${saturation}% ${backgroundLightness}%)`,
-    foregroundColor: `hsl(${hue} ${saturation + 8}% ${foregroundLightness}%)`,
-    cells: buildAvatarCells(hash),
+    foregroundColor: `hsl(${(hue + 18) % 360} ${Math.max(42, saturation - 6)}% 32%)`,
+    accentColor: `hsl(${(hue + 210) % 360} ${Math.min(84, saturation + 10)}% 52%)`,
+    borderColor: `hsl(${hue} ${Math.max(38, saturation - 10)}% ${backgroundLightness - 11}%)`,
+    silhouetteIndex,
+    centerIndex,
+    topperIndex,
+    orbitIndex,
+    baseIndex,
   };
 }
 
@@ -91,12 +214,21 @@ export const DeterministicAvatar = React.memo(function DeterministicAvatar({
   ariaHidden = true,
 }: DeterministicAvatarProps) {
   const model = buildDeterministicAvatarModel(name, stableId);
+  const layerProps = {
+    foregroundColor: model.foregroundColor,
+    accentColor: model.accentColor,
+  };
   return (
     <span
       className={`inline-flex shrink-0 overflow-hidden rounded-full ${className}`.trim()}
       data-avatar-seed={model.seed}
+      data-avatar-variant={String(model.variantKey)}
       title={title}
       aria-hidden={ariaHidden}
+      style={{
+        backgroundColor: model.backgroundColor,
+        boxShadow: `inset 0 0 0 1px ${model.borderColor}`,
+      }}
     >
       <svg
         viewBox="0 0 48 48"
@@ -105,26 +237,11 @@ export const DeterministicAvatar = React.memo(function DeterministicAvatar({
         focusable="false"
       >
         <rect width="48" height="48" rx="24" fill={model.backgroundColor} />
-        {model.cells.map((filled, index) => {
-          if (!filled) {
-            return null;
-          }
-          const row = Math.floor(index / 5);
-          const col = index % 5;
-          const x = 7 + col * 7;
-          const y = 7 + row * 7;
-          return (
-            <rect
-              key={`${row}-${col}`}
-              x={x}
-              y={y}
-              width="6"
-              height="6"
-              rx="1.5"
-              fill={model.foregroundColor}
-            />
-          );
-        })}
+        {ORBIT_LAYERS[model.orbitIndex]?.(layerProps) ?? null}
+        {SILHOUETTE_LAYERS[model.silhouetteIndex]?.(layerProps) ?? null}
+        {CENTER_LAYERS[model.centerIndex]?.(layerProps) ?? null}
+        {TOPPER_LAYERS[model.topperIndex]?.(layerProps) ?? null}
+        {BASE_LAYERS[model.baseIndex]?.(layerProps) ?? null}
       </svg>
     </span>
   );

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -73,7 +73,7 @@ describe("TeamThreadPane", () => {
       </MantineProvider>
     );
 
-    expect(html).toContain("Thread");
+    expect(html).toContain("Reply in thread");
     expect(html).toContain("# all");
     expect(html).toContain("1 reply");
     expect(html).toContain("Focused replies stay anchored to the source message.");
@@ -83,12 +83,12 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("View in channel");
     expect(html).toContain("Close thread");
     expect(html).toContain("Original");
-    expect(html).toContain("Thread replies");
+    expect(html).toContain("Replies");
     expect(html).toContain("leader");
     expect(html).toContain('data-avatar-seed="leader::leader"');
     expect(html).toContain("#42");
     expect(html).toContain("Investigate the regression in a focused thread.");
-    expect(html).toContain("Thread replies");
+    expect(html).toContain("Replies");
     expect(html).toContain("worker-agent");
     expect(html).toContain('data-avatar-seed="worker-agent::worker-agent"');
     expect(html).toContain("#43");
@@ -153,7 +153,7 @@ describe("TeamThreadPane", () => {
     );
 
     expect(html).toContain("From leader · #88");
-    expect(html).toContain("Thread replies");
+    expect(html).toContain("Replies");
     expect(html).toContain(
       "This is a long source message that should stay fully visible in the original root bubble while the compact source str..."
     );

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -85,12 +85,12 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("Original");
     expect(html).toContain("Thread replies");
     expect(html).toContain("leader");
-    expect(html).toContain(">L<");
+    expect(html).toContain('data-avatar-seed="leader::leader"');
     expect(html).toContain("#42");
     expect(html).toContain("Investigate the regression in a focused thread.");
     expect(html).toContain("Thread replies");
     expect(html).toContain("worker-agent");
-    expect(html).toContain(">W<");
+    expect(html).toContain('data-avatar-seed="worker-agent::worker-agent"');
     expect(html).toContain("#43");
     expect(html).toContain("I can take the follow-up from here.");
     expect(html).toContain("Draft follow-up");

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -129,6 +129,38 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("Reply");
   });
 
+  it("uses the root message id for unknown-author avatar seeds", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamThreadPane
+          channelLabel="# review"
+          rootMessageId={51}
+          rootAuthorLabel={null}
+          rootCreatedAt={1713480000000}
+          rootText={null}
+          replies={[
+            {
+              messageId: 52,
+              authorLabel: null,
+              createdAt: 1713480060000,
+              text: "System follow-up",
+            },
+          ]}
+          replyDraft=""
+          onReplyDraftChange={vi.fn()}
+          onSendReply={vi.fn()}
+          replyBusy={false}
+          formatTs={() => "2026/4/19 00:00:00"}
+          onViewInChannel={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain('data-avatar-seed="Unknown::51"');
+    expect(html).toContain('data-avatar-seed="Unknown::52"');
+  });
+
   it("truncates long source previews without changing the root thread content", () => {
     const longRootText =
       "This is a long source message that should stay fully visible in the original root bubble while the compact source strip only carries a short preview for context.";

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -228,7 +228,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             <div className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
               <DeterministicAvatar
                 name={rootRenderMessage?.authorLabel ?? "Unknown"}
-                stableId={rootRenderMessage?.authorLabel ?? rootMessageId}
+                stableId={
+                  rootRenderMessage?.authorLabel === "Unknown"
+                    ? rootRenderMessage.messageId
+                    : rootRenderMessage?.authorLabel ?? rootMessageId
+                }
                 className={TEAM_THREAD_MESSAGE_AVATAR_CLASS}
               />
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
@@ -276,7 +280,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   <div key={reply.messageId} className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
                     <DeterministicAvatar
                       name={reply.authorLabel}
-                      stableId={reply.authorLabel || reply.messageId}
+                      stableId={reply.authorLabel === "Unknown" ? reply.messageId : reply.authorLabel}
                       className={TEAM_THREAD_MESSAGE_AVATAR_CLASS}
                     />
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -8,6 +8,7 @@ import {
   SurfaceCard,
   ToolbarRow,
 } from "../../ui/primitives";
+import { DeterministicAvatar } from "../../components/deterministic_avatar";
 import { TeamThreadRichText } from "./team_thread_rich_text";
 import {
   CONVERSATION_MESSAGE_INLINE_ROW_CLASS,
@@ -30,7 +31,6 @@ type TeamThreadReplyItem = {
 type TeamThreadRenderMessage = {
   messageId: number;
   authorLabel: string;
-  avatarLabel: string;
   createdAtLabel: string;
   text: string;
 };
@@ -70,14 +70,6 @@ function formatThreadComposerHelperText(sendOnEnter: boolean): string {
   return sendOnEnter
     ? "Reply stays in this thread · Enter to reply"
     : "Reply stays in this thread · Enter adds a new line";
-}
-
-function resolveThreadAvatarLabel(authorLabel: string | null): string {
-  const trimmed = authorLabel?.trim();
-  if (!trimmed) {
-    return "?";
-  }
-  return trimmed.charAt(0).toUpperCase();
 }
 
 function formatThreadSourceSummary(
@@ -134,7 +126,6 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
     return {
       messageId: rootMessageId,
       authorLabel,
-      avatarLabel: resolveThreadAvatarLabel(authorLabel),
       createdAtLabel: formatTs(rootCreatedAt),
       text: rootText ?? "",
     };
@@ -146,7 +137,6 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         return {
           messageId: reply.messageId,
           authorLabel,
-          avatarLabel: resolveThreadAvatarLabel(authorLabel),
           createdAtLabel: formatTs(reply.createdAt),
           text: reply.text,
         };
@@ -236,9 +226,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         ) : (
           <div className="flex flex-col gap-3">
             <div className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
-              <div className={TEAM_THREAD_MESSAGE_AVATAR_CLASS} aria-hidden="true">
-                {rootRenderMessage?.avatarLabel ?? "?"}
-              </div>
+              <DeterministicAvatar
+                name={rootRenderMessage?.authorLabel ?? "Unknown"}
+                stableId={rootRenderMessage?.authorLabel ?? rootMessageId}
+                className={TEAM_THREAD_MESSAGE_AVATAR_CLASS}
+              />
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                 <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                   <span className="font-semibold text-notion-text">
@@ -282,9 +274,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
               ) : (
                 replyRenderMessages.map((reply) => (
                   <div key={reply.messageId} className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
-                    <div className={TEAM_THREAD_MESSAGE_AVATAR_CLASS} aria-hidden="true">
-                      {reply.avatarLabel}
-                    </div>
+                    <DeterministicAvatar
+                      name={reply.authorLabel}
+                      stableId={reply.authorLabel || reply.messageId}
+                      className={TEAM_THREAD_MESSAGE_AVATAR_CLASS}
+                    />
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                       <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
                         <span className="font-semibold text-notion-text">{reply.authorLabel}</span>

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -228,11 +228,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             <div className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
               <DeterministicAvatar
                 name={rootRenderMessage?.authorLabel ?? "Unknown"}
-                stableId={
-                  rootRenderMessage?.authorLabel === "Unknown"
-                    ? rootRenderMessage.messageId
-                    : rootRenderMessage?.authorLabel ?? rootMessageId
-                }
+                stableId={rootAuthorLabel || rootMessageId}
                 className={TEAM_THREAD_MESSAGE_AVATAR_CLASS}
               />
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -165,7 +165,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
-              Thread
+              Reply in thread
             </div>
             <Badge
               tone="outline"
@@ -262,7 +262,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             </div>
             <div className={TEAM_THREAD_SECTION_ROW_CLASS}>
               <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
-                Thread replies
+                Replies
               </div>
               <span className="text-[10px] text-notion-text-muted">{replyCountLabel}</span>
             </div>

--- a/web/src/pages/team/team_workspace_header.test.tsx
+++ b/web/src/pages/team/team_workspace_header.test.tsx
@@ -128,6 +128,7 @@ describe("TeamWorkspaceHeader", () => {
     expect(html).toContain("aria-label=\"Agent\"");
     expect(html).toContain("worker-1");
     expect(html).toContain("Own planning and keep the team aligned.");
+    expect(html).toContain('data-avatar-seed="worker-1::member-1"');
     expect(html).toContain("team=abc");
     expect(html).not.toContain("3/3 online");
   });

--- a/web/src/pages/team/team_workspace_header.tsx
+++ b/web/src/pages/team/team_workspace_header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { HoverCard, Menu, Tooltip } from "@mantine/core";
 import { NOTION_FLOATING_MENU_PROPS } from "../../ui/floating_surfaces";
+import { DeterministicAvatar } from "../../components/deterministic_avatar";
 import { ActionButton } from "../../ui/primitives";
 import { TEAM_SOFT_CHROME_SHADOW_CLASS } from "../../ui/tailwind_classes";
 import { TeamTabsBar } from "../team_tabs_bar";
@@ -191,9 +192,11 @@ export const TeamWorkspaceHeader = React.memo(function TeamWorkspaceHeader({
                       aria-label="Agent"
                       title={selectedAgentIdentityDescription}
                     >
-                      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-sky-200/80 bg-sky-50 text-sky-700">
-                        <i className="bi bi-person text-[11px]" aria-hidden="true" />
-                      </span>
+                      <DeterministicAvatar
+                        name={selectedAgentLabel}
+                        stableId={selectedAgentWorkspaceMemberId}
+                        className="h-5 w-5 border border-sky-200/80"
+                      />
                       <span className="min-w-0 flex items-center gap-1.5">
                         <span className="max-w-[11rem] truncate text-[12px] font-semibold leading-5 text-notion-text">
                           {selectedAgentLabel}
@@ -265,9 +268,11 @@ export const TeamWorkspaceHeader = React.memo(function TeamWorkspaceHeader({
               </Menu>
               <HoverCard.Dropdown className="rounded-2xl border border-black/6 bg-white/95 p-2.5 shadow-[0_12px_40px_rgba(15,23,42,0.12)] backdrop-blur-md">
                 <div className="flex min-w-0 items-start gap-2.5">
-                  <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-sky-200/80 bg-sky-50 text-sky-700">
-                    <i className="bi bi-person text-[13px]" aria-hidden="true" />
-                  </span>
+                  <DeterministicAvatar
+                    name={selectedAgentLabel}
+                    stableId={selectedAgentWorkspaceMemberId}
+                    className="h-7 w-7 border border-sky-200/80"
+                  />
                   <div className="min-w-0 flex-1">
                     <div className="flex min-w-0 items-center gap-2">
                       <span className="truncate text-[13px] font-semibold text-notion-text">

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -536,6 +536,8 @@ describe("team panels interactions", () => {
     });
 
     expect(container.querySelector('[data-team-surface="sidebar"]')).not.toBeNull();
+    expect(container.querySelector('[data-avatar-seed="Leader Agent::leader-agent"]')).not.toBeNull();
+    expect(container.querySelector('[data-avatar-seed="Worker Agent::worker-agent"]')).not.toBeNull();
     clickElement(findButtonByAriaLabel(container, "Refresh teams"));
     clickMenuTrigger(findButtonByAriaLabel(container, "Open team actions"));
     await waitForCondition(() => document.body.textContent?.includes("Create Team") ?? false);

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CloseButton, Menu, TextInput, UnstyledButton } from "@mantine/core";
+import { DeterministicAvatar } from "../components/deterministic_avatar";
 import { TeamDefinitionRecord } from "../api";
 import { NOTION_FLOATING_MENU_PROPS } from "../ui/floating_surfaces";
 import { IconButton } from "../ui/primitives";
@@ -825,13 +826,20 @@ function TeamSidebarImpl(props: TeamSidebarProps) {
                     >
                       <span className="flex w-full items-center justify-between gap-1.5">
                         <span className="min-w-0 flex items-center gap-1.5">
-                          <span
-                            className={`${TEAM_SIDEBAR_INDICATOR_DOT_CLASS} ${resolveMemberIndicatorClassName(
-                              lifecycle,
-                              workStatus
-                            )}`}
-                            aria-hidden="true"
-                          />
+                          <span className="relative inline-flex h-5 w-5 shrink-0 items-center justify-center">
+                            <DeterministicAvatar
+                              name={primaryLabel}
+                              stableId={member.member_id}
+                              className="h-5 w-5 border border-black/8 shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
+                            />
+                            <span
+                              className={`absolute -bottom-0.5 -right-0.5 ${TEAM_SIDEBAR_INDICATOR_DOT_CLASS} ${resolveMemberIndicatorClassName(
+                                lifecycle,
+                                workStatus
+                              )}`}
+                              aria-hidden="true"
+                            />
+                          </span>
                           <span className="truncate text-[11px] font-medium leading-5">
                             {primaryLabel}
                           </span>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -45,6 +45,7 @@ import {
 } from "./team/mailbox_helpers";
 import { TeamThreadRichText } from "./team/team_thread_rich_text";
 import { isMobileInputViewport } from "../components/input_dock";
+import { DeterministicAvatar } from "../components/deterministic_avatar";
 import {
   TEAM_PANEL_CARD_CLASS,
   TEAM_PANEL_TEXTAREA_CLASS,
@@ -1666,15 +1667,15 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
                         data-team-channel-item="true"
                         data-team-thread-root-active={isActiveThreadRoot ? "true" : "false"}
                       >
-                        <div
+                        <DeterministicAvatar
+                          name={authorLabel}
+                          stableId={item.fromActorId || item.sequence}
                           className={
                             isHumanAuthor
                               ? TEAM_TASK_ACTIVITY_AVATAR_HUMAN_CLASS
                               : TEAM_TASK_ACTIVITY_AVATAR_AGENT_CLASS
                           }
-                        >
-                          {isHumanAuthor ? "U" : authorLabel.charAt(0).toUpperCase()}
-                        </div>
+                        />
                         <div className={contentClassName}>
                           <div className={TEAM_TASK_ACTIVITY_HEADER_ROW_CLASS}>
                             <div className={TEAM_TASK_ACTIVITY_AUTHOR_ROW_CLASS}>


### PR DESCRIPTION
## Summary

- add deterministic fallback avatars across Team surfaces
- refine the pixel-grid variants and lighten the palette
- use per-message stable ids for `Unknown` authors in the thread pane so anonymous replies do not collapse to the same avatar
- simplify thread reply copy to `Reply in thread` and `Replies`

## Testing

- `cd web && pnpm exec vitest run src/components/deterministic_avatar.test.tsx src/pages/team/team_thread_pane.test.tsx src/pages/team/team_workspace_header.test.tsx src/pages/team_panels.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run build`
