### PR TITLE
fix: tsc gate clear + channel/thread prompt alignment + responsive thread pane + workspace lens placeholders

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
@@ -31,6 +31,12 @@ Coordination contract:
 - Treat `spec.members[]` as static baseline; when live roster and static spec differ, trust `actor team-members` for current execution decisions.
 - Record discovery-card identity policy and update checkpoints in `AGENTS.md`.
 - Treat `AGENTS.md` as the stable coordination index and `.cache/context/run/<run_id>/...` as the place for overflow evidence; prefer pointer-first summaries over pasting large mailbox/tool payloads back into the prompt.
+Channel and thread contract:
+- Team channels (`# all`, `# review`, etc.) are coordination communication lanes. Use channels for broad visibility, announcements, human requests, and planning.
+- Threads are focused reply contexts rooted in one channel message. Use threads for deeper context: evidence, logs, detailed back-and-forth, and topic-specific follow-up.
+- Channel root messages should stay summary-first. Move long background, logs, and evidence into threads instead of pasting them into the main channel.
+- When you open a thread, you are making the deeper context available without cluttering the main channel for everyone else.
+- Treat `agenthub actor team-thread-open` and `agenthub actor team-thread-reply` as the canonical agent-side way to move a topic from summary root into thread-scoped deep context.
 - Keep TODO/task statuses aligned with mailbox evidence and compact stale duplicate entries.
 - Use `agenthub actor team-tasks` to inspect the canonical Team Kanban view before assuming task state from mailbox summaries alone.
 - Use `agenthub actor team-task-create` to create canonical Team tasks; a conversational claim like 'task opened' is not sufficient unless the task is visible through `agenthub actor team-tasks`.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -15,6 +15,11 @@ Workspace policy:
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for timed rechecks, reminders, or follow-ups that should wake you up later through ACP.
 - `agent_loop` is an operator-controlled idle watchdog: it is disabled by default, enabled externally per agent, and only injects a configured ACP reminder after silence. Treat loop prompts as follow-up nudges, not as new human intent.
 - Do not assume you may enable or retune `agent_loop` yourself unless a human/operator explicitly asks for it.
+Channel and thread contract:
+- Team channels (`# all`, `# review`, etc.) are coordination lanes. Read channel root messages for summary-first awareness before opening a thread.
+- Threads are focused reply contexts with the full discussion. When you need deeper context on a topic, open the thread before assuming the root message contains the complete picture.
+- Keep channel root messages summary-first. Put long evidence, logs, and detailed follow-up into threads.
+- Use `agenthub actor team-thread-open` and `agenthub actor team-thread-reply` to follow up on topics inside their thread context.
 - Team ACP permission review is operator-facing ACP runtime control flow, not a normal worker coordination task.
 - Only review a Team ACP permission request when ACP exposes the review action in your current session; evaluate the request against least-privilege intent.
 - If agent review is unavailable or times out, the system may post a human-review request into `Channel` (`all`) without blocking your current run.

--- a/web/src/components/acp_debug.tsx
+++ b/web/src/components/acp_debug.tsx
@@ -643,7 +643,7 @@ function DebugTerminalOutput({
   return (
     <div
       className={DEBUG_TERMINAL_CONTAINER_CLASS}
-      ref={containerRef as React.RefObject<HTMLDivElement>}
+      ref={containerRef as React.Ref<HTMLDivElement>}
       onScroll={onScroll}
     >
       {outputs.map((line) => {

--- a/web/src/components/acp_debug.tsx
+++ b/web/src/components/acp_debug.tsx
@@ -643,7 +643,7 @@ function DebugTerminalOutput({
   return (
     <div
       className={DEBUG_TERMINAL_CONTAINER_CLASS}
-      ref={containerRef}
+      ref={containerRef as React.RefObject<HTMLDivElement>}
       onScroll={onScroll}
     >
       {outputs.map((line) => {

--- a/web/src/components/agents_root_page.tsx
+++ b/web/src/components/agents_root_page.tsx
@@ -114,10 +114,10 @@ export const AgentsRootPage = React.memo(function AgentsRootPage({
   onSelectLens,
 }: AgentsRootPageProps) {
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-white" ref={appRootRef as React.RefObject<HTMLDivElement>}>
+    <div className="flex h-screen flex-col overflow-hidden bg-white" ref={appRootRef as React.Ref<HTMLDivElement>}>
       {auth ? (
         <WorkspaceShellHeader
-          ref={appHeaderRef as React.RefObject<HTMLElement>}
+          ref={appHeaderRef as React.Ref<HTMLElement>}
           activeSurface="workspace"
           title="Workspace"
           subtitle={null}

--- a/web/src/components/agents_root_page.tsx
+++ b/web/src/components/agents_root_page.tsx
@@ -114,10 +114,10 @@ export const AgentsRootPage = React.memo(function AgentsRootPage({
   onSelectLens,
 }: AgentsRootPageProps) {
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-white" ref={appRootRef}>
+    <div className="flex h-screen flex-col overflow-hidden bg-white" ref={appRootRef as React.RefObject<HTMLDivElement>}>
       {auth ? (
         <WorkspaceShellHeader
-          ref={appHeaderRef}
+          ref={appHeaderRef as React.RefObject<HTMLElement>}
           activeSurface="workspace"
           title="Workspace"
           subtitle={null}

--- a/web/src/components/agents_route_shell.tsx
+++ b/web/src/components/agents_route_shell.tsx
@@ -57,7 +57,7 @@ export const AgentsRouteShellView = React.memo(function AgentsRouteShellView({
           ? APP_WORKSPACE_ROOT_COLLAPSED_CLASS
           : APP_WORKSPACE_ROOT_CLASS
       }
-      ref={workspaceRef}
+      ref={workspaceRef as React.RefObject<HTMLElement>}
       style={workspaceStyle}
     >
       <AgentsPanel {...agentsPanelProps} />

--- a/web/src/components/agents_route_shell.tsx
+++ b/web/src/components/agents_route_shell.tsx
@@ -57,7 +57,7 @@ export const AgentsRouteShellView = React.memo(function AgentsRouteShellView({
           ? APP_WORKSPACE_ROOT_COLLAPSED_CLASS
           : APP_WORKSPACE_ROOT_CLASS
       }
-      ref={workspaceRef as React.RefObject<HTMLElement>}
+      ref={workspaceRef as React.Ref<HTMLElement>}
       style={workspaceStyle}
     >
       <AgentsPanel {...agentsPanelProps} />

--- a/web/src/components/terminal_output.tsx
+++ b/web/src/components/terminal_output.tsx
@@ -5,7 +5,7 @@ import { OutputLine } from "../output_cache";
 type TerminalOutputProps = {
   outputs: OutputLine[];
   ansi: (input: string) => string;
-  containerRef?: React.RefObject<HTMLDivElement | null>;
+  containerRef?: React.Ref<HTMLDivElement>;
   onScroll?: () => void;
 };
 
@@ -25,7 +25,7 @@ export function TerminalOutput({
   return (
     <Box
       className={TERMINAL_CONTAINER_CLASS}
-      ref={containerRef as React.RefObject<HTMLDivElement>}
+      ref={containerRef}
       onScroll={onScroll}
     >
       {outputs.map((line) => {

--- a/web/src/components/terminal_output.tsx
+++ b/web/src/components/terminal_output.tsx
@@ -25,7 +25,7 @@ export function TerminalOutput({
   return (
     <Box
       className={TERMINAL_CONTAINER_CLASS}
-      ref={containerRef}
+      ref={containerRef as React.RefObject<HTMLDivElement>}
       onScroll={onScroll}
     >
       {outputs.map((line) => {

--- a/web/src/components/workspace_lens_placeholder.test.tsx
+++ b/web/src/components/workspace_lens_placeholder.test.tsx
@@ -5,6 +5,9 @@ import {
   WorkspaceMachinesUnavailablePlaceholder,
   WorkspaceLensPlaceholder,
   WorkspaceSearchLensPlaceholder,
+  WorkspaceChannelsLensPlaceholder,
+  WorkspaceTasksLensPlaceholder,
+  WorkspaceMembersLensPlaceholder,
 } from "./workspace_lens_placeholder";
 
 describe("WorkspaceLensPlaceholder", () => {
@@ -52,5 +55,47 @@ describe("WorkspaceLensPlaceholder", () => {
     expect(html).toContain("permission to manage machines");
     expect(html).toContain("machines-card");
     expect(html).toContain("data-workspace-lens-placeholder=\"machines\"");
+  });
+
+  it("renders the workspace channels cross-entity placeholder", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceChannelsLensPlaceholder className="channels-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Channels");
+    expect(html).toContain("Workspace channels aggregate across teams");
+    expect(html).toContain("cross-team channel index");
+    expect(html).toContain("channels-card");
+    expect(html).toContain("data-workspace-lens-placeholder=\"channels\"");
+  });
+
+  it("renders the workspace tasks cross-entity placeholder", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceTasksLensPlaceholder className="tasks-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Tasks");
+    expect(html).toContain("Workspace tasks aggregate across teams");
+    expect(html).toContain("cross-team task view");
+    expect(html).toContain("tasks-card");
+    expect(html).toContain("data-workspace-lens-placeholder=\"tasks\"");
+  });
+
+  it("renders the workspace members cross-entity placeholder", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <WorkspaceMembersLensPlaceholder className="members-card" />
+      </MantineProvider>
+    );
+
+    expect(html).toContain("Members");
+    expect(html).toContain("Workspace members aggregate across teams");
+    expect(html).toContain("cross-team member directory");
+    expect(html).toContain("members-card");
+    expect(html).toContain("data-workspace-lens-placeholder=\"members\"");
   });
 });

--- a/web/src/components/workspace_lens_placeholder.tsx
+++ b/web/src/components/workspace_lens_placeholder.tsx
@@ -10,6 +10,18 @@ export const SHARED_WORKSPACE_SEARCH_LENS_HINT =
 export const WORKSPACE_MACHINES_UNAVAILABLE_TITLE = "Machines unavailable";
 export const WORKSPACE_MACHINES_UNAVAILABLE_BODY =
   "You do not have permission to manage machines. Select another workspace view to continue.";
+const WORKSPACE_CROSS_ENTITY_CHANNELS_TITLE =
+  "Workspace channels aggregate across teams";
+const WORKSPACE_CROSS_ENTITY_CHANNELS_BODY =
+  "Open a team to browse its channels and threads. A shared cross-team channel index will land in a future workspace shell phase.";
+const WORKSPACE_CROSS_ENTITY_TASKS_TITLE =
+  "Workspace tasks aggregate across teams";
+const WORKSPACE_CROSS_ENTITY_TASKS_BODY =
+  "Open a team to browse its Kanban board and active tasks. A shared cross-team task view will land in a future workspace shell phase.";
+const WORKSPACE_CROSS_ENTITY_MEMBERS_TITLE =
+  "Workspace members aggregate across teams";
+const WORKSPACE_CROSS_ENTITY_MEMBERS_BODY =
+  "Open a team to browse its member roster. A shared cross-team member directory will land in a future workspace shell phase.";
 
 type WorkspaceLensPlaceholderProps = {
   lensLabel: string;
@@ -63,6 +75,51 @@ export function WorkspaceMachinesUnavailablePlaceholder({
       lensLabel="Machines"
       title={WORKSPACE_MACHINES_UNAVAILABLE_TITLE}
       body={WORKSPACE_MACHINES_UNAVAILABLE_BODY}
+      className={className}
+    />
+  );
+}
+
+export function WorkspaceChannelsLensPlaceholder({
+  className = "",
+}: {
+  className?: string;
+}) {
+  return (
+    <WorkspaceLensPlaceholder
+      lensLabel="Channels"
+      title={WORKSPACE_CROSS_ENTITY_CHANNELS_TITLE}
+      body={WORKSPACE_CROSS_ENTITY_CHANNELS_BODY}
+      className={className}
+    />
+  );
+}
+
+export function WorkspaceTasksLensPlaceholder({
+  className = "",
+}: {
+  className?: string;
+}) {
+  return (
+    <WorkspaceLensPlaceholder
+      lensLabel="Tasks"
+      title={WORKSPACE_CROSS_ENTITY_TASKS_TITLE}
+      body={WORKSPACE_CROSS_ENTITY_TASKS_BODY}
+      className={className}
+    />
+  );
+}
+
+export function WorkspaceMembersLensPlaceholder({
+  className = "",
+}: {
+  className?: string;
+}) {
+  return (
+    <WorkspaceLensPlaceholder
+      lensLabel="Members"
+      title={WORKSPACE_CROSS_ENTITY_MEMBERS_TITLE}
+      body={WORKSPACE_CROSS_ENTITY_MEMBERS_BODY}
       className={className}
     />
   );

--- a/web/src/hooks/conversation_height_estimate.test.ts
+++ b/web/src/hooks/conversation_height_estimate.test.ts
@@ -3,7 +3,7 @@ import { layout, prepare } from "@chenglou/pretext";
 import type { ConversationItem } from "../conversation";
 
 vi.mock("@chenglou/pretext", () => ({
-  prepare: vi.fn((text: string, _font?: string) => ({ text })),
+  prepare: vi.fn((text: string) => ({ text })),
   layout: vi.fn(
     (
       prepared: { text: string },

--- a/web/src/hooks/conversation_height_estimate.test.ts
+++ b/web/src/hooks/conversation_height_estimate.test.ts
@@ -3,7 +3,7 @@ import { layout, prepare } from "@chenglou/pretext";
 import type { ConversationItem } from "../conversation";
 
 vi.mock("@chenglou/pretext", () => ({
-  prepare: vi.fn((text: string) => ({ text })),
+  prepare: vi.fn((text: string, _font?: string) => ({ text })),
   layout: vi.fn(
     (
       prepared: { text: string },
@@ -246,7 +246,7 @@ describe("conversation_height_estimate", () => {
     );
     const prepareMock = vi.mocked(prepare);
     expect(
-      prepareMock.mock.calls.some(([text]) =>
+      prepareMock.mock.calls.some(([text]: [string, string]) =>
         String(text).includes("#123") && String(text).includes("a > b")
       )
     ).toBe(true);
@@ -260,12 +260,12 @@ describe("conversation_height_estimate", () => {
     );
     const prepareMock = vi.mocked(prepare);
     expect(
-      prepareMock.mock.calls.some(([, font]) =>
+      prepareMock.mock.calls.some(([, font]: [string, string]) =>
         String(font).includes('600 18px "Space Grotesk"')
       )
     ).toBe(true);
     expect(
-      prepareMock.mock.calls.some(([, font]) =>
+      prepareMock.mock.calls.some(([, font]: [string, string]) =>
         String(font).includes('600 14px "Space Grotesk"')
       )
     ).toBe(true);
@@ -289,7 +289,7 @@ describe("conversation_height_estimate", () => {
     estimateConversationItemHeight(makeMessage("font check", 18), 720, 48);
     const prepareMock = vi.mocked(prepare);
     expect(
-      prepareMock.mock.calls.some(([, font]) =>
+      prepareMock.mock.calls.some(([, font]: [string, string]) =>
         String(font).includes("Space Grotesk")
       )
     ).toBe(true);

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -386,7 +386,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         <div className="border-t border-notion-border/55 bg-white/92 px-2.5 py-1.5">
           <div className={TEAM_MESSAGE_COMPOSER_SHELL_CLASS}>
             <div className="px-1 pb-1 text-[10px] leading-5 text-notion-text-muted">
-              Reply in thread · {channelLabel}
+              Full context in thread · root message stays summary-first · {channelLabel}
             </div>
             <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
               <textarea

--- a/web/src/pages/team/team_workbench_content.test.tsx
+++ b/web/src/pages/team/team_workbench_content.test.tsx
@@ -1,11 +1,15 @@
 // @vitest-environment jsdom
+import { renderToStaticMarkup } from "react-dom/server";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TeamDefinitionRecord } from "../../api";
 import {
+  TeamWorkbenchContent,
   TeamPanelLoadingFallback,
   prefetchTeamSetupSurface,
   prefetchTeamWorkbenchTab,
+  type TeamWorkbenchContentProps,
 } from "./team_workbench_content";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -49,5 +53,127 @@ describe("team_workbench_content", () => {
     await act(async () => {
       await vi.dynamicImportSettled();
     });
+  });
+
+  it("only renders the constrained thread wrapper when a thread pane is present", () => {
+    const baseProps = {
+      showTeamBootstrapLoading: false,
+      showTeamUnavailable: false,
+      onBackToSelector: vi.fn(),
+      selectedTeam: {
+        team_id: "team-1",
+        name: "Team One",
+      } as unknown as TeamDefinitionRecord,
+      isAgentWorkspace: false,
+      teamSectionCardClassName: "team-card",
+      teamSectionTitleClassName: "team-title",
+      teamSectionBodyTextClassName: "team-body",
+      panelSecondaryButtonClassName: "team-button",
+      teamWorkbenchWorkspaceShellClassName: "team-shell",
+      workspaceHeaderProps: {
+        workspaceEyebrow: null,
+        showDedicatedWorkspaceHeading: true,
+        workspaceTitle: "# all",
+        workspaceDescription: "Shared channel",
+        isAgentWorkspace: false,
+        selectedAgentLabel: "worker-1",
+        selectedAgentWorkspaceMemberId: "member-1",
+        selectedAgentStatusView: {
+          role: "worker",
+          lifecycle: "idle",
+          work: "idle",
+          inbox: "0",
+          currentWork: "Idle",
+        },
+        selectedAgentSpecDraft: null,
+        selectedAgentControlState: {
+          canStart: false,
+          canStop: false,
+          canDelete: false,
+        },
+        showWorkspaceRuntimeBadge: false,
+        selectedTeamRuntimeStatusLabel: "stopped",
+        selectedTeamRuntimeOnline: 0,
+        selectedTeamRuntimeTotal: 0,
+        selectedTeamRuntimeControlTone: {
+          statusColor: "gray",
+          countColor: "gray",
+        } as const,
+        workspaceAdvancedTabItems: [],
+        isAdvancedWorkspace: false,
+        showRunActionsInAdvanced: false,
+        activeRunStatus: null,
+        canResumeActiveRun: false,
+        canRestartActiveRun: false,
+        developerMode: false,
+        workspaceDetailsOpen: false,
+        workspaceDetailItems: [],
+        workspaceNoticeText: null,
+        workspaceNoticeDotClassName: "dot",
+        workflowTabItems: [],
+        tab: "conversation" as const,
+        busy: null,
+        chrome: {
+          mutedButtonClassName: "muted",
+          headerActionButtonClassName: "header-action",
+          toolbarClassName: "toolbar",
+          toolbarButtonActiveClassName: "toolbar-active",
+          toolbarButtonIdleClassName: "toolbar-idle",
+          noticeClassName: "notice",
+          noticeTextClassName: "notice-text",
+          runMetaItemClassName: "run-meta",
+        },
+        onTabChange: vi.fn(),
+        onToggleWorkspaceDetails: vi.fn(),
+        onRefreshActiveRun: vi.fn(),
+        onCancelRun: vi.fn(),
+        onResumeRun: vi.fn(),
+        onRestartRun: vi.fn(),
+        onOpenTeamMemberEditModal: vi.fn(),
+        onStartSelectedTeamAgent: vi.fn(),
+        onStopSelectedTeamAgent: vi.fn(),
+        onDeleteSelectedTeamAgent: vi.fn(),
+      },
+      selectedTeamHasConfiguredMembers: true,
+      selectedTeamDescription: null,
+      teamMemberForgeLabel: "Add Agent",
+      teamMemberCopyExistingLabel: "Copy Existing Agent",
+      onOpenTeamMemberForge: vi.fn(),
+      onOpenTeamMemberCopyExisting: vi.fn(),
+      tab: "conversation" as const,
+      runsPanelProps: {} as TeamWorkbenchContentProps["runsPanelProps"],
+      showRunContextLoading: false,
+      showNoActiveRunNotice: false,
+      activeWorkspaceLens: "channels" as const,
+      conversationPanel: <div data-testid="conversation-panel">Conversation</div>,
+      tasksPanel: <div>Tasks</div>,
+      agentAcpPanel: <div>ACP</div>,
+      overviewPanelProps: null,
+      eventsPanelProps: null,
+      stepsPanelProps: null,
+      mailboxHasActiveRun: false,
+      mailboxEmptyTitle: "No active run",
+      mailboxEmptyBody: "Start a run to see mailbox activity.",
+      onGoToRuns: vi.fn(),
+      mailboxPanelProps: null,
+      memberConsolePanelProps: null,
+      debugPanel: <div>Debug</div>,
+    };
+
+    const withoutThread = renderToStaticMarkup(
+      <TeamWorkbenchContent {...baseProps} threadPane={null} />
+    );
+    expect(withoutThread).not.toContain("max-h-[40vh]");
+
+    const withThread = renderToStaticMarkup(
+      <TeamWorkbenchContent
+        {...baseProps}
+        threadPane={<aside data-testid="thread-pane">Thread</aside>}
+      />
+    );
+    expect(withThread).toContain("data-testid=\"thread-pane\"");
+    expect(withThread).toContain("max-h-[40vh]");
+    expect(withThread).toContain("flex-col");
+    expect(withThread).not.toContain("overflow-y-auto");
   });
 });

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -246,9 +246,11 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
               {activeWorkspaceLens !== "search" && tab === "conversation" && (
                 <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden lg:flex-row">
                   <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{conversationPanel}</div>
-                  <div className="max-h-[40vh] min-h-0 shrink-0 overflow-y-auto lg:max-h-none lg:w-[380px] lg:flex-shrink-0">
-                    {threadPane}
-                  </div>
+                  {threadPane && (
+                    <div className="flex max-h-[40vh] min-h-0 shrink-0 flex-col lg:max-h-none lg:w-[380px] lg:flex-shrink-0">
+                      {threadPane}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -244,9 +244,11 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
               )}
 
               {activeWorkspaceLens !== "search" && tab === "conversation" && (
-                <div className="flex min-h-0 min-w-0 flex-1 gap-3 overflow-hidden">
+                <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden lg:flex-row">
                   <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{conversationPanel}</div>
-                  {threadPane}
+                  <div className="max-h-[40vh] min-h-0 shrink-0 overflow-y-auto lg:max-h-none lg:w-[380px] lg:flex-shrink-0">
+                    {threadPane}
+                  </div>
                 </div>
               )}
 

--- a/web/src/pages/team_mailbox_panel.tsx
+++ b/web/src/pages/team_mailbox_panel.tsx
@@ -557,7 +557,7 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
 
             <ul
               className={MAILBOX_MESSAGE_LIST_CLASS}
-              ref={chatMessagesRef as React.RefObject<HTMLUListElement>}
+              ref={chatMessagesRef as React.Ref<HTMLUListElement>}
               onScroll={() => onConversationScroll()}
             >
               {conversationRows.map((row) => {

--- a/web/src/pages/team_mailbox_panel.tsx
+++ b/web/src/pages/team_mailbox_panel.tsx
@@ -557,7 +557,7 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
 
             <ul
               className={MAILBOX_MESSAGE_LIST_CLASS}
-              ref={chatMessagesRef}
+              ref={chatMessagesRef as React.RefObject<HTMLUListElement>}
               onScroll={() => onConversationScroll()}
             >
               {conversationRows.map((row) => {

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -665,7 +665,7 @@ export function TeamPage(props: TeamPageProps) {
     const normalized = normalizeWorkdirInput(props.defaultWorktreeRoot ?? "");
     return normalized || DEFAULT_WORKTREE_ROOT;
   }, [props.defaultWorktreeRoot]);
-  const isCompactWorkbench = useMediaQuery("(max-width: 1023px)");
+  const isCompactWorkbench = useMediaQuery("(max-width: 1023px)") ?? false;
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -676,7 +676,7 @@ export function TeamPage(props: TeamPageProps) {
   const [workspaceDetailsOpen, setWorkspaceDetailsOpen] = useState(false);
   const [teamDebugTag, setTeamDebugTag] = useState<TeamDebugTag>("run_ops");
   const mobileRouteTeamIdRef = useRef<string | null>(null);
-  const previousCompactWorkbenchRef = useRef<boolean>(isCompactWorkbench);
+  const previousCompactWorkbenchRef = useRef<boolean>(isCompactWorkbench ?? false);
   useEffect(() => {
     document.body.classList.add("teams-page");
     return () => {

--- a/web/src/pretext.d.ts
+++ b/web/src/pretext.d.ts
@@ -1,0 +1,12 @@
+declare module "@chenglou/pretext" {
+  export interface PreparedText {
+    text: string;
+  }
+
+  export function prepare(text: string, font: string): PreparedText;
+  export function layout(
+    prepared: PreparedText,
+    maxWidth: number,
+    lineHeight: number
+  ): { lineCount: number; height: number };
+}

--- a/web/src/routes/admin_route_container.tsx
+++ b/web/src/routes/admin_route_container.tsx
@@ -109,7 +109,7 @@ export function AdminRouteContainer({
   };
 
   return (
-    <div className="app bg-white" ref={appRootRef as React.RefObject<HTMLDivElement>}>
+    <div className="app bg-white" ref={appRootRef as React.Ref<HTMLDivElement>}>
       <Suspense fallback={<RouteFallback label="Loading admin console..." />}>
         <LazyAdminPage {...pageProps} />
       </Suspense>

--- a/web/src/routes/admin_route_container.tsx
+++ b/web/src/routes/admin_route_container.tsx
@@ -109,7 +109,7 @@ export function AdminRouteContainer({
   };
 
   return (
-    <div className="app bg-white" ref={appRootRef}>
+    <div className="app bg-white" ref={appRootRef as React.RefObject<HTMLDivElement>}>
       <Suspense fallback={<RouteFallback label="Loading admin console..." />}>
         <LazyAdminPage {...pageProps} />
       </Suspense>

--- a/web/src/routes/agents_route_container.tsx
+++ b/web/src/routes/agents_route_container.tsx
@@ -88,10 +88,10 @@ export function AgentsRouteContainer({
   const showRouteOutputHeader = activeWorkspaceLens !== "nodes";
   const canManageNodes = canManageAgentNodes(auth);
   const rootWorkbenchNode = React.useMemo(
-    () =>
-      activeWorkspaceLens === "nodes"
-        ? canManageNodes
-          ? (
+    () => {
+      switch (activeWorkspaceLens) {
+        case "nodes":
+          return canManageNodes ? (
             <AgentNodesWorkbench
               nodes={nodes}
               agents={agents}
@@ -109,27 +109,21 @@ export function AgentsRouteContainer({
               onUpdateNode={onUpdateNode}
               onDeleteNode={onDeleteNode}
             />
-          )
-          : (
+          ) : (
             <WorkspaceMachinesUnavailablePlaceholder className="m-6 text-center" />
-          )
-        : activeWorkspaceLens === "search"
-          ? (
-            <WorkspaceSearchLensPlaceholder className="m-4" />
-          )
-          : activeWorkspaceLens === "channels"
-            ? (
-              <WorkspaceChannelsLensPlaceholder className="m-4" />
-            )
-            : activeWorkspaceLens === "tasks"
-              ? (
-                <WorkspaceTasksLensPlaceholder className="m-4" />
-              )
-              : activeWorkspaceLens === "members"
-                ? (
-                  <WorkspaceMembersLensPlaceholder className="m-4" />
-                )
-                : null,
+          );
+        case "search":
+          return <WorkspaceSearchLensPlaceholder className="m-4" />;
+        case "channels":
+          return <WorkspaceChannelsLensPlaceholder className="m-4" />;
+        case "tasks":
+          return <WorkspaceTasksLensPlaceholder className="m-4" />;
+        case "members":
+          return <WorkspaceMembersLensPlaceholder className="m-4" />;
+        default:
+          return null;
+      }
+    },
     [
       activeWorkspaceLens,
       canManageNodes,

--- a/web/src/routes/agents_route_container.tsx
+++ b/web/src/routes/agents_route_container.tsx
@@ -17,6 +17,9 @@ import type { OutputHeaderProps } from "../components/output_header";
 import {
   WorkspaceMachinesUnavailablePlaceholder,
   WorkspaceSearchLensPlaceholder,
+  WorkspaceChannelsLensPlaceholder,
+  WorkspaceTasksLensPlaceholder,
+  WorkspaceMembersLensPlaceholder,
 } from "../components/workspace_lens_placeholder";
 
 type AgentsRouteContainerProps = Omit<
@@ -114,7 +117,19 @@ export function AgentsRouteContainer({
           ? (
             <WorkspaceSearchLensPlaceholder className="m-4" />
           )
-          : null,
+          : activeWorkspaceLens === "channels"
+            ? (
+              <WorkspaceChannelsLensPlaceholder className="m-4" />
+            )
+            : activeWorkspaceLens === "tasks"
+              ? (
+                <WorkspaceTasksLensPlaceholder className="m-4" />
+              )
+              : activeWorkspaceLens === "members"
+                ? (
+                  <WorkspaceMembersLensPlaceholder className="m-4" />
+                )
+                : null,
     [
       activeWorkspaceLens,
       canManageNodes,


### PR DESCRIPTION
- tsc --noEmit: fix React 19 Ref type errors in 7 files, add @chenglou/pretext type declaration, fix useMediaQuery undefined handling
- Channel/thread: add summary-first helper text to thread pane, add Channel and thread contract section to coordinator and worker prompts
- Responsive: thread pane uses flex-col lg:flex-row with max-h-[40vh] on narrow screens
- Workspace shell Phase 2: add cross-entity lens placeholders for channels/tasks/members at root workspace level
- Confirm Team create flow already simplified (mission-first, first-agent=coordinator)
- Confirm node detail page already has separated danger zone, connect command, agents roster