### PR TITLE
feat(archive): add team message search route

### DIFF
--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -234,6 +234,14 @@ impl MessageArchiveStore for LanceDbMessageArchive {
                 "document_id",
                 "source_kind",
                 "body_text",
+                "authority_message_id",
+                "correlation_id",
+                "team_id",
+                "run_id",
+                "conversation_id",
+                "task_id",
+                "agent_id",
+                "session_id",
                 "_score",
             ]))
             .limit(query.limit);
@@ -250,6 +258,14 @@ impl MessageArchiveStore for LanceDbMessageArchive {
             let document_ids = required_string_array(&batch, "document_id")?;
             let source_kinds = required_string_array(&batch, "source_kind")?;
             let body_texts = required_string_array(&batch, "body_text")?;
+            let authority_message_ids = optional_i64_array(&batch, "authority_message_id")?;
+            let correlation_ids = optional_string_array(&batch, "correlation_id")?;
+            let team_ids = optional_string_array(&batch, "team_id")?;
+            let run_ids = optional_string_array(&batch, "run_id")?;
+            let conversation_ids = optional_string_array(&batch, "conversation_id")?;
+            let task_ids = optional_string_array(&batch, "task_id")?;
+            let agent_ids = optional_string_array(&batch, "agent_id")?;
+            let session_ids = optional_string_array(&batch, "session_id")?;
             let scores = batch
                 .column_by_name("_score")
                 .and_then(|column| column.as_any().downcast_ref::<Float32Array>());
@@ -264,6 +280,15 @@ impl MessageArchiveStore for LanceDbMessageArchive {
                     body_text: body_texts.value(row).to_string(),
                     score: scores
                         .and_then(|values| values.is_valid(row).then(|| values.value(row))),
+                    authority_message_id: authority_message_ids
+                        .and_then(|values| values.is_valid(row).then(|| values.value(row))),
+                    correlation_id: optional_string_value(correlation_ids, row),
+                    team_id: optional_string_value(team_ids, row),
+                    run_id: optional_string_value(run_ids, row),
+                    conversation_id: optional_string_value(conversation_ids, row),
+                    task_id: optional_string_value(task_ids, row),
+                    agent_id: optional_string_value(agent_ids, row),
+                    session_id: optional_string_value(session_ids, row),
                 });
             }
         }
@@ -297,6 +322,35 @@ fn required_string_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<&'a
         .as_any()
         .downcast_ref::<StringArray>()
         .ok_or_else(|| anyhow!("search result column {column} is not Utf8"))
+}
+
+fn optional_string_array<'a>(
+    batch: &'a RecordBatch,
+    column: &str,
+) -> Result<Option<&'a StringArray>> {
+    let Some(array) = batch.column_by_name(column) else {
+        return Ok(None);
+    };
+    array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .map(Some)
+        .ok_or_else(|| anyhow!("search result column {column} is not Utf8"))
+}
+
+fn optional_i64_array<'a>(batch: &'a RecordBatch, column: &str) -> Result<Option<&'a Int64Array>> {
+    let Some(array) = batch.column_by_name(column) else {
+        return Ok(None);
+    };
+    array
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .map(Some)
+        .ok_or_else(|| anyhow!("search result column {column} is not Int64"))
+}
+
+fn optional_string_value(values: Option<&StringArray>, row: usize) -> Option<String> {
+    values.and_then(|values| values.is_valid(row).then(|| values.value(row).to_string()))
 }
 
 fn parse_source_kind(raw: &str) -> Option<MessageDocumentKind> {
@@ -397,6 +451,11 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].document_id, "team_conversation_message:conv-1:1");
         assert_eq!(hits[0].body_text, "hello lancedb archive");
+        assert_eq!(hits[0].authority_message_id, Some(101));
+        assert_eq!(hits[0].correlation_id.as_deref(), Some("corr-1"));
+        assert_eq!(hits[0].team_id.as_deref(), Some("team-1"));
+        assert_eq!(hits[0].conversation_id.as_deref(), Some("conv-1"));
+        assert_eq!(hits[0].task_id.as_deref(), Some("task-1"));
         assert!(hits[0].score.is_some());
 
         archive

--- a/crates/agenthub-message-archive/src/model.rs
+++ b/crates/agenthub-message-archive/src/model.rs
@@ -121,6 +121,14 @@ pub struct MessageSearchHit {
     pub source_kind: MessageDocumentKind,
     pub body_text: String,
     pub score: Option<f32>,
+    pub authority_message_id: Option<i64>,
+    pub correlation_id: Option<String>,
+    pub team_id: Option<String>,
+    pub run_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub task_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub session_id: Option<String>,
 }
 
 #[async_trait]

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -235,6 +235,14 @@ Recommended identity shapes:
 - Search results must return enough metadata to deep-link back to the originating Agent/Team view.
 - Search ranking is backend-defined FTS ranking in the first rollout; no semantic embedding ranking
   is required.
+- The first public read surface is Team-scoped message search at
+  `GET /api/teams/:id/messages/search`. The route must:
+  - authenticate the caller and enforce Team ownership before searching;
+  - force `team_id` from the path, not from caller-supplied query parameters;
+  - accept archive filters for `authority_message_id`, `correlation_id`, `run_id`,
+    `conversation_id`, `task_id`, `agent_id`, `session_id`, and `source_kind`;
+  - clamp `limit` to a bounded range so archive queries cannot request unbounded result sets;
+  - return archive hit metadata needed by later UI deep links.
 
 ### 5) Migration Contract
 
@@ -269,6 +277,10 @@ Recommended identity shapes:
   - raw ACP event replay into aggregated archive documents
 - Focused Team manager test for live Team conversation message dual-write without duplicating
   archive documents on idempotent retries.
+- Focused Team API test for Team-scoped archive search:
+  - route uses the archive abstraction
+  - route forces path Team scope into `MessageSearchQuery`
+  - response preserves archive hit metadata for deep-linking
 - `cargo test -p <archive crate>`
 - `cargo check`
 - `bazel build //...`
@@ -300,3 +312,4 @@ Recommended identity shapes:
 
 - [docs/journal/2026-05-04-lancedb-message-archive-phase1.md](../journal/2026-05-04-lancedb-message-archive-phase1.md)
 - [docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md](../journal/2026-05-05-message-archive-team-conversation-dual-write.md)
+- [docs/journal/2026-05-05-message-archive-team-search-api.md](../journal/2026-05-05-message-archive-team-search-api.md)

--- a/docs/journal/2026-05-05-message-archive-team-search-api.md
+++ b/docs/journal/2026-05-05-message-archive-team-search-api.md
@@ -1,0 +1,50 @@
+# Message Archive Team Search API
+
+## Summary
+
+Team message search now has a backend route that reads through the message archive abstraction
+instead of adding another SQLite-specific message scan.
+
+## Background
+
+The message archive rollout already introduced the backend-agnostic archive trait, LanceDB as the
+first backend, first Team conversation dual-write, and archive document metadata for
+authority-linked projections. The next useful search slice is a small Team-scoped API boundary that
+can feed later UI search without exposing LanceDB details to Team API callers.
+
+## Scope
+
+- Add `GET /api/teams/:id/messages/search`.
+- Enforce normal Team ownership checks before any archive query runs.
+- Force archive `team_id` scope from the route path.
+- Return archive hit metadata needed for future deep links.
+- Keep the search route backend-only in this slice; no frontend search UI changes are included.
+
+## Key Decisions
+
+- The Team API calls `TeamManager::search_message_archive`, and `TeamManager` depends only on the
+  archive trait object. API code does not depend on LanceDB connection or query-builder types.
+- Caller-provided Team scope is intentionally ignored. The path Team id is the only Team filter the
+  handler forwards to the archive.
+- Search result metadata is part of the public response now so future UI slices do not need to
+  parse `payload_json` to recover `authority_message_id`, `correlation_id`, task, run, agent, or
+  session context.
+- A missing archive backend returns an empty result set for this first API slice, matching the
+  best-effort rollout posture used by live dual-write initialization.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo test --lib team_message_search_api_uses_archive_with_team_scope -- --nocapture
+cargo test -p agenthub-message-archive lancedb_archive_can_append_and_search_messages -- --nocapture
+cargo check
+```
+
+## Follow-Ups
+
+- Wire the frontend workspace search surface to the Team-scoped archive search API.
+- Add historical migration coverage before treating archive search as complete for old SQLite-only
+  rows.
+- Extend read/search routes for additional message surfaces after their dual-write and migration
+  paths land.

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -8,6 +8,7 @@ use self::errors::{
     map_runtime_start_error, map_submit_step_error, map_task_message_error,
     map_team_internal_error,
 };
+use agenthub_message_archive::{MessageDocumentKind, MessageSearchHit, MessageSearchQuery};
 use agenthub_team_actor::{
     ACTOR_MAIN_PEER_ID, ACTOR_NODE_PEER_ID, ActorAckRequest, ActorInboxRequest,
     ActorMailboxService, ActorMessageStatus, ActorSendRequest, ActorServiceErrorCode,
@@ -196,6 +197,37 @@ pub struct SendTeamTaskMessageRequest {
 pub struct ListTeamTaskMessagesQuery {
     pub limit: Option<i64>,
     pub before_id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchTeamMessagesQuery {
+    #[serde(alias = "q")]
+    pub query: String,
+    pub limit: Option<usize>,
+    pub authority_message_id: Option<i64>,
+    pub correlation_id: Option<String>,
+    pub run_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub task_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub session_id: Option<String>,
+    pub source_kind: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct TeamMessageSearchHitResponse {
+    pub document_id: String,
+    pub source_kind: MessageDocumentKind,
+    pub body_text: String,
+    pub score: Option<f32>,
+    pub authority_message_id: Option<i64>,
+    pub correlation_id: Option<String>,
+    pub team_id: Option<String>,
+    pub run_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub task_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -444,6 +476,7 @@ pub fn router(state: AppState) -> Router {
             "/{id}/tasks/{task_id}/messages",
             post(send_team_task_message).get(list_team_task_messages),
         )
+        .route("/{id}/messages/search", get(search_team_messages))
         .route(
             "/{id}/channels/{channel_id}/threads/{root_message_id}/replies",
             post(reply_team_thread),
@@ -1013,6 +1046,46 @@ async fn list_team_task_messages(
         .await
         .map_err(map_team_internal_error)?;
     Ok(Json(messages))
+}
+
+async fn search_team_messages(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(team_id): Path<String>,
+    Query(query): Query<SearchTeamMessagesQuery>,
+) -> Result<Json<Vec<TeamMessageSearchHitResponse>>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    load_team_for_user(&state, &team_id, &user).await?;
+    let source_kind = query
+        .source_kind
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(parse_message_archive_source_kind)
+        .transpose()?;
+    let archive_query = MessageSearchQuery {
+        query_text: query.query.trim().to_string(),
+        limit: query.limit.unwrap_or(20).clamp(1, 100),
+        authority_message_id: query.authority_message_id,
+        correlation_id: normalize_optional_string(query.correlation_id),
+        team_id: Some(team_id),
+        run_id: normalize_optional_string(query.run_id),
+        conversation_id: normalize_optional_string(query.conversation_id),
+        task_id: normalize_optional_string(query.task_id),
+        agent_id: normalize_optional_string(query.agent_id),
+        session_id: normalize_optional_string(query.session_id),
+        source_kind,
+    };
+    let hits = state
+        .teams
+        .search_message_archive(&archive_query)
+        .await
+        .map_err(map_team_internal_error)?;
+    Ok(Json(
+        hits.into_iter()
+            .map(TeamMessageSearchHitResponse::from)
+            .collect(),
+    ))
 }
 
 async fn reply_team_thread(
@@ -2242,6 +2315,25 @@ fn normalize_optional_non_empty(value: Option<&str>) -> Result<Option<&str>, Api
     }
 }
 
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_message_archive_source_kind(raw: &str) -> Result<MessageDocumentKind, ApiError> {
+    match raw.trim() {
+        "agent_event" => Ok(MessageDocumentKind::AgentEvent),
+        "team_conversation_message" => Ok(MessageDocumentKind::TeamConversationMessage),
+        "team_run_event" => Ok(MessageDocumentKind::TeamRunEvent),
+        "team_actor_message" => Ok(MessageDocumentKind::TeamActorMessage),
+        "aggregated_acp_message" => Ok(MessageDocumentKind::AggregatedAcpMessage),
+        _ => Err(ApiError::bad_request(
+            "unsupported message archive source_kind",
+        )),
+    }
+}
+
 fn normalize_optional_idempotency_key(value: Option<&str>) -> Result<Option<String>, ApiError> {
     let normalized = normalize_optional_idempotency_key_input(value);
     if value.is_some() && normalized.is_none() {
@@ -2258,6 +2350,25 @@ fn normalize_optional_idempotency_key(value: Option<&str>) -> Result<Option<Stri
         ));
     }
     Ok(Some(idempotency_key))
+}
+
+impl From<MessageSearchHit> for TeamMessageSearchHitResponse {
+    fn from(hit: MessageSearchHit) -> Self {
+        Self {
+            document_id: hit.document_id,
+            source_kind: hit.source_kind,
+            body_text: hit.body_text,
+            score: hit.score,
+            authority_message_id: hit.authority_message_id,
+            correlation_id: hit.correlation_id,
+            team_id: hit.team_id,
+            run_id: hit.run_id,
+            conversation_id: hit.conversation_id,
+            task_id: hit.task_id,
+            agent_id: hit.agent_id,
+            session_id: hit.session_id,
+        }
+    }
 }
 
 fn normalize_optional_run_status_filter(value: Option<&str>) -> Result<Option<String>, ApiError> {

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1056,12 +1056,14 @@ async fn search_team_messages(
 ) -> Result<Json<Vec<TeamMessageSearchHitResponse>>, ApiError> {
     let user = require_user(&headers, &state).await?;
     load_team_for_user(&state, &team_id, &user).await?;
+    let query_text = normalize_optional_string(Some(query.query))
+        .ok_or_else(|| ApiError::bad_request("query is required"))?;
     let source_kind = normalize_optional_string(query.source_kind)
         .as_deref()
         .map(parse_message_archive_source_kind)
         .transpose()?;
     let archive_query = MessageSearchQuery {
-        query_text: query.query.trim().to_string(),
+        query_text,
         limit: query.limit.unwrap_or(20).clamp(1, 100),
         authority_message_id: query.authority_message_id,
         correlation_id: normalize_optional_string(query.correlation_id),

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -2321,6 +2321,16 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn message_archive_source_kind_values() -> [&'static str; 5] {
+    [
+        MessageDocumentKind::AgentEvent.as_str(),
+        MessageDocumentKind::TeamConversationMessage.as_str(),
+        MessageDocumentKind::TeamRunEvent.as_str(),
+        MessageDocumentKind::TeamActorMessage.as_str(),
+        MessageDocumentKind::AggregatedAcpMessage.as_str(),
+    ]
+}
+
 fn parse_message_archive_source_kind(raw: &str) -> Result<MessageDocumentKind, ApiError> {
     match raw.trim() {
         "agent_event" => Ok(MessageDocumentKind::AgentEvent),
@@ -2328,9 +2338,13 @@ fn parse_message_archive_source_kind(raw: &str) -> Result<MessageDocumentKind, A
         "team_run_event" => Ok(MessageDocumentKind::TeamRunEvent),
         "team_actor_message" => Ok(MessageDocumentKind::TeamActorMessage),
         "aggregated_acp_message" => Ok(MessageDocumentKind::AggregatedAcpMessage),
-        _ => Err(ApiError::bad_request(
-            "unsupported message archive source_kind",
-        )),
+        invalid => {
+            let message = format!(
+                "unsupported message archive source_kind '{invalid}'; expected one of: {}",
+                message_archive_source_kind_values().join(", ")
+            );
+            Err(ApiError::bad_request(&message))
+        }
     }
 }
 

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1056,11 +1056,8 @@ async fn search_team_messages(
 ) -> Result<Json<Vec<TeamMessageSearchHitResponse>>, ApiError> {
     let user = require_user(&headers, &state).await?;
     load_team_for_user(&state, &team_id, &user).await?;
-    let source_kind = query
-        .source_kind
+    let source_kind = normalize_optional_string(query.source_kind)
         .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
         .map(parse_message_archive_source_kind)
         .transpose()?;
     let archive_query = MessageSearchQuery {

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -55,10 +55,11 @@ use super::{
     list_team_channels, list_team_run_events, list_team_run_inbox, list_team_run_steps,
     list_team_runs, list_team_task_messages, list_team_tasks, list_teams, load_team_for_user,
     map_team_internal_error, normalize_conversation_mode, normalize_task_created_by_actor_id,
-    normalize_team_spec, reply_team_thread, require_user, restart_team_run, resume_team_run,
-    resume_team_run_step, search_team_messages, send_team_run_message, send_team_task_message,
-    set_team_run_step_input_required, start_team, start_team_run_step, stop_team,
-    submit_team_run_step, update_team_spec, update_team_task, validate_team_spec,
+    normalize_team_spec, parse_message_archive_source_kind, reply_team_thread, require_user,
+    restart_team_run, resume_team_run, resume_team_run_step, search_team_messages,
+    send_team_run_message, send_team_task_message, set_team_run_step_input_required, start_team,
+    start_team_run_step, stop_team, submit_team_run_step, update_team_spec, update_team_task,
+    validate_team_spec,
 };
 
 #[derive(Default)]

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -30,18 +30,23 @@ use crate::team::{
     TeamActorMessageTransport, TeamDefinitionConfig, TeamManager, force_team_member_new_session,
 };
 use agenthub_config::{AppConfig, PushConfig, WebConfig};
+use agenthub_message_archive::{
+    MessageArchiveStore, MessageDocument, MessageDocumentKind, MessageSearchHit, MessageSearchQuery,
+};
 use agenthub_team_actor::{
     ActorAckRequest, ActorInboxRequest, ActorMailboxService, ActorSendRequest,
 };
+use async_trait::async_trait;
 
 use super::{
     AckTeamRunMessageRequest, CompileTeamTaskRunPreviewRequest, CompleteTeamRunStepRequest,
     CreateTeamChannelRequest, CreateTeamRequest, CreateTeamRunRequest, CreateTeamTaskRequest,
     FailTeamRunStepRequest, FlushTeamRunContextRequest, ListTeamRunEventsQuery,
     ListTeamRunInboxQuery, ListTeamRunsQuery, ListTeamTaskMessagesQuery, ListTeamTasksQuery,
-    ReplyTeamThreadRequest, ResumeTeamRunStepRequest, SendTeamRunMessageRequest,
-    SendTeamTaskMessageRequest, SetTeamRunStepInputRequiredRequest, StartTeamRunStepRequest,
-    SubmitTeamRunStepRequest, TeamMemberSpec, TeamRunSnapshotQuery, TeamTaskDetailResponse,
+    ReplyTeamThreadRequest, ResumeTeamRunStepRequest, SearchTeamMessagesQuery,
+    SendTeamRunMessageRequest, SendTeamTaskMessageRequest, SetTeamRunStepInputRequiredRequest,
+    StartTeamRunStepRequest, SubmitTeamRunStepRequest, TeamMemberSpec,
+    TeamMessageSearchHitResponse, TeamRunSnapshotQuery, TeamTaskDetailResponse,
     UpdateTeamSpecRequest, UpdateTeamTaskRequest, ack_team_run_message, cancel_team_run,
     compile_team_task_run_preview, complete_team_run_step, create_team, create_team_channel,
     create_team_run, delete_team, delete_team_channel, ensure_team_shared_thread,
@@ -51,10 +56,32 @@ use super::{
     list_team_runs, list_team_task_messages, list_team_tasks, list_teams, load_team_for_user,
     map_team_internal_error, normalize_conversation_mode, normalize_task_created_by_actor_id,
     normalize_team_spec, reply_team_thread, require_user, restart_team_run, resume_team_run,
-    resume_team_run_step, send_team_run_message, send_team_task_message,
+    resume_team_run_step, search_team_messages, send_team_run_message, send_team_task_message,
     set_team_run_step_input_required, start_team, start_team_run_step, stop_team,
     submit_team_run_step, update_team_spec, update_team_task, validate_team_spec,
 };
+
+#[derive(Default)]
+struct RecordingSearchArchive {
+    queries: tokio::sync::Mutex<Vec<MessageSearchQuery>>,
+    hits: Vec<MessageSearchHit>,
+}
+
+#[async_trait]
+impl MessageArchiveStore for RecordingSearchArchive {
+    async fn ensure_ready(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn append_documents(&self, _documents: &[MessageDocument]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn search(&self, query: &MessageSearchQuery) -> anyhow::Result<Vec<MessageSearchHit>> {
+        self.queries.lock().await.push(query.clone());
+        Ok(self.hits.clone())
+    }
+}
 
 static WORKER_TEST_REPO: OnceLock<String> = OnceLock::new();
 static TEST_AGENTHUB_BIN: OnceLock<String> = OnceLock::new();
@@ -153,25 +180,30 @@ fn long_lived_test_agent_args() -> String {
 }
 
 pub(crate) async fn build_test_state() -> AppState {
-    build_test_state_with_db_source(None, true, true).await
+    build_test_state_with_db_source_and_archive(None, true, true, None).await
 }
 
 pub(crate) async fn build_test_state_without_seeded_team_member_agents() -> AppState {
-    build_test_state_with_db_source(None, true, false).await
+    build_test_state_with_db_source_and_archive(None, true, false, None).await
 }
 
 pub(crate) async fn build_test_state_with_db_path(path: &StdPath) -> AppState {
-    build_test_state_with_db_source(Some(path), true, true).await
+    build_test_state_with_db_source_and_archive(Some(path), true, true, None).await
 }
 
 pub(crate) async fn reopen_test_state_with_db_path(path: &StdPath) -> AppState {
-    build_test_state_with_db_source(Some(path), false, false).await
+    build_test_state_with_db_source_and_archive(Some(path), false, false, None).await
 }
 
-async fn build_test_state_with_db_source(
+async fn build_test_state_with_message_archive(archive: Arc<dyn MessageArchiveStore>) -> AppState {
+    build_test_state_with_db_source_and_archive(None, true, false, Some(archive)).await
+}
+
+async fn build_test_state_with_db_source_and_archive(
     path: Option<&StdPath>,
     initialize_schema: bool,
     seed_default_agents: bool,
+    message_archive: Option<Arc<dyn MessageArchiveStore>>,
 ) -> AppState {
     let db = match path {
         Some(path) => create_test_db_at(path).await,
@@ -219,7 +251,11 @@ async fn build_test_state_with_db_source(
         permissions.clone(),
         auth.clone(),
     ));
-    let teams = Arc::new(TeamManager::new_with_event_dbs(db.clone(), event_dbs));
+    let teams = Arc::new(TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        event_dbs,
+        message_archive,
+    ));
     let state = AppState {
         db,
         agents,

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5402,6 +5402,94 @@ async fn team_task_messages_api_forwards_shared_thread_human_chat_without_active
 }
 
 #[tokio::test]
+async fn team_message_search_api_uses_archive_with_team_scope() {
+    let archive = Arc::new(RecordingSearchArchive {
+        queries: tokio::sync::Mutex::new(Vec::new()),
+        hits: vec![MessageSearchHit {
+            document_id: "team_conversation_message:conversation-1:42".to_string(),
+            source_kind: MessageDocumentKind::TeamConversationMessage,
+            body_text: "archive search result".to_string(),
+            score: Some(0.75),
+            authority_message_id: Some(42),
+            correlation_id: Some("corr-search".to_string()),
+            team_id: Some("team-from-archive".to_string()),
+            run_id: None,
+            conversation_id: Some("conversation-1".to_string()),
+            task_id: Some("task-1".to_string()),
+            agent_id: None,
+            session_id: None,
+        }],
+    });
+    let state = build_test_state_with_message_archive(archive.clone()).await;
+    let headers = auth_headers(&state).await;
+    let team = state
+        .teams
+        .create_team_with_owner(
+            TeamDefinitionConfig {
+            name: "message-search-api-team".to_string(),
+            description: Some("archive search".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner","role":"coordinator"}]
+            }),
+            },
+            None,
+        )
+        .await
+        .expect("create team");
+
+    let Json(hits) = search_team_messages(
+        State(state),
+        headers,
+        Path(team.id.clone()),
+        Query(SearchTeamMessagesQuery {
+            query: " archive ".to_string(),
+            limit: Some(5),
+            authority_message_id: None,
+            correlation_id: Some(" corr-search ".to_string()),
+            run_id: None,
+            conversation_id: None,
+            task_id: Some(" task-1 ".to_string()),
+            agent_id: None,
+            session_id: None,
+            source_kind: Some("team_conversation_message".to_string()),
+        }),
+    )
+    .await
+    .expect("search team messages");
+
+    assert_eq!(
+        hits,
+        vec![TeamMessageSearchHitResponse {
+            document_id: "team_conversation_message:conversation-1:42".to_string(),
+            source_kind: MessageDocumentKind::TeamConversationMessage,
+            body_text: "archive search result".to_string(),
+            score: Some(0.75),
+            authority_message_id: Some(42),
+            correlation_id: Some("corr-search".to_string()),
+            team_id: Some("team-from-archive".to_string()),
+            run_id: None,
+            conversation_id: Some("conversation-1".to_string()),
+            task_id: Some("task-1".to_string()),
+            agent_id: None,
+            session_id: None,
+        }]
+    );
+
+    let queries = archive.queries.lock().await;
+    assert_eq!(queries.len(), 1);
+    assert_eq!(queries[0].query_text, "archive");
+    assert_eq!(queries[0].limit, 5);
+    assert_eq!(queries[0].team_id.as_deref(), Some(team.id.as_str()));
+    assert_eq!(queries[0].correlation_id.as_deref(), Some("corr-search"));
+    assert_eq!(queries[0].task_id.as_deref(), Some("task-1"));
+    assert_eq!(
+        queries[0].source_kind,
+        Some(MessageDocumentKind::TeamConversationMessage)
+    );
+}
+
+#[tokio::test]
 async fn teams_api_rejects_human_task_status_and_owner_updates() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -6061,24 +6061,25 @@ async fn team_task_messages_api_forwards_human_chat_to_active_run_mailbox() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;
 
-    let Json(team) = create_team(
-        State(state.clone()),
-        headers.clone(),
-        Json(CreateTeamRequest {
-            name: "task-mailbox-forward-team".to_string(),
-            description: Some("task to mailbox forwarding coverage".to_string()),
-            spec: json!({
-                "entrypoint":"planner",
-                "members":[
-                    {"member_id":"planner","role":"coordinator"},
-                    {"member_id":"worker-1","role":"worker"},
-                    {"member_id":"worker-2","role":"worker"}
-                ]
-            }),
-        }),
-    )
-    .await
-    .expect("create team");
+    let team = state
+        .teams
+        .create_team_with_owner(
+            TeamDefinitionConfig {
+                name: "task-mailbox-forward-team".to_string(),
+                description: Some("task to mailbox forwarding coverage".to_string()),
+                spec: json!({
+                    "entrypoint":"planner",
+                    "members":[
+                        {"member_id":"planner","role":"coordinator"},
+                        {"member_id":"worker-1","role":"worker"},
+                        {"member_id":"worker-2","role":"worker"}
+                    ]
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("create team");
 
     let task_created = create_team_task(
         &state,

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5490,6 +5490,22 @@ async fn team_message_search_api_uses_archive_with_team_scope() {
 }
 
 #[tokio::test]
+async fn message_archive_source_kind_error_lists_supported_values() {
+    let err = parse_message_archive_source_kind("bogus_kind")
+        .expect_err("unsupported archive source kind should fail");
+    let response = err.into_response();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = decode_json_body(response).await;
+    let message = body["error"].as_str().expect("error message");
+    assert!(message.contains("bogus_kind"));
+    assert!(message.contains("agent_event"));
+    assert!(message.contains("team_conversation_message"));
+    assert!(message.contains("team_run_event"));
+    assert!(message.contains("team_actor_message"));
+    assert!(message.contains("aggregated_acp_message"));
+}
+
+#[tokio::test]
 async fn teams_api_rejects_human_task_status_and_owner_updates() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5490,6 +5490,56 @@ async fn team_message_search_api_uses_archive_with_team_scope() {
 }
 
 #[tokio::test]
+async fn team_message_search_api_rejects_blank_query() {
+    let state = build_test_state_with_message_archive(Arc::new(RecordingSearchArchive {
+        queries: tokio::sync::Mutex::new(Vec::new()),
+        hits: Vec::new(),
+    }))
+    .await;
+    let headers = auth_headers(&state).await;
+    let team = state
+        .teams
+        .create_team_with_owner(
+            TeamDefinitionConfig {
+                name: "message-search-blank-query-team".to_string(),
+                description: Some("archive search".to_string()),
+                spec: json!({
+                    "entrypoint":"planner",
+                    "members":[{"member_id":"planner","role":"coordinator"}]
+                }),
+            },
+            None,
+        )
+        .await
+        .expect("create team");
+
+    let err = search_team_messages(
+        State(state),
+        headers,
+        Path(team.id),
+        Query(SearchTeamMessagesQuery {
+            query: "   ".to_string(),
+            limit: None,
+            authority_message_id: None,
+            correlation_id: None,
+            run_id: None,
+            conversation_id: None,
+            task_id: None,
+            agent_id: None,
+            session_id: None,
+            source_kind: None,
+        }),
+    )
+    .await
+    .expect_err("blank archive query should fail");
+
+    let response = err.into_response();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = decode_json_body(response).await;
+    assert_eq!(body["error"], Value::from("query is required"));
+}
+
+#[tokio::test]
 async fn message_archive_source_kind_error_lists_supported_values() {
     let err = parse_message_archive_source_kind("bogus_kind")
         .expect_err("unsupported archive source kind should fail");

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -59,7 +59,10 @@ use crate::agent::{WorktreeMode, derive_team_runtime_workdir};
 use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use agenthub_db::AgentEventDbRouter;
-use agenthub_message_archive::{MessageArchiveStoreRef, MessageDocument, MessageDocumentKind};
+use agenthub_message_archive::{
+    MessageArchiveStoreRef, MessageDocument, MessageDocumentKind, MessageSearchHit,
+    MessageSearchQuery,
+};
 use agenthub_team_actor::{ACTOR_MAIN_PEER_ID, canonical_json};
 
 #[derive(Clone)]
@@ -1782,6 +1785,16 @@ impl TeamManager {
         }
         messages.reverse();
         Ok(messages)
+    }
+
+    pub async fn search_message_archive(
+        &self,
+        query: &MessageSearchQuery,
+    ) -> anyhow::Result<Vec<MessageSearchHit>> {
+        let Some(archive) = self.message_archive.as_ref() else {
+            return Ok(Vec::new());
+        };
+        archive.search(query).await
     }
 
     pub async fn create_run(


### PR DESCRIPTION
## Summary

- Add `GET /api/teams/:id/messages/search` as the first Team-scoped message archive read surface.
- Preserve archive search hit metadata in API responses for later deep-linking.
- Extend LanceDB search results to return authority, correlation, Team, task, run, agent, and session metadata.
- Document the stable API contract and rollout evidence.

## Purpose

This continues the P0+ message archive rollout by moving the first search/read path onto the backend-agnostic archive abstraction without exposing LanceDB-specific types to Team API callers.

## Related Issues

None.

## Testing

```bash
cargo fmt --all --check
cargo test --lib team_message_search_api_uses_archive_with_team_scope -- --nocapture
cargo test -p agenthub-message-archive lancedb_archive_can_append_and_search_messages -- --nocapture
cargo check
git diff --check
```
