### PR TITLE
feat(storage): promote archive message identity fields

### DIFF
--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -33,6 +33,8 @@ impl LanceDbMessageArchive {
             Field::new("source_kind", DataType::Utf8, false),
             Field::new("source_id", DataType::Utf8, false),
             Field::new("logical_message_id", DataType::Utf8, true),
+            Field::new("authority_message_id", DataType::Int64, true),
+            Field::new("correlation_id", DataType::Utf8, true),
             Field::new("team_id", DataType::Utf8, true),
             Field::new("run_id", DataType::Utf8, true),
             Field::new("conversation_id", DataType::Utf8, true),
@@ -82,6 +84,18 @@ impl LanceDbMessageArchive {
                 documents
                     .iter()
                     .map(|doc| doc.logical_message_id.as_deref())
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(
+                documents
+                    .iter()
+                    .map(|doc| doc.authority_message_id)
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                documents
+                    .iter()
+                    .map(|doc| doc.correlation_id.as_deref())
                     .collect::<Vec<_>>(),
             )),
             Arc::new(StringArray::from(
@@ -162,6 +176,16 @@ impl LanceDbMessageArchive {
 
     fn build_filter(query: &MessageSearchQuery) -> Option<String> {
         let mut predicates = Vec::new();
+        append_i64_filter(
+            &mut predicates,
+            "authority_message_id",
+            query.authority_message_id,
+        );
+        append_string_filter(
+            &mut predicates,
+            "correlation_id",
+            query.correlation_id.as_deref(),
+        );
         append_string_filter(&mut predicates, "team_id", query.team_id.as_deref());
         append_string_filter(&mut predicates, "run_id", query.run_id.as_deref());
         append_string_filter(
@@ -264,6 +288,13 @@ fn append_string_filter(predicates: &mut Vec<String>, column: &str, value: Optio
     predicates.push(format!("{column} = '{}'", escape_sql_literal(value)));
 }
 
+fn append_i64_filter(predicates: &mut Vec<String>, column: &str, value: Option<i64>) {
+    let Some(value) = value else {
+        return;
+    };
+    predicates.push(format!("{column} = {value}"));
+}
+
 fn escape_sql_literal(value: &str) -> String {
     value.replace('\'', "''")
 }
@@ -323,6 +354,8 @@ mod tests {
                 source_kind: MessageDocumentKind::TeamConversationMessage,
                 source_id: "1".to_string(),
                 logical_message_id: Some("msg-1".to_string()),
+                authority_message_id: Some(101),
+                correlation_id: Some("corr-1".to_string()),
                 team_id: Some("team-1".to_string()),
                 run_id: None,
                 conversation_id: Some("conv-1".to_string()),
@@ -376,6 +409,8 @@ mod tests {
                     source_kind: MessageDocumentKind::TeamConversationMessage,
                     source_id: "1".to_string(),
                     logical_message_id: Some("msg-1".to_string()),
+                    authority_message_id: Some(101),
+                    correlation_id: Some("corr-alpha".to_string()),
                     team_id: Some("team-a".to_string()),
                     run_id: Some("run-a".to_string()),
                     conversation_id: Some("conv-1".to_string()),
@@ -394,6 +429,8 @@ mod tests {
                     source_kind: MessageDocumentKind::TeamRunEvent,
                     source_id: "2".to_string(),
                     logical_message_id: Some("msg-2".to_string()),
+                    authority_message_id: None,
+                    correlation_id: Some("corr-beta".to_string()),
                     team_id: Some("team-b".to_string()),
                     run_id: Some("run-b".to_string()),
                     conversation_id: Some("conv-2".to_string()),
@@ -425,6 +462,8 @@ mod tests {
             .search(&MessageSearchQuery {
                 query_text: "hello".to_string(),
                 limit: 5,
+                authority_message_id: None,
+                correlation_id: Some("corr-beta".to_string()),
                 team_id: Some("team-b".to_string()),
                 run_id: Some("run-b".to_string()),
                 conversation_id: Some("conv-2".to_string()),
@@ -438,6 +477,19 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].document_id, "doc-2");
         assert!(filtered[0].score.is_some());
+
+        let authority_filtered = archive
+            .search(&MessageSearchQuery {
+                query_text: "hello".to_string(),
+                limit: 5,
+                authority_message_id: Some(101),
+                correlation_id: Some("corr-alpha".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("search docs");
+        assert_eq!(authority_filtered.len(), 1);
+        assert_eq!(authority_filtered[0].document_id, "doc-1");
     }
 
     #[test]

--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -51,118 +51,108 @@ impl LanceDbMessageArchive {
     }
 
     async fn ensure_table(&self) -> Result<lancedb::Table> {
-        let table = self
+        let table = match self
             .connection
-            .create_empty_table(&self.config.message_table, Self::schema())
-            .mode(CreateTableMode::exist_ok(|request| request))
+            .open_table(&self.config.message_table)
             .execute()
-            .await?;
+            .await
+        {
+            Ok(table) => table,
+            Err(lancedb::Error::TableNotFound { .. }) => {
+                self.connection
+                    .create_empty_table(&self.config.message_table, Self::schema())
+                    .mode(CreateTableMode::exist_ok(|request| request))
+                    .execute()
+                    .await?
+            }
+            Err(err) => return Err(err.into()),
+        };
+        self.ensure_message_identity_columns(&table).await?;
         Ok(table)
+    }
+
+    async fn ensure_message_identity_columns(&self, table: &lancedb::Table) -> Result<()> {
+        let schema = table.schema().await?;
+        let mut transforms = Vec::new();
+        if schema.field_with_name("authority_message_id").is_err() {
+            transforms.push((
+                "authority_message_id".to_string(),
+                "cast(NULL as bigint)".to_string(),
+            ));
+        }
+        if schema.field_with_name("correlation_id").is_err() {
+            transforms.push((
+                "correlation_id".to_string(),
+                "cast(NULL as string)".to_string(),
+            ));
+        }
+        if transforms.is_empty() {
+            return Ok(());
+        }
+
+        table
+            .add_columns(
+                lancedb::table::NewColumnTransform::SqlExpressions(transforms),
+                None,
+            )
+            .await?;
+        Ok(())
     }
 
     fn documents_to_record_batch(documents: &[MessageDocument]) -> Result<RecordBatch> {
         let arrays: Vec<ArrayRef> = vec![
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| Some(doc.document_id.as_str()))
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| Some(doc.document_id.as_str())),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| Some(doc.source_kind.as_str()))
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| Some(doc.source_kind.as_str())),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| Some(doc.source_id.as_str()))
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| Some(doc.source_id.as_str())),
             )),
-            Arc::new(StringArray::from(
+            Arc::new(StringArray::from_iter(
                 documents
                     .iter()
-                    .map(|doc| doc.logical_message_id.as_deref())
-                    .collect::<Vec<_>>(),
+                    .map(|doc| doc.logical_message_id.as_deref()),
             )),
-            Arc::new(Int64Array::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.authority_message_id)
-                    .collect::<Vec<_>>(),
+            Arc::new(Int64Array::from_iter(
+                documents.iter().map(|doc| doc.authority_message_id),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.correlation_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.correlation_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.team_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.team_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.run_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.run_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.conversation_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.conversation_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.task_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.task_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.agent_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.agent_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.session_id.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.session_id.as_deref()),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| Some(doc.body_text.as_str()))
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| Some(doc.body_text.as_str())),
             )),
-            Arc::new(StringArray::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.payload_json.as_deref())
-                    .collect::<Vec<_>>(),
+            Arc::new(StringArray::from_iter(
+                documents.iter().map(|doc| doc.payload_json.as_deref()),
             )),
-            Arc::new(Int64Array::from(
-                documents
-                    .iter()
-                    .map(|doc| Some(doc.created_at))
-                    .collect::<Vec<_>>(),
+            Arc::new(Int64Array::from_iter(
+                documents.iter().map(|doc| Some(doc.created_at)),
             )),
-            Arc::new(Int64Array::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.event_id_from)
-                    .collect::<Vec<_>>(),
+            Arc::new(Int64Array::from_iter(
+                documents.iter().map(|doc| doc.event_id_from),
             )),
-            Arc::new(Int64Array::from(
-                documents
-                    .iter()
-                    .map(|doc| doc.event_id_to)
-                    .collect::<Vec<_>>(),
+            Arc::new(Int64Array::from_iter(
+                documents.iter().map(|doc| doc.event_id_to),
             )),
             Arc::new(UInt32Array::from(
                 documents
@@ -331,11 +321,35 @@ fn is_existing_index_error(err: &lancedb::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::{LanceDbMessageArchive, escape_sql_literal, parse_source_kind};
     use crate::model::{
         MessageArchiveBackend, MessageArchiveConfig, MessageArchiveStore, MessageDocument,
         MessageDocumentKind, MessageSearchQuery,
     };
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
+
+    fn legacy_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("document_id", DataType::Utf8, false),
+            Field::new("source_kind", DataType::Utf8, false),
+            Field::new("source_id", DataType::Utf8, false),
+            Field::new("logical_message_id", DataType::Utf8, true),
+            Field::new("team_id", DataType::Utf8, true),
+            Field::new("run_id", DataType::Utf8, true),
+            Field::new("conversation_id", DataType::Utf8, true),
+            Field::new("task_id", DataType::Utf8, true),
+            Field::new("agent_id", DataType::Utf8, true),
+            Field::new("session_id", DataType::Utf8, true),
+            Field::new("body_text", DataType::Utf8, false),
+            Field::new("payload_json", DataType::Utf8, true),
+            Field::new("created_at", DataType::Int64, false),
+            Field::new("event_id_from", DataType::Int64, true),
+            Field::new("event_id_to", DataType::Int64, true),
+            Field::new("chunk_count", DataType::UInt32, true),
+        ]))
+    }
 
     #[tokio::test]
     async fn lancedb_archive_can_append_and_search_messages() {
@@ -490,6 +504,68 @@ mod tests {
             .expect("search docs");
         assert_eq!(authority_filtered.len(), 1);
         assert_eq!(authority_filtered[0].document_id, "doc-1");
+    }
+
+    #[tokio::test]
+    async fn lancedb_archive_migrates_existing_tables_without_identity_columns() {
+        let config = MessageArchiveConfig {
+            backend: MessageArchiveBackend::LanceDb,
+            uri: "memory://agenthub-message-archive-legacy".to_string(),
+            message_table: "messages".to_string(),
+        };
+        let archive = LanceDbMessageArchive::connect(config)
+            .await
+            .expect("connect archive");
+        archive
+            .connection
+            .create_empty_table(&archive.config.message_table, legacy_schema())
+            .execute()
+            .await
+            .expect("create legacy table");
+
+        archive.ensure_ready().await.expect("migrate legacy table");
+
+        let table = archive.ensure_table().await.expect("open migrated table");
+        let schema = table.schema().await.expect("table schema");
+        assert!(schema.field_with_name("authority_message_id").is_ok());
+        assert!(schema.field_with_name("correlation_id").is_ok());
+
+        archive
+            .append_documents(&[MessageDocument {
+                document_id: "legacy-doc-1".to_string(),
+                source_kind: MessageDocumentKind::TeamConversationMessage,
+                source_id: "1".to_string(),
+                logical_message_id: Some("msg-legacy-1".to_string()),
+                authority_message_id: Some(501),
+                correlation_id: Some("corr-legacy".to_string()),
+                team_id: Some("team-legacy".to_string()),
+                run_id: None,
+                conversation_id: Some("conv-legacy".to_string()),
+                task_id: Some("task-legacy".to_string()),
+                agent_id: None,
+                session_id: None,
+                body_text: "hello legacy".to_string(),
+                payload_json: None,
+                created_at: 1,
+                event_id_from: None,
+                event_id_to: None,
+                chunk_count: None,
+            }])
+            .await
+            .expect("append migrated docs");
+
+        let hits = archive
+            .search(&MessageSearchQuery {
+                query_text: "legacy".to_string(),
+                limit: 5,
+                authority_message_id: Some(501),
+                correlation_id: Some("corr-legacy".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("search migrated docs");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document_id, "legacy-doc-1");
     }
 
     #[test]

--- a/crates/agenthub-message-archive/src/model.rs
+++ b/crates/agenthub-message-archive/src/model.rs
@@ -56,6 +56,8 @@ pub struct MessageDocument {
     pub source_kind: MessageDocumentKind,
     pub source_id: String,
     pub logical_message_id: Option<String>,
+    pub authority_message_id: Option<i64>,
+    pub correlation_id: Option<String>,
     pub team_id: Option<String>,
     pub run_id: Option<String>,
     pub conversation_id: Option<String>,
@@ -74,6 +76,8 @@ pub struct MessageDocument {
 pub struct MessageSearchQuery {
     pub query_text: String,
     pub limit: usize,
+    pub authority_message_id: Option<i64>,
+    pub correlation_id: Option<String>,
     pub team_id: Option<String>,
     pub run_id: Option<String>,
     pub conversation_id: Option<String>,

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -89,6 +89,8 @@ The archive stores one canonical document shape for every message-like record:
 - `source_kind`
 - `source_id`
 - optional logical grouping IDs:
+  - `authority_message_id`
+  - `correlation_id`
   - `team_id`
   - `run_id`
   - `conversation_id`
@@ -110,6 +112,10 @@ The archive stores one canonical document shape for every message-like record:
 - `team_run_event`
 - `team_actor_message`
 - `aggregated_acp_message`
+
+`logical_message_id` remains the generic non-Team logical grouping field, mainly for aggregated ACP
+messages. Human-visible Team projections should prefer explicit `authority_message_id +
+correlation_id` fields instead of overloading `logical_message_id`.
 
 ### 4) ACP Aggregation Layer
 

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -154,6 +154,8 @@ The initial search target is the canonical `body_text` field, backed by LanceDB 
 
 Search queries may filter by archive scope:
 
+- `authority_message_id`
+- `correlation_id`
 - `team_id`
 - `run_id`
 - `conversation_id`

--- a/docs/journal/2026-05-05-message-metadata-surface-rollout-phase-a.md
+++ b/docs/journal/2026-05-05-message-metadata-surface-rollout-phase-a.md
@@ -5,6 +5,13 @@
 This pass extends the archive/search projection contract so archive documents can preserve the same
 message-identity references already being tightened on Team relay and replica paths.
 
+## Background
+
+PR 484 established the authority-message contract on Team relay and replica ingress, but archive
+documents were still treating `authority_message_id` and `correlation_id` as implicit payload
+details instead of stable searchable fields. This pass makes the archive/search surface preserve the
+same canonical references before broader dual-write ingress rollout begins.
+
 ## Scope
 
 - promote `authority_message_id` and `correlation_id` into the archive document model as first-class

--- a/docs/journal/2026-05-05-message-metadata-surface-rollout-phase-a.md
+++ b/docs/journal/2026-05-05-message-metadata-surface-rollout-phase-a.md
@@ -1,0 +1,42 @@
+# Message Metadata Surface Rollout Phase A
+
+## Summary
+
+This pass extends the archive/search projection contract so archive documents can preserve the same
+message-identity references already being tightened on Team relay and replica paths.
+
+## Scope
+
+- promote `authority_message_id` and `correlation_id` into the archive document model as first-class
+  optional fields;
+- keep `logical_message_id` for generic/non-Team logical grouping, especially aggregated ACP
+  messages;
+- make LanceDB schema plus search filtering understand the new fields;
+- avoid broader ingest wiring changes in this slice.
+
+## Key Decisions
+
+- `authority_message_id` is the Team-facing canonical message identity for archive/search
+  projections when the source record ultimately reconciles to a canonical conversation message.
+- `correlation_id` should stay first-class in archive documents so search/replay can preserve
+  intent lineage instead of re-parsing payload JSON everywhere.
+- `logical_message_id` is still needed, but its meaning is narrower: it remains the generic logical
+  grouping field for sources such as aggregated ACP messages where there is no Team authority
+  message row.
+
+## Validation
+
+Validated with:
+
+```bash
+cargo test -p agenthub-message-archive -- --nocapture
+cargo check -p agenthub-message-archive
+```
+
+## Follow-Ups
+
+- wire the archive document contract into the first real dual-write ingress paths instead of
+  keeping it test-only inside the archive crate;
+- continue the remaining message-surface matrix so relay payloads, node-local caches, and archive
+  docs all carry the same canonical identity references where applicable;
+- plan the later `group_id` rollout separately from this archive-document identity pass.


### PR DESCRIPTION
# Summary

- promote `authority_message_id` and `correlation_id` into the archive document model as first-class optional fields
- extend the LanceDB schema and search filters to preserve and query those canonical message identity references
- document the narrower contract that `logical_message_id` remains the generic grouping field, mainly for aggregated ACP messages

# Validation

- `cargo fmt --all --check`
- `cargo test -p agenthub-message-archive -- --nocapture`
- `cargo check -p agenthub-message-archive`
