### PR TITLE
feat(archive): dual-write team conversation messages

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,6 +23,7 @@ env:
     //crates/agenthub-internal-p2p:agenthub_internal_p2p_tests
     //crates/agenthub-logging:agenthub_logging_tests
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
+    //crates/agenthub-message-archive:agenthub_message_archive_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests
@@ -38,6 +39,7 @@ env:
     //crates/agenthub-internal-p2p:agenthub_internal_p2p_tests
     //crates/agenthub-logging:agenthub_logging_tests
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
+    //crates/agenthub-message-archive:agenthub_message_archive_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests
@@ -52,7 +54,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -74,7 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -98,7 +100,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -120,7 +122,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.95.0
         with:

--- a/.github/workflows/distributed-p2p.yml
+++ b/.github/workflows/distributed-p2p.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.95.0
       - name: Rust cache

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ rust_library(
         "//crates/agenthub-team-domain:agenthub_team_domain",
         "//crates/agenthub-team-prompts:agenthub_team_prompts",
         "//crates/agenthub-logging:agenthub_logging",
+        "//crates/agenthub-message-archive:agenthub_message_archive",
         "//crates/agenthub-pyroscope:agenthub_pyroscope",
         "//crates/agenthub-config:agenthub_config",
         "//crates/agenthub-db:agenthub_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "agenthub-internal-p2p",
  "agenthub-logging",
  "agenthub-managed-skills",
+ "agenthub-message-archive",
  "agenthub-pyroscope",
  "agenthub-team-actor",
  "agenthub-team-domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ agenthub-team-actor = { path = "crates/agenthub-team-actor" }
 agenthub-team-domain = { path = "crates/agenthub-team-domain" }
 agenthub-team-prompts = { path = "crates/agenthub-team-prompts" }
 agenthub-logging = { path = "crates/agenthub-logging" }
+agenthub-message-archive = { path = "crates/agenthub-message-archive" }
 agenthub-config = { path = "crates/agenthub-config" }
 agenthub-db = { path = "crates/agenthub-db" }
 agenthub-pyroscope = { path = "crates/agenthub-pyroscope" }

--- a/crates/agenthub-message-archive/src/model.rs
+++ b/crates/agenthub-message-archive/src/model.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -10,6 +11,33 @@ pub enum MessageArchiveBackend {
     #[serde(rename = "lancedb", alias = "lance_db")]
     LanceDb,
 }
+
+impl FromStr for MessageArchiveBackend {
+    type Err = MessageArchiveBackendParseError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "sqlite" => Ok(Self::Sqlite),
+            "lancedb" | "lance_db" => Ok(Self::LanceDb),
+            other => Err(MessageArchiveBackendParseError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageArchiveBackendParseError {
+    value: String,
+}
+
+impl fmt::Display for MessageArchiveBackendParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unsupported message archive backend: {}", self.value)
+    }
+}
+
+impl std::error::Error for MessageArchiveBackendParseError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MessageArchiveConfig {
@@ -105,6 +133,7 @@ pub trait MessageArchiveStore: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::MessageArchiveBackend;
+    use std::str::FromStr;
 
     #[test]
     fn lancedb_backend_uses_canonical_config_string() {
@@ -119,5 +148,25 @@ mod tests {
         let legacy_alias: MessageArchiveBackend =
             serde_json::from_str("\"lance_db\"").expect("legacy alias parses");
         assert_eq!(legacy_alias, MessageArchiveBackend::LanceDb);
+    }
+
+    #[test]
+    fn message_archive_backend_parses_config_values() {
+        assert_eq!(
+            MessageArchiveBackend::from_str(" lancedb ").expect("parse canonical backend"),
+            MessageArchiveBackend::LanceDb
+        );
+        assert_eq!(
+            MessageArchiveBackend::from_str("lance_db").expect("parse legacy backend alias"),
+            MessageArchiveBackend::LanceDb
+        );
+        assert_eq!(
+            MessageArchiveBackend::from_str("sqlite").expect("parse sqlite backend"),
+            MessageArchiveBackend::Sqlite
+        );
+        assert!(
+            MessageArchiveBackend::from_str("tantivy").is_err(),
+            "unsupported backends should fail fast"
+        );
     }
 }

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -66,6 +66,11 @@ This means the rollout is staged:
 5. switch search and history-oriented read paths to the archive
 6. only then evaluate whether any SQLite message tables can be demoted or trimmed
 
+The first live dual-write surface is Team conversation messages. They continue to commit to SQLite
+first, then best-effort append a deterministic archive document. Archive append failures must be
+logged and recovered by the historical migration path rather than rolling back the user-visible
+conversation write.
+
 ### 2) Pluggable Backend Boundary
 
 Business logic must not depend directly on `lancedb::Connection` or LanceDB query builders.
@@ -262,6 +267,8 @@ Recommended identity shapes:
   - Team run events
   - Team actor messages
   - raw ACP event replay into aggregated archive documents
+- Focused Team manager test for live Team conversation message dual-write without duplicating
+  archive documents on idempotent retries.
 - `cargo test -p <archive crate>`
 - `cargo check`
 - `bazel build //...`
@@ -271,6 +278,9 @@ Recommended identity shapes:
 - Keep SQLite message tables intact until archive read paths and migration are both validated.
 - Treat the archive as a search/retrieval plane first, not as a replacement for transactionally
   sensitive runtime state.
+- Live archive dual-write should not make Team conversation writes depend on LanceDB availability;
+  deterministic document ids and historical migration are the recovery boundary for missed archive
+  appends.
 - ACP aggregation should be deterministic so historical re-indexing produces the same logical
   archive documents as live dual-write.
 - ACP aggregation keeps parseable chunks with the same grouping key in one logical archive
@@ -289,3 +299,4 @@ Recommended identity shapes:
 ## Source Journals
 
 - [docs/journal/2026-05-04-lancedb-message-archive-phase1.md](../journal/2026-05-04-lancedb-message-archive-phase1.md)
+- [docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md](../journal/2026-05-05-message-archive-team-conversation-dual-write.md)

--- a/docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md
+++ b/docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md
@@ -1,0 +1,46 @@
+# Message Archive Team Conversation Dual Write
+
+## Summary
+
+Team conversation message creation now dual-writes newly created SQLite rows into the configured
+message archive. This is the first live message-shaped write path connected to the archive trait.
+
+## Background
+
+The LanceDB archive phase 1 introduced the backend-agnostic archive crate, LanceDB implementation,
+search contract, and ACP chunk aggregation. The next rollout step is to start feeding new
+message-shaped records into the archive without replacing the relational SQLite tables.
+
+## Scope
+
+- Open the configured message archive during application service initialization.
+- Pass the archive trait object into `TeamManager`.
+- Append a deterministic `team_conversation_message:<conversation_id>:<message_id>` document when a
+  Team conversation message row is newly created.
+- Keep idempotent retries from writing duplicate archive documents.
+
+## Key Decisions
+
+- SQLite remains the transactional system of record for Team conversation messages.
+- Archive append is best-effort after the SQLite insert succeeds. If archive append fails, the user
+  visible conversation write remains committed and the failure is logged for later migration repair.
+- The archive document uses `authority_message_id = message_id` and preserves `correlation_id` from
+  the message payload when present.
+- `body_text` is extracted from `payload.text`, then `payload.summary`, then the redacted JSON
+  payload as a fallback.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo test -p agenthub-message-archive message_archive_backend_parses_config_values -- --nocapture
+cargo test append_task_conversation_message_dual_writes_created_rows_to_archive -- --nocapture
+cargo check
+```
+
+## Follow-Ups
+
+- Add migration for historical `team_conversation_messages` rows into the archive.
+- Extend live dual-write to Team run events and Team actor mailbox messages.
+- Switch message search/read paths from direct SQLite scans to the archive search contract after
+  migration coverage is in place.

--- a/docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md
+++ b/docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md
@@ -22,19 +22,24 @@ message-shaped records into the archive without replacing the relational SQLite 
 ## Key Decisions
 
 - SQLite remains the transactional system of record for Team conversation messages.
-- Archive append is best-effort after the SQLite insert succeeds. If archive append fails, the user
-  visible conversation write remains committed and the failure is logged for later migration repair.
+- Archive append is best-effort after the SQLite insert succeeds. The append is dispatched in the
+  background with a bounded timeout, so archive latency does not block the user-visible
+  conversation write. Failures are logged for later migration repair.
+- Archive initialization is best-effort for this rollout slice. Startup logs failures and disables
+  dual-writes instead of making the message archive a hard boot dependency.
 - The archive document uses `authority_message_id = message_id` and preserves `correlation_id` from
   the message payload when present.
-- `body_text` is extracted from `payload.text`, then `payload.summary`, then the redacted JSON
-  payload as a fallback.
+- `body_text` is extracted from `payload.text`, then `payload.summary`. If neither field carries
+  text, it stays empty because the full structured payload is already preserved in `payload_json`.
 
 ## Validation
 
 ```bash
 cargo fmt --all --check
 cargo test -p agenthub-message-archive message_archive_backend_parses_config_values -- --nocapture
-cargo test append_task_conversation_message_dual_writes_created_rows_to_archive -- --nocapture
+cargo test --lib append_task_conversation_message_dual_writes_created_rows_to_archive -- --nocapture
+cargo test --lib append_task_conversation_message_does_not_wait_for_slow_archive -- --nocapture
+cargo test --lib message_archive_body_text_does_not_index_structured_payload_fallback -- --nocapture
 cargo check
 ```
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,11 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use agenthub_config::ServerRole;
+use agenthub_message_archive::{
+    MessageArchiveBackend, MessageArchiveConfig, MessageArchiveStoreRef, open_message_archive_store,
+};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -178,6 +182,7 @@ impl AppState {
         };
         let acp_permissions = Arc::new(AcpPermissionService::new(db.clone()));
         let auth = Arc::new(AuthService::new(db.clone(), config).await?);
+        let message_archive = Self::initialize_message_archive(config).await?;
         let agents = Arc::new(AgentManager::new_with_internal_grpc(
             db.clone(),
             event_dbs.clone(),
@@ -192,9 +197,10 @@ impl AppState {
             internal_peer_client.clone(),
         ));
 
-        let teams = Arc::new(TeamManager::new_with_event_dbs(
+        let teams = Arc::new(TeamManager::new_with_event_dbs_and_message_archive(
             db.clone(),
             event_dbs.clone(),
+            message_archive,
         ));
         if let Some(peer_client) = internal_peer_client.as_ref() {
             teams.configure_internal_grpc_relay(
@@ -216,6 +222,19 @@ impl AppState {
         )));
 
         Ok((agents, teams, push, auth, acp_permissions))
+    }
+
+    async fn initialize_message_archive(
+        config: &agenthub_config::AppConfig,
+    ) -> anyhow::Result<Option<MessageArchiveStoreRef>> {
+        let archive_config = MessageArchiveConfig {
+            backend: MessageArchiveBackend::from_str(&config.message_archive_backend())?,
+            uri: config.message_archive_uri(),
+            message_table: config.message_archive_table(),
+        };
+        let archive = open_message_archive_store(archive_config).await?;
+        archive.ensure_ready().await?;
+        Ok(Some(archive))
     }
 
     async fn run_startup_cleanup(agents: &AgentManager, teams: &TeamManager) -> anyhow::Result<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -227,7 +227,13 @@ impl AppState {
     async fn initialize_message_archive(
         config: &agenthub_config::AppConfig,
     ) -> anyhow::Result<Option<MessageArchiveStoreRef>> {
-        let backend = match MessageArchiveBackend::from_str(&config.message_archive_backend()) {
+        let backend_config = config.message_archive_backend();
+        let backend_config = backend_config.trim();
+        if backend_config.is_empty() {
+            tracing::warn!("message archive disabled because backend config is empty");
+            return Ok(None);
+        }
+        let backend = match MessageArchiveBackend::from_str(backend_config) {
             Ok(backend) => backend,
             Err(error) => {
                 tracing::warn!(

--- a/src/state.rs
+++ b/src/state.rs
@@ -227,13 +227,38 @@ impl AppState {
     async fn initialize_message_archive(
         config: &agenthub_config::AppConfig,
     ) -> anyhow::Result<Option<MessageArchiveStoreRef>> {
+        let backend = match MessageArchiveBackend::from_str(&config.message_archive_backend()) {
+            Ok(backend) => backend,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    "message archive disabled because backend config could not be parsed"
+                );
+                return Ok(None);
+            }
+        };
         let archive_config = MessageArchiveConfig {
-            backend: MessageArchiveBackend::from_str(&config.message_archive_backend())?,
+            backend,
             uri: config.message_archive_uri(),
             message_table: config.message_archive_table(),
         };
-        let archive = open_message_archive_store(archive_config).await?;
-        archive.ensure_ready().await?;
+        let archive = match open_message_archive_store(archive_config).await {
+            Ok(archive) => archive,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    "message archive disabled because backend initialization failed"
+                );
+                return Ok(None);
+            }
+        };
+        if let Err(error) = archive.ensure_ready().await {
+            tracing::warn!(
+                error = ?error,
+                "message archive disabled because backend readiness check failed"
+            );
+            return Ok(None);
+        }
         Ok(Some(archive))
     }
 

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -9,6 +9,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 pub use agenthub_team_domain::TeamRunResumeError;
@@ -92,6 +93,7 @@ pub(crate) const TEAM_CHANNEL_BOOTSTRAP_KIND: &str = "team_channel";
 const TEAM_CHANNEL_BOOTSTRAP_SOURCE: &str = "coordinator_created";
 const SQLITE_CONSTRAINT_UNIQUE_CODE: &str = "2067";
 const TEAM_CHANNEL_BOOTSTRAP_UNIQUE_INDEX: &str = "idx_team_channel_bootstrap_unique";
+const MESSAGE_ARCHIVE_APPEND_TIMEOUT: Duration = Duration::from_secs(2);
 const TEAM_CHANNEL_BOOTSTRAP_UNIQUE_CHANNEL_EXPR: &str =
     "lower(trim(COALESCE(json_extract(context_json, '$.channel_id'), '')))";
 const TASK_CONVERSATION_MESSAGE_IDEMPOTENCY_UNIQUE_COLUMNS: &str = "team_conversation_messages.conversation_id, team_conversation_messages.from_actor_id, team_conversation_messages.idempotency_key";
@@ -1643,8 +1645,7 @@ impl TeamManager {
         };
 
         if created {
-            self.archive_task_conversation_message(&conversation, &message)
-                .await;
+            self.spawn_archive_task_conversation_message(&conversation, &message);
             self.emit_conversation_event(TeamConversationStreamEvent {
                 team_id: conversation.team_id.clone(),
                 task_id: task_id.to_string(),
@@ -1657,7 +1658,7 @@ impl TeamManager {
         Ok((message, created))
     }
 
-    async fn archive_task_conversation_message(
+    fn spawn_archive_task_conversation_message(
         &self,
         conversation: &TeamConversationRecord,
         message: &TeamConversationMessageRecord,
@@ -1665,15 +1666,37 @@ impl TeamManager {
         let Some(archive) = self.message_archive.as_ref() else {
             return;
         };
+        let archive = archive.clone();
         let document = team_conversation_message_archive_document(conversation, message);
-        if let Err(error) = archive.append_documents(&[document]).await {
-            tracing::warn!(
-                error = ?error,
-                conversation_id = %message.conversation_id,
-                message_id = message.message_id,
-                "failed to dual-write team conversation message to archive"
-            );
-        }
+        let conversation_id = message.conversation_id.clone();
+        let message_id = message.message_id;
+
+        tokio::spawn(async move {
+            match tokio::time::timeout(
+                MESSAGE_ARCHIVE_APPEND_TIMEOUT,
+                archive.append_documents(&[document]),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        error = ?error,
+                        conversation_id = %conversation_id,
+                        message_id,
+                        "failed to dual-write team conversation message to archive"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        conversation_id = %conversation_id,
+                        message_id,
+                        timeout_ms = MESSAGE_ARCHIVE_APPEND_TIMEOUT.as_millis(),
+                        "timed out dual-writing team conversation message to archive"
+                    );
+                }
+            }
+        });
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -58,12 +58,14 @@ use crate::agent::{WorktreeMode, derive_team_runtime_workdir};
 use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use agenthub_db::AgentEventDbRouter;
+use agenthub_message_archive::{MessageArchiveStoreRef, MessageDocument, MessageDocumentKind};
 use agenthub_team_actor::{ACTOR_MAIN_PEER_ID, canonical_json};
 
 #[derive(Clone)]
 pub struct TeamManager {
     db: SqlitePool,
     event_dbs: AgentEventDbRouter,
+    message_archive: Option<MessageArchiveStoreRef>,
     conversation_events: broadcast::Sender<TeamConversationStreamEvent>,
     remote_relay_adapter: Arc<TeamRemoteRelayAdapter>,
     agents_target_node_id_column: Arc<Mutex<Option<bool>>>,
@@ -107,6 +109,50 @@ fn normalize_team_channel_id(channel_id: &str) -> anyhow::Result<String> {
         anyhow::bail!("channel_id is required");
     }
     Ok(normalized)
+}
+
+fn team_conversation_message_archive_document(
+    conversation: &TeamConversationRecord,
+    message: &TeamConversationMessageRecord,
+) -> MessageDocument {
+    MessageDocument {
+        document_id: format!(
+            "team_conversation_message:{}:{}",
+            message.conversation_id, message.message_id
+        ),
+        source_kind: MessageDocumentKind::TeamConversationMessage,
+        source_id: message.message_id.to_string(),
+        logical_message_id: None,
+        authority_message_id: Some(message.message_id),
+        correlation_id: message
+            .payload
+            .get("correlation_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        team_id: Some(conversation.team_id.clone()),
+        run_id: None,
+        conversation_id: Some(message.conversation_id.clone()),
+        task_id: Some(message.task_id.clone()),
+        agent_id: None,
+        session_id: None,
+        body_text: message_archive_body_text(&message.payload),
+        payload_json: Some(message.payload.to_string()),
+        created_at: message.created_at,
+        event_id_from: None,
+        event_id_to: None,
+        chunk_count: None,
+    }
+}
+
+fn message_archive_body_text(payload: &Value) -> String {
+    payload
+        .as_str()
+        .or_else(|| payload.get("text").and_then(Value::as_str))
+        .or_else(|| payload.get("summary").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| payload.to_string())
 }
 
 fn build_step_runtime_handle_event_payload(step: &TeamStepRecord, status: &'static str) -> Value {
@@ -495,13 +541,23 @@ impl TeamManager {
         Self::new_with_event_dbs(db, AgentEventDbRouter::with_default_base_dir())
     }
 
+    #[cfg(test)]
     pub fn new_with_event_dbs(db: SqlitePool, event_dbs: AgentEventDbRouter) -> Self {
+        Self::new_with_event_dbs_and_message_archive(db, event_dbs, None)
+    }
+
+    pub fn new_with_event_dbs_and_message_archive(
+        db: SqlitePool,
+        event_dbs: AgentEventDbRouter,
+        message_archive: Option<MessageArchiveStoreRef>,
+    ) -> Self {
         let (conversation_events, _) = broadcast::channel(TEAM_CONVERSATION_STREAM_BUFFER_CAPACITY);
         let remote_relay_adapter = Arc::new(TeamRemoteRelayAdapter::new(db.clone()));
         let agents_target_node_id_column = Arc::new(Mutex::new(None));
         Self {
             db,
             event_dbs,
+            message_archive,
             conversation_events,
             remote_relay_adapter,
             agents_target_node_id_column,
@@ -1587,6 +1643,8 @@ impl TeamManager {
         };
 
         if created {
+            self.archive_task_conversation_message(&conversation, &message)
+                .await;
             self.emit_conversation_event(TeamConversationStreamEvent {
                 team_id: conversation.team_id.clone(),
                 task_id: task_id.to_string(),
@@ -1597,6 +1655,25 @@ impl TeamManager {
         }
 
         Ok((message, created))
+    }
+
+    async fn archive_task_conversation_message(
+        &self,
+        conversation: &TeamConversationRecord,
+        message: &TeamConversationMessageRecord,
+    ) {
+        let Some(archive) = self.message_archive.as_ref() else {
+            return;
+        };
+        let document = team_conversation_message_archive_document(conversation, message);
+        if let Err(error) = archive.append_documents(&[document]).await {
+            tracing::warn!(
+                error = ?error,
+                conversation_id = %message.conversation_id,
+                message_id = message.message_id,
+                "failed to dual-write team conversation message to archive"
+            );
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -154,7 +154,7 @@ fn message_archive_body_text(payload: &Value) -> String {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
-        .unwrap_or_else(|| payload.to_string())
+        .unwrap_or_default()
 }
 
 fn build_step_runtime_handle_event_payload(step: &TeamStepRecord, status: &'static str) -> Value {

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::codec::team_run_status_from_str;
-use super::{TeamManager, TeamRunResumeError};
+use super::{TeamManager, TeamRunResumeError, message_archive_body_text};
 use crate::acp::{AcpActorSkillContext, DEFAULT_ACTOR_CHANNEL};
 use crate::agent::{WorktreeMode, derive_team_runtime_workdir};
 use crate::internal::client::InternalGrpcPeerClientConfig;
@@ -930,6 +930,22 @@ async fn append_task_conversation_message_dual_writes_created_rows_to_archive() 
     assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
     assert_eq!(document.body_text, "archive this message");
     assert_eq!(document.created_at, first.created_at);
+}
+
+#[test]
+fn message_archive_body_text_does_not_index_structured_payload_fallback() {
+    assert_eq!(
+        message_archive_body_text(&json!({"type": "event", "metadata": {"id": "meta-1"}})),
+        ""
+    );
+    assert_eq!(
+        message_archive_body_text(&json!({"text": "  searchable text  "})),
+        "searchable text"
+    );
+    assert_eq!(
+        message_archive_body_text(&json!({"summary": "  searchable summary  "})),
+        "searchable summary"
+    );
 }
 
 #[tokio::test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -14,10 +14,14 @@ use crate::team::{
     TeamTaskListQuery, TeamTaskStatus,
 };
 use agenthub_db::AgentEventDbRouter;
+use agenthub_message_archive::{
+    MessageArchiveStore, MessageDocument, MessageDocumentKind, MessageSearchHit, MessageSearchQuery,
+};
 use agenthub_team_actor::{
     ACTOR_MAIN_PEER_ID, ACTOR_NODE_PEER_ID, ActorAckRequest, ActorIdentityKind, ActorInboxRequest,
     ActorMailboxService, ActorSendRequest, ActorServiceErrorCode,
 };
+use async_trait::async_trait;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, Method, StatusCode};
@@ -29,6 +33,27 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
 use tokio::sync::Mutex;
 use uuid::Uuid;
+
+#[derive(Default)]
+struct RecordingMessageArchive {
+    documents: Mutex<Vec<MessageDocument>>,
+}
+
+#[async_trait]
+impl MessageArchiveStore for RecordingMessageArchive {
+    async fn ensure_ready(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn append_documents(&self, documents: &[MessageDocument]) -> anyhow::Result<()> {
+        self.documents.lock().await.extend_from_slice(documents);
+        Ok(())
+    }
+
+    async fn search(&self, _query: &MessageSearchQuery) -> anyhow::Result<Vec<MessageSearchHit>> {
+        Ok(Vec::new())
+    }
+}
 
 async fn setup_test_db() -> SqlitePool {
     let options = SqliteConnectOptions::new()
@@ -773,6 +798,102 @@ async fn append_task_conversation_message_honors_idempotency_key() {
         .expect("list conversation messages");
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].message_id, first.message_id);
+}
+
+#[tokio::test]
+async fn append_task_conversation_message_dual_writes_created_rows_to_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "task-archive-team".to_string(),
+            description: Some("team for task message archive dual-write".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "all",
+            "user",
+            json!({"bootstrap_kind":"shared_thread"}),
+            "group_chat",
+            Some("all"),
+        )
+        .await
+        .expect("create task");
+
+    let (first, first_created) = manager
+        .append_task_conversation_message_with_created(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({
+                "type": "chat_message",
+                "text": "archive this message",
+                "correlation_id": "corr-archive-1"
+            }),
+            Some("task-archive-msg-1"),
+        )
+        .await
+        .expect("append first message");
+    assert!(first_created);
+
+    let (retry, retry_created) = manager
+        .append_task_conversation_message_with_created(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({
+                "type": "chat_message",
+                "text": "archive this message",
+                "correlation_id": "corr-archive-1"
+            }),
+            Some("task-archive-msg-1"),
+        )
+        .await
+        .expect("append retry message");
+    assert!(!retry_created);
+    assert_eq!(retry.message_id, first.message_id);
+
+    let documents = archive.documents.lock().await.clone();
+    assert_eq!(
+        documents.len(),
+        1,
+        "idempotent retries should not dual-write duplicate archive documents"
+    );
+    let document = &documents[0];
+    assert_eq!(
+        document.document_id,
+        format!(
+            "team_conversation_message:{}:{}",
+            conversation.id, first.message_id
+        )
+    );
+    assert_eq!(
+        document.source_kind,
+        MessageDocumentKind::TeamConversationMessage
+    );
+    assert_eq!(document.source_id, first.message_id.to_string());
+    assert_eq!(document.authority_message_id, Some(first.message_id));
+    assert_eq!(document.correlation_id.as_deref(), Some("corr-archive-1"));
+    assert_eq!(document.team_id.as_deref(), Some(team.id.as_str()));
+    assert_eq!(
+        document.conversation_id.as_deref(),
+        Some(conversation.id.as_str())
+    );
+    assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
+    assert_eq!(document.body_text, "archive this message");
+    assert_eq!(document.created_at, first.created_at);
 }
 
 #[tokio::test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::codec::team_run_status_from_str;
 use super::{TeamManager, TeamRunResumeError};
@@ -32,6 +32,7 @@ use serde_json::{Value, json};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
 use tokio::sync::Mutex;
+use tokio::time::{sleep, timeout};
 use uuid::Uuid;
 
 #[derive(Default)]
@@ -53,6 +54,41 @@ impl MessageArchiveStore for RecordingMessageArchive {
     async fn search(&self, _query: &MessageSearchQuery) -> anyhow::Result<Vec<MessageSearchHit>> {
         Ok(Vec::new())
     }
+}
+
+struct PendingMessageArchive;
+
+#[async_trait]
+impl MessageArchiveStore for PendingMessageArchive {
+    async fn ensure_ready(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn append_documents(&self, _documents: &[MessageDocument]) -> anyhow::Result<()> {
+        std::future::pending::<()>().await;
+        Ok(())
+    }
+
+    async fn search(&self, _query: &MessageSearchQuery) -> anyhow::Result<Vec<MessageSearchHit>> {
+        Ok(Vec::new())
+    }
+}
+
+async fn wait_for_archive_documents(
+    archive: &RecordingMessageArchive,
+    expected_len: usize,
+) -> Vec<MessageDocument> {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let documents = archive.documents.lock().await.clone();
+            if documents.len() >= expected_len {
+                return documents;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("archive documents should be appended")
 }
 
 async fn setup_test_db() -> SqlitePool {
@@ -865,7 +901,7 @@ async fn append_task_conversation_message_dual_writes_created_rows_to_archive() 
     assert!(!retry_created);
     assert_eq!(retry.message_id, first.message_id);
 
-    let documents = archive.documents.lock().await.clone();
+    let documents = wait_for_archive_documents(&archive, 1).await;
     assert_eq!(
         documents.len(),
         1,
@@ -894,6 +930,53 @@ async fn append_task_conversation_message_dual_writes_created_rows_to_archive() 
     assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
     assert_eq!(document.body_text, "archive this message");
     assert_eq!(document.created_at, first.created_at);
+}
+
+#[tokio::test]
+async fn append_task_conversation_message_does_not_wait_for_slow_archive() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(Arc::new(PendingMessageArchive)),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "task-slow-archive-team".to_string(),
+            description: Some("team for slow archive dual-write".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, _) = manager
+        .create_task(
+            &team.id,
+            "all",
+            "user",
+            json!({"bootstrap_kind":"shared_thread"}),
+            "group_chat",
+            Some("all"),
+        )
+        .await
+        .expect("create task");
+
+    let result = timeout(
+        Duration::from_millis(200),
+        manager.append_task_conversation_message_with_created(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({"type": "chat_message", "text": "archive should not block"}),
+            Some("task-slow-archive-msg-1"),
+        ),
+    )
+    .await
+    .expect("conversation append should not wait for archive append")
+    .expect("append message");
+
+    assert!(result.1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Open the configured message archive during service initialization and pass it into `TeamManager`.
- Dual-write newly created Team conversation messages into the archive with deterministic document ids.
- Keep idempotent retries from appending duplicate archive documents, and log archive append failures without rolling back SQLite writes.
- Update the LanceDB archive spec and add a rollout journal for this slice.

## Purpose

This advances the P0+ message archive rollout by connecting the first live message-shaped write path to the backend-agnostic archive trait while keeping SQLite as the transactional source of truth.

## Related Issue

- None.

## Testing

```bash
cargo fmt --all --check
cargo test append_task_conversation_message_dual_writes_created_rows_to_archive -- --nocapture
cargo test -p agenthub-message-archive message_archive_backend_parses_config_values -- --nocapture
cargo check
git diff --check
```

## Notes

- `cargo clean` was run to recover from a local linker failure caused by `No space left on device`; the focused test passed after cleaning `target/`.
