### PR TITLE
fix(actor): validate direct remote mailbox sends

### DIFF
--- a/docs/features/actor-foundation.md
+++ b/docs/features/actor-foundation.md
@@ -117,7 +117,7 @@ Peer identity policy:
 
 - `from_peer_id` defaults to `main` when omitted; callers SHOULD set it explicitly in multi-peer deployments.
 - `to_peer_id` defaults to `main` for local transport when omitted.
-- For remote transport, callers MUST provide a relay `route` and set `to_peer_id` to a non-`main` peer (for example `node`). Backend mailbox service validation rejects route-less remote sends and remote sends addressed to `main`.
+- For remote transport, callers MUST provide a relay `route` object containing a non-empty `endpoint` or `grpc_target`, and set `to_peer_id` to a non-`main` peer (for example `node`). Backend mailbox service validation rejects route-less or malformed remote sends and remote sends addressed to `main`.
 
 Identity-kind projection (for UX/policy):
 

--- a/docs/features/actor-foundation.md
+++ b/docs/features/actor-foundation.md
@@ -117,7 +117,7 @@ Peer identity policy:
 
 - `from_peer_id` defaults to `main` when omitted; callers SHOULD set it explicitly in multi-peer deployments.
 - `to_peer_id` defaults to `main` for local transport when omitted.
-- For remote transport, callers MUST set `to_peer_id` to a non-`main` peer (for example `node`); if omitted, current implementation falls back to `main` and delivers locally (backward-compatibility path).
+- For remote transport, callers MUST provide a relay `route` and set `to_peer_id` to a non-`main` peer (for example `node`). Backend mailbox service validation rejects route-less remote sends and remote sends addressed to `main`.
 
 Identity-kind projection (for UX/policy):
 

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -563,6 +563,36 @@ impl TeamActorMailboxService {
         validate_direct_mailbox_target_for_member_specs(&member_specs, to_actor_id)
     }
 
+    fn validate_direct_remote_route(route: Option<&Value>) -> Result<(), ActorServiceError> {
+        let Some(route) = route else {
+            return Err(ActorServiceError::new(
+                ActorServiceErrorCode::BadRequest,
+                "route is required for remote transport",
+            ));
+        };
+        let Some(object) = route.as_object() else {
+            return Err(ActorServiceError::new(
+                ActorServiceErrorCode::BadRequest,
+                "route must be a JSON object for remote transport",
+            ));
+        };
+        let has_http_route = object
+            .get("endpoint")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_grpc_route = object
+            .get("grpc_target")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
+        if has_http_route || has_grpc_route {
+            return Ok(());
+        }
+        Err(ActorServiceError::new(
+            ActorServiceErrorCode::BadRequest,
+            "route must contain endpoint or grpc_target for remote transport",
+        ))
+    }
+
     async fn load_member_specs_for_run(
         &self,
         run_id: &str,
@@ -762,12 +792,7 @@ impl ActorMailboxService for TeamActorMailboxService {
                     .await?;
             }
             TeamActorMessageTransport::Remote => {
-                if request.route.is_none() {
-                    return Err(ActorServiceError::new(
-                        ActorServiceErrorCode::BadRequest,
-                        "route is required for remote transport",
-                    ));
-                }
+                Self::validate_direct_remote_route(request.route.as_ref())?;
                 if to_peer_id == ACTOR_MAIN_PEER_ID {
                     return Err(ActorServiceError::new(
                         ActorServiceErrorCode::BadRequest,

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -756,9 +756,25 @@ impl ActorMailboxService for TeamActorMailboxService {
                 .map_err(map_actor_service_error);
         }
         let to_actor_id = to_actor_id.expect("validated actor target");
-        if transport == TeamActorMessageTransport::Local {
-            self.validate_direct_send_target(run_id, to_actor_id)
-                .await?;
+        match transport {
+            TeamActorMessageTransport::Local => {
+                self.validate_direct_send_target(run_id, to_actor_id)
+                    .await?;
+            }
+            TeamActorMessageTransport::Remote => {
+                if request.route.is_none() {
+                    return Err(ActorServiceError::new(
+                        ActorServiceErrorCode::BadRequest,
+                        "route is required for remote transport",
+                    ));
+                }
+                if to_peer_id == ACTOR_MAIN_PEER_ID {
+                    return Err(ActorServiceError::new(
+                        ActorServiceErrorCode::BadRequest,
+                        "to_peer_id must not be 'main' for remote transport",
+                    ));
+                }
+            }
         }
 
         let (message, created) = self

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -5295,6 +5295,113 @@ async fn actor_mailbox_service_channel_send_reuses_canonical_message_on_idempote
 }
 
 #[tokio::test]
+async fn actor_mailbox_service_direct_remote_send_requires_relay_route_and_remote_peer() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+    let service = manager.actor_mailbox_service();
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "actor-mailbox-direct-remote-validation-team".to_string(),
+            description: Some("team for direct remote mailbox validation".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[
+                    {"member_id":"planner"},
+                    {"member_id":"reviewer"}
+                ]
+            }),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some("ctx-direct-remote-validation"),
+            json!({"payload":"start"}),
+        )
+        .await
+        .expect("create run");
+
+    let missing_route = service
+        .actor_send(ActorSendRequest {
+            run_id: run.id.clone(),
+            from_actor_id: "planner".to_string(),
+            from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            to_actor_id: Some("remote-reviewer".to_string()),
+            channel_id: None,
+            to_peer_id: Some(ACTOR_NODE_PEER_ID.to_string()),
+            channel: Some("coordination".to_string()),
+            transport: Some(TeamActorMessageTransport::Remote),
+            route: None,
+            payload: json!({"text":"please review remotely"}),
+            idempotency_key: Some("msg-direct-remote-missing-route".to_string()),
+        })
+        .await
+        .expect_err("remote direct send without route should fail");
+    assert_eq!(missing_route.code, ActorServiceErrorCode::BadRequest);
+    assert_eq!(
+        missing_route.message,
+        "route is required for remote transport"
+    );
+
+    let main_peer = service
+        .actor_send(ActorSendRequest {
+            run_id: run.id.clone(),
+            from_actor_id: "planner".to_string(),
+            from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            to_actor_id: Some("remote-reviewer".to_string()),
+            channel_id: None,
+            to_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            channel: Some("coordination".to_string()),
+            transport: Some(TeamActorMessageTransport::Remote),
+            route: Some(json!({"endpoint":"https://remote.example/mailbox"})),
+            payload: json!({"text":"please review remotely"}),
+            idempotency_key: Some("msg-direct-remote-main-peer".to_string()),
+        })
+        .await
+        .expect_err("remote direct send to main peer should fail");
+    assert_eq!(main_peer.code, ActorServiceErrorCode::BadRequest);
+    assert_eq!(
+        main_peer.message,
+        "to_peer_id must not be 'main' for remote transport"
+    );
+
+    let valid = service
+        .actor_send(ActorSendRequest {
+            run_id: run.id.clone(),
+            from_actor_id: "planner".to_string(),
+            from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            to_actor_id: Some("remote-reviewer".to_string()),
+            channel_id: None,
+            to_peer_id: Some(ACTOR_NODE_PEER_ID.to_string()),
+            channel: Some("coordination".to_string()),
+            transport: Some(TeamActorMessageTransport::Remote),
+            route: Some(json!({"endpoint":"https://remote.example/mailbox"})),
+            payload: json!({"text":"please review remotely"}),
+            idempotency_key: Some("msg-direct-remote-valid".to_string()),
+        })
+        .await
+        .expect("valid remote direct send");
+    assert_eq!(valid.state, TeamActorMessageStatus::Pending);
+    assert_eq!(valid.message.to_peer_id, ACTOR_NODE_PEER_ID);
+    assert_eq!(valid.message.transport, TeamActorMessageTransport::Remote);
+
+    let mailbox_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM team_actor_messages
+        WHERE run_id = ?1
+        "#,
+    )
+    .bind(&run.id)
+    .fetch_one(&db)
+    .await
+    .expect("count persisted mailbox rows");
+    assert_eq!(mailbox_count, 1);
+}
+
+#[tokio::test]
 async fn actor_mailbox_service_channel_send_auto_routes_remote_recipients_over_p2p() {
     let db = setup_test_db().await;
     sqlx::query("ALTER TABLE agents ADD COLUMN target_node_id TEXT")

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -5345,6 +5345,50 @@ async fn actor_mailbox_service_direct_remote_send_requires_relay_route_and_remot
         "route is required for remote transport"
     );
 
+    let null_route = service
+        .actor_send(ActorSendRequest {
+            run_id: run.id.clone(),
+            from_actor_id: "planner".to_string(),
+            from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            to_actor_id: Some("remote-reviewer".to_string()),
+            channel_id: None,
+            to_peer_id: Some(ACTOR_NODE_PEER_ID.to_string()),
+            channel: Some("coordination".to_string()),
+            transport: Some(TeamActorMessageTransport::Remote),
+            route: Some(Value::Null),
+            payload: json!({"text":"please review remotely"}),
+            idempotency_key: Some("msg-direct-remote-null-route".to_string()),
+        })
+        .await
+        .expect_err("remote direct send with null route should fail");
+    assert_eq!(null_route.code, ActorServiceErrorCode::BadRequest);
+    assert_eq!(
+        null_route.message,
+        "route must be a JSON object for remote transport"
+    );
+
+    let empty_route = service
+        .actor_send(ActorSendRequest {
+            run_id: run.id.clone(),
+            from_actor_id: "planner".to_string(),
+            from_peer_id: Some(ACTOR_MAIN_PEER_ID.to_string()),
+            to_actor_id: Some("remote-reviewer".to_string()),
+            channel_id: None,
+            to_peer_id: Some(ACTOR_NODE_PEER_ID.to_string()),
+            channel: Some("coordination".to_string()),
+            transport: Some(TeamActorMessageTransport::Remote),
+            route: Some(json!({})),
+            payload: json!({"text":"please review remotely"}),
+            idempotency_key: Some("msg-direct-remote-empty-route".to_string()),
+        })
+        .await
+        .expect_err("remote direct send with empty route should fail");
+    assert_eq!(empty_route.code, ActorServiceErrorCode::BadRequest);
+    assert_eq!(
+        empty_route.message,
+        "route must contain endpoint or grpc_target for remote transport"
+    );
+
     let main_peer = service
         .actor_send(ActorSendRequest {
             run_id: run.id.clone(),


### PR DESCRIPTION
## Summary

- Enforce direct remote mailbox sends at the backend service boundary.
- Reject route-less remote sends and remote sends addressed to the `main` peer before they can persist non-relayable mailbox rows.
- Update the actor foundation spec so the stable peer identity contract matches the backend behavior.

## Purpose

Direct remote mailbox sends were already constrained by the HTTP API and CLI, but lower-level backend callers could still bypass those entry points. This keeps the actor mailbox service itself aligned with the remote relay contract.

## Related Issues

- None.

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub actor_mailbox_service_direct_remote_send_requires_relay_route_and_remote_peer`
- `cargo test -p agenthub actor_mailbox_service_channel_send_auto_routes_remote_recipients_over_p2p`
