### PR TITLE
feat(node): refine node detail object sections

### DIFF
--- a/docs/journal/2026-05-04-node-detail-name-section.md
+++ b/docs/journal/2026-05-04-node-detail-name-section.md
@@ -1,0 +1,45 @@
+# Node Detail Name Section
+
+## Summary
+
+Split `Name` out of the larger remote-node `Settings` form so node detail reads more like an
+object page and less like one merged admin panel.
+
+## Background
+
+The node detail route already had a dedicated object surface, but the editable node name still
+lived inside the broader routing/settings form alongside:
+
+- `gRPC target`
+- `TLS server name`
+- `Default worktree root`
+
+That made the canonical object field harder to scan and kept the page closer to one large settings
+editor than the intended detail-page hierarchy from the node detail spec.
+
+## Scope
+
+- add a dedicated `Name` section to node detail;
+- keep remote-node rename as a separate save path from route/worktree settings;
+- keep the existing backend update contract unchanged;
+- leave the local control-plane node name read only from this surface.
+
+## Key Decisions
+
+- remote node detail now exposes:
+  - `Name`
+  - `Settings`
+  - `Danger Zone`
+- `Save Name` only persists the canonical display name and reuses the currently persisted route /
+  worktree fields for the update payload
+- `Save Settings` only persists routing/worktree fields and reuses the currently persisted node
+  name for the update payload
+- local `Main Node` now shows a dedicated read-only `Name` section instead of skipping the field
+  entirely
+
+## Validation
+
+```bash
+cd web && npm exec vitest -- run src/components/agent_nodes_workbench.test.tsx
+cd web && npm exec tsc -- --noEmit
+```

--- a/docs/journal/2026-05-04-node-detail-runtime-labels.md
+++ b/docs/journal/2026-05-04-node-detail-runtime-labels.md
@@ -1,0 +1,60 @@
+# Node Detail Runtime Labels
+
+## Summary
+
+Improved the first node detail slice by making attached-agent runtime/provider labels explicit on
+the canonical `Agents on this node` roster.
+
+## Background
+
+The node detail route already exposed:
+
+- object header;
+- `Info`;
+- `Connect Command`;
+- attached-agent roster;
+- remote-node settings and danger zone.
+
+But the attached-agent rows still stopped at:
+
+- name;
+- status;
+- worktree summary;
+- workdir;
+
+That left one product gap versus the node detail spec: operators could see which agents were
+attached to a node, but not what runtime/provider surface each attached agent was actually using.
+
+## Scope
+
+- keep the existing node detail/backend contracts unchanged;
+- add explicit runtime/provider labels to attached-agent rows;
+- keep the implementation inference-only for now, derived from current agent runtime fields;
+- add focused regression coverage around the new labels.
+
+## Key Decisions
+
+- the node detail page now derives attached-agent runtime labels from existing agent fields instead
+  of waiting for a new backend payload:
+  - `AgentHub Runtime`
+  - `Codex CLI`
+  - `Gemini CLI`
+  - fallback `Custom Runtime`
+- labels are intentionally additive:
+  - an agent may show both `AgentHub Runtime` and `Codex CLI`
+  - unknown commands fall back to `Custom Runtime` instead of rendering nothing
+- this remains a UI inference layer only; it does not claim host-probed runtime truth
+
+## Validation
+
+```bash
+cd web && npm exec vitest -- run src/components/agent_node_detail_shared.test.ts src/components/agent_nodes_workbench.test.tsx
+cd web && npm exec tsc -- --noEmit
+```
+
+## Follow-Ups
+
+- if node/runtime discovery grows a canonical backend payload later, replace the current inference
+  labels with persisted runtime/provider identity
+- consider surfacing the same runtime/provider chips in the compact inline `Agents` node-management
+  surface if operators need parity there

--- a/web/src/components/agent_node_detail_shared.test.ts
+++ b/web/src/components/agent_node_detail_shared.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { AgentNodeRecord, AgentRecord } from "../api";
-import { deriveDetectedNodeRuntimes } from "./agent_node_detail_shared";
+import {
+  deriveDetectedNodeRuntimes,
+  resolveAgentRuntimeLabels,
+} from "./agent_node_detail_shared";
 
 const remoteNode: AgentNodeRecord = {
   id: "node-east",
@@ -55,5 +58,25 @@ describe("deriveDetectedNodeRuntimes", () => {
       { label: "Codex CLI (not detected)", available: false },
       { label: "Gemini CLI (not detected)", available: false },
     ]);
+  });
+});
+
+describe("resolveAgentRuntimeLabels", () => {
+  it("keeps stable runtime badges for agenthub and codex-backed agents", () => {
+    expect(resolveAgentRuntimeLabels(agent({ command: "agenthub codex" }))).toEqual([
+      { label: "AgentHub Runtime", tone: "outline" },
+      { label: "Codex CLI", tone: "subtle" },
+    ]);
+  });
+
+  it("falls back to a custom runtime label when no known provider is detected", () => {
+    expect(
+      resolveAgentRuntimeLabels(
+        agent({
+          command: "python worker.py",
+          code_mode: false,
+        })
+      )
+    ).toEqual([{ label: "Custom Runtime", tone: "outline" }]);
   });
 });

--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -75,6 +75,41 @@ export function describeAgentAttachment(agent: AgentRecord): string {
   return `Worktree: ${worktreeModeLabel}`;
 }
 
+type AgentRuntimeLabel = {
+  label: string;
+  tone: "subtle" | "outline";
+};
+
+export function resolveAgentRuntimeLabels(agent: AgentRecord): AgentRuntimeLabel[] {
+  const command = (agent.command ?? "").trim().toLowerCase();
+  const labels = new Map<string, AgentRuntimeLabel>();
+  if (command.includes("agenthub")) {
+    labels.set("AgentHub Runtime", {
+      label: "AgentHub Runtime",
+      tone: "outline",
+    });
+  }
+  if (command.includes("codex") || agent.code_mode) {
+    labels.set("Codex CLI", {
+      label: "Codex CLI",
+      tone: "subtle",
+    });
+  }
+  if (command.includes("gemini")) {
+    labels.set("Gemini CLI", {
+      label: "Gemini CLI",
+      tone: "subtle",
+    });
+  }
+  if (labels.size === 0) {
+    labels.set("Custom Runtime", {
+      label: "Custom Runtime",
+      tone: "outline",
+    });
+  }
+  return Array.from(labels.values());
+}
+
 function formatAgentStatusLabel(status: string): string {
   const normalized = status.trim().toLowerCase();
   switch (normalized) {
@@ -601,6 +636,14 @@ export function AgentNodeDetailCard({
                       <Badge tone="subtle" className="uppercase">
                         {formatAgentStatusLabel(agent.status)}
                       </Badge>
+                      {resolveAgentRuntimeLabels(agent).map((runtime) => (
+                        <Badge
+                          key={`${agent.id}-${runtime.label}`}
+                          tone={runtime.tone}
+                        >
+                          {runtime.label}
+                        </Badge>
+                      ))}
                     </div>
                     {describeAgentAttachment(agent) ? (
                       <Text size="xs" c="dimmed" mt={2}>

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -1,9 +1,15 @@
+// @vitest-environment jsdom
 import type { ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { MantineProvider } from "@mantine/core";
 
-import { AgentNodesWorkbench } from "./agent_nodes_workbench";
+import {
+  AgentNodesWorkbench,
+  buildNodeEditDraft,
+  buildNodeNameUpdatePayload,
+  buildNodeSettingsUpdatePayload,
+} from "./agent_nodes_workbench";
 
 const baseProps: ComponentProps<typeof AgentNodesWorkbench> = {
   nodes: [
@@ -272,5 +278,51 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("Gemini CLI");
     expect(html).toContain("Custom Worker");
     expect(html).toContain("Custom Runtime");
+  });
+
+  it("builds a name-update payload without dropping persisted routing metadata", () => {
+    expect(
+      buildNodeNameUpdatePayload(baseProps.nodes[1], {
+        ...buildNodeEditDraft(baseProps.nodes[1]),
+        name: "Node East Renamed",
+      })
+    ).toEqual({
+      name: "Node East Renamed",
+      grpc_target: "https://node-east.internal:50051",
+      tls_server_name: "node-east.internal",
+      default_worktree_root: "~/.agenthub/worktrees/node-east",
+    });
+  });
+
+  it("builds a settings-update payload without mutating the persisted node name", () => {
+    expect(
+      buildNodeSettingsUpdatePayload(baseProps.nodes[1], {
+        grpcTarget: "https://node-east.internal:60061",
+        tlsServerName: "node-east-alt.internal",
+        defaultWorktreeRoot: "/srv/agenthub/worktrees/node-east",
+      })
+    ).toEqual({
+      name: "Node East",
+      grpc_target: "https://node-east.internal:60061",
+      tls_server_name: "node-east-alt.internal",
+      default_worktree_root: "/srv/agenthub/worktrees/node-east",
+    });
+  });
+
+  it("refuses to build a name-update payload when no routing target exists", () => {
+    expect(
+      buildNodeNameUpdatePayload(
+        {
+          ...baseProps.nodes[1],
+          grpc_target: null,
+        },
+        {
+          name: "Node East Renamed",
+          grpcTarget: "",
+          tlsServerName: "",
+          defaultWorktreeRoot: "",
+        }
+      )
+    ).toBeNull();
   });
 });

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -325,6 +325,22 @@ describe("AgentNodesWorkbench", () => {
     });
   });
 
+  it("keeps unsaved routing edits out of the name-only payload", () => {
+    expect(
+      buildNodeNameUpdatePayload(baseProps.nodes[1], {
+        name: "Node East Renamed",
+        grpcTarget: "https://unsaved-change.internal:60061",
+        tlsServerName: "unsaved-change.internal",
+        defaultWorktreeRoot: "/srv/unsaved-change",
+      })
+    ).toEqual({
+      name: "Node East Renamed",
+      grpc_target: "https://node-east.internal:50051",
+      tls_server_name: "node-east.internal",
+      default_worktree_root: "~/.agenthub/worktrees/node-east",
+    });
+  });
+
   it("builds a settings-update payload without mutating the persisted node name", () => {
     expect(
       buildNodeSettingsUpdatePayload(baseProps.nodes[1], {

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import type { ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MantineProvider } from "@mantine/core";
 
 import {
@@ -10,6 +12,11 @@ import {
   buildNodeNameUpdatePayload,
   buildNodeSettingsUpdatePayload,
 } from "./agent_nodes_workbench";
+import {
+  installReactDomTestGlobals,
+  renderWithMantine,
+  required,
+} from "../test_utils/react_test_helpers";
 
 const baseProps: ComponentProps<typeof AgentNodesWorkbench> = {
   nodes: [
@@ -62,6 +69,23 @@ const renderWorkbench = (overrides?: Partial<ComponentProps<typeof AgentNodesWor
   );
 
 describe("AgentNodesWorkbench", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    installReactDomTestGlobals();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it("renders name, settings, and danger zone on remote node detail", () => {
     const html = renderWorkbench({
       agents: [
@@ -281,6 +305,13 @@ describe("AgentNodesWorkbench", () => {
   });
 
   it("builds a name-update payload without dropping persisted routing metadata", () => {
+    expect(buildNodeEditDraft(baseProps.nodes[1])).toEqual({
+      name: "Node East",
+      grpcTarget: "https://node-east.internal:50051",
+      tlsServerName: "node-east.internal",
+      defaultWorktreeRoot: "~/.agenthub/worktrees/node-east",
+    });
+
     expect(
       buildNodeNameUpdatePayload(baseProps.nodes[1], {
         ...buildNodeEditDraft(baseProps.nodes[1]),
@@ -324,5 +355,99 @@ describe("AgentNodesWorkbench", () => {
         }
       )
     ).toBeNull();
+  });
+
+  it("renders the no-team empty state when no teams use the selected node", () => {
+    const html = renderWorkbench({
+      agents: [],
+      teams: [],
+    });
+
+    expect(html).toContain("Teams Using This Node");
+    expect(html).toContain("No team attachments yet");
+    expect(html).toContain("No current team members resolve to this node");
+  });
+
+  it("routes node roster, create-agent, open-agent, and delete-node actions", () => {
+    const onSelectNode = vi.fn();
+    const onCreateAgent = vi.fn();
+    const onOpenAgent = vi.fn();
+    const onDeleteNode = vi.fn();
+
+    renderWithMantine(
+      root,
+      <AgentNodesWorkbench
+        {...baseProps}
+        agents={[
+          {
+            id: "agent-remote-1",
+            name: "Worker A",
+            command: "agenthub",
+            args: [],
+            workdir: "/tmp/worker-a",
+            status: "idle",
+            target_node_id: "node-east",
+            worktree_mode: "use_existing",
+            code_mode: false,
+            created_at: 1,
+            updated_at: 1,
+          },
+        ]}
+        onSelectNode={onSelectNode}
+        onCreateAgent={onCreateAgent}
+        onOpenAgent={onOpenAgent}
+        onDeleteNode={onDeleteNode}
+        deletingNodeIds={{ "node-east": false }}
+      />
+    );
+
+    act(() => {
+      required(
+        Array.from(container.querySelectorAll("button")).find((node) =>
+          node.textContent?.includes("Main Node")
+        ) as HTMLButtonElement | undefined,
+        "main node roster button missing"
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    act(() => {
+      required(
+        Array.from(container.querySelectorAll("button")).find((node) =>
+          node.textContent?.includes("Create Agent")
+        ) as HTMLButtonElement | undefined,
+        "create agent button missing"
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    act(() => {
+      required(
+        Array.from(container.querySelectorAll("button")).find((node) =>
+          node.textContent?.includes("Open")
+        ) as HTMLButtonElement | undefined,
+        "open agent button missing"
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onSelectNode).toHaveBeenCalledWith("main");
+    expect(onCreateAgent).toHaveBeenCalledTimes(1);
+    expect(onOpenAgent).toHaveBeenCalledWith("agent-remote-1");
+
+    renderWithMantine(
+      root,
+      <AgentNodesWorkbench
+        {...baseProps}
+        agents={[]}
+        onDeleteNode={onDeleteNode}
+      />
+    );
+
+    act(() => {
+      required(
+        Array.from(container.querySelectorAll("button")).find((node) =>
+          node.textContent?.includes("Delete Node")
+        ) as HTMLButtonElement | undefined,
+        "delete node button missing"
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onDeleteNode).toHaveBeenCalledWith("node-east");
   });
 });

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -56,7 +56,7 @@ const renderWorkbench = (overrides?: Partial<ComponentProps<typeof AgentNodesWor
   );
 
 describe("AgentNodesWorkbench", () => {
-  it("renders settings and danger zone on remote node detail", () => {
+  it("renders name, settings, and danger zone on remote node detail", () => {
     const html = renderWorkbench({
       agents: [
         {
@@ -108,6 +108,8 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("internal_grpc.bootstrap.token");
     expect(html).toContain("Runtime signal");
     expect(html).toContain("Registry evidence");
+    expect(html).toContain("Name");
+    expect(html).toContain("Save Name");
     expect(html).toContain("Settings");
     expect(html).toContain("Save Settings");
     expect(html).toContain("Teams Using This Node");
@@ -122,6 +124,7 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("1 agent · 1 team");
     expect(html).toContain("Worker A · coordinator");
     expect(html).toContain("Working");
+    expect(html).toContain("AgentHub Runtime");
     expect(html).toContain("Worktree: Existing workdir");
     expect(html).toContain('href="/workspace/teams/team-1?lens=members&amp;member=agent-remote-1&amp;tab=thread"');
     expect(
@@ -145,8 +148,11 @@ describe("AgentNodesWorkbench", () => {
 
     expect(html).toContain("Main Node");
     expect(html).toContain("Connected");
+    expect(html).toContain("Name");
     expect(html).toContain("Danger Zone");
+    expect(html).toContain("read only");
     expect(html).toContain("cannot be deleted");
+    expect(html).not.toContain("Save Name");
     expect(html).not.toContain("Save Settings");
   });
 
@@ -228,5 +234,43 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("1 team");
     expect(html).toContain("1 member");
     expect(html).toContain("tidb-fuzz-bugfix-team-worker-1 · worker");
+  });
+
+  it("shows explicit runtime/provider badges for attached agents", () => {
+    const html = renderWorkbench({
+      agents: [
+        {
+          id: "agent-gemini-1",
+          name: "Gemini Worker",
+          command: "gemini --model gemini-pro",
+          args: [],
+          workdir: "/tmp/gemini-worker",
+          status: "idle",
+          target_node_id: "node-east",
+          worktree_mode: "create_worktree",
+          code_mode: false,
+          created_at: 1,
+          updated_at: 1,
+        },
+        {
+          id: "agent-custom-1",
+          name: "Custom Worker",
+          command: "python worker.py",
+          args: [],
+          workdir: "/tmp/custom-worker",
+          status: "stopped",
+          target_node_id: "node-east",
+          worktree_mode: "reuse_worktree",
+          code_mode: false,
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+    });
+
+    expect(html).toContain("Gemini Worker");
+    expect(html).toContain("Gemini CLI");
+    expect(html).toContain("Custom Worker");
+    expect(html).toContain("Custom Runtime");
   });
 });

--- a/web/src/components/agent_nodes_workbench.tsx
+++ b/web/src/components/agent_nodes_workbench.tsx
@@ -284,6 +284,45 @@ export function AgentNodesWorkbench({
     });
   }, [availableNodes]);
 
+  const handleSaveNodeName = React.useCallback(
+    (nodeId: string, nextName: string) => {
+      const node = availableNodes.find((candidate) => candidate.id === nodeId);
+      if (!node) {
+        return;
+      }
+      onUpdateNode?.(nodeId, {
+        name: nextName.trim(),
+        grpc_target: node.grpc_target?.trim() ?? "",
+        tls_server_name: node.tls_server_name?.trim() || null,
+        default_worktree_root: node.default_worktree_root?.trim() || null,
+      });
+    },
+    [availableNodes, onUpdateNode]
+  );
+
+  const handleSaveNodeSettings = React.useCallback(
+    (
+      nodeId: string,
+      draft: {
+        grpcTarget: string;
+        tlsServerName: string;
+        defaultWorktreeRoot: string;
+      }
+    ) => {
+      const node = availableNodes.find((candidate) => candidate.id === nodeId);
+      if (!node) {
+        return;
+      }
+      onUpdateNode?.(nodeId, {
+        name: node.name.trim(),
+        grpc_target: draft.grpcTarget.trim(),
+        tls_server_name: draft.tlsServerName.trim() || null,
+        default_worktree_root: draft.defaultWorktreeRoot.trim() || null,
+      });
+    },
+    [availableNodes, onUpdateNode]
+  );
+
   if (!selectedNode) {
     return (
       <div className="flex h-full min-h-0 flex-col overflow-auto bg-white px-4 py-4 sm:px-6">
@@ -374,25 +413,106 @@ export function AgentNodesWorkbench({
               onCreateAgent={onCreateAgent}
             />
             {selectedNode.is_main ? (
-              <div className={SECTION_CARD_CLASS}>
-                <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                  Danger Zone
-                </Text>
-                <Text size="sm" c="dimmed" mt={8}>
-                  The local control-plane node cannot be deleted or re-pointed from this surface.
-                </Text>
-              </div>
-            ) : (
-              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+              <>
                 <div className={SECTION_CARD_CLASS}>
+                  <Stack gap="sm">
+                    <div>
+                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                        Name
+                      </Text>
+                      <Text size="sm" c="dimmed" mt={6}>
+                        Canonical display name for the local control-plane node.
+                      </Text>
+                    </div>
+                    <div className="rounded-xl border border-ui-border/75 bg-white/80 px-3 py-3">
+                      <Text size="sm" fw={600}>
+                        {selectedNode.name}
+                      </Text>
+                      <Text size="xs" c="dimmed" mt={6}>
+                        The local control-plane node name is currently read only from this surface.
+                      </Text>
+                    </div>
+                  </Stack>
+                </div>
+                <div className={SECTION_CARD_CLASS}>
+                  <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                    Danger Zone
+                  </Text>
+                  <Text size="sm" c="dimmed" mt={8}>
+                    The local control-plane node cannot be deleted or re-pointed from this surface.
+                  </Text>
+                </div>
+              </>
+            ) : (
+              <div className="space-y-4">
+                <div className={SECTION_CARD_CLASS}>
+                  <Stack gap="sm">
+                    <div>
+                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                        Name
+                      </Text>
+                      <Text size="sm" c="dimmed" mt={6}>
+                        Keep the node display name visible and editable as a first-class object field.
+                      </Text>
+                    </div>
+                    {(() => {
+                      const draft = editDrafts[selectedNode.id] ?? {
+                        name: selectedNode.name,
+                        grpcTarget: selectedNode.grpc_target ?? "",
+                        tlsServerName: selectedNode.tls_server_name ?? "",
+                        defaultWorktreeRoot: selectedNode.default_worktree_root ?? "",
+                      };
+                      const nameError = draft.name.trim() ? null : "Node name is required.";
+                      return (
+                        <>
+                          <TextInput
+                            label="Node name"
+                            value={draft.name}
+                            onChange={(event) =>
+                              setEditDrafts((prev) => ({
+                                ...prev,
+                                [selectedNode.id]: {
+                                  ...draft,
+                                  name: event.currentTarget.value,
+                                },
+                              }))
+                            }
+                          />
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <Text size="xs" c={nameError ? "red" : "dimmed"}>
+                              {nameError ??
+                                "This is the canonical operator-facing name shown in global node rosters and detail pages."}
+                            </Text>
+                            <Button
+                              variant="light"
+                              size="xs"
+                              loading={Boolean(updatingNodeIds[selectedNode.id])}
+                              disabled={
+                                Boolean(updatingNodeIds[selectedNode.id]) || nameError !== null
+                              }
+                              onClick={() =>
+                                handleSaveNodeName(selectedNode.id, draft.name)
+                              }
+                            >
+                              Save Name
+                            </Button>
+                          </div>
+                        </>
+                      );
+                    })()}
+                  </Stack>
+                </div>
+
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+                  <div className={SECTION_CARD_CLASS}>
                   <Stack gap="sm">
                     <div>
                       <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
                         Settings
                       </Text>
                       <Text size="sm" c="dimmed" mt={6}>
-                        Update routing and default worktree behavior for this node from the canonical
-                        detail page.
+                        Update routing and default worktree behavior for this node without mixing in
+                        the object name field.
                       </Text>
                     </div>
                     {(() => {
@@ -408,34 +528,19 @@ export function AgentNodesWorkbench({
                       });
                       return (
                         <>
-                          <div className="grid gap-3 lg:grid-cols-2">
-                            <TextInput
-                              label="Node name"
-                              value={draft.name}
-                              onChange={(event) =>
-                                setEditDrafts((prev) => ({
-                                  ...prev,
-                                  [selectedNode.id]: {
-                                    ...draft,
-                                    name: event.currentTarget.value,
-                                  },
-                                }))
-                              }
-                            />
-                            <TextInput
-                              label="gRPC target"
-                              value={draft.grpcTarget}
-                              onChange={(event) =>
-                                setEditDrafts((prev) => ({
-                                  ...prev,
-                                  [selectedNode.id]: {
-                                    ...draft,
-                                    grpcTarget: event.currentTarget.value,
-                                  },
-                                }))
-                              }
-                            />
-                          </div>
+                          <TextInput
+                            label="gRPC target"
+                            value={draft.grpcTarget}
+                            onChange={(event) =>
+                              setEditDrafts((prev) => ({
+                                ...prev,
+                                [selectedNode.id]: {
+                                  ...draft,
+                                  grpcTarget: event.currentTarget.value,
+                                },
+                              }))
+                            }
+                          />
                           <div className="grid gap-3 lg:grid-cols-2">
                             <TextInput
                               label="TLS server name"
@@ -478,11 +583,10 @@ export function AgentNodesWorkbench({
                                 Boolean(updatingNodeIds[selectedNode.id]) || updateError !== null
                               }
                               onClick={() =>
-                                onUpdateNode?.(selectedNode.id, {
-                                  name: draft.name.trim(),
-                                  grpc_target: draft.grpcTarget.trim(),
-                                  tls_server_name: draft.tlsServerName.trim() || null,
-                                  default_worktree_root: draft.defaultWorktreeRoot.trim() || null,
+                                handleSaveNodeSettings(selectedNode.id, {
+                                  grpcTarget: draft.grpcTarget,
+                                  tlsServerName: draft.tlsServerName,
+                                  defaultWorktreeRoot: draft.defaultWorktreeRoot,
                                 })
                               }
                             >
@@ -524,6 +628,7 @@ export function AgentNodesWorkbench({
                     </Button>
                   </Stack>
                 </div>
+              </div>
               </div>
             )}
           </div>

--- a/web/src/components/agent_nodes_workbench.tsx
+++ b/web/src/components/agent_nodes_workbench.tsx
@@ -52,8 +52,52 @@ type NodeTeamUsageSummary = {
   activeAgentCount: number;
 };
 
+export type NodeEditDraft = {
+  name: string;
+  grpcTarget: string;
+  tlsServerName: string;
+  defaultWorktreeRoot: string;
+};
+
 function pluralize(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+export function buildNodeEditDraft(node: AgentNodeRecord): NodeEditDraft {
+  return {
+    name: node.name,
+    grpcTarget: node.grpc_target ?? "",
+    tlsServerName: node.tls_server_name ?? "",
+    defaultWorktreeRoot: node.default_worktree_root ?? "",
+  };
+}
+
+export function buildNodeNameUpdatePayload(
+  node: AgentNodeRecord,
+  draft: NodeEditDraft
+): AgentNodeUpdate | null {
+  const grpcTarget = draft.grpcTarget.trim() || node.grpc_target?.trim() || "";
+  if (!grpcTarget) {
+    return null;
+  }
+  return {
+    name: draft.name.trim(),
+    grpc_target: grpcTarget,
+    tls_server_name: node.tls_server_name?.trim() || null,
+    default_worktree_root: node.default_worktree_root?.trim() || null,
+  };
+}
+
+export function buildNodeSettingsUpdatePayload(
+  node: AgentNodeRecord,
+  draft: Pick<NodeEditDraft, "grpcTarget" | "tlsServerName" | "defaultWorktreeRoot">
+): AgentNodeUpdate {
+  return {
+    name: node.name.trim(),
+    grpc_target: draft.grpcTarget.trim(),
+    tls_server_name: draft.tlsServerName.trim() || null,
+    default_worktree_root: draft.defaultWorktreeRoot.trim() || null,
+  };
 }
 
 function parseTeamSpecMembers(
@@ -255,15 +299,7 @@ export function AgentNodesWorkbench({
     0
   );
   const [editDrafts, setEditDrafts] = React.useState<
-    Record<
-      string,
-      {
-        name: string;
-        grpcTarget: string;
-        tlsServerName: string;
-        defaultWorktreeRoot: string;
-      }
-    >
+    Record<string, NodeEditDraft>
   >({});
 
   React.useEffect(() => {
@@ -273,29 +309,23 @@ export function AgentNodesWorkbench({
         if (node.is_main) {
           continue;
         }
-        next[node.id] = prev[node.id] ?? {
-          name: node.name,
-          grpcTarget: node.grpc_target ?? "",
-          tlsServerName: node.tls_server_name ?? "",
-          defaultWorktreeRoot: node.default_worktree_root ?? "",
-        };
+        next[node.id] = prev[node.id] ?? buildNodeEditDraft(node);
       }
       return next;
     });
   }, [availableNodes]);
 
   const handleSaveNodeName = React.useCallback(
-    (nodeId: string, nextName: string) => {
+    (nodeId: string, draft: NodeEditDraft) => {
       const node = availableNodes.find((candidate) => candidate.id === nodeId);
       if (!node) {
         return;
       }
-      onUpdateNode?.(nodeId, {
-        name: nextName.trim(),
-        grpc_target: node.grpc_target?.trim() ?? "",
-        tls_server_name: node.tls_server_name?.trim() || null,
-        default_worktree_root: node.default_worktree_root?.trim() || null,
-      });
+      const payload = buildNodeNameUpdatePayload(node, draft);
+      if (!payload) {
+        return;
+      }
+      onUpdateNode?.(nodeId, payload);
     },
     [availableNodes, onUpdateNode]
   );
@@ -313,12 +343,7 @@ export function AgentNodesWorkbench({
       if (!node) {
         return;
       }
-      onUpdateNode?.(nodeId, {
-        name: node.name.trim(),
-        grpc_target: draft.grpcTarget.trim(),
-        tls_server_name: draft.tlsServerName.trim() || null,
-        default_worktree_root: draft.defaultWorktreeRoot.trim() || null,
-      });
+      onUpdateNode?.(nodeId, buildNodeSettingsUpdatePayload(node, draft));
     },
     [availableNodes, onUpdateNode]
   );
@@ -456,13 +481,11 @@ export function AgentNodesWorkbench({
                       </Text>
                     </div>
                     {(() => {
-                      const draft = editDrafts[selectedNode.id] ?? {
-                        name: selectedNode.name,
-                        grpcTarget: selectedNode.grpc_target ?? "",
-                        tlsServerName: selectedNode.tls_server_name ?? "",
-                        defaultWorktreeRoot: selectedNode.default_worktree_root ?? "",
-                      };
-                      const nameError = draft.name.trim() ? null : "Node name is required.";
+                      const draft = editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
+                      const nameError = validateAgentNodeUpdateDraft({
+                        nodeName: draft.name,
+                        grpcTarget: draft.grpcTarget,
+                      });
                       return (
                         <>
                           <TextInput
@@ -490,9 +513,7 @@ export function AgentNodesWorkbench({
                               disabled={
                                 Boolean(updatingNodeIds[selectedNode.id]) || nameError !== null
                               }
-                              onClick={() =>
-                                handleSaveNodeName(selectedNode.id, draft.name)
-                              }
+                              onClick={() => handleSaveNodeName(selectedNode.id, draft)}
                             >
                               Save Name
                             </Button>
@@ -505,130 +526,127 @@ export function AgentNodesWorkbench({
 
                 <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
                   <div className={SECTION_CARD_CLASS}>
-                  <Stack gap="sm">
-                    <div>
-                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                        Settings
-                      </Text>
-                      <Text size="sm" c="dimmed" mt={6}>
-                        Update routing and default worktree behavior for this node without mixing in
-                        the object name field.
-                      </Text>
-                    </div>
-                    {(() => {
-                      const draft = editDrafts[selectedNode.id] ?? {
-                        name: selectedNode.name,
-                        grpcTarget: selectedNode.grpc_target ?? "",
-                        tlsServerName: selectedNode.tls_server_name ?? "",
-                        defaultWorktreeRoot: selectedNode.default_worktree_root ?? "",
-                      };
-                      const updateError = validateAgentNodeUpdateDraft({
-                        nodeName: draft.name,
-                        grpcTarget: draft.grpcTarget,
-                      });
-                      return (
-                        <>
-                          <TextInput
-                            label="gRPC target"
-                            value={draft.grpcTarget}
-                            onChange={(event) =>
-                              setEditDrafts((prev) => ({
-                                ...prev,
-                                [selectedNode.id]: {
-                                  ...draft,
-                                  grpcTarget: event.currentTarget.value,
-                                },
-                              }))
-                            }
-                          />
-                          <div className="grid gap-3 lg:grid-cols-2">
+                    <Stack gap="sm">
+                      <div>
+                        <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                          Settings
+                        </Text>
+                        <Text size="sm" c="dimmed" mt={6}>
+                          Update routing and default worktree behavior for this node without mixing
+                          in the object name field.
+                        </Text>
+                      </div>
+                      {(() => {
+                        const draft =
+                          editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
+                        const updateError = validateAgentNodeUpdateDraft({
+                          nodeName: draft.name,
+                          grpcTarget: draft.grpcTarget,
+                        });
+                        return (
+                          <>
                             <TextInput
-                              label="TLS server name"
-                              value={draft.tlsServerName}
+                              label="gRPC target"
+                              value={draft.grpcTarget}
                               onChange={(event) =>
                                 setEditDrafts((prev) => ({
                                   ...prev,
                                   [selectedNode.id]: {
                                     ...draft,
-                                    tlsServerName: event.currentTarget.value,
+                                    grpcTarget: event.currentTarget.value,
                                   },
                                 }))
                               }
                             />
-                            <TextInput
-                              label="Default worktree root"
-                              placeholder="Optional"
-                              value={draft.defaultWorktreeRoot}
-                              onChange={(event) =>
-                                setEditDrafts((prev) => ({
-                                  ...prev,
-                                  [selectedNode.id]: {
-                                    ...draft,
-                                    defaultWorktreeRoot: event.currentTarget.value,
-                                  },
-                                }))
-                              }
-                            />
-                          </div>
-                          <div className="flex flex-wrap items-center justify-between gap-3">
-                            <Text size="xs" c={updateError ? "red" : "dimmed"}>
-                              {updateError ??
-                                "Leave Default worktree root blank to require explicit remote workdir."}
-                            </Text>
-                            <Button
-                              variant="light"
-                              size="xs"
-                              loading={Boolean(updatingNodeIds[selectedNode.id])}
-                              disabled={
-                                Boolean(updatingNodeIds[selectedNode.id]) || updateError !== null
-                              }
-                              onClick={() =>
-                                handleSaveNodeSettings(selectedNode.id, {
-                                  grpcTarget: draft.grpcTarget,
-                                  tlsServerName: draft.tlsServerName,
-                                  defaultWorktreeRoot: draft.defaultWorktreeRoot,
-                                })
-                              }
-                            >
-                              Save Settings
-                            </Button>
-                          </div>
-                        </>
-                      );
-                    })()}
-                  </Stack>
-                </div>
+                            <div className="grid gap-3 lg:grid-cols-2">
+                              <TextInput
+                                label="TLS server name"
+                                value={draft.tlsServerName}
+                                onChange={(event) =>
+                                  setEditDrafts((prev) => ({
+                                    ...prev,
+                                    [selectedNode.id]: {
+                                      ...draft,
+                                      tlsServerName: event.currentTarget.value,
+                                    },
+                                  }))
+                                }
+                              />
+                              <TextInput
+                                label="Default worktree root"
+                                placeholder="Optional"
+                                value={draft.defaultWorktreeRoot}
+                                onChange={(event) =>
+                                  setEditDrafts((prev) => ({
+                                    ...prev,
+                                    [selectedNode.id]: {
+                                      ...draft,
+                                      defaultWorktreeRoot: event.currentTarget.value,
+                                    },
+                                  }))
+                                }
+                              />
+                            </div>
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <Text size="xs" c={updateError ? "red" : "dimmed"}>
+                                {updateError ??
+                                  "Leave Default worktree root blank to require explicit remote workdir."}
+                              </Text>
+                              <Button
+                                variant="light"
+                                size="xs"
+                                loading={Boolean(updatingNodeIds[selectedNode.id])}
+                                disabled={
+                                  Boolean(updatingNodeIds[selectedNode.id]) ||
+                                  updateError !== null
+                                }
+                                onClick={() =>
+                                  handleSaveNodeSettings(selectedNode.id, {
+                                    grpcTarget: draft.grpcTarget,
+                                    tlsServerName: draft.tlsServerName,
+                                    defaultWorktreeRoot: draft.defaultWorktreeRoot,
+                                  })
+                                }
+                              >
+                                Save Settings
+                              </Button>
+                            </div>
+                          </>
+                        );
+                      })()}
+                    </Stack>
+                  </div>
 
-                <div className="rounded-xl border border-red-200 bg-red-50/70 px-4 py-4">
-                  <Stack gap="sm">
-                    <div>
-                      <Text size="xs" fw={700} c="red" className={SECTION_HEADER_CLASS}>
-                        Danger Zone
+                  <div className="rounded-xl border border-red-200 bg-red-50/70 px-4 py-4">
+                    <Stack gap="sm">
+                      <div>
+                        <Text size="xs" fw={700} c="red" className={SECTION_HEADER_CLASS}>
+                          Danger Zone
+                        </Text>
+                        <Text size="sm" c="dimmed" mt={6}>
+                          Delete this node only after its attached agents have been removed or rerouted.
+                        </Text>
+                      </div>
+                      <Text size="xs" c={selectedNodeAgents.length > 0 ? "red" : "dimmed"}>
+                        {selectedNodeAgents.length > 0
+                          ? `This node still has ${selectedNodeAgents.length} attached agent${selectedNodeAgents.length === 1 ? "" : "s"}.`
+                          : "No attached agents remain on this node."}
                       </Text>
-                      <Text size="sm" c="dimmed" mt={6}>
-                        Delete this node only after its attached agents have been removed or rerouted.
-                      </Text>
-                    </div>
-                    <Text size="xs" c={selectedNodeAgents.length > 0 ? "red" : "dimmed"}>
-                      {selectedNodeAgents.length > 0
-                        ? `This node still has ${selectedNodeAgents.length} attached agent${selectedNodeAgents.length === 1 ? "" : "s"}.`
-                        : "No attached agents remain on this node."}
-                    </Text>
-                    <Button
-                      color="red"
-                      variant="light"
-                      size="xs"
-                      loading={Boolean(deletingNodeIds[selectedNode.id])}
-                      disabled={
-                        Boolean(deletingNodeIds[selectedNode.id]) || selectedNodeAgents.length > 0
-                      }
-                      onClick={() => onDeleteNode?.(selectedNode.id)}
-                    >
-                      Delete Node
-                    </Button>
-                  </Stack>
+                      <Button
+                        color="red"
+                        variant="light"
+                        size="xs"
+                        loading={Boolean(deletingNodeIds[selectedNode.id])}
+                        disabled={
+                          Boolean(deletingNodeIds[selectedNode.id]) || selectedNodeAgents.length > 0
+                        }
+                        onClick={() => onDeleteNode?.(selectedNode.id)}
+                      >
+                        Delete Node
+                      </Button>
+                    </Stack>
+                  </div>
                 </div>
-              </div>
               </div>
             )}
           </div>

--- a/web/src/components/agent_nodes_workbench.tsx
+++ b/web/src/components/agent_nodes_workbench.tsx
@@ -76,7 +76,7 @@ export function buildNodeNameUpdatePayload(
   node: AgentNodeRecord,
   draft: NodeEditDraft
 ): AgentNodeUpdate | null {
-  const grpcTarget = draft.grpcTarget.trim() || node.grpc_target?.trim() || "";
+  const grpcTarget = node.grpc_target?.trim() || "";
   if (!grpcTarget) {
     return null;
   }
@@ -98,6 +98,16 @@ export function buildNodeSettingsUpdatePayload(
     tls_server_name: draft.tlsServerName.trim() || null,
     default_worktree_root: draft.defaultWorktreeRoot.trim() || null,
   };
+}
+
+function resolveNameUpdateError(node: AgentNodeRecord, draft: NodeEditDraft): string | null {
+  if (!draft.name.trim()) {
+    return "Node name is required.";
+  }
+  if (!node.grpc_target?.trim()) {
+    return "This node is missing a persisted gRPC target.";
+  }
+  return null;
 }
 
 function parseTeamSpecMembers(
@@ -482,10 +492,7 @@ export function AgentNodesWorkbench({
                     </div>
                     {(() => {
                       const draft = editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
-                      const nameError = validateAgentNodeUpdateDraft({
-                        nodeName: draft.name,
-                        grpcTarget: draft.grpcTarget,
-                      });
+                      const nameError = resolveNameUpdateError(selectedNode, draft);
                       return (
                         <>
                           <TextInput
@@ -540,7 +547,7 @@ export function AgentNodesWorkbench({
                         const draft =
                           editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
                         const updateError = validateAgentNodeUpdateDraft({
-                          nodeName: draft.name,
+                          nodeName: selectedNode.name,
                           grpcTarget: draft.grpcTarget,
                         });
                         return (


### PR DESCRIPTION
## Summary

- refine node detail attached-agent rows with explicit runtime/provider badges
- split `Name` out of the broader remote-node `Settings` form
- keep local `Main Node` name visible as a read-only object field

## Why

The node detail route already had the right high-level structure, but two object-page gaps remained:

- attached agents did not clearly show what runtime/provider surface they were using
- the canonical node name was still buried inside one larger settings editor

This keeps the page closer to the node detail spec without expanding backend contracts.

## Validation

```bash
cd web && npm exec vitest -- run src/components/agent_node_detail_shared.test.ts src/components/agent_nodes_workbench.test.tsx
cd web && npm exec tsc -- --noEmit
```

## Notes

- runtime/provider labels are still UI inference from current agent runtime fields
- this PR does not change node backend payloads or heartbeat semantics
