### PR TITLE
docs(readme): add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,13 @@ expectations live in [docs/developer-setup.md](docs/developer-setup.md).
 ## License
 
 Apache-2.0
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=hawkingrei%2Fagenthub&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hawkingrei/agenthub&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hawkingrei/agenthub&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hawkingrei/agenthub&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
Add a Star History chart to the end of README, supporting light/dark mode.