### PR TITLE
fix(actor): prefer run env for run-scoped commands

### DIFF
--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -2177,7 +2177,7 @@ mod tests {
         let prev_run = std::env::var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV).ok();
         let prev_actor = std::env::var(ACTOR_RUNTIME_ACTOR_ID_ENV).ok();
         unsafe {
-            std::env::remove_var(ACTOR_RUNTIME_TEAM_ID_ENV);
+            std::env::set_var(ACTOR_RUNTIME_TEAM_ID_ENV, "team-env-ignored-for-run-note");
             std::env::set_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, "run-note");
             std::env::set_var(ACTOR_RUNTIME_ACTOR_ID_ENV, "coordinator-note");
         }

--- a/src/actor_cli/parse.rs
+++ b/src/actor_cli/parse.rs
@@ -132,19 +132,13 @@ fn resolve_team_run_scope(
 ) -> (Option<String>, Option<String>) {
     let explicit_team_id = take_optional(team_id);
     let explicit_run_id = take_optional(run_id);
-    let resolved_team_id = explicit_team_id.clone().or_else(|| {
-        if explicit_run_id.is_some() {
-            return None;
-        }
-        normalized_env_var(ACTOR_RUNTIME_TEAM_ID_ENV)
-    });
-    let resolved_run_id = explicit_run_id.or_else(|| {
-        if explicit_team_id.is_some() || resolved_team_id.is_some() {
-            return None;
-        }
-        normalized_env_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV)
-    });
-    (resolved_team_id, resolved_run_id)
+    if explicit_team_id.is_some() || explicit_run_id.is_some() {
+        return (explicit_team_id, explicit_run_id);
+    }
+    if let Some(run_id) = normalized_env_var(ACTOR_RUNTIME_CURRENT_RUN_ID_ENV) {
+        return (None, Some(run_id));
+    }
+    (normalized_env_var(ACTOR_RUNTIME_TEAM_ID_ENV), None)
 }
 
 fn resolve_team_context_scope(


### PR DESCRIPTION
## Summary

- Prefer `AGENTHUB_ACTOR_CURRENT_RUN_ID` over `AGENTHUB_ACTOR_TEAM_ID` for run-scoped actor CLI commands when no explicit scope flag is provided.
- Keep explicit `--team-id` and `--run-id` behavior unchanged.
- Strengthen the `team-task-note` parser regression test so team env plus current-run env resolves to run scope.

## Motivation

Run-scoped commands such as `team-task-note` should follow the current actor run context. When both team and current-run env vars are present, resolving to team scope drops the intended run context and fails CI expectations.

## Related Issue

None.

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub parse_team_members_uses_env_fallback -- --nocapture`
- `cargo test -p agenthub parse_team_task_note_accepts_kind_and_run_scope -- --nocapture`
- `cargo test -p agenthub actor_cli::tests -- --nocapture`
