### PR TITLE
fix(team): align thread replies with mentions

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -885,6 +885,41 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
 
     if let Err(err) = sqlx::query(
         r#"
+        CREATE INDEX IF NOT EXISTS idx_team_conversation_messages_task_route_id
+        ON team_conversation_messages(task_id, route, id);
+        "#,
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!(
+            "db init: failed to create idx_team_conversation_messages_task_route_id: {}",
+            err
+        );
+    }
+
+    if let Err(err) = sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_team_conversation_messages_task_route_thread_root_id
+        ON team_conversation_messages(
+            task_id,
+            route,
+            json_extract(payload_json, '$.thread_root_message_id'),
+            id
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!(
+            "db init: failed to create idx_team_conversation_messages_task_route_thread_root_id: {}",
+            err
+        );
+    }
+
+    if let Err(err) = sqlx::query(
+        r#"
         CREATE INDEX IF NOT EXISTS idx_team_channel_message_replicas_run_channel
         ON team_channel_message_replicas(run_id, channel_id, stored_at DESC);
         "#,
@@ -2902,6 +2937,45 @@ mod tests {
             "unexpected error: {err:?}"
         );
 
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn init_db_creates_team_conversation_task_route_indexes() {
+        let dir = unique_temp_dir("db-team-conversation-task-route-indexes");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let db_path = dir.join("agenthub.db");
+
+        let pool = init_db_at_path(&db_path)
+            .await
+            .expect("init db with team conversation indexes");
+
+        let index_names = sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND tbl_name = 'team_conversation_messages'
+              AND name IN (
+                'idx_team_conversation_messages_task_route_id',
+                'idx_team_conversation_messages_task_route_thread_root_id'
+              )
+            ORDER BY name ASC
+            "#,
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("read team conversation task route indexes");
+        assert_eq!(
+            index_names,
+            vec![
+                "idx_team_conversation_messages_task_route_id".to_string(),
+                "idx_team_conversation_messages_task_route_thread_root_id".to_string(),
+            ]
+        );
+
+        pool.close().await;
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1029,8 +1029,10 @@ async fn reply_team_thread(
     if text.is_empty() {
         return Err(ApiError::bad_request("text is required"));
     }
-    let mention_actor_ids =
-        normalize_thread_reply_mention_actor_ids(payload.mention_actor_ids, &actor_scope.member_ids);
+    let mention_actor_ids = normalize_thread_reply_mention_actor_ids(
+        payload.mention_actor_ids,
+        &actor_scope.member_ids,
+    );
     let reply = state
         .teams
         .reply_thread(
@@ -2822,11 +2824,23 @@ async fn collect_thread_participant_actor_ids(
             &candidate_message.payload,
             &actor_scope.member_ids,
         ) {
-            push_member_mention(actor_id.as_str(), &actor_scope.member_ids, &mut seen, &mut participant_ids);
+            push_member_mention(
+                actor_id.as_str(),
+                &actor_scope.member_ids,
+                &mut seen,
+                &mut participant_ids,
+            );
         }
     }
-    for actor_id in extract_task_message_mention_actor_ids(&message.payload, &actor_scope.member_ids) {
-        push_member_mention(actor_id.as_str(), &actor_scope.member_ids, &mut seen, &mut participant_ids);
+    for actor_id in
+        extract_task_message_mention_actor_ids(&message.payload, &actor_scope.member_ids)
+    {
+        push_member_mention(
+            actor_id.as_str(),
+            &actor_scope.member_ids,
+            &mut seen,
+            &mut participant_ids,
+        );
     }
     Ok(participant_ids)
 }

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -2714,9 +2714,15 @@ async fn maybe_forward_thread_reply_to_mailbox(
     let Some(mailbox_sender) = resolve_task_mailbox_sender(actor_scope) else {
         return Ok(());
     };
-    let recipient_ids =
-        collect_thread_participant_actor_ids(state, task, actor_scope, root_message_id, message)
-            .await?;
+    let recipient_ids = collect_thread_participant_actor_ids(
+        state,
+        task,
+        actor_scope,
+        root_message_id,
+        mailbox_sender.as_str(),
+        message,
+    )
+    .await?;
     if recipient_ids.is_empty() {
         return Ok(());
     }
@@ -2749,12 +2755,14 @@ async fn collect_thread_participant_actor_ids(
     task: &TeamTaskRecord,
     actor_scope: &TaskActorScope,
     root_message_id: i64,
+    mailbox_sender: &str,
     message: &TeamConversationMessageRecord,
 ) -> Result<Vec<String>, ApiError> {
     let messages =
         query_thread_participant_messages(state, task.id.as_str(), root_message_id).await?;
     let mut participant_ids = Vec::new();
     let mut seen = HashSet::new();
+    seen.insert(mailbox_sender.to_string());
     for candidate_message in messages {
         push_member_mention(
             candidate_message.from_actor_id.as_str(),
@@ -2804,14 +2812,21 @@ async fn query_thread_participant_messages(
             payload_json,
             created_at
         FROM team_conversation_messages
+        WHERE id = ?2
+        UNION ALL
+        SELECT
+            id,
+            conversation_id,
+            task_id,
+            from_actor_id,
+            to_actor_id,
+            route,
+            payload_json,
+            created_at
+        FROM team_conversation_messages
         WHERE task_id = ?1
-          AND (
-            id = ?2
-            OR (
-              route = 'team_thread_reply'
-              AND json_extract(payload_json, '$.thread_root_message_id') = ?2
-            )
-          )
+          AND route = 'team_thread_reply'
+          AND json_extract(payload_json, '$.thread_root_message_id') = ?2
         ORDER BY id ASC
         "#,
     )
@@ -2836,7 +2851,7 @@ fn parse_thread_participant_message_row(
         conversation_id: row.get("conversation_id"),
         task_id: row.get("task_id"),
         from_actor_id: row.get("from_actor_id"),
-        to_actor_id: row.try_get("to_actor_id")?,
+        to_actor_id: row.get::<Option<String>, _>("to_actor_id"),
         route: row.get("route"),
         payload,
         created_at: row.get("created_at"),

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -199,6 +199,8 @@ pub struct ListTeamTaskMessagesQuery {
 #[derive(Debug, Deserialize)]
 pub struct ReplyTeamThreadRequest {
     pub text: String,
+    #[serde(default)]
+    pub mention_actor_ids: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1019,6 +1021,7 @@ async fn reply_team_thread(
 ) -> Result<Json<TeamThreadReplyRecord>, ApiError> {
     let user = require_user(&headers, &state).await?;
     let team = load_team_for_user(&state, &team_id, &user).await?;
+    let actor_scope = parse_task_actor_scope(&team.spec, &user)?;
     if root_message_id <= 0 {
         return Err(ApiError::bad_request("root_message_id must be positive"));
     }
@@ -1026,6 +1029,8 @@ async fn reply_team_thread(
     if text.is_empty() {
         return Err(ApiError::bad_request("text is required"));
     }
+    let mention_actor_ids =
+        normalize_thread_reply_mention_actor_ids(payload.mention_actor_ids, &actor_scope.member_ids);
     let reply = state
         .teams
         .reply_thread(
@@ -1034,9 +1039,34 @@ async fn reply_team_thread(
             root_message_id,
             &canonical_user_actor_id(&user),
             text,
+            mention_actor_ids.as_slice(),
         )
         .await
         .map_err(map_reply_thread_error)?;
+    let task = state
+        .teams
+        .get_task(&reply.thread.task_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "task not found"))?;
+    if let Err(err) = maybe_forward_thread_reply_to_mailbox(
+        &state,
+        &team,
+        &task,
+        &actor_scope,
+        root_message_id,
+        &reply.message,
+    )
+    .await
+    {
+        tracing::warn!(
+            team_id = %team.id,
+            task_id = %reply.thread.task_id,
+            message_id = reply.message.message_id,
+            root_message_id,
+            "thread reply mailbox forwarding failed: {:?}",
+            err
+        );
+    }
     Ok(Json(reply))
 }
 
@@ -2693,6 +2723,141 @@ async fn maybe_forward_task_message_to_mailbox(
         }
     }
     Ok(())
+}
+
+async fn maybe_forward_thread_reply_to_mailbox(
+    state: &AppState,
+    team: &TeamDefinitionRecord,
+    task: &TeamTaskRecord,
+    actor_scope: &TaskActorScope,
+    root_message_id: i64,
+    message: &TeamConversationMessageRecord,
+) -> Result<(), ApiError> {
+    let Some(mailbox_sender) = resolve_task_mailbox_sender(actor_scope) else {
+        return Ok(());
+    };
+    let recipient_ids =
+        collect_thread_participant_actor_ids(state, task, actor_scope, root_message_id, message)
+            .await?;
+    if recipient_ids.is_empty() {
+        return Ok(());
+    }
+    let Some(run) =
+        resolve_task_message_mailbox_run(state, team, task, &message.conversation_id).await?
+    else {
+        return Ok(());
+    };
+    let mention_ids =
+        extract_task_message_mention_actor_ids(&message.payload, &actor_scope.member_ids);
+    for to_actor_id in recipient_ids {
+        let forwarded_payload = build_task_mailbox_forward_payload(
+            &message.payload,
+            message,
+            mention_ids.as_slice(),
+            "thread_participants",
+        );
+        let send_result = state
+            .teams
+            .actor_mailbox_service()
+            .actor_send(ActorSendRequest {
+                run_id: run.id.clone(),
+                from_actor_id: mailbox_sender.clone(),
+                from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+                to_actor_id: Some(to_actor_id.clone()),
+                channel_id: None,
+                to_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+                channel: Some("default".to_string()),
+                transport: Some(TeamActorMessageTransport::Local),
+                route: None,
+                payload: forwarded_payload,
+                idempotency_key: Some(format!(
+                    "thread:{}:{}:{}",
+                    message.task_id, message.message_id, to_actor_id
+                )),
+            })
+            .await
+            .map_err(map_actor_service_api_error)?;
+        if let Err(err) =
+            maybe_notify_actor_new_mailbox_message_type(state, &run.id, &send_result).await
+        {
+            tracing::warn!(
+                run_id = %run.id,
+                to_actor_id = %to_actor_id,
+                message_id = send_result.message_id,
+                "thread mailbox type hint notify failed: {}",
+                err
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn collect_thread_participant_actor_ids(
+    state: &AppState,
+    task: &TeamTaskRecord,
+    actor_scope: &TaskActorScope,
+    root_message_id: i64,
+    message: &TeamConversationMessageRecord,
+) -> Result<Vec<String>, ApiError> {
+    // Thread replies live in the parent channel conversation, so participant discovery
+    // has to reconstruct the thread slice from root metadata before we fan out mailbox work.
+    let messages = state
+        .teams
+        .list_task_conversation_messages(&task.id, TEAM_TASK_COMPILE_MESSAGE_LIMIT, None)
+        .await
+        .map_err(map_team_internal_error)?;
+    let mut participant_ids = Vec::new();
+    let mut seen = HashSet::new();
+    for candidate_message in messages {
+        if !thread_message_belongs_to_root(&candidate_message, root_message_id) {
+            continue;
+        }
+        push_member_mention(
+            candidate_message.from_actor_id.as_str(),
+            &actor_scope.member_ids,
+            &mut seen,
+            &mut participant_ids,
+        );
+        for actor_id in extract_task_message_mention_actor_ids(
+            &candidate_message.payload,
+            &actor_scope.member_ids,
+        ) {
+            push_member_mention(actor_id.as_str(), &actor_scope.member_ids, &mut seen, &mut participant_ids);
+        }
+    }
+    for actor_id in extract_task_message_mention_actor_ids(&message.payload, &actor_scope.member_ids) {
+        push_member_mention(actor_id.as_str(), &actor_scope.member_ids, &mut seen, &mut participant_ids);
+    }
+    Ok(participant_ids)
+}
+
+fn thread_message_belongs_to_root(
+    message: &TeamConversationMessageRecord,
+    root_message_id: i64,
+) -> bool {
+    if message.message_id == root_message_id {
+        return true;
+    }
+    if message.route != "team_thread_reply" {
+        return false;
+    }
+    message
+        .payload
+        .get("thread_root_message_id")
+        .and_then(Value::as_i64)
+        .is_some_and(|candidate| candidate == root_message_id)
+}
+
+fn normalize_thread_reply_mention_actor_ids(
+    mention_actor_ids: Vec<String>,
+    member_ids: &HashSet<String>,
+) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    for actor_id in mention_actor_ids {
+        push_member_mention(actor_id.as_str(), member_ids, &mut seen, &mut normalized);
+    }
+    normalized
 }
 
 async fn load_latest_active_run_for_team(

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -22,9 +22,11 @@ use axum::{
     http::HeaderMap,
     routing::{delete, get, post, put},
 };
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
+use sqlx::Row;
 use uuid::Uuid;
 
 use crate::api::authz::require_user;
@@ -2684,47 +2686,21 @@ async fn maybe_forward_task_message_to_mailbox(
     else {
         return Ok(());
     };
-    for to_actor_id in recipient_ids {
-        let forwarded_payload = build_task_mailbox_forward_payload(
-            &message.payload,
-            message,
-            mention_ids.as_slice(),
-            delivery_scope,
-        );
-        let send_result = state
-            .teams
-            .actor_mailbox_service()
-            .actor_send(ActorSendRequest {
-                run_id: run.id.clone(),
-                from_actor_id: mailbox_sender.clone(),
-                from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
-                to_actor_id: Some(to_actor_id.clone()),
-                channel_id: None,
-                to_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
-                channel: Some("default".to_string()),
-                transport: Some(TeamActorMessageTransport::Local),
-                route: None,
-                payload: forwarded_payload,
-                idempotency_key: Some(format!(
-                    "task:{}:{}:{}",
-                    message.task_id, message.message_id, to_actor_id
-                )),
-            })
-            .await
-            .map_err(map_actor_service_api_error)?;
-        if let Err(err) =
-            maybe_notify_actor_new_mailbox_message_type(state, &run.id, &send_result).await
-        {
-            tracing::warn!(
-                run_id = %run.id,
-                to_actor_id = %to_actor_id,
-                message_id = send_result.message_id,
-                "task mailbox type hint notify failed: {}",
-                err
-            );
-        }
-    }
-    Ok(())
+    let forwarded_payload = build_task_mailbox_forward_payload(
+        &message.payload,
+        message,
+        mention_ids.as_slice(),
+        delivery_scope,
+    );
+    forward_mailbox_payload_to_actor_ids(
+        state,
+        &run,
+        mailbox_sender.as_str(),
+        recipient_ids,
+        forwarded_payload,
+        format!("task:{}:{}", message.task_id, message.message_id),
+    )
+    .await
 }
 
 async fn maybe_forward_thread_reply_to_mailbox(
@@ -2751,47 +2727,21 @@ async fn maybe_forward_thread_reply_to_mailbox(
     };
     let mention_ids =
         extract_task_message_mention_actor_ids(&message.payload, &actor_scope.member_ids);
-    for to_actor_id in recipient_ids {
-        let forwarded_payload = build_task_mailbox_forward_payload(
-            &message.payload,
-            message,
-            mention_ids.as_slice(),
-            "thread_participants",
-        );
-        let send_result = state
-            .teams
-            .actor_mailbox_service()
-            .actor_send(ActorSendRequest {
-                run_id: run.id.clone(),
-                from_actor_id: mailbox_sender.clone(),
-                from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
-                to_actor_id: Some(to_actor_id.clone()),
-                channel_id: None,
-                to_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
-                channel: Some("default".to_string()),
-                transport: Some(TeamActorMessageTransport::Local),
-                route: None,
-                payload: forwarded_payload,
-                idempotency_key: Some(format!(
-                    "thread:{}:{}:{}",
-                    message.task_id, message.message_id, to_actor_id
-                )),
-            })
-            .await
-            .map_err(map_actor_service_api_error)?;
-        if let Err(err) =
-            maybe_notify_actor_new_mailbox_message_type(state, &run.id, &send_result).await
-        {
-            tracing::warn!(
-                run_id = %run.id,
-                to_actor_id = %to_actor_id,
-                message_id = send_result.message_id,
-                "thread mailbox type hint notify failed: {}",
-                err
-            );
-        }
-    }
-    Ok(())
+    let forwarded_payload = build_task_mailbox_forward_payload(
+        &message.payload,
+        message,
+        mention_ids.as_slice(),
+        "thread_participants",
+    );
+    forward_mailbox_payload_to_actor_ids(
+        state,
+        &run,
+        mailbox_sender.as_str(),
+        recipient_ids,
+        forwarded_payload,
+        format!("thread:{}:{}", message.task_id, message.message_id),
+    )
+    .await
 }
 
 async fn collect_thread_participant_actor_ids(
@@ -2801,19 +2751,11 @@ async fn collect_thread_participant_actor_ids(
     root_message_id: i64,
     message: &TeamConversationMessageRecord,
 ) -> Result<Vec<String>, ApiError> {
-    // Thread replies live in the parent channel conversation, so participant discovery
-    // has to reconstruct the thread slice from root metadata before we fan out mailbox work.
-    let messages = state
-        .teams
-        .list_task_conversation_messages(&task.id, TEAM_TASK_COMPILE_MESSAGE_LIMIT, None)
-        .await
-        .map_err(map_team_internal_error)?;
+    let messages =
+        query_thread_participant_messages(state, task.id.as_str(), root_message_id).await?;
     let mut participant_ids = Vec::new();
     let mut seen = HashSet::new();
     for candidate_message in messages {
-        if !thread_message_belongs_to_root(&candidate_message, root_message_id) {
-            continue;
-        }
         push_member_mention(
             candidate_message.from_actor_id.as_str(),
             &actor_scope.member_ids,
@@ -2845,21 +2787,60 @@ async fn collect_thread_participant_actor_ids(
     Ok(participant_ids)
 }
 
-fn thread_message_belongs_to_root(
-    message: &TeamConversationMessageRecord,
+async fn query_thread_participant_messages(
+    state: &AppState,
+    task_id: &str,
     root_message_id: i64,
-) -> bool {
-    if message.message_id == root_message_id {
-        return true;
-    }
-    if message.route != "team_thread_reply" {
-        return false;
-    }
-    message
-        .payload
-        .get("thread_root_message_id")
-        .and_then(Value::as_i64)
-        .is_some_and(|candidate| candidate == root_message_id)
+) -> Result<Vec<TeamConversationMessageRecord>, ApiError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            id,
+            conversation_id,
+            task_id,
+            from_actor_id,
+            to_actor_id,
+            route,
+            payload_json,
+            created_at
+        FROM team_conversation_messages
+        WHERE task_id = ?1
+          AND (
+            id = ?2
+            OR (
+              route = 'team_thread_reply'
+              AND json_extract(payload_json, '$.thread_root_message_id') = ?2
+            )
+          )
+        ORDER BY id ASC
+        "#,
+    )
+    .bind(task_id)
+    .bind(root_message_id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|err| map_team_internal_error(err.into()))?;
+    rows.iter()
+        .map(parse_thread_participant_message_row)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_team_internal_error)
+}
+
+fn parse_thread_participant_message_row(
+    row: &sqlx::sqlite::SqliteRow,
+) -> anyhow::Result<TeamConversationMessageRecord> {
+    let payload_json: String = row.get("payload_json");
+    let payload: Value = serde_json::from_str(&payload_json)?;
+    Ok(TeamConversationMessageRecord {
+        message_id: row.get("id"),
+        conversation_id: row.get("conversation_id"),
+        task_id: row.get("task_id"),
+        from_actor_id: row.get("from_actor_id"),
+        to_actor_id: row.try_get("to_actor_id")?,
+        route: row.get("route"),
+        payload,
+        created_at: row.get("created_at"),
+    })
 }
 
 fn normalize_thread_reply_mention_actor_ids(
@@ -2872,6 +2853,58 @@ fn normalize_thread_reply_mention_actor_ids(
         push_member_mention(actor_id.as_str(), member_ids, &mut seen, &mut normalized);
     }
     normalized
+}
+
+async fn forward_mailbox_payload_to_actor_ids(
+    state: &AppState,
+    run: &TeamRunRecord,
+    from_actor_id: &str,
+    recipient_ids: Vec<String>,
+    forwarded_payload: Value,
+    idempotency_prefix: String,
+) -> Result<(), ApiError> {
+    let actor_mailbox_service = state.teams.actor_mailbox_service();
+    let run_id = run.id.clone();
+    let sender = from_actor_id.to_string();
+    try_join_all(recipient_ids.into_iter().map(|to_actor_id| {
+        let run_id = run_id.clone();
+        let sender = sender.clone();
+        let payload = forwarded_payload.clone();
+        let actor_mailbox_service = actor_mailbox_service.clone();
+        let idempotency_key = format!("{idempotency_prefix}:{to_actor_id}");
+        async move {
+            let send_result = actor_mailbox_service
+                .actor_send(ActorSendRequest {
+                    run_id: run_id.clone(),
+                    from_actor_id: sender,
+                    from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+                    to_actor_id: Some(to_actor_id.clone()),
+                    channel_id: None,
+                    to_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+                    channel: Some("default".to_string()),
+                    transport: Some(TeamActorMessageTransport::Local),
+                    route: None,
+                    payload,
+                    idempotency_key: Some(idempotency_key),
+                })
+                .await
+                .map_err(map_actor_service_api_error)?;
+            if let Err(err) =
+                maybe_notify_actor_new_mailbox_message_type(state, &run_id, &send_result).await
+            {
+                tracing::warn!(
+                    run_id = %run_id,
+                    to_actor_id = %to_actor_id,
+                    message_id = send_result.message_id,
+                    "mailbox type hint notify failed: {}",
+                    err
+                );
+            }
+            Ok::<(), ApiError>(())
+        }
+    }))
+    .await?;
+    Ok(())
 }
 
 async fn load_latest_active_run_for_team(

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -4902,6 +4902,7 @@ async fn team_thread_reply_api_appends_reply_metadata_for_root_message() {
         Path((team.id.clone(), "all".to_string(), root_message.message_id)),
         Json(ReplyTeamThreadRequest {
             text: "Threaded follow-up".to_string(),
+            mention_actor_ids: vec![],
         }),
     )
     .await
@@ -4917,6 +4918,7 @@ async fn team_thread_reply_api_appends_reply_metadata_for_root_message() {
         json!(root_message.message_id)
     );
     assert_eq!(reply.message.payload["text"], json!("Threaded follow-up"));
+    assert_eq!(reply.message.payload["mention_actor_ids"], json!([]));
 }
 
 #[tokio::test]
@@ -5054,6 +5056,7 @@ async fn team_thread_reply_api_maps_missing_channel_and_root_to_not_found() {
         Path((team.id.clone(), "review".to_string(), 17)),
         Json(ReplyTeamThreadRequest {
             text: "Missing channel".to_string(),
+            mention_actor_ids: vec![],
         }),
     )
     .await
@@ -5070,6 +5073,7 @@ async fn team_thread_reply_api_maps_missing_channel_and_root_to_not_found() {
         Path((team.id.clone(), "all".to_string(), 99999)),
         Json(ReplyTeamThreadRequest {
             text: "Missing root".to_string(),
+            mention_actor_ids: vec![],
         }),
     )
     .await
@@ -5082,6 +5086,128 @@ async fn team_thread_reply_api_maps_missing_channel_and_root_to_not_found() {
         .await
         .expect("shared thread task still exists");
     assert_eq!(shared_task.team_id, team.id);
+}
+
+#[tokio::test]
+async fn team_thread_reply_api_notifies_existing_thread_participants() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "thread-reply-participants-team".to_string(),
+            description: Some("thread participant mailbox forwarding coverage".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[
+                    {"member_id":"planner","role":"leader"},
+                    {"member_id":"worker-1","role":"worker"},
+                    {"member_id":"worker-2","role":"worker"}
+                ]
+            }),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    let Json(shared_thread) =
+        ensure_team_shared_thread(State(state.clone()), headers.clone(), Path(team.id.clone()))
+            .await
+            .expect("ensure shared thread");
+
+    let root_message = state
+        .teams
+        .append_task_conversation_message(
+            &shared_thread.task.id,
+            "planner",
+            None,
+            "group_chat",
+            json!({
+                "type":"chat_message",
+                "text":"Track the follow-up in this thread"
+            }),
+        )
+        .await
+        .expect("append shared root message");
+
+    state
+        .teams
+        .reply_thread(
+            &team.id,
+            "all",
+            root_message.message_id,
+            "worker-1",
+            "I am already looking into it.",
+            &[],
+        )
+        .await
+        .expect("append worker thread reply");
+
+    let Json(reply) = reply_team_thread(
+        State(state.clone()),
+        headers,
+        Path((team.id.clone(), "all".to_string(), root_message.message_id)),
+        Json(ReplyTeamThreadRequest {
+            text: "Please keep this thread updated.".to_string(),
+            mention_actor_ids: vec!["worker-2".to_string()],
+        }),
+    )
+    .await
+    .expect("reply team thread");
+
+    let mailbox_run = state
+        .teams
+        .get_latest_run_for_task(&team.id, &shared_thread.task.id)
+        .await
+        .expect("load shared thread mailbox run")
+        .expect("shared thread mailbox run should exist");
+
+    let rows = sqlx::query(
+        r#"
+        SELECT from_actor_id, to_actor_id, payload_json
+        FROM team_actor_messages
+        WHERE run_id = ?1
+        ORDER BY id ASC
+        "#,
+    )
+    .bind(&mailbox_run.id)
+    .fetch_all(&state.db)
+    .await
+    .expect("load mailbox rows");
+
+    let recipients = rows
+        .iter()
+        .map(|row| row.get::<String, _>("to_actor_id"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recipients,
+        vec![
+            "planner".to_string(),
+            "worker-1".to_string(),
+            "worker-2".to_string()
+        ]
+    );
+    for row in &rows {
+        assert_eq!(row.get::<String, _>("from_actor_id"), "planner");
+        let forwarded_payload: Value =
+            serde_json::from_str(row.get::<String, _>("payload_json").as_str())
+                .expect("parse forwarded payload");
+        assert_eq!(
+            forwarded_payload["delivery_scope"],
+            Value::from("thread_participants")
+        );
+        assert_eq!(
+            forwarded_payload["task_message_id"],
+            Value::from(reply.message.message_id)
+        );
+        assert_eq!(
+            forwarded_payload["thread_root_message_id"],
+            Value::from(root_message.message_id)
+        );
+        assert_eq!(forwarded_payload["mention_actor_ids"], json!(["worker-2"]));
+    }
 }
 
 #[tokio::test]

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5181,14 +5181,7 @@ async fn team_thread_reply_api_notifies_existing_thread_participants() {
         .iter()
         .map(|row| row.get::<String, _>("to_actor_id"))
         .collect::<Vec<_>>();
-    assert_eq!(
-        recipients,
-        vec![
-            "planner".to_string(),
-            "worker-1".to_string(),
-            "worker-2".to_string()
-        ]
-    );
+    assert_eq!(recipients, vec!["worker-1".to_string(), "worker-2".to_string()]);
     for row in &rows {
         assert_eq!(row.get::<String, _>("from_actor_id"), "planner");
         let forwarded_payload: Value =

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -677,6 +677,7 @@ impl TeamInternalControl for TeamInternalControlService {
                 payload.root_message_id,
                 actor_id,
                 text,
+                &[],
             )
             .await
             .map_err(map_manager_error)?;

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -1084,6 +1084,7 @@ impl TeamManager {
         root_message_id: i64,
         from_actor_id: &str,
         text: &str,
+        mention_actor_ids: &[String],
     ) -> anyhow::Result<super::TeamThreadReplyRecord> {
         let normalized_actor_id = from_actor_id.trim();
         if normalized_actor_id.is_empty() {
@@ -1094,6 +1095,12 @@ impl TeamManager {
             anyhow::bail!("text is required");
         }
 
+        let normalized_mentions = mention_actor_ids
+            .iter()
+            .map(|actor_id| actor_id.trim())
+            .filter(|actor_id| !actor_id.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
         let thread = self
             .open_thread(team_id, channel_id, root_message_id)
             .await?;
@@ -1106,6 +1113,7 @@ impl TeamManager {
                 serde_json::json!({
                     "type": "chat_message",
                     "text": normalized_text,
+                    "mention_actor_ids": normalized_mentions,
                     "thread_root_message_id": root_message_id,
                 }),
             )

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -2226,6 +2226,7 @@ async fn open_team_thread_supports_shared_and_custom_channels() {
             review_root_message_id,
             "worker",
             "This should stay in the review thread.",
+            &[],
         )
         .await
         .expect("reply to review thread");

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -169,13 +169,16 @@ describe("api request headers", () => {
 
     await api.replyTeamThread("token-1", "team-1", "review", 42, {
       text: "Thread reply",
+      mention_actor_ids: ["worker-1"],
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("/api/teams/team-1/channels/review/threads/42/replies");
     expect(init.method).toBe("POST");
-    expect(init.body).toBe(JSON.stringify({ text: "Thread reply" }));
+    expect(init.body).toBe(
+      JSON.stringify({ text: "Thread reply", mention_actor_ids: ["worker-1"] })
+    );
     const headers = new Headers(init.headers);
     expect(headers.get("Authorization")).toBe("Bearer token-1");
     expect(headers.get("Content-Type")).toBe("application/json");

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -916,7 +916,7 @@ export const api = {
     teamId: string,
     channelId: string,
     rootMessageId: number,
-    payload: { text: string }
+    payload: { text: string; mention_actor_ids?: string[] }
   ) =>
     apiFetch<TeamThreadReplyRecord>(
       `/api/teams/${encodePathSegment(teamId)}/channels/${encodePathSegment(channelId)}/threads/${rootMessageId}/replies`,

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -95,7 +95,7 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("I can take the follow-up from here.");
     expect(html).toContain("Draft follow-up");
     expect(html).toContain("Reply in thread · # all");
-    expect(html).toContain("Reply stays in this thread · Enter to reply");
+    expect(html).toContain("@name to reply · Enter to reply");
     expect(html).toContain("Reply");
     expect(html).toContain("max-w-[360px]");
     expect(html).toContain("rounded-full");
@@ -257,7 +257,11 @@ describe("TeamThreadPane", () => {
     });
 
     expect(onSendReply).toHaveBeenCalledTimes(1);
-    expect(container.textContent).toContain("Reply stays in this thread · Enter to reply");
+    expect(onSendReply).toHaveBeenCalledWith({
+      text: "Ready to reply",
+      mentionActorIds: [],
+    });
+    expect(container.textContent).toContain("@name to reply · Enter to reply");
   });
 
   it("keeps Enter as newline on mobile-sized viewports", () => {
@@ -302,6 +306,100 @@ describe("TeamThreadPane", () => {
     });
 
     expect(onSendReply).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Reply stays in this thread · Enter adds a new line");
+    expect(container.textContent).toContain("@name to reply · Enter adds a new line");
+  });
+
+  it("lets the thread composer select teammate mentions", () => {
+    const onSendReply = vi.fn();
+    const onReplyDraftChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={88}
+            rootAuthorLabel="leader"
+            rootCreatedAt={1713480000000}
+            rootText="Discuss here."
+            replies={[]}
+            replyDraft="@wo"
+            onReplyDraftChange={onReplyDraftChange}
+            onSendReply={onSendReply}
+            replyBusy={false}
+            mentionCandidates={[
+              {
+                actorId: "worker-agent",
+                label: "Worker Agent",
+                aliases: ["worker-agent"],
+              },
+            ]}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("Select teammate mention");
+    const option = container.querySelector('[data-team-mention-option="worker-agent"]');
+    expect(option).not.toBeNull();
+    act(() => {
+      option?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+    expect(onReplyDraftChange).toHaveBeenCalledWith("@Worker Agent");
+    expect(onSendReply).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes teammate mentions before sending a thread reply", () => {
+    const onSendReply = vi.fn();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1440,
+    });
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={88}
+            rootAuthorLabel="leader"
+            rootCreatedAt={1713480000000}
+            rootText="Discuss here."
+            replies={[]}
+            replyDraft="Ping @worker-agent now"
+            onReplyDraftChange={vi.fn()}
+            onSendReply={onSendReply}
+            replyBusy={false}
+            mentionCandidates={[
+              {
+                actorId: "worker-agent",
+                label: "Worker Agent",
+                aliases: ["worker-agent"],
+              },
+            ]}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    act(() => {
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onSendReply).toHaveBeenCalledWith({
+      text: "Ping <at>worker-agent</at> now",
+      mentionActorIds: ["worker-agent"],
+    });
   });
 });

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -402,4 +402,65 @@ describe("TeamThreadPane", () => {
       mentionActorIds: ["worker-agent"],
     });
   });
+
+  it("keeps keyboard mention selection when arrow navigation updates the active option", () => {
+    const onReplyDraftChange = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={88}
+            rootAuthorLabel="leader"
+            rootCreatedAt={1713480000000}
+            rootText="Discuss here."
+            replies={[]}
+            replyDraft="@w"
+            onReplyDraftChange={onReplyDraftChange}
+            onSendReply={vi.fn()}
+            replyBusy={false}
+            mentionCandidates={[
+              {
+                actorId: "worker-agent",
+                label: "Worker Agent",
+                aliases: ["worker-agent"],
+              },
+              {
+                actorId: "writer-agent",
+                label: "Writer Agent",
+                aliases: ["writer-agent"],
+              },
+            ]}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      textarea?.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+      textarea?.setSelectionRange(2, 2);
+      textarea?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })
+      );
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keyup", { key: "ArrowDown", bubbles: true, cancelable: true })
+      );
+    });
+
+    act(() => {
+      textarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onReplyDraftChange).toHaveBeenCalledWith("@Writer Agent");
+  });
 });

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -5,11 +5,18 @@ import {
   CompactButton,
   ConversationBubble,
   EmptyState,
+  MenuOptionButton,
   SurfaceCard,
   ToolbarRow,
 } from "../../ui/primitives";
 import { DeterministicAvatar } from "../../components/deterministic_avatar";
 import { TeamThreadRichText } from "./team_thread_rich_text";
+import {
+  applyMentionAtTag,
+  canonicalizeMentionDraft,
+  type MentionCandidate,
+  resolveMentionDraftQuery,
+} from "./mailbox_helpers";
 import {
   CONVERSATION_MESSAGE_INLINE_ROW_CLASS,
   TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
@@ -44,11 +51,12 @@ type TeamThreadPaneProps = {
   replies: TeamThreadReplyItem[];
   replyDraft: string;
   onReplyDraftChange: (value: string) => void;
-  onSendReply: () => void | Promise<void>;
+  onSendReply: (payload: { text: string; mentionActorIds: string[] }) => void | Promise<void>;
   replyBusy?: boolean;
   formatTs: (ts?: number | null) => string;
   onViewInChannel: () => void;
   onClose: () => void;
+  mentionCandidates?: MentionCandidate[];
 };
 
 const TEAM_THREAD_MESSAGE_ROW_CLASS =
@@ -65,13 +73,6 @@ const TEAM_THREAD_SECTION_ROW_CLASS =
 function formatThreadReplyCount(count: number): string {
   return count === 1 ? "1 reply" : `${count} replies`;
 }
-
-function formatThreadComposerHelperText(sendOnEnter: boolean): string {
-  return sendOnEnter
-    ? "Reply stays in this thread · Enter to reply"
-    : "Reply stays in this thread · Enter adds a new line";
-}
-
 function formatThreadSourceSummary(
   rootAuthorLabel: string | null,
   rootMessageId: number | null
@@ -108,8 +109,12 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
   formatTs,
   onViewInChannel,
   onClose,
+  mentionCandidates = [],
 }: TeamThreadPaneProps) {
   const hasSelectedRoot = rootMessageId != null;
+  const replyTextareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const [activeMention, setActiveMention] = React.useState<ReturnType<typeof resolveMentionDraftQuery>>(null);
+  const [activeMentionIndex, setActiveMentionIndex] = React.useState(0);
   const [sendOnEnter, setSendOnEnter] = React.useState(() =>
     typeof window === "undefined" ? true : !isMobileInputViewport(window.innerWidth)
   );
@@ -156,6 +161,84 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
       window.removeEventListener("resize", syncViewport);
     };
   }, []);
+  const filteredMentionCandidates = React.useMemo(() => {
+    if (!activeMention) {
+      return [];
+    }
+    const keyword = activeMention.keyword.trim().toLowerCase();
+    return mentionCandidates
+      .filter((candidate) =>
+        keyword.length === 0
+          ? true
+          : [candidate.label, candidate.actorId, ...candidate.aliases].some((value) =>
+              value.toLowerCase().startsWith(keyword)
+            )
+      )
+      .slice(0, 8);
+  }, [activeMention, mentionCandidates]);
+  const mentionQueryMatches = React.useCallback(
+    (
+      left: ReturnType<typeof resolveMentionDraftQuery>,
+      right: ReturnType<typeof resolveMentionDraftQuery>
+    ) =>
+      left?.start === right?.start &&
+      left?.end === right?.end &&
+      left?.keyword === right?.keyword,
+    []
+  );
+  const updateMentionQuery = React.useCallback((draft: string, cursor: number | null) => {
+    if (cursor === null || Number.isNaN(cursor)) {
+      setActiveMention(null);
+      setActiveMentionIndex(0);
+      return;
+    }
+    const next = resolveMentionDraftQuery(draft, cursor);
+    setActiveMention((prev) => {
+      if (mentionQueryMatches(prev, next)) {
+        return prev;
+      }
+      setActiveMentionIndex(0);
+      return next;
+    });
+  }, [mentionQueryMatches]);
+  React.useEffect(() => {
+    const textarea = replyTextareaRef.current;
+    const cursor =
+      textarea && document.activeElement === textarea
+        ? textarea.selectionStart
+        : replyDraft.length;
+    updateMentionQuery(replyDraft, cursor);
+  }, [replyDraft, updateMentionQuery]);
+  const applyMentionSelection = React.useCallback(
+    (candidate: MentionCandidate) => {
+      if (!activeMention) {
+        return;
+      }
+      const applied = applyMentionAtTag(replyDraft, activeMention, candidate.label);
+      onReplyDraftChange(applied.text);
+      setActiveMention(null);
+      setActiveMentionIndex(0);
+      requestAnimationFrame(() => {
+        const textarea = replyTextareaRef.current;
+        if (!textarea) {
+          return;
+        }
+        textarea.focus();
+        textarea.setSelectionRange(applied.cursor, applied.cursor);
+      });
+    },
+    [activeMention, onReplyDraftChange, replyDraft]
+  );
+  const sendCurrentReply = React.useCallback(() => {
+    const normalizedDraft = canonicalizeMentionDraft(replyDraft, mentionCandidates);
+    if (!normalizedDraft.text.trim()) {
+      return;
+    }
+    void onSendReply({
+      text: normalizedDraft.text,
+      mentionActorIds: normalizedDraft.mentionActorIds,
+    });
+  }, [mentionCandidates, onSendReply, replyDraft]);
   return (
     <SurfaceCard
       className="flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80"
@@ -307,12 +390,58 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
             </div>
             <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
               <textarea
+                ref={replyTextareaRef}
                 className={`${TEAM_PANEL_TEXTAREA_CLASS} min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0`}
                 rows={2}
                 placeholder={`Reply in thread · ${channelLabel}`}
                 value={replyDraft}
-                onChange={(event) => onReplyDraftChange(event.currentTarget.value)}
+                onChange={(event) => {
+                  const nextDraft = event.currentTarget.value;
+                  onReplyDraftChange(nextDraft);
+                  updateMentionQuery(nextDraft, event.currentTarget.selectionStart);
+                }}
+                onClick={(event) =>
+                  updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+                }
+                onKeyUp={(event) =>
+                  updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+                }
+                onBlur={() => {
+                  setTimeout(() => {
+                    setActiveMention(null);
+                    setActiveMentionIndex(0);
+                  }, 0);
+                }}
                 onKeyDown={(event) => {
+                  if (activeMention && filteredMentionCandidates.length > 0) {
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      setActiveMentionIndex((prev) => (prev + 1) % filteredMentionCandidates.length);
+                      return;
+                    }
+                    if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      setActiveMentionIndex((prev) =>
+                        prev === 0 ? filteredMentionCandidates.length - 1 : prev - 1
+                      );
+                      return;
+                    }
+                    if ((event.key === "Enter" || event.key === "Tab") && !event.metaKey && !event.ctrlKey) {
+                      event.preventDefault();
+                      const selected =
+                        filteredMentionCandidates[activeMentionIndex] ?? filteredMentionCandidates[0];
+                      if (selected) {
+                        applyMentionSelection(selected);
+                      }
+                      return;
+                    }
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      setActiveMention(null);
+                      setActiveMentionIndex(0);
+                      return;
+                    }
+                  }
                   if (
                     event.key === "Enter" &&
                     !event.shiftKey &&
@@ -324,22 +453,49 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                     replyDraft.trim().length > 0
                   ) {
                     event.preventDefault();
-                    void onSendReply();
+                    sendCurrentReply();
                   }
                 }}
               />
               <ActionButton
                 type="button"
                 className={TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS}
-                onClick={() => void onSendReply()}
+                onClick={() => {
+                  sendCurrentReply();
+                }}
                 disabled={replyBusy || replyDraft.trim().length === 0}
               >
                 {replyBusy ? "Replying..." : "Reply"}
               </ActionButton>
             </div>
+            {activeMention && filteredMentionCandidates.length > 0 && (
+              <div className="mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm">
+                <div className="px-3 py-1 text-xs text-ui-text-muted">
+                  Select teammate mention (`@` without selection stays plain text)
+                </div>
+                <div className="max-h-44 overflow-auto py-1">
+                  {filteredMentionCandidates.map((candidate, index) => (
+                    <MenuOptionButton
+                      key={candidate.actorId}
+                      active={index === activeMentionIndex}
+                      data-team-mention-option={candidate.actorId}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        applyMentionSelection(candidate);
+                      }}
+                    >
+                      <span>{candidate.label}</span>
+                      <span className="text-[11px] text-ui-text-muted">{`@${candidate.label}`}</span>
+                    </MenuOptionButton>
+                  ))}
+                </div>
+              </div>
+            )}
             <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
               <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>
-                {formatThreadComposerHelperText(sendOnEnter)}
+                {sendOnEnter
+                  ? "@name to reply · Enter to reply"
+                  : "@name to reply · Enter adds a new line"}
               </span>
             </ToolbarRow>
           </div>

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -96,6 +96,7 @@ import {
 } from "./team/forge_helpers";
 import {
   MailboxTemplateKey,
+  type MentionCandidate,
   buildMailboxConversationKey,
   buildMailboxPayloadTemplate,
   countUnreadConversationMessages,
@@ -3132,12 +3133,12 @@ export function TeamPage(props: TeamPageProps) {
     setError,
     teamExecutionBlockedReason,
   ]);
-  const onSendThreadReply = useCallback(async () => {
+  const onSendThreadReply = useCallback(async (payload: { text: string; mentionActorIds: string[] }) => {
     if (!effectiveSelectedTeamId || !routeThreadRootMessageId) {
       setError("Open a thread first");
       return;
     }
-    const text = threadReplyDraft.trim();
+    const text = payload.text.trim();
     if (!text) {
       setError("Thread reply is required");
       return;
@@ -3150,7 +3151,7 @@ export function TeamPage(props: TeamPageProps) {
         effectiveSelectedTeamId,
         selectedChannelItem.id,
         routeThreadRootMessageId,
-        { text }
+        { text, mention_actor_ids: payload.mentionActorIds }
       );
       setThreadReplyDraft("");
       if (typeof EventSource === "undefined") {
@@ -3170,7 +3171,6 @@ export function TeamPage(props: TeamPageProps) {
     selectedConversation?.id,
     setBusy,
     setError,
-    threadReplyDraft,
   ]);
   useEffect(() => {
     setThreadReplyDraft("");
@@ -3266,6 +3266,22 @@ export function TeamPage(props: TeamPageProps) {
         : [],
     [canOpenThreadForSelectedConversation, routeThreadRootMessageId, taskMessages]
   );
+  const threadMentionCandidates = useMemo<MentionCandidate[]>(
+    () =>
+      selectedTeamMemberLiveStates.map((member) => {
+        const actorId = member.member_id.trim();
+        const label =
+          member.agent_name?.trim() ||
+          mailboxDisplayNameByActorId[actorId]?.trim() ||
+          actorId;
+        return {
+          actorId,
+          label,
+          aliases: [actorId],
+        };
+      }),
+    [mailboxDisplayNameByActorId, selectedTeamMemberLiveStates]
+  );
   const buildCurrentThreadlessPath = useCallback(() => {
     if (!effectiveSelectedTeamId) {
       return null;
@@ -3297,6 +3313,7 @@ export function TeamPage(props: TeamPageProps) {
       onReplyDraftChange={setThreadReplyDraft}
       onSendReply={onSendThreadReply}
       replyBusy={busy === "send-thread-reply"}
+      mentionCandidates={threadMentionCandidates}
       formatTs={formatTs}
       onViewInChannel={() => {
         setChannelFocusMessageId(routeThreadRootMessageId);


### PR DESCRIPTION
## Summary

- add `@mention` selection and canonicalization to the thread reply composer so it matches the channel composer
- forward thread replies with `mention_actor_ids` in the public web API payload
- notify existing thread participants when a human posts a new thread reply

## Testing

- `cd web && pnpm exec vitest run src/api.test.ts src/pages/team/team_thread_pane.test.tsx src/pages/team_page.smoke.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cargo test team_thread_reply_api -- --nocapture`
- `cargo test thread_reply -- --nocapture`
