### PR TITLE
docs(skills): add journal and spec writing guides

### DIFF
--- a/.agents/skills/agenthub-docs-journal/SKILL.md
+++ b/.agents/skills/agenthub-docs-journal/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: agenthub-docs-journal
+description: "Use when creating, updating, compacting, or reviewing AgentHub implementation journals under docs/journal/. Applies to dated rollout notes, implementation checkpoints, CI/run evidence, and deciding what belongs in a journal vs a feature spec or TODO."
+---
+
+# AgentHub Journal Writing
+
+Use this skill when writing or reviewing `docs/journal/YYYY-MM-DD-topic.md` files in this repository.
+
+## Goal
+
+Keep journals as concise, dated implementation records:
+
+- what changed
+- why it changed
+- what was validated
+- what still remains open
+
+Journals are not canonical specs and are not historical dumping grounds for every scratch note.
+
+## Surface Rules
+
+- Journal files live under `docs/journal/`
+- Filenames must use `YYYY-MM-DD-topic.md`
+- One topic per file; append to an existing journal when the follow-up is part of the same rollout
+- Stable contracts belong in `docs/features/`, not only in a journal
+- Open follow-up work belongs in `docs/todo.md`, not buried in prose
+
+## Required Structure
+
+Keep the structure operational and predictable. A normal journal should contain:
+
+- `Summary`
+- `Background`
+- `Scope`
+- `Key Decisions`
+- `Validation`
+- `Follow-Ups`
+
+You may add a short `Files` section for implementation-heavy notes, but do not turn the journal into a file-by-file changelog unless that is the point of the record.
+
+## Writing Rules
+
+### 1. Record the post-change truth
+
+Do not leave pre-fix wording in place once the same PR already changed the code or doc.
+
+Examples:
+
+- do not say a file "still remains" if the same change already updated it
+- do not leave migration steps marked as pending when this journal already records them as done
+- do not describe the audit as complete if only one slice landed
+
+### 2. Keep effort and follow-up estimates aligned
+
+If `docs/todo.md` references a journal estimate, the journal and TODO must agree.
+
+Do not let:
+
+- `docs/todo.md` say `~12h`
+- while the linked journal says `~8h`
+
+### 3. Validation must be concrete
+
+List the focused checks that actually support the journal entry.
+
+Good examples:
+
+```bash
+cargo test -p agenthub-acp prompt_prefix_blocks_append_runtime_context_after_skills -- --nocapture
+cd web && npm exec vitest -- run src/pages/team_page.smoke.test.tsx
+gh pr checks 468 | cat
+```
+
+Bad examples:
+
+- "tested locally"
+- "CI should pass"
+- "verified"
+
+### 4. Follow-ups should describe remaining work only
+
+If a step landed in the same change, remove it from the remaining-work list or rewrite it as the narrower unresolved tail.
+
+### 5. Keep chronology factual
+
+- Use the real implementation date in the filename
+- Do not use future-dated journals
+- Do not split one tiny documentation cleanup into many micro-journals without distinct decisions
+
+## Compaction Guidance
+
+When journals start repeating the same surface:
+
+1. Extract stable conclusions into `docs/features/<topic>.md`
+2. Keep journals for rollout evidence, CI notes, and decision checkpoints
+3. Remove stale or contradictory detail from older journal prose when the newer journal supersedes it
+
+## Decision Boundary
+
+Write a journal when:
+
+- implementation behavior changed
+- a rollout checkpoint needs validation evidence
+- a PR leaves meaningful engineering follow-up context
+
+Do not create a journal for:
+
+- one-line typo-only fixes with no workflow significance
+- stable product contracts that belong directly in `docs/features/`
+
+## Before Finishing
+
+Check these:
+
+- filename uses `YYYY-MM-DD-topic.md`
+- wording matches the actual post-change state
+- validation commands are explicit
+- remaining work is really still remaining
+- any stable contract change also updated the relevant `docs/features/` file
+

--- a/.agents/skills/agenthub-docs-spec/SKILL.md
+++ b/.agents/skills/agenthub-docs-spec/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: agenthub-docs-spec
+description: "Use when creating, revising, or reviewing AgentHub canonical feature specs under docs/features/. Applies to stable runtime/UI/API contracts, scope boundaries, validation matrices, and deciding what belongs in a spec vs a journal or TODO."
+---
+
+# AgentHub Feature Spec Writing
+
+Use this skill when writing or reviewing `docs/features/*.md` files in this repository.
+
+## Goal
+
+Keep feature specs as the stable source of truth for:
+
+- product and engineering scope
+- runtime or UI contracts
+- architecture boundaries
+- validation expectations
+- known operational risks
+
+Feature specs are not date-stamped rollout notes and should not read like a changelog.
+
+## Surface Rules
+
+- Canonical specs live under `docs/features/`
+- Filenames should be topic-oriented kebab-case
+- No date prefixes in `docs/features/`
+- Chronological implementation notes belong in `docs/journal/`
+- Open verification or rollout tails belong in `docs/todo.md`
+
+## Required Structure
+
+Each active feature spec should include:
+
+- `Problem`
+- `Scope`
+- `Non-Goals`
+- `Architecture`
+- `Contracts`
+- `Validation Matrix`
+- `Operational Notes`
+- `Open Risks`
+- `Source Journals`
+
+If a section is intentionally short, keep it short, but do not silently drop it.
+
+## Writing Rules
+
+### 1. Capture stable contracts, not transient implementation trivia
+
+A spec should answer:
+
+- what behavior is intended
+- what boundary is canonical
+- what consumers may rely on
+
+Avoid low-signal content such as:
+
+- PR-by-PR change logs
+- temporary debugging notes
+- CI run chatter
+- file-by-file implementation inventory without contract value
+
+### 2. Keep scope and non-goals explicit
+
+Do not let a spec silently expand into adjacent product surfaces.
+
+Examples:
+
+- if a feature is currently single-operator only, say so
+- if multi-user or QR onboarding is out of scope, say so
+- if a runtime tag is derived rather than backend-detected, say so
+
+### 3. Contracts must describe the canonical path
+
+When there is a transition period, distinguish:
+
+- canonical path
+- compatibility path
+
+Example shape:
+
+- canonical route: `/workspace/nodes/:node_id`
+- legacy compatibility: `?lens=nodes&node=...`
+
+Do not leave both paths sounding equally primary unless that is truly intended.
+
+### 4. Validation should be product-aware
+
+The `Validation Matrix` should describe the focused checks needed to trust the spec:
+
+- focused Rust tests
+- focused web tests
+- typecheck/lint/build gates
+- browser/MCP verification when relevant
+- push/PR CI evidence when rollout closure depends on it
+
+### 5. Source journals should point back to implementation evidence
+
+Every non-trivial spec should link the journals that established or evolved it.
+
+This lets the spec stay compact while journals retain the chronology.
+
+## Compaction Guidance
+
+When multiple journals describe the same area:
+
+1. Move durable conclusions into the feature spec
+2. Leave rollout details and validation evidence in journals
+3. Point `docs/todo.md` follow-ups at the canonical spec, not at drifting scratch context
+
+## Decision Boundary
+
+Create or update a feature spec when:
+
+- product behavior changed
+- UI/UX contracts changed
+- runtime/API boundaries changed
+- a backlog item needs a stable canonical target before implementation
+
+Do not use a spec for:
+
+- one-off implementation diary notes
+- transient cleanup progress
+- unresolved brainstorming with no accepted contract
+
+## Before Finishing
+
+Check these:
+
+- filename is topic-oriented, not date-oriented
+- scope and non-goals are explicit
+- contracts describe the post-change canonical behavior
+- validation matrix is concrete
+- source journals are linked
+- any remaining rollout tail lives in `docs/todo.md`, not only in prose
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,4 +50,6 @@ AgentHub is a single-binary control plane for long-lived AI agents.
 - Stable design belongs in `docs/features/`.
 - Implementation checkpoints belong in `docs/journal/`.
 - Follow-up verification belongs in `docs/todo.md`.
+- Use `.agents/skills/agenthub-docs-spec/SKILL.md` when creating or revising canonical feature specs under `docs/features/`.
+- Use `.agents/skills/agenthub-docs-journal/SKILL.md` when creating or revising dated rollout notes under `docs/journal/`.
 - Frontend changes should use Chrome DevTools MCP for before/after validation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,13 @@ implementation-facing.
 - Feature spec standard:
   - [features/README.md](features/README.md)
 
+## Repo-Local Documentation Skills
+
+- Journal writing and review:
+  - `.agents/skills/agenthub-docs-journal/SKILL.md`
+- Canonical feature spec writing and review:
+  - `.agents/skills/agenthub-docs-spec/SKILL.md`
+
 ## Documentation Surfaces
 
 - `docs/features/`
@@ -85,6 +92,8 @@ Use this checklist for every non-trivial change:
   - Key decisions
   - Validation
   - Follow-ups
+- Prefer the repo-local journal skill for structure and compaction rules:
+  - `.agents/skills/agenthub-docs-journal/SKILL.md`
 
 ## Compaction Rules
 
@@ -95,6 +104,8 @@ Use this checklist for every non-trivial change:
   journal note.
 - When documentation-only journals stop carrying distinct decisions, merge them
   into a background journal and remove the stale micro-journals.
+- Prefer the repo-local feature spec skill when extracting stable conclusions:
+  - `.agents/skills/agenthub-docs-spec/SKILL.md`
 
 ## TODO Hygiene
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -3,6 +3,11 @@
 This directory stores stable, domain-oriented technical specifications.
 Chronological implementation records are stored in `docs/journal/`.
 
+For repo-local writing rules, also use:
+
+- `.agents/skills/agenthub-docs-spec/SKILL.md`
+- `.agents/skills/agenthub-docs-journal/SKILL.md`
+
 ## Goal
 
 Keep a small set of durable feature docs as the source of truth for:


### PR DESCRIPTION
docs(skills): add journal and spec writing guides

## Summary

- add a repo-local `agenthub-docs-journal` skill for `docs/journal/` writing and review
- add a repo-local `agenthub-docs-spec` skill for `docs/features/` writing and review
- wire both skills into `AGENTS.md`, `docs/README.md`, and `docs/features/README.md` so contributors have a clear entrypoint

## Testing

- not run (docs/skills-only change)
