### PR TITLE
chore(ci): deduplicate native rust tests on PR, add bazel coveralls upload

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -155,6 +155,15 @@ jobs:
           env_vars: AGENTHUB_CODECOV_UPLOAD_TAG
           name: bazel-coverage
           fail_ci_if_error: true
+      - name: Upload coverage reports to Coveralls
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: bazel.lcov
+          format: lcov
+          flag-name: bazel
+          parallel: false
 
   bazel:
     name: Bazel Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ jobs:
   rust-grpc-integration:
     name: Rust (gRPC Integration)
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -83,6 +84,7 @@ jobs:
   rust-coverage:
     name: Rust (Coverage)
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,7 +110,7 @@ jobs:
           cargo llvm-cov --workspace --locked --lcov --output-path rust-cargo.lcov
           wc -l rust-cargo.lcov
       - name: Upload coverage reports to Codecov
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What

Deduplicate CI test jobs between Rust native (`cargo`) and Bazel, and add Coveralls upload to the Bazel coverage job.

## Changes

### `.github/workflows/rust.yml`

- `rust-grpc-integration` and `rust-coverage` now only run on `push` to `main` (`if: github.event_name == 'push'`), not on `pull_request`.
- Rationale: these tests are already covered by Bazel (`//:agenthub_unit_tests` and `bazel_coverage`). Avoid running duplicate test suites on every PR while keeping post-merge verification.

### `.github/workflows/bazel.yml`

- Added `coverallsapp/github-action@v2` step to the `bazel_coverage` job, uploading the same `bazel.lcov` to Coveralls alongside the existing Codecov upload.

## Test Plan

- CI on this PR: Bazel `bazel_test_root`, `bazel_test_crates`, `bazel_coverage` cover all tests; Rust `rust-grpc-integration` and `rust-coverage` are skipped.
- Post-merge on `main`: both Rust and Bazel test/coverage jobs run.