### PR TITLE
fix(team): suppress stopped ACP startup chrome

### DIFF
--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -37,6 +37,10 @@ function normalizeStatusValue(status?: string | null): string {
   return status?.trim().toLowerCase() || "";
 }
 
+function isActiveMemberStatus(status: string): boolean {
+  return ACTIVE_MEMBER_STATUSES.has(status);
+}
+
 type UseTeamMemberAcpViewModelArgs = {
   developerMode: boolean;
   selectedMemberId: string;
@@ -267,6 +271,9 @@ export function useTeamMemberAcpViewModel({
     normalizeStatusValue(selectedMemberSnapshot?.status) ||
     normalizeStatusValue(selectedMemberSnapshot?.session_status);
   const acpRunStatus = normalizeStatusValue(acpView.runStatus?.status);
+  const hasAuthoritativeStoppedStatus =
+    (Boolean(normalizedAgentStatus) && !isAgentActiveStatus(normalizedAgentStatus)) ||
+    (Boolean(snapshotStatus) && !isActiveMemberStatus(snapshotStatus));
   const memberStatus =
     (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)
       ? normalizedAgentStatus
@@ -277,14 +284,15 @@ export function useTeamMemberAcpViewModel({
   // ACP stream state does not keep the UI in a misleading "starting" mode.
   const isStartingAcpSession = Boolean(
     selectedMemberId.trim() &&
+      !hasAuthoritativeStoppedStatus &&
       !selectedSessionId &&
-      ((snapshotStatus && isAgentActiveStatus(snapshotStatus)) ||
+      ((snapshotStatus && isActiveMemberStatus(snapshotStatus)) ||
         (!snapshotStatus &&
           normalizedAgentStatus &&
           isAgentActiveStatus(normalizedAgentStatus)))
   );
   const thinkingLabel =
-    acpView.thinkingStartTs && ACTIVE_MEMBER_STATUSES.has(snapshotStatus || acpRunStatus)
+    acpView.thinkingStartTs && isActiveMemberStatus(snapshotStatus || acpRunStatus)
     ? `thinking ${Math.max(0, Math.floor(Date.now() / 1000 - acpView.thinkingStartTs))}s`
     : null;
   const memberStatusLabel = thinkingLabel
@@ -379,7 +387,12 @@ export function useTeamMemberAcpViewModel({
     acpView.toolCalls.length,
   ]);
   const activitySummaryItems = React.useMemo<TeamMemberAcpActivityItem[]>(() => {
-    if (!selectedMemberId.trim() || !selectedSessionId || isStartingAcpSession) {
+    if (
+      !selectedMemberId.trim() ||
+      !selectedSessionId ||
+      isStartingAcpSession ||
+      hasAuthoritativeStoppedStatus
+    ) {
       return [];
     }
     const items: TeamMemberAcpActivityItem[] = [];
@@ -419,6 +432,7 @@ export function useTeamMemberAcpViewModel({
   }, [
     acpConversation.conversationSourceItems,
     acpView.toolCalls.length,
+    hasAuthoritativeStoppedStatus,
     isStartingAcpSession,
     memberEventsHasMore,
     memberEventsLoading,
@@ -429,7 +443,7 @@ export function useTeamMemberAcpViewModel({
     if (!selectedMemberId.trim()) {
       return null;
     }
-    if (normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)) {
+    if (hasAuthoritativeStoppedStatus) {
       return "Agent is stopped";
     }
     if (isStartingAcpSession) {
@@ -447,9 +461,9 @@ export function useTeamMemberAcpViewModel({
     return "Active thread";
   }, [
     acpView.hasAcp,
+    hasAuthoritativeStoppedStatus,
     hasRenderableConversationContent,
     memberEventsLoading,
-    normalizedAgentStatus,
     isStartingAcpSession,
     selectedMemberId,
     selectedSessionId,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -5843,6 +5843,58 @@ describe("team panels interactions", () => {
     expect(container.querySelector("textarea")).toBeNull();
   });
 
+  it("TeamMemberAcpPanel suppresses stale active-thread chrome when a stopped snapshot still points at an old session", async () => {
+    renderWithMantine(
+      root,
+      <TeamMemberAcpPanel
+        developerMode={true}
+        selectedMemberId="worker-agent"
+        memberTitle="Worker agent"
+        selectedMemberSnapshot={buildMemberSnapshot({
+          member_id: "worker-agent",
+          role: "worker",
+          status: "stopped",
+          session_status: "stopped",
+          latest_step: buildStep({ member_id: "worker-agent", remote_task_id: "stale-session-1" }),
+        })}
+        selectedMemberRole="worker"
+        selectedAgentStatus="stopped"
+        selectedSessionId="stale-session-1"
+        memberEvents={[
+          {
+            event_id: 31,
+            agent_id: "worker-agent",
+            session_id: "stale-session-1",
+            seq: "31",
+            ts: 1_700_000_301,
+            stream: "acp",
+            message: JSON.stringify({
+              type: "agent_message",
+              text: "Runtime session fallback works.",
+            }),
+          },
+        ]}
+        memberEventsHasMore={true}
+        memberEventsLoading={true}
+        eventsLoading={false}
+        oldestMemberEventId={31}
+        onSendInput={vi.fn()}
+        onLoadOlder={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Agent is stopped");
+    expect(container.textContent).not.toContain("Active thread");
+    expect(container.textContent).not.toContain("Starting session");
+    expect(container.textContent).not.toContain("Syncing");
+    expect(container.querySelector('[data-team-member-acp-activity-strip="true"]')).toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
   it("TeamMemberAcpPanel keeps ACP shell visible when the session has no thread events yet", () => {
     saveTeamMemberAcpRenderCache("worker-agent", "runtime-session-1", [
       {


### PR DESCRIPTION
## Summary

- suppress stale ACP startup chrome when a stopped member still points at an old session
- distinguish member lifecycle statuses like `working` from runtime-only agent statuses
- add a focused panel regression test for stopped members with stale ACP session data

## Validation

- `cd web && pnpm exec vitest run src/pages/team_panels.test.tsx`
- `cd web && npm exec tsc -- --noEmit`

