### PR TITLE
feat(web): add canonical node detail routing

### DIFF
--- a/docs/features/node-detail-and-connect-command.md
+++ b/docs/features/node-detail-and-connect-command.md
@@ -98,6 +98,10 @@ Detected runtimes should render as compact capability tags, including unavailabl
 
 This is more useful than hiding runtime support behind raw config text.
 
+For the first rollout slice, it is acceptable to derive these tags from attached-agent runtime
+signals plus known operator-facing runtime surfaces, as long as the UI does not overclaim that the
+values came from a direct host probe.
+
 ### 4) Connect Command
 
 This section is required.

--- a/web/src/app.route_shell.test.tsx
+++ b/web/src/app.route_shell.test.tsx
@@ -330,7 +330,7 @@ describe("App route shell wiring", () => {
     );
   });
 
-  it("renders a non-empty root workbench node when the machines lens is unsupported", async () => {
+  it("renders a non-empty root workbench node when the nodes lens is unsupported", async () => {
     globalThis.localStorage.setItem(
       "agenthub_auth",
       JSON.stringify({
@@ -340,7 +340,7 @@ describe("App route shell wiring", () => {
         role: "user",
       })
     );
-    window.history.replaceState({}, "", "/workspace?lens=nodes&node=node-east");
+    window.history.replaceState({}, "", "/workspace/nodes/node-east");
 
     act(() => {
       renderApp(root);
@@ -397,7 +397,7 @@ describe("App route shell wiring", () => {
     expect(rootWorkbenchHtml).toContain("data-workspace-lens-placeholder=\"search\"");
   });
 
-  it("omits the agent output header when the machines lens is active", async () => {
+  it("omits the agent output header when the nodes lens is active", async () => {
     globalThis.localStorage.setItem(
       "agenthub_auth",
       JSON.stringify({
@@ -407,7 +407,7 @@ describe("App route shell wiring", () => {
         role: "root",
       })
     );
-    window.history.replaceState({}, "", "/workspace?lens=nodes&node=node-east");
+    window.history.replaceState({}, "", "/workspace/nodes/node-east");
 
     act(() => {
       renderApp(root);

--- a/web/src/app.route_shell.test.tsx
+++ b/web/src/app.route_shell.test.tsx
@@ -424,4 +424,63 @@ describe("App route shell wiring", () => {
 
     expect(lastCall?.showOutputHeader).toBe(false);
   });
+
+  it("keeps the canonical nodes list route while defaulting the detail panel to the main node", async () => {
+    globalThis.localStorage.setItem(
+      "agenthub_auth",
+      JSON.stringify({
+        token: "token-root",
+        userId: "user-1",
+        username: "root",
+        role: "root",
+      })
+    );
+    listAgentNodesMock.mockResolvedValue([
+      {
+        id: "main",
+        name: "Main Node",
+        grpc_target: null,
+        tls_server_name: null,
+        default_worktree_root: null,
+        last_seen_at: null,
+        is_main: true,
+        created_at: 0,
+        updated_at: 0,
+      },
+      {
+        id: "node-east",
+        name: "Node East",
+        grpc_target: "https://node-east.internal:50051",
+        tls_server_name: "node-east.internal",
+        default_worktree_root: "~/.agenthub/worktrees/node-east",
+        last_seen_at: null,
+        is_main: false,
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    window.history.replaceState({}, "", "/workspace/nodes");
+
+    act(() => {
+      renderApp(root);
+    });
+    await flushRenderFrames(10);
+
+    expect(window.location.pathname).toBe("/workspace/nodes");
+
+    const lastCall = agentsRouteShellPropsMock.mock.calls[
+      agentsRouteShellPropsMock.mock.calls.length - 1
+    ]?.[0] as
+      | {
+          rootWorkbenchNode: React.ReactNode;
+        }
+      | undefined;
+
+    expect(lastCall?.rootWorkbenchNode).toBeTruthy();
+    const rootWorkbenchHtml = renderToStaticMarkup(
+      <MantineProvider>{lastCall?.rootWorkbenchNode}</MantineProvider>
+    );
+    expect(rootWorkbenchHtml).toContain("Main Node");
+    expect(rootWorkbenchHtml).toContain("Connected");
+  });
 });

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -20,7 +20,7 @@ import {
   resolveAppRouteKind,
   resolvePostAuthRedirectTarget,
   resolveTeamRoute,
-  isAgentsWorkbenchRoute,
+  isWorkspaceWorkbenchRoute,
   resolveWorkspaceAgentRoute,
   resolveWorkspaceLens,
   resolveWorkspaceNodeId,
@@ -126,6 +126,7 @@ export {
 export {
   isAgentsWorkbenchRoute,
   isTeamsRoute,
+  isWorkspaceWorkbenchRoute,
   resolveAppRouteKind,
   resolveWorkspaceAgentRoute,
   resolvePostAuthRedirectTarget,
@@ -188,7 +189,7 @@ export function App() {
     pathname: location.pathname,
     search: location.search,
   }));
-  const isAgentsRoute = isAgentsWorkbenchRoute(routeLocation.pathname);
+  const isAgentsRoute = isWorkspaceWorkbenchRoute(routeLocation.pathname);
   const isAdminRoute = routeLocation.pathname.startsWith("/admin");
 
   const {
@@ -430,10 +431,10 @@ export function App() {
   const selectedWorkspaceNodeId = useMemo(
     () =>
       workspaceNodeRoute?.nodeId ??
-      resolveWorkspaceNodeId(routeLocation.search) ??
-      "main",
+      resolveWorkspaceNodeId(routeLocation.search),
     [routeLocation.search, workspaceNodeRoute]
   );
+  const effectiveSelectedWorkspaceNodeId = selectedWorkspaceNodeId ?? "main";
 
   const workspaceLensItems = useMemo(
     () =>
@@ -1255,7 +1256,7 @@ export function App() {
           agents={agents}
           teams={teams}
           teamMemberAgentsById={teamMemberAgentsById}
-          selectedNodeId={selectedWorkspaceNodeId}
+          selectedNodeId={effectiveSelectedWorkspaceNodeId}
           nodeJoinBootstrap={agentNodeJoinBootstrap}
           nodeJoinBootstrapLoading={agentNodeJoinBootstrapLoading}
           nodeJoinBootstrapError={agentNodeJoinBootstrapError}

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -24,6 +24,7 @@ import {
   resolveWorkspaceAgentRoute,
   resolveWorkspaceLens,
   resolveWorkspaceNodeId,
+  resolveWorkspaceNodeRoute,
   buildWorkspacePath,
   type WorkspaceLens,
 } from "./app_route_selection";
@@ -414,14 +415,24 @@ export function App() {
     () => resolveWorkspaceAgentRoute(routeLocation.pathname),
     [routeLocation.pathname]
   );
+  const workspaceNodeRoute = useMemo(
+    () => resolveWorkspaceNodeRoute(routeLocation.pathname, routeLocation.search),
+    [routeLocation.pathname, routeLocation.search]
+  );
   const routeAgentId = workspaceAgentRoute?.mode === "agent" ? workspaceAgentRoute.agentId : null;
   const activeWorkspaceLens = useMemo(
-    () => resolveWorkspaceLens(routeLocation.search) ?? "channels",
-    [routeLocation.search]
+    () =>
+      workspaceNodeRoute
+        ? "nodes"
+        : (resolveWorkspaceLens(routeLocation.search) ?? "channels"),
+    [routeLocation.search, workspaceNodeRoute]
   );
   const selectedWorkspaceNodeId = useMemo(
-    () => resolveWorkspaceNodeId(routeLocation.search) ?? "main",
-    [routeLocation.search]
+    () =>
+      workspaceNodeRoute?.nodeId ??
+      resolveWorkspaceNodeId(routeLocation.search) ??
+      "main",
+    [routeLocation.search, workspaceNodeRoute]
   );
 
   const workspaceLensItems = useMemo(

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -7,6 +7,8 @@ import {
   buildTeamWorkspacePath,
   buildWorkspaceNodePath,
   buildWorkspacePath,
+  isAgentsWorkbenchRoute,
+  isWorkspaceWorkbenchRoute,
   isTeamMemberRouteTab,
   navigateToPath,
   resolveAppRouteKind,
@@ -211,6 +213,17 @@ describe("app route selection", () => {
       nodeId: null,
     });
     expect(resolveWorkspaceNodeRoute("/workspace/agents/agent-1", "")).toBeNull();
+  });
+
+  it("treats both agents and nodes pages as workspace workbench routes", () => {
+    expect(isWorkspaceWorkbenchRoute("/workspace")).toBe(true);
+    expect(isWorkspaceWorkbenchRoute("/workspace/agents/agent-1")).toBe(true);
+    expect(isWorkspaceWorkbenchRoute("/workspace/nodes")).toBe(true);
+    expect(isWorkspaceWorkbenchRoute("/workspace/nodes/node-east")).toBe(true);
+    expect(isWorkspaceWorkbenchRoute("/workspace/teams/team-1")).toBe(false);
+
+    expect(isAgentsWorkbenchRoute("/workspace/agents/agent-1")).toBe(true);
+    expect(isAgentsWorkbenchRoute("/workspace/nodes/node-east")).toBe(true);
   });
 
   it("does not duplicate history entries when navigating to the current path", () => {

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -17,6 +17,7 @@ import {
   resolveWorkspaceLens,
   resolveWorkspaceAgentRoute,
   resolveWorkspaceNodeId,
+  resolveWorkspaceNodeRoute,
   shouldHandleInAppLinkClick,
   shouldRedirectTeamsToLogin,
   type RouteLocationState,
@@ -121,7 +122,8 @@ describe("app route selection", () => {
     ).toBe("/workspace/teams/team-1?lens=members&task=task-9&member=worker-1&tab=thread");
     expect(resolveWorkspaceNodeId("?lens=nodes&node=node-east")).toBe("node-east");
     expect(resolveWorkspaceNodeId("?lens=nodes")).toBeNull();
-    expect(buildWorkspaceNodePath("node-east")).toBe("/workspace?lens=nodes&node=node-east");
+    expect(buildWorkspaceNodePath("node-east")).toBe("/workspace/nodes/node-east");
+    expect(buildWorkspaceNodePath()).toBe("/workspace/nodes");
     expect(resolveTeamSelectedTaskId("?task=task-9")).toBe("task-9");
     expect(resolveTeamSelectedTaskId("?task=%20task-9%20")).toBe("task-9");
     expect(resolveTeamSelectedTaskId("")).toBe("");
@@ -179,19 +181,46 @@ describe("app route selection", () => {
     expect(resolveAppRouteKind(location("/workspace/agents/agent-1"), null, null, null)).toBe(
       "workspace"
     );
+    expect(resolveAppRouteKind(location("/workspace/nodes/node-east"), null, null, null)).toBe(
+      "workspace"
+    );
     expect(resolveAppRouteKind(location("/workspace/teams/team-1"), rootAuth, "token-1", null)).toBe(
       "teams"
     );
   });
 
+  it("resolves canonical and legacy workspace node routes", () => {
+    expect(resolveWorkspaceNodeRoute("/workspace/nodes", "")).toEqual({
+      mode: "list",
+      nodeId: null,
+    });
+    expect(resolveWorkspaceNodeRoute("/workspace/nodes/node-east", "")).toEqual({
+      mode: "detail",
+      nodeId: "node-east",
+    });
+    expect(resolveWorkspaceNodeRoute("/workspace/nodes/node%2Feast", "")).toEqual({
+      mode: "detail",
+      nodeId: "node/east",
+    });
+    expect(resolveWorkspaceNodeRoute("/workspace", "?lens=nodes&node=node-east")).toEqual({
+      mode: "detail",
+      nodeId: "node-east",
+    });
+    expect(resolveWorkspaceNodeRoute("/workspace", "?lens=nodes")).toEqual({
+      mode: "list",
+      nodeId: null,
+    });
+    expect(resolveWorkspaceNodeRoute("/workspace/agents/agent-1", "")).toBeNull();
+  });
+
   it("does not duplicate history entries when navigating to the current path", () => {
-    window.history.replaceState({}, "", "/workspace?lens=nodes&node=node-east");
+    window.history.replaceState({}, "", "/workspace/nodes/node-east");
     const pushStateSpy = vi.spyOn(window.history, "pushState");
 
-    navigateToPath("/workspace?lens=nodes&node=node-east");
+    navigateToPath("/workspace/nodes/node-east");
     expect(pushStateSpy).not.toHaveBeenCalled();
 
-    navigateToPath("/workspace?lens=nodes&node=node-west");
+    navigateToPath("/workspace/nodes/node-west");
     expect(pushStateSpy).toHaveBeenCalledOnce();
   });
 

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -196,7 +196,7 @@ export function isWorkspaceRootRoute(pathname: string): boolean {
   return pathname === "/" || pathname === "/workspace" || pathname === "/workspace/";
 }
 
-export function isAgentsWorkbenchRoute(pathname: string): boolean {
+export function isWorkspaceWorkbenchRoute(pathname: string): boolean {
   return (
     isWorkspaceRootRoute(pathname) ||
     pathname.startsWith("/workspace/agents/") ||
@@ -204,6 +204,10 @@ export function isAgentsWorkbenchRoute(pathname: string): boolean {
     pathname === "/workspace/nodes/" ||
     pathname.startsWith("/workspace/nodes/")
   );
+}
+
+export function isAgentsWorkbenchRoute(pathname: string): boolean {
+  return isWorkspaceWorkbenchRoute(pathname);
 }
 
 export function resolveTeamRoute(pathname: string): TeamRouteState | null {

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -16,6 +16,16 @@ export type WorkspaceAgentRouteState =
       agentId: string;
     };
 
+export type WorkspaceNodeRouteState =
+  | {
+      mode: "list";
+      nodeId: null;
+    }
+  | {
+      mode: "detail";
+      nodeId: string;
+    };
+
 export type TeamRouteState =
   | {
       mode: "selector";
@@ -83,12 +93,11 @@ export function resolveWorkspaceNodeId(search: string): string | null {
 }
 
 export function buildWorkspaceNodePath(nodeId?: string | null): string {
-  const params = new URLSearchParams();
-  params.set("lens", "nodes");
-  if (nodeId?.trim()) {
-    params.set("node", nodeId.trim());
+  const normalizedNodeId = nodeId?.trim() ?? "";
+  if (!normalizedNodeId) {
+    return "/workspace/nodes";
   }
-  return `/workspace?${params.toString()}`;
+  return `/workspace/nodes/${encodeURIComponent(normalizedNodeId)}`;
 }
 
 export function buildTeamDetailPath(teamId?: string | null): string {
@@ -188,7 +197,13 @@ export function isWorkspaceRootRoute(pathname: string): boolean {
 }
 
 export function isAgentsWorkbenchRoute(pathname: string): boolean {
-  return isWorkspaceRootRoute(pathname) || pathname.startsWith("/workspace/agents/");
+  return (
+    isWorkspaceRootRoute(pathname) ||
+    pathname.startsWith("/workspace/agents/") ||
+    pathname === "/workspace/nodes" ||
+    pathname === "/workspace/nodes/" ||
+    pathname.startsWith("/workspace/nodes/")
+  );
 }
 
 export function resolveTeamRoute(pathname: string): TeamRouteState | null {
@@ -241,6 +256,38 @@ export function resolveWorkspaceAgentRoute(pathname: string): WorkspaceAgentRout
       agentId: rawAgentId,
     };
   }
+}
+
+export function resolveWorkspaceNodeRoute(pathname: string, search: string): WorkspaceNodeRouteState | null {
+  if (pathname === "/workspace/nodes" || pathname === "/workspace/nodes/") {
+    return { mode: "list", nodeId: null };
+  }
+  if (pathname.startsWith("/workspace/nodes/")) {
+    const suffix = pathname.slice("/workspace/nodes/".length);
+    const [rawNodeId] = suffix.split("/");
+    if (!rawNodeId) {
+      return { mode: "list", nodeId: null };
+    }
+    try {
+      return {
+        mode: "detail",
+        nodeId: decodeURIComponent(rawNodeId),
+      };
+    } catch {
+      return {
+        mode: "detail",
+        nodeId: rawNodeId,
+      };
+    }
+  }
+  const legacyNodeId = resolveWorkspaceNodeId(search);
+  const legacyLens = resolveWorkspaceLens(search);
+  if (isWorkspaceRootRoute(pathname) && legacyLens === "nodes") {
+    return legacyNodeId
+      ? { mode: "detail", nodeId: legacyNodeId }
+      : { mode: "list", nodeId: null };
+  }
+  return null;
 }
 
 export function shouldRedirectTeamsToLogin(

--- a/web/src/components/agent_node_detail_shared.test.ts
+++ b/web/src/components/agent_node_detail_shared.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentNodeRecord, AgentRecord } from "../api";
+import { deriveDetectedNodeRuntimes } from "./agent_node_detail_shared";
+
+const remoteNode: AgentNodeRecord = {
+  id: "node-east",
+  name: "Node East",
+  grpc_target: "https://node-east.internal:50051",
+  tls_server_name: "node-east.internal",
+  default_worktree_root: "~/.agenthub/worktrees/node-east",
+  last_seen_at: null,
+  is_main: false,
+  created_at: 1,
+  updated_at: 1,
+};
+
+function agent(overrides: Partial<AgentRecord>): AgentRecord {
+  return {
+    id: "agent-1",
+    name: "Worker A",
+    command: "agenthub codex",
+    args: [],
+    workdir: "/tmp/worker-a",
+    status: "running",
+    target_node_id: "node-east",
+    worktree_mode: "use_existing",
+    code_mode: false,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+describe("deriveDetectedNodeRuntimes", () => {
+  it("returns runtime tags in a stable product order", () => {
+    const runtimes = deriveDetectedNodeRuntimes(remoteNode, [
+      agent({ command: "gemini" }),
+      agent({ id: "agent-2", command: "agenthub codex" }),
+    ]);
+
+    expect(runtimes).toEqual([
+      { label: "AgentHub Runtime", available: true },
+      { label: "Codex CLI", available: true },
+      { label: "Gemini CLI", available: true },
+    ]);
+  });
+
+  it("tolerates missing commands and keeps unavailable runtime markers", () => {
+    const runtimes = deriveDetectedNodeRuntimes(remoteNode, [
+      agent({ command: undefined as unknown as string }),
+    ]);
+
+    expect(runtimes).toEqual([
+      { label: "Codex CLI (not detected)", available: false },
+      { label: "Gemini CLI (not detected)", available: false },
+    ]);
+  });
+});

--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -178,7 +178,7 @@ export function deriveDetectedNodeRuntimes(
     observed.add("AgentHub Control Plane");
   }
   for (const agent of agents) {
-    const command = agent.command.trim().toLowerCase();
+    const command = (agent.command ?? "").trim().toLowerCase();
     if (command.includes("codex") || agent.code_mode) {
       observed.add("Codex CLI");
     }
@@ -189,12 +189,19 @@ export function deriveDetectedNodeRuntimes(
       observed.add("AgentHub Runtime");
     }
   }
-  const tags: NodeDetectedRuntime[] = Array.from(observed).map((label) => ({
-    label,
-    available: true,
-  }));
-  for (const label of ["Codex CLI", "Gemini CLI"]) {
-    if (!observed.has(label)) {
+  const orderedLabels = [
+    "AgentHub Control Plane",
+    "AgentHub Runtime",
+    "Codex CLI",
+    "Gemini CLI",
+  ] as const;
+  const tags: NodeDetectedRuntime[] = [];
+  for (const label of orderedLabels) {
+    if (observed.has(label)) {
+      tags.push({ label, available: true });
+      continue;
+    }
+    if (label === "Codex CLI" || label === "Gemini CLI") {
       tags.push({
         label: `${label} (not detected)`,
         available: false,

--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -108,9 +108,15 @@ function formatWorktreeModeLabel(
 }
 
 type NodeRuntimeSummary = {
+  status: "connected" | "degraded" | "offline";
   label: string;
   tone: "subtle" | "outline";
   hint: string;
+};
+
+type NodeDetectedRuntime = {
+  label: string;
+  available: boolean;
 };
 
 const NODE_LAST_SEEN_RECENT_WINDOW_SECONDS = 10 * 60;
@@ -121,6 +127,7 @@ export function deriveNodeRuntimeSummary(
 ): NodeRuntimeSummary {
   if (node.is_main) {
     return {
+      status: "connected",
       label: "Connected",
       tone: "subtle",
       hint: "Local control plane node. This is the only node whose connectivity is directly implied by the current process.",
@@ -133,29 +140,68 @@ export function deriveNodeRuntimeSummary(
     );
     if (ageSeconds <= NODE_LAST_SEEN_RECENT_WINDOW_SECONDS) {
       return {
-        label: "Recently Seen",
+        status: "connected",
+        label: "Connected",
         tone: "subtle",
         hint: `This node most recently bootstrapped ${formatNodeTimestamp(node.last_seen_at)}.`,
       };
     }
     return {
-      label: "Seen Earlier",
+      status: "degraded",
+      label: "Degraded",
       tone: "outline",
-      hint: `The latest bootstrap credential issuance was recorded ${formatNodeTimestamp(node.last_seen_at)}.`,
+      hint: `The latest bootstrap credential issuance was recorded ${formatNodeTimestamp(node.last_seen_at)}, so the node identity is known but not recently refreshed.`,
     };
   }
   if (agents.some((agent) => isAgentActiveStatus(agent.status))) {
     return {
-      label: "Agent Activity Detected",
+      status: "degraded",
+      label: "Degraded",
       tone: "subtle",
       hint: "At least one attached agent is currently active. This is an indirect runtime signal, not a node heartbeat.",
     };
   }
   return {
-    label: "Unverified",
+    status: "offline",
+    label: "Offline",
     tone: "outline",
     hint: "AgentHub currently has registry metadata for this node, but no direct heartbeat or last-seen signal.",
   };
+}
+
+export function deriveDetectedNodeRuntimes(
+  node: AgentNodeRecord,
+  agents: AgentRecord[]
+): NodeDetectedRuntime[] {
+  const observed = new Set<string>();
+  if (node.is_main) {
+    observed.add("AgentHub Control Plane");
+  }
+  for (const agent of agents) {
+    const command = agent.command.trim().toLowerCase();
+    if (command.includes("codex") || agent.code_mode) {
+      observed.add("Codex CLI");
+    }
+    if (command.includes("gemini")) {
+      observed.add("Gemini CLI");
+    }
+    if (command.includes("agenthub")) {
+      observed.add("AgentHub Runtime");
+    }
+  }
+  const tags: NodeDetectedRuntime[] = Array.from(observed).map((label) => ({
+    label,
+    available: true,
+  }));
+  for (const label of ["Codex CLI", "Gemini CLI"]) {
+    if (!observed.has(label)) {
+      tags.push({
+        label: `${label} (not detected)`,
+        available: false,
+      });
+    }
+  }
+  return tags;
 }
 
 function escapeShellValue(value: string): string {
@@ -264,6 +310,10 @@ export function AgentNodeDetailCard({
 }: AgentNodeDetailCardProps) {
   const connectCommand = buildNodeConnectCommandSpec({ node, bootstrap: nodeJoinBootstrap });
   const runtimeSummary = deriveNodeRuntimeSummary(node, agents);
+  const detectedRuntimes = React.useMemo(
+    () => deriveDetectedNodeRuntimes(node, agents),
+    [node, agents]
+  );
   const infoItems = React.useMemo(
     () =>
       node.is_main
@@ -297,9 +347,10 @@ export function AgentNodeDetailCard({
   const [copyError, setCopyError] = React.useState<string | null>(null);
   const resetCopiedTimeoutRef = React.useRef<number | null>(null);
   const connectTone =
-    node.is_main || connectCommand?.hasBootstrapToken
+    runtimeSummary.status === "connected" && (node.is_main || connectCommand?.hasBootstrapToken)
       ? "border-ui-border/80 bg-white/72"
       : "border-amber-300 bg-amber-50/70";
+  const showConnectFirst = runtimeSummary.status !== "connected";
 
   React.useEffect(() => {
     return () => {
@@ -376,7 +427,7 @@ export function AgentNodeDetailCard({
       </div>
 
       <div className="grid gap-3 xl:grid-cols-2">
-        <div className={MACHINE_DETAIL_SECTION_CLASS}>
+        <div className={`${MACHINE_DETAIL_SECTION_CLASS} ${showConnectFirst ? "xl:order-2" : ""}`}>
           <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
             <div>
               <Text size="xs" fw={700} c="dimmed" className="uppercase tracking-[0.08em]">
@@ -398,16 +449,36 @@ export function AgentNodeDetailCard({
               />
             ))}
           </KeyValueList>
+          <div className="mt-3 rounded-lg border border-ui-border/80 bg-white/80 px-3 py-3">
+            <Text size="xs" fw={700} c="dimmed" className="uppercase tracking-[0.08em]">
+              Detected Runtimes
+            </Text>
+            <Text size="xs" c="dimmed" mt={4}>
+              Derived from current attached agents and known operator-facing runtime surfaces.
+            </Text>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {detectedRuntimes.map((runtime) => (
+                <Badge
+                  key={runtime.label}
+                  tone={runtime.available ? "subtle" : "outline"}
+                >
+                  {runtime.label}
+                </Badge>
+              ))}
+            </div>
+          </div>
         </div>
 
-        <div className={`${MACHINE_DETAIL_SECTION_CLASS} ${connectTone}`}>
+        <div
+          className={`${MACHINE_DETAIL_SECTION_CLASS} ${connectTone} ${showConnectFirst ? "xl:order-1" : ""}`}
+        >
           <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
             <div>
               <Text size="xs" fw={700} c="dimmed" className="uppercase tracking-[0.08em]">
-                Connect
+                Connect Command
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
-                Bootstrap this node from the control plane, or inspect the canonical connect
+                Bootstrap this node from the control plane, or inspect the canonical reconnect
                 contract if you need to wire it into longer-lived infra.
               </Text>
             </div>

--- a/web/src/components/agent_node_section.test.tsx
+++ b/web/src/components/agent_node_section.test.tsx
@@ -197,6 +197,7 @@ describe("AgentNodeSection", () => {
     expect(html).toContain("Machines");
     expect(html).toContain("Info");
     expect(html).toContain("Connect Command");
+    expect(html).toContain("Detected Runtimes");
     expect(html).toContain("~/.agenthub/worktrees/node-east");
     expect(html).toContain("Agents on this node (0)");
     expect(html).toContain("Node ID");
@@ -204,6 +205,7 @@ describe("AgentNodeSection", () => {
     expect(html).toContain("Default worktree root");
     expect(html).toContain("No agents on this node");
     expect(html).toContain("Save");
+    expect(html).toContain("Offline");
   });
 
   it("marks the selected node chooser button with aria-pressed", () => {
@@ -297,7 +299,10 @@ describe("AgentNodeSection", () => {
     expect(html).toContain("Remote execution routes through encrypted gRPC (node-east.internal).");
     expect(html).toContain("2 attached agents");
     expect(html).toContain("Agents on this node (2)");
-    expect(html).toContain("running");
+    expect(html).toContain("Degraded");
+    expect(html).toContain("Detected Runtimes");
+    expect(html).toContain("AgentHub Runtime");
+    expect(html).toContain("Codex CLI (not detected)");
   });
 
   it("falls back to the main node chooser and truncates long agent lists", () => {

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -93,7 +93,6 @@ describe("AgentNodesWorkbench", () => {
 
     expect(html).toContain("Node Detail");
     expect(html).toContain("Connect Command");
-    expect(html).toContain("Connect Command");
     expect(html).toContain("Connect Config");
     expect(html).toContain("Degraded");
     expect(html).toContain("indirect runtime signal");

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -92,11 +92,15 @@ describe("AgentNodesWorkbench", () => {
     });
 
     expect(html).toContain("Node Detail");
-    expect(html).toContain("Connect");
+    expect(html).toContain("Connect Command");
     expect(html).toContain("Connect Command");
     expect(html).toContain("Connect Config");
-    expect(html).toContain("Agent Activity Detected");
+    expect(html).toContain("Degraded");
     expect(html).toContain("indirect runtime signal");
+    expect(html).toContain("Detected Runtimes");
+    expect(html).toContain("AgentHub Runtime");
+    expect(html).toContain("Codex CLI (not detected)");
+    expect(html).toContain("Gemini CLI (not detected)");
     expect(html).toContain("bootstrap-token");
     expect(html).toContain("Copy");
     expect(html).toContain("node_id=node-east");
@@ -154,7 +158,7 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("&lt;bootstrap-token-from-main-control-plane&gt;");
     expect(html).toContain("needs: bootstrap token");
     expect(html).toContain("explicit token placeholder");
-    expect(html).toContain("Unverified");
+    expect(html).toContain("Offline");
   });
 
   it("prefers persisted last_seen_at over indirect agent activity hints", () => {
@@ -180,10 +184,10 @@ describe("AgentNodesWorkbench", () => {
       ],
     });
 
-    expect(html).toContain("Recently Seen");
+    expect(html).toContain("Connected");
     expect(html).toContain("Last seen");
     expect(html).toContain("lightweight node last-seen signal");
-    expect(html).not.toContain("Agent Activity Detected");
+    expect(html).not.toContain("indirect runtime signal");
   });
 
   it("uses fallback member agents when the root agents list hides team members", () => {

--- a/web/src/components/workbench_header_menu.tsx
+++ b/web/src/components/workbench_header_menu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Menu, UnstyledButton } from "@mantine/core";
+import { buildWorkspaceNodePath } from "../app_route_selection";
 import { NOTION_FLOATING_MENU_PROPS } from "../ui/floating_surfaces";
 
 type WorkbenchHeaderMenuProps = {
@@ -49,8 +50,8 @@ export const WorkbenchHeaderMenu = React.memo(function WorkbenchHeaderMenu({
           Teams
         </Menu.Item>
         {isRoot ? (
-          <Menu.Item onClick={() => onNavigate("/workspace?lens=nodes")}>
-            Machines
+          <Menu.Item onClick={() => onNavigate(buildWorkspaceNodePath())}>
+            Nodes
           </Menu.Item>
         ) : null}
         <Menu.Divider />

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -1904,7 +1904,7 @@ describe("team panels interactions", () => {
     expect(container.innerHTML).toContain("min-w-0 flex-1 break-words whitespace-normal");
     expect(container.textContent).toContain("Machine main");
     expect(container.textContent).toContain("Machine node-east");
-    expect(container.innerHTML).toContain("/workspace?lens=nodes&amp;node=node-east");
+    expect(container.innerHTML).toContain("/workspace/nodes/node-east");
 
     act(() => {
       root.render(
@@ -2010,7 +2010,7 @@ describe("team panels interactions", () => {
 
     expect(container.textContent).toContain("attached_node");
     expect(container.textContent).toContain("node-east");
-    expect(container.innerHTML).toContain("/workspace?lens=nodes&amp;node=node-east");
+    expect(container.innerHTML).toContain("/workspace/nodes/node-east");
     clickElement(findButtonByText(container, "Load Older"));
     expect(container.textContent).toContain("Selected member has no associated session yet.");
 
@@ -5338,7 +5338,7 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("worker");
     expect(container.textContent).toContain("Active thread has no events yet");
     expect(container.textContent).toContain("Details");
-    expect(container.innerHTML).toContain("/workspace?lens=nodes&amp;node=node-east");
+    expect(container.innerHTML).toContain("/workspace/nodes/node-east");
     expect(container.textContent).not.toContain("member");
     expect(container.textContent).not.toContain("session");
     expect(container.textContent).not.toContain("role=worker");

--- a/web/src/workbench_header_menu.interaction.test.tsx
+++ b/web/src/workbench_header_menu.interaction.test.tsx
@@ -74,7 +74,7 @@ describe("WorkbenchHeaderMenu interactions", () => {
       );
     });
     act(() => {
-      findButtonByText(container, "Machines").dispatchEvent(
+      findButtonByText(container, "Nodes").dispatchEvent(
         new MouseEvent("click", { bubbles: true, cancelable: true })
       );
     });
@@ -85,7 +85,7 @@ describe("WorkbenchHeaderMenu interactions", () => {
     });
 
     expect(onNavigate).toHaveBeenNthCalledWith(1, "/workspace");
-    expect(onNavigate).toHaveBeenNthCalledWith(2, "/workspace?lens=nodes");
+    expect(onNavigate).toHaveBeenNthCalledWith(2, "/workspace/nodes");
     expect(onNavigate).toHaveBeenNthCalledWith(3, "/admin");
   });
 });

--- a/web/src/workbench_header_menu.test.tsx
+++ b/web/src/workbench_header_menu.test.tsx
@@ -27,7 +27,7 @@ describe("WorkbenchHeaderMenu", () => {
     const html = renderMenu();
     expect(html).toContain("Workspace");
     expect(html).toContain("Teams");
-    expect(html).toContain("Machines");
+    expect(html).toContain("Nodes");
     expect(html).toContain("Settings");
     expect(html).toContain("Logout");
     expect(html).toContain("Workspace");
@@ -37,7 +37,7 @@ describe("WorkbenchHeaderMenu", () => {
     const html = renderMenu({ isRoot: false });
     expect(html).toContain("Workspace");
     expect(html).toContain("Teams");
-    expect(html).not.toContain("Machines");
+    expect(html).not.toContain("Nodes");
     expect(html).not.toContain("Settings");
     expect(html).toContain("Logout");
   });


### PR DESCRIPTION
## Summary

- add canonical node detail routes under `/workspace/nodes` and `/workspace/nodes/:node_id`
- keep legacy `?lens=nodes` deep links compatible while moving new navigation to canonical node paths
- refine the node detail surface with product-facing runtime states, stronger connect-command emphasis, and derived detected-runtime tags

## Testing

- `cd web && npm exec vitest -- run src/app_route_selection.test.ts src/app.route_shell.test.tsx src/workbench_header_menu.interaction.test.tsx src/components/agent_nodes_workbench.test.tsx src/components/agent_node_section.test.tsx src/pages/team_panels.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run lint`
