### PR TITLE
feat(archive): migrate team messages into archive

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,13 @@
 ignore:
   - "src/internal/proto/agenthub.internal.v1.rs"
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        removed_code_behavior: fully_covered_patch
+
 flag_management:
   default_rules:
     carryforward: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,9 @@
 ignore:
   - "src/internal/proto/agenthub.internal.v1.rs"
+
+flag_management:
+  default_rules:
+    carryforward: false
+  individual_flags:
+    - name: rust-cargo
+      carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,7 @@ flag_management:
   default_rules:
     carryforward: false
   individual_flags:
+    - name: bazel
+      carryforward: true
     - name: rust-cargo
       carryforward: true

--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -100,69 +100,92 @@ impl LanceDbMessageArchive {
         Ok(())
     }
 
-    fn documents_to_record_batch(documents: &[MessageDocument]) -> Result<RecordBatch> {
-        let arrays: Vec<ArrayRef> = vec![
-            Arc::new(StringArray::from_iter(
+    fn documents_to_record_batch(
+        documents: &[MessageDocument],
+        target_schema: SchemaRef,
+    ) -> Result<RecordBatch> {
+        let arrays = target_schema
+            .fields()
+            .iter()
+            .map(|field| Self::document_field_array(documents, field.name(), field.data_type()))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(RecordBatch::try_new(target_schema, arrays)?)
+    }
+
+    fn document_field_array(
+        documents: &[MessageDocument],
+        field_name: &str,
+        data_type: &DataType,
+    ) -> Result<ArrayRef> {
+        let array: ArrayRef = match (field_name, data_type) {
+            ("document_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| Some(doc.document_id.as_str())),
             )),
-            Arc::new(StringArray::from_iter(
+            ("source_kind", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| Some(doc.source_kind.as_str())),
             )),
-            Arc::new(StringArray::from_iter(
+            ("source_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| Some(doc.source_id.as_str())),
             )),
-            Arc::new(StringArray::from_iter(
+            ("logical_message_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents
                     .iter()
                     .map(|doc| doc.logical_message_id.as_deref()),
             )),
-            Arc::new(Int64Array::from_iter(
+            ("authority_message_id", DataType::Int64) => Arc::new(Int64Array::from_iter(
                 documents.iter().map(|doc| doc.authority_message_id),
             )),
-            Arc::new(StringArray::from_iter(
+            ("correlation_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.correlation_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("team_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.team_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("run_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.run_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("conversation_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.conversation_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("task_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.task_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("agent_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.agent_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("session_id", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.session_id.as_deref()),
             )),
-            Arc::new(StringArray::from_iter(
+            ("body_text", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| Some(doc.body_text.as_str())),
             )),
-            Arc::new(StringArray::from_iter(
+            ("payload_json", DataType::Utf8) => Arc::new(StringArray::from_iter(
                 documents.iter().map(|doc| doc.payload_json.as_deref()),
             )),
-            Arc::new(Int64Array::from_iter(
+            ("created_at", DataType::Int64) => Arc::new(Int64Array::from_iter(
                 documents.iter().map(|doc| Some(doc.created_at)),
             )),
-            Arc::new(Int64Array::from_iter(
+            ("event_id_from", DataType::Int64) => Arc::new(Int64Array::from_iter(
                 documents.iter().map(|doc| doc.event_id_from),
             )),
-            Arc::new(Int64Array::from_iter(
+            ("event_id_to", DataType::Int64) => Arc::new(Int64Array::from_iter(
                 documents.iter().map(|doc| doc.event_id_to),
             )),
-            Arc::new(UInt32Array::from(
+            ("chunk_count", DataType::UInt32) => Arc::new(UInt32Array::from(
                 documents
                     .iter()
                     .map(|doc| doc.chunk_count)
                     .collect::<Vec<_>>(),
             )),
-        ];
-        Ok(RecordBatch::try_new(Self::schema(), arrays)?)
+            _ => {
+                return Err(anyhow!(
+                    "unsupported message archive field `{}` with type {:?}",
+                    field_name,
+                    data_type
+                ));
+            }
+        };
+        Ok(array)
     }
 
     fn build_filter(query: &MessageSearchQuery) -> Option<String> {
@@ -216,8 +239,9 @@ impl MessageArchiveStore for LanceDbMessageArchive {
             return Ok(());
         }
         let table = self.ensure_table().await?;
-        let batch = Self::documents_to_record_batch(documents)?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], Self::schema());
+        let table_schema = table.schema().await?;
+        let batch = Self::documents_to_record_batch(documents, table_schema.clone())?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], table_schema);
         let mut merge = table.merge_insert(&["document_id"]);
         merge.when_matched_update_all(None);
         merge.when_not_matched_insert_all();

--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
 use arrow_array::{
-    Array, ArrayRef, Float32Array, Int64Array, RecordBatch, StringArray, UInt32Array,
+    Array, ArrayRef, Float32Array, Int64Array, RecordBatch, RecordBatchIterator, StringArray,
+    UInt32Array,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
@@ -216,7 +217,11 @@ impl MessageArchiveStore for LanceDbMessageArchive {
         }
         let table = self.ensure_table().await?;
         let batch = Self::documents_to_record_batch(documents)?;
-        table.add(batch).execute().await?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], Self::schema());
+        let mut merge = table.merge_insert(&["document_id"]);
+        merge.when_matched_update_all(None);
+        merge.when_not_matched_insert_all();
+        merge.execute(Box::new(reader)).await?;
         Ok(())
     }
 
@@ -563,6 +568,63 @@ mod tests {
             .expect("search docs");
         assert_eq!(authority_filtered.len(), 1);
         assert_eq!(authority_filtered[0].document_id, "doc-1");
+    }
+
+    #[tokio::test]
+    async fn lancedb_archive_upserts_documents_by_document_id() {
+        let config = MessageArchiveConfig {
+            backend: MessageArchiveBackend::LanceDb,
+            uri: "memory://agenthub-message-archive-upsert".to_string(),
+            message_table: "messages".to_string(),
+        };
+        let archive = LanceDbMessageArchive::connect(config)
+            .await
+            .expect("connect archive");
+        archive.ensure_ready().await.expect("ensure ready");
+
+        let mut document = MessageDocument {
+            document_id: "team_run_event:run-1:1".to_string(),
+            source_kind: MessageDocumentKind::TeamRunEvent,
+            source_id: "1".to_string(),
+            logical_message_id: None,
+            authority_message_id: Some(1),
+            correlation_id: None,
+            team_id: Some("team-1".to_string()),
+            run_id: Some("run-1".to_string()),
+            conversation_id: None,
+            task_id: None,
+            agent_id: None,
+            session_id: None,
+            body_text: "first archive body".to_string(),
+            payload_json: None,
+            created_at: 1,
+            event_id_from: Some(1),
+            event_id_to: Some(1),
+            chunk_count: None,
+        };
+        archive
+            .append_documents(&[document.clone()])
+            .await
+            .expect("append first doc");
+
+        document.body_text = "second archive body".to_string();
+        archive
+            .append_documents(&[document])
+            .await
+            .expect("upsert doc");
+
+        let hits = archive
+            .search(&MessageSearchQuery {
+                query_text: "second".to_string(),
+                limit: 5,
+                run_id: Some("run-1".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("search docs");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document_id, "team_run_event:run-1:1");
+        assert_eq!(hits[0].body_text, "second archive body");
     }
 
     #[tokio::test]

--- a/crates/agenthub-message-archive/src/lance.rs
+++ b/crates/agenthub-message-archive/src/lance.rs
@@ -625,6 +625,20 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].document_id, "team_run_event:run-1:1");
         assert_eq!(hits[0].body_text, "second archive body");
+
+        let stale_hits = archive
+            .search(&MessageSearchQuery {
+                query_text: "first".to_string(),
+                limit: 5,
+                run_id: Some("run-1".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("search stale doc");
+        assert!(
+            stale_hits.is_empty(),
+            "upsert should not keep stale full-text tokens"
+        );
     }
 
     #[tokio::test]

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -264,6 +264,16 @@ actor-scoped archive filters find messages delivered to that actor.
 - Team migration excludes `shared_thread_mailbox` bootstrap runs from run-event and actor-mailbox
   archive documents because those runs are internal transport bookkeeping rather than visible Team
   messages.
+- The first Team migration operator endpoint is a bounded synchronous trigger. It is suitable for
+  small or manually sliced backfills, but large production backfills require a durable background job
+  with persisted progress before operators can rely on retry/resume visibility.
+- The first migration report counts source rows converted into canonical archive documents. It does
+  not distinguish newly inserted archive rows from idempotent updates; archive backends need an
+  inserted/updated write-result contract before the admin API can expose that distinction.
+- Live Team actor mailbox sends dual-write created rows to the archive with the same canonical
+  document identity as migration. Team run-event live dual-write still requires a follow-up
+  consolidation of the multiple event insertion paths before run-event search can be fully
+  continuous without rerunning migration.
 
 ### 6) Multi-Database Extensibility Contract
 

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -214,6 +214,16 @@ Recommended identity shapes:
 - `team_actor_message:<run_id>:<message_id>`
 - `aggregated_acp_message:<agent_id>:<session_id>:<message_id>:<kind>`
 
+Team run-event archive documents use the event payload for `task_id` and `conversation_id` when
+present, then fall back to the owning run `input_json`. If a run-event payload has no human text,
+`body_text` falls back to the event type so operational lifecycle events remain searchable.
+
+Team actor mailbox archive documents preserve `authority_message_id` from the mailbox payload when
+present, because channel fan-out messages use that field to point back to the canonical conversation
+message. Their `conversation_id` is resolved from `task_conversation_id`,
+`channel_conversation_id`, then `conversation_id`. Their `agent_id` is the target actor id so
+actor-scoped archive filters find messages delivered to that actor.
+
 ### 3) ACP Aggregation Contract
 
 - Archive indexing of ACP chunks must produce one logical message document per `(session_id, type,
@@ -249,6 +259,11 @@ Recommended identity shapes:
 - Migration is one-way from SQLite message history into archive documents.
 - Migration must be resumable and idempotent.
 - New dual-written documents and migrated historical documents must share the same canonical schema.
+- Team migration batches source rows and appends each batch immediately; `batch_size` must bound both
+  source rows materialized at once and archive writes.
+- Team migration excludes `shared_thread_mailbox` bootstrap runs from run-event and actor-mailbox
+  archive documents because those runs are internal transport bookkeeping rather than visible Team
+  messages.
 
 ### 6) Multi-Database Extensibility Contract
 

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -313,3 +313,4 @@ Recommended identity shapes:
 - [docs/journal/2026-05-04-lancedb-message-archive-phase1.md](../journal/2026-05-04-lancedb-message-archive-phase1.md)
 - [docs/journal/2026-05-05-message-archive-team-conversation-dual-write.md](../journal/2026-05-05-message-archive-team-conversation-dual-write.md)
 - [docs/journal/2026-05-05-message-archive-team-search-api.md](../journal/2026-05-05-message-archive-team-search-api.md)
+- [docs/journal/2026-05-05-message-archive-team-migration.md](../journal/2026-05-05-message-archive-team-migration.md)

--- a/docs/journal/2026-05-05-message-archive-team-migration.md
+++ b/docs/journal/2026-05-05-message-archive-team-migration.md
@@ -16,6 +16,7 @@ remaining gap was historical Team data that already lived only in SQLite.
 - Add `TeamManager::migrate_team_messages_to_archive(batch_size)` for historical Team message rows.
 - Convert `team_conversation_messages`, `team_run_events`, and `team_actor_messages` into canonical
   archive documents.
+- Add a root-only admin trigger at `POST /api/admin/message_archive/team_messages/migrate`.
 - Preserve stable document identities for re-runnable migration:
   - `team_conversation_message:<conversation_id>:<message_id>`
   - `team_run_event:<run_id>:<event_id>`
@@ -38,6 +39,7 @@ remaining gap was historical Team data that already lived only in SQLite.
 ```bash
 cargo test -p agenthub-message-archive lancedb_archive_upserts_documents_by_document_id -- --nocapture
 cargo test --lib migrate_team_messages_to_archive_covers_team_message_tables -- --nocapture
+cargo clippy --locked -p agenthub --lib -- -D warnings
 cargo fmt --all --check
 git diff --check
 ```
@@ -45,6 +47,5 @@ git diff --check
 ## Follow-Ups
 
 - Add historical ACP event aggregation into archive documents.
-- Add an operator-facing migration trigger or startup-safe migration runner.
 - Extend live dual-write beyond Team conversation messages where the write path can tolerate
   best-effort archive append semantics.

--- a/docs/journal/2026-05-05-message-archive-team-migration.md
+++ b/docs/journal/2026-05-05-message-archive-team-migration.md
@@ -1,0 +1,50 @@
+# Message Archive Team Migration
+
+## Summary
+
+Added a Team SQLite history migration path into the message archive and made LanceDB archive writes
+idempotent by `document_id`.
+
+## Background
+
+The previous message archive slices introduced the backend-agnostic archive contract, LanceDB as the
+first backend, Team conversation dual-write, and the first Team-scoped archive search API. The
+remaining gap was historical Team data that already lived only in SQLite.
+
+## Scope
+
+- Add `TeamManager::migrate_team_messages_to_archive(batch_size)` for historical Team message rows.
+- Convert `team_conversation_messages`, `team_run_events`, and `team_actor_messages` into canonical
+  archive documents.
+- Preserve stable document identities for re-runnable migration:
+  - `team_conversation_message:<conversation_id>:<message_id>`
+  - `team_run_event:<run_id>:<event_id>`
+  - `team_actor_message:<run_id>:<message_id>`
+- Upsert LanceDB archive batches by `document_id` so migration retries replace the same logical
+  document instead of appending duplicates.
+
+## Key Decisions
+
+- Keep the Team migration entrypoint on `TeamManager` for this slice because it already owns the
+  SQLite Team schema and archive trait object.
+- Put idempotent upsert behavior in the LanceDB backend adapter rather than making every migration
+  caller reason about backend-specific duplicate handling.
+- Use `run_event.event_type` as searchable body fallback when a run-event payload has no human text.
+- Keep actor mailbox migration scoped to the target actor in `agent_id`, while preserving the full
+  original payload for future richer routing metadata.
+
+## Validation
+
+```bash
+cargo test -p agenthub-message-archive lancedb_archive_upserts_documents_by_document_id -- --nocapture
+cargo test --lib migrate_team_messages_to_archive_covers_team_message_tables -- --nocapture
+cargo fmt --all --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Add historical ACP event aggregation into archive documents.
+- Add an operator-facing migration trigger or startup-safe migration runner.
+- Extend live dual-write beyond Team conversation messages where the write path can tolerate
+  best-effort archive append semantics.

--- a/docs/journal/2026-05-05-message-archive-team-migration.md
+++ b/docs/journal/2026-05-05-message-archive-team-migration.md
@@ -17,6 +17,7 @@ remaining gap was historical Team data that already lived only in SQLite.
 - Convert `team_conversation_messages`, `team_run_events`, and `team_actor_messages` into canonical
   archive documents.
 - Add a root-only admin trigger at `POST /api/admin/message_archive/team_messages/migrate`.
+- Process migration source rows in bounded batches and append each batch immediately.
 - Preserve stable document identities for re-runnable migration:
   - `team_conversation_message:<conversation_id>:<message_id>`
   - `team_run_event:<run_id>:<event_id>`
@@ -31,8 +32,12 @@ remaining gap was historical Team data that already lived only in SQLite.
 - Put idempotent upsert behavior in the LanceDB backend adapter rather than making every migration
   caller reason about backend-specific duplicate handling.
 - Use `run_event.event_type` as searchable body fallback when a run-event payload has no human text.
-- Keep actor mailbox migration scoped to the target actor in `agent_id`, while preserving the full
-  original payload for future richer routing metadata.
+- Resolve run-event `task_id` and `conversation_id` from the run input when the event payload lacks
+  those fields.
+- Keep actor mailbox migration scoped to the target actor in `agent_id`, preserve
+  `authority_message_id` from channel fan-out payloads, and recognize `channel_conversation_id`.
+- Exclude `shared_thread_mailbox` bootstrap runs from run-event and actor-mailbox migration so
+  internal transport bookkeeping does not appear in Team message search.
 
 ## Validation
 

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -336,10 +336,19 @@ async fn migrate_team_messages_archive(
     Json(payload): Json<MigrateTeamMessagesArchiveRequest>,
 ) -> Result<Json<MigrateTeamMessagesArchiveResponse>, ApiError> {
     let user = require_root(&headers, &state).await?;
-    let report = state
+    let report = match state
         .teams
         .migrate_team_messages_to_archive(payload.batch_size.unwrap_or(500))
-        .await?;
+        .await
+    {
+        Ok(report) => report,
+        Err(err) if err.to_string() == "message archive is not configured" => {
+            return Err(ApiError::conflict(
+                "message archive is not configured; enable a supported message archive backend before migrating team messages",
+            ));
+        }
+        Err(err) => return Err(err.into()),
+    };
     let total_documents = report.total_documents();
     let detail = format!(
         "team_conversation_messages={},team_run_events={},team_actor_messages={},total_documents={}",
@@ -616,6 +625,32 @@ mod tests {
             detail
                 .as_deref()
                 .is_some_and(|value| value.contains("total_documents=1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_team_messages_archive_reports_missing_archive_as_conflict() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let response = super::router(state)
+            .oneshot(build_json_request(
+                "/message_archive/team_messages/migrate",
+                Some(&token),
+                json!({}),
+            ))
+            .await
+            .expect("execute migration request");
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&bytes).expect("decode response body");
+        assert_eq!(
+            body["error"].as_str(),
+            Some(
+                "message archive is not configured; enable a supported message archive backend before migrating team messages"
+            )
         );
     }
 }

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -32,6 +32,19 @@ pub struct SetPasskeyEnabledRequest {
     pub enabled: bool,
 }
 
+#[derive(Debug, serde::Deserialize)]
+pub struct MigrateTeamMessagesArchiveRequest {
+    pub batch_size: Option<usize>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct MigrateTeamMessagesArchiveResponse {
+    pub team_conversation_messages: usize,
+    pub team_run_events: usize,
+    pub team_actor_messages: usize,
+    pub total_documents: usize,
+}
+
 #[derive(Debug, serde::Serialize)]
 pub struct AdminSettingsResponse {
     pub passkey_enabled: bool,
@@ -64,6 +77,10 @@ pub fn router(state: AppState) -> Router {
         .route("/audits", get(list_audits))
         .route("/settings", get(get_settings))
         .route("/settings/passkey", post(set_passkey_enabled))
+        .route(
+            "/message_archive/team_messages/migrate",
+            post(migrate_team_messages_archive),
+        )
         .route("/join/start", post(join_start))
         .with_state(state)
 }
@@ -311,6 +328,43 @@ async fn set_passkey_enabled(
         )
         .await;
     Ok(ok_response())
+}
+
+async fn migrate_team_messages_archive(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<MigrateTeamMessagesArchiveRequest>,
+) -> Result<Json<MigrateTeamMessagesArchiveResponse>, ApiError> {
+    let user = require_root(&headers, &state).await?;
+    let report = state
+        .teams
+        .migrate_team_messages_to_archive(payload.batch_size.unwrap_or(500))
+        .await?;
+    let total_documents = report.total_documents();
+    let detail = format!(
+        "team_conversation_messages={},team_run_events={},team_actor_messages={},total_documents={}",
+        report.team_conversation_messages,
+        report.team_run_events,
+        report.team_actor_messages,
+        total_documents
+    );
+    let _ = state
+        .auth
+        .record_audit(
+            Some(&user.id),
+            None,
+            "message_archive_team_messages_migrated",
+            Some(&detail),
+            extract_ip(&headers).as_deref(),
+            extract_ua(&headers).as_deref(),
+        )
+        .await;
+    Ok(Json(MigrateTeamMessagesArchiveResponse {
+        team_conversation_messages: report.team_conversation_messages,
+        team_run_events: report.team_run_events,
+        team_actor_messages: report.team_actor_messages,
+        total_documents,
+    }))
 }
 
 async fn join_start(

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -431,12 +431,44 @@ fn hash_pin(pin: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use agenthub_message_archive::{
+        MessageArchiveStore, MessageDocument, MessageSearchHit, MessageSearchQuery,
+    };
+    use async_trait::async_trait;
     use axum::body::Body;
+    use axum::body::to_bytes;
     use axum::http::{Method, Request, StatusCode, header};
+    use serde_json::{Value, json};
     use sqlx::Row;
     use tower::util::ServiceExt;
 
-    use crate::api::teams::tests::{build_test_state, create_auth_token};
+    use crate::api::teams::tests::{
+        build_test_state, build_test_state_with_message_archive, create_auth_token,
+    };
+    use crate::team::TeamDefinitionConfig;
+
+    #[derive(Default)]
+    struct NoopMessageArchive;
+
+    #[async_trait]
+    impl MessageArchiveStore for NoopMessageArchive {
+        async fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn append_documents(&self, _documents: &[MessageDocument]) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn search(
+            &self,
+            _query: &MessageSearchQuery,
+        ) -> anyhow::Result<Vec<MessageSearchHit>> {
+            Ok(Vec::new())
+        }
+    }
 
     fn build_request(token: Option<&str>) -> Request<Body> {
         let mut builder = Request::builder().method(Method::POST).uri("/join/start");
@@ -444,6 +476,17 @@ mod tests {
             builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
         }
         builder.body(Body::empty()).expect("build request")
+    }
+
+    fn build_json_request(path: &str, token: Option<&str>, payload: Value) -> Request<Body> {
+        let mut builder = Request::builder().method(Method::POST).uri(path);
+        if let Some(token) = token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(payload.to_string()))
+            .expect("build json request")
     }
 
     #[tokio::test]
@@ -484,6 +527,95 @@ mod tests {
             detail
                 .as_deref()
                 .is_some_and(|value| value.starts_with("expires_at="))
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_team_messages_archive_requires_root_and_records_audit() {
+        let state = build_test_state_with_message_archive(Arc::new(NoopMessageArchive)).await;
+        let team = state
+            .teams
+            .create_team(TeamDefinitionConfig {
+                name: "admin-archive-migration-team".to_string(),
+                description: None,
+                spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+            })
+            .await
+            .expect("create team");
+        let (task, _) = state
+            .teams
+            .create_task(
+                &team.id,
+                "Admin archive migration",
+                "user",
+                json!({}),
+                "group_chat",
+                None,
+            )
+            .await
+            .expect("create task");
+        state
+            .teams
+            .append_task_conversation_message(
+                &task.id,
+                "user",
+                Some("coordinator"),
+                "to_coordinator",
+                json!({"type":"chat_message","text":"archive via admin route"}),
+            )
+            .await
+            .expect("append conversation message");
+
+        let app = super::router(state.clone());
+        let unauthorized = app
+            .clone()
+            .oneshot(build_json_request(
+                "/message_archive/team_messages/migrate",
+                None,
+                json!({}),
+            ))
+            .await
+            .expect("execute unauthorized request");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let token = create_auth_token(&state).await;
+        let response = app
+            .oneshot(build_json_request(
+                "/message_archive/team_messages/migrate",
+                Some(&token),
+                json!({}),
+            ))
+            .await
+            .expect("execute migration request");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&bytes).expect("decode response body");
+        assert_eq!(body["team_conversation_messages"], 1);
+        assert_eq!(body["team_run_events"], 0);
+        assert_eq!(body["team_actor_messages"], 0);
+        assert_eq!(body["total_documents"], 1);
+
+        let row = sqlx::query(
+            r#"
+            SELECT event, detail
+            FROM login_audit
+            WHERE event = 'message_archive_team_messages_migrated'
+            ORDER BY ts DESC
+            LIMIT 1
+            "#,
+        )
+        .fetch_one(&state.db)
+        .await
+        .expect("fetch migration audit");
+        let event: String = row.get("event");
+        let detail: Option<String> = row.get("detail");
+        assert_eq!(event, "message_archive_team_messages_migrated");
+        assert!(
+            detail
+                .as_deref()
+                .is_some_and(|value| value.contains("total_documents=1"))
         );
     }
 }

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -32,7 +32,7 @@ pub struct SetPasskeyEnabledRequest {
     pub enabled: bool,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 pub struct MigrateTeamMessagesArchiveRequest {
     pub batch_size: Option<usize>,
 }
@@ -333,9 +333,10 @@ async fn set_passkey_enabled(
 async fn migrate_team_messages_archive(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(payload): Json<MigrateTeamMessagesArchiveRequest>,
+    payload: Option<Json<MigrateTeamMessagesArchiveRequest>>,
 ) -> Result<Json<MigrateTeamMessagesArchiveResponse>, ApiError> {
     let user = require_root(&headers, &state).await?;
+    let payload = payload.map(|Json(payload)| payload).unwrap_or_default();
     let report = match state
         .teams
         .migrate_team_messages_to_archive(payload.batch_size.unwrap_or(500))
@@ -498,6 +499,14 @@ mod tests {
             .expect("build json request")
     }
 
+    fn build_empty_post_request(path: &str, token: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().method(Method::POST).uri(path);
+        if let Some(token) = token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        builder.body(Body::empty()).expect("build empty request")
+    }
+
     #[tokio::test]
     async fn join_start_records_audit_entry() {
         let state = build_test_state().await;
@@ -589,10 +598,9 @@ mod tests {
 
         let token = create_auth_token(&state).await;
         let response = app
-            .oneshot(build_json_request(
+            .oneshot(build_empty_post_request(
                 "/message_archive/team_messages/migrate",
                 Some(&token),
-                json!({}),
             ))
             .await
             .expect("execute migration request");

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -196,7 +196,9 @@ pub(crate) async fn reopen_test_state_with_db_path(path: &StdPath) -> AppState {
     build_test_state_with_db_source_and_archive(Some(path), false, false, None).await
 }
 
-async fn build_test_state_with_message_archive(archive: Arc<dyn MessageArchiveStore>) -> AppState {
+pub(crate) async fn build_test_state_with_message_archive(
+    archive: Arc<dyn MessageArchiveStore>,
+) -> AppState {
     build_test_state_with_db_source_and_archive(None, true, false, Some(archive)).await
 }
 

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -1829,6 +1829,95 @@ impl TeamManager {
         });
     }
 
+    pub(super) fn spawn_archive_team_actor_message(&self, message: &TeamActorMessageRecord) {
+        if self.message_archive.is_none() {
+            return;
+        }
+        let manager = self.clone();
+        let message = message.clone();
+        let run_id = message.run_id.clone();
+        let message_id = message.message_id;
+
+        tokio::spawn(async move {
+            match manager.team_actor_message_archive_document(&message).await {
+                Ok(Some(document)) => {
+                    let Some(archive) = manager.message_archive.as_ref().cloned() else {
+                        return;
+                    };
+                    match tokio::time::timeout(
+                        MESSAGE_ARCHIVE_APPEND_TIMEOUT,
+                        archive.append_documents(&[document]),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                error = ?error,
+                                run_id = %run_id,
+                                message_id,
+                                "failed to dual-write team actor message to archive"
+                            );
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                run_id = %run_id,
+                                message_id,
+                                timeout_ms = MESSAGE_ARCHIVE_APPEND_TIMEOUT.as_millis(),
+                                "timed out dual-writing team actor message to archive"
+                            );
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = ?error,
+                        run_id = %run_id,
+                        message_id,
+                        "failed to build team actor message archive document"
+                    );
+                }
+            }
+        });
+    }
+
+    async fn team_actor_message_archive_document(
+        &self,
+        message: &TeamActorMessageRecord,
+    ) -> anyhow::Result<Option<MessageDocument>> {
+        let row = sqlx::query(
+            r#"
+            SELECT team_id, input_json
+            FROM team_runs
+            WHERE id = ?1
+            "#,
+        )
+        .bind(&message.run_id)
+        .fetch_one(&self.db)
+        .await?;
+        let team_id: String = row.get("team_id");
+        let input_json: String = row.get("input_json");
+        let run_input: Value = serde_json::from_str(&input_json)?;
+        if message_archive_payload_string(&run_input, "bootstrap_kind").as_deref()
+            == Some(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
+        {
+            return Ok(None);
+        }
+        let base_scope = MessageArchiveScopeFallback::from_run_input(&run_input);
+        let scope = self
+            .message_archive_scope_for_payload(
+                &team_id,
+                &message.payload,
+                &base_scope,
+                &mut HashMap::new(),
+            )
+            .await?;
+        Ok(Some(team_actor_message_archive_document(
+            &team_id, message, &scope,
+        )))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn append_channel_replica_message(
         &self,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -162,7 +162,11 @@ fn team_conversation_message_archive_document(
     }
 }
 
-fn team_run_event_archive_document(team_id: &str, event: &TeamRunEventRecord) -> MessageDocument {
+fn team_run_event_archive_document(
+    team_id: &str,
+    event: &TeamRunEventRecord,
+    run_input: &Value,
+) -> MessageDocument {
     let body_text = message_archive_body_text(&event.payload);
     MessageDocument {
         document_id: format!("team_run_event:{}:{}", event.run_id, event.event_id),
@@ -173,8 +177,10 @@ fn team_run_event_archive_document(team_id: &str, event: &TeamRunEventRecord) ->
         correlation_id: message_archive_payload_string(&event.payload, "correlation_id"),
         team_id: Some(team_id.to_string()),
         run_id: Some(event.run_id.clone()),
-        conversation_id: message_archive_payload_string(&event.payload, "conversation_id"),
-        task_id: message_archive_payload_string(&event.payload, "task_id"),
+        conversation_id: message_archive_payload_string(&event.payload, "conversation_id")
+            .or_else(|| message_archive_payload_string(run_input, "conversation_id")),
+        task_id: message_archive_payload_string(&event.payload, "task_id")
+            .or_else(|| message_archive_payload_string(run_input, "task_id")),
         agent_id: None,
         session_id: None,
         body_text: if body_text.is_empty() {
@@ -202,12 +208,19 @@ fn team_actor_message_archive_document(
         source_kind: MessageDocumentKind::TeamActorMessage,
         source_id: message.message_id.to_string(),
         logical_message_id: None,
-        authority_message_id: Some(message.message_id),
+        authority_message_id: message_archive_payload_i64(&message.payload, "authority_message_id")
+            .or(Some(message.message_id)),
         correlation_id: message_archive_payload_string(&message.payload, "correlation_id"),
         team_id: Some(team_id.to_string()),
         run_id: Some(message.run_id.clone()),
-        conversation_id: message_archive_payload_string(&message.payload, "task_conversation_id")
-            .or_else(|| message_archive_payload_string(&message.payload, "conversation_id")),
+        conversation_id: message_archive_payload_string_any(
+            &message.payload,
+            &[
+                "task_conversation_id",
+                "channel_conversation_id",
+                "conversation_id",
+            ],
+        ),
         task_id: message_archive_payload_string(&message.payload, "task_id"),
         agent_id: Some(message.to_actor_id.clone()),
         session_id: None,
@@ -220,6 +233,11 @@ fn team_actor_message_archive_document(
     }
 }
 
+fn message_archive_payload_string_any(payload: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| message_archive_payload_string(payload, key))
+}
+
 fn message_archive_payload_string(payload: &Value, key: &str) -> Option<String> {
     payload
         .get(key)
@@ -227,6 +245,16 @@ fn message_archive_payload_string(payload: &Value, key: &str) -> Option<String> 
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn message_archive_payload_i64(payload: &Value, key: &str) -> Option<i64> {
+    match payload.get(key)? {
+        Value::Number(value) => value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|raw| i64::try_from(raw).ok())),
+        Value::String(value) => value.trim().parse::<i64>().ok(),
+        _ => None,
+    }
 }
 
 fn message_archive_body_text(payload: &Value) -> String {
@@ -1885,103 +1913,147 @@ impl TeamManager {
             anyhow::bail!("message archive is not configured");
         };
         let mut report = TeamMessageArchiveMigrationReport::default();
-        let mut documents = Vec::new();
-
-        let conversation_rows = sqlx::query(
-            r#"
-            SELECT
-                m.id,
-                m.conversation_id,
-                m.task_id,
-                m.from_actor_id,
-                m.to_actor_id,
-                m.route,
-                m.payload_json,
-                m.created_at,
-                c.team_id
-            FROM team_conversation_messages m
-            INNER JOIN team_conversations c ON c.id = m.conversation_id
-            ORDER BY m.id ASC
-            "#,
-        )
-        .fetch_all(&self.db)
-        .await?;
-        for row in conversation_rows {
-            let conversation = TeamConversationRecord {
-                id: row.get("conversation_id"),
-                team_id: row.get("team_id"),
-                task_id: row.get("task_id"),
-                mode: String::new(),
-                topic: None,
-                created_at: 0,
-                updated_at: 0,
-            };
-            let message = parse_team_conversation_message_row(&row)?;
-            documents.push(team_conversation_message_archive_document(
-                &conversation,
-                &message,
-            ));
-            report.team_conversation_messages += 1;
-        }
-
-        let run_event_rows = sqlx::query(
-            r#"
-            SELECT
-                e.id,
-                e.run_id,
-                e.step_id,
-                e.event_type,
-                e.ts,
-                e.payload_json,
-                r.team_id
-            FROM team_run_events e
-            INNER JOIN team_runs r ON r.id = e.run_id
-            ORDER BY e.id ASC
-            "#,
-        )
-        .fetch_all(&self.db)
-        .await?;
-        for row in run_event_rows {
-            let team_id: String = row.get("team_id");
-            let event = parse_run_event_row(&row)?;
-            documents.push(team_run_event_archive_document(&team_id, &event));
-            report.team_run_events += 1;
-        }
-
-        let actor_message_rows = sqlx::query(
-            r#"
-            SELECT
-                m.id,
-                m.run_id,
-                m.from_actor_id,
-                m.from_peer_id,
-                m.to_actor_id,
-                m.to_peer_id,
-                m.channel,
-                m.transport,
-                m.route_json,
-                m.payload_json,
-                m.status,
-                m.created_at,
-                m.delivered_at,
-                r.team_id
-            FROM team_actor_messages m
-            INNER JOIN team_runs r ON r.id = m.run_id
-            ORDER BY m.id ASC
-            "#,
-        )
-        .fetch_all(&self.db)
-        .await?;
-        for row in actor_message_rows {
-            let team_id: String = row.get("team_id");
-            let message = parse_team_actor_message_row(&row)?;
-            documents.push(team_actor_message_archive_document(&team_id, &message));
-            report.team_actor_messages += 1;
-        }
-
         let batch_size = batch_size.clamp(1, 1000);
-        for chunk in documents.chunks(batch_size) {
-            archive.append_documents(chunk).await?;
+        let batch_limit = i64::try_from(batch_size)?;
+
+        let mut last_id = 0_i64;
+        loop {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    m.id,
+                    m.conversation_id,
+                    m.task_id,
+                    m.from_actor_id,
+                    m.to_actor_id,
+                    m.route,
+                    m.payload_json,
+                    m.created_at,
+                    c.team_id
+                FROM team_conversation_messages m
+                INNER JOIN team_conversations c ON c.id = m.conversation_id
+                WHERE m.id > ?1
+                ORDER BY m.id ASC
+                LIMIT ?2
+                "#,
+            )
+            .bind(last_id)
+            .bind(batch_limit)
+            .fetch_all(&self.db)
+            .await?;
+            if rows.is_empty() {
+                break;
+            }
+            let mut documents = Vec::with_capacity(rows.len());
+            for row in rows {
+                last_id = row.get("id");
+                let conversation = TeamConversationRecord {
+                    id: row.get("conversation_id"),
+                    team_id: row.get("team_id"),
+                    task_id: row.get("task_id"),
+                    mode: String::new(),
+                    topic: None,
+                    created_at: 0,
+                    updated_at: 0,
+                };
+                let message = parse_team_conversation_message_row(&row)?;
+                documents.push(team_conversation_message_archive_document(
+                    &conversation,
+                    &message,
+                ));
+                report.team_conversation_messages += 1;
+            }
+            archive.append_documents(&documents).await?;
+        }
+
+        let mut last_id = 0_i64;
+        loop {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    e.id,
+                    e.run_id,
+                    e.step_id,
+                    e.event_type,
+                    e.ts,
+                    e.payload_json,
+                    r.team_id,
+                    r.input_json
+                FROM team_run_events e
+                INNER JOIN team_runs r ON r.id = e.run_id
+                WHERE e.id > ?1
+                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?2
+                ORDER BY e.id ASC
+                LIMIT ?3
+                "#,
+            )
+            .bind(last_id)
+            .bind(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
+            .bind(batch_limit)
+            .fetch_all(&self.db)
+            .await?;
+            if rows.is_empty() {
+                break;
+            }
+            let mut documents = Vec::with_capacity(rows.len());
+            for row in rows {
+                last_id = row.get("id");
+                let team_id: String = row.get("team_id");
+                let input_json: String = row.get("input_json");
+                let run_input: Value = serde_json::from_str(&input_json)?;
+                let event = parse_run_event_row(&row)?;
+                documents.push(team_run_event_archive_document(
+                    &team_id, &event, &run_input,
+                ));
+                report.team_run_events += 1;
+            }
+            archive.append_documents(&documents).await?;
+        }
+
+        let mut last_id = 0_i64;
+        loop {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    m.id,
+                    m.run_id,
+                    m.from_actor_id,
+                    m.from_peer_id,
+                    m.to_actor_id,
+                    m.to_peer_id,
+                    m.channel,
+                    m.transport,
+                    m.route_json,
+                    m.payload_json,
+                    m.status,
+                    m.created_at,
+                    m.delivered_at,
+                    r.team_id
+                FROM team_actor_messages m
+                INNER JOIN team_runs r ON r.id = m.run_id
+                WHERE m.id > ?1
+                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?2
+                ORDER BY m.id ASC
+                LIMIT ?3
+                "#,
+            )
+            .bind(last_id)
+            .bind(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
+            .bind(batch_limit)
+            .fetch_all(&self.db)
+            .await?;
+            if rows.is_empty() {
+                break;
+            }
+            let mut documents = Vec::with_capacity(rows.len());
+            for row in rows {
+                last_id = row.get("id");
+                let team_id: String = row.get("team_id");
+                let message = parse_team_actor_message_row(&row)?;
+                documents.push(team_actor_message_archive_document(&team_id, &message));
+                report.team_actor_messages += 1;
+            }
+            archive.append_documents(&documents).await?;
         }
         Ok(report)
     }

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -1967,17 +1967,17 @@ impl TeamManager {
         let task_id = message_archive_payload_string(payload, "task_id")
             .or_else(|| base_scope.task_id.clone());
         let mut conversation_id = base_scope.conversation_id.clone();
-        if conversation_id.is_none() {
-            if let Some(task_id) = task_id.as_deref() {
-                let cache_key = (team_id.to_string(), task_id.to_string());
-                if !task_conversation_cache.contains_key(&cache_key) {
-                    let resolved = self
-                        .message_archive_task_conversation_id(team_id, task_id)
-                        .await?;
-                    task_conversation_cache.insert(cache_key.clone(), resolved);
-                }
-                conversation_id = task_conversation_cache.get(&cache_key).cloned().flatten();
+        if conversation_id.is_none()
+            && let Some(task_id) = task_id.as_deref()
+        {
+            let cache_key = (team_id.to_string(), task_id.to_string());
+            if !task_conversation_cache.contains_key(&cache_key) {
+                let resolved = self
+                    .message_archive_task_conversation_id(team_id, task_id)
+                    .await?;
+                task_conversation_cache.insert(cache_key.clone(), resolved);
             }
+            conversation_id = task_conversation_cache.get(&cache_key).cloned().flatten();
         }
         Ok(MessageArchiveScopeFallback {
             conversation_id,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -168,12 +168,13 @@ fn team_run_event_archive_document(
     run_input: &Value,
 ) -> MessageDocument {
     let body_text = message_archive_body_text(&event.payload);
+    let redacted_payload = redact_sensitive_json(&event.payload);
     MessageDocument {
         document_id: format!("team_run_event:{}:{}", event.run_id, event.event_id),
         source_kind: MessageDocumentKind::TeamRunEvent,
         source_id: event.event_id.to_string(),
         logical_message_id: None,
-        authority_message_id: Some(event.event_id),
+        authority_message_id: message_archive_payload_i64(&event.payload, "authority_message_id"),
         correlation_id: message_archive_payload_string(&event.payload, "correlation_id"),
         team_id: Some(team_id.to_string()),
         run_id: Some(event.run_id.clone()),
@@ -188,7 +189,7 @@ fn team_run_event_archive_document(
         } else {
             body_text
         },
-        payload_json: Some(event.payload.to_string()),
+        payload_json: Some(redacted_payload.to_string()),
         created_at: event.ts,
         event_id_from: Some(event.event_id),
         event_id_to: Some(event.event_id),
@@ -199,7 +200,9 @@ fn team_run_event_archive_document(
 fn team_actor_message_archive_document(
     team_id: &str,
     message: &TeamActorMessageRecord,
+    run_input: &Value,
 ) -> MessageDocument {
+    let redacted_payload = redact_sensitive_json(&message.payload);
     MessageDocument {
         document_id: format!(
             "team_actor_message:{}:{}",
@@ -208,8 +211,7 @@ fn team_actor_message_archive_document(
         source_kind: MessageDocumentKind::TeamActorMessage,
         source_id: message.message_id.to_string(),
         logical_message_id: None,
-        authority_message_id: message_archive_payload_i64(&message.payload, "authority_message_id")
-            .or(Some(message.message_id)),
+        authority_message_id: message_archive_payload_i64(&message.payload, "authority_message_id"),
         correlation_id: message_archive_payload_string(&message.payload, "correlation_id"),
         team_id: Some(team_id.to_string()),
         run_id: Some(message.run_id.clone()),
@@ -220,12 +222,14 @@ fn team_actor_message_archive_document(
                 "channel_conversation_id",
                 "conversation_id",
             ],
-        ),
-        task_id: message_archive_payload_string(&message.payload, "task_id"),
+        )
+        .or_else(|| message_archive_payload_string(run_input, "conversation_id")),
+        task_id: message_archive_payload_string(&message.payload, "task_id")
+            .or_else(|| message_archive_payload_string(run_input, "task_id")),
         agent_id: Some(message.to_actor_id.clone()),
         session_id: None,
         body_text: message_archive_body_text(&message.payload),
-        payload_json: Some(message.payload.to_string()),
+        payload_json: Some(redacted_payload.to_string()),
         created_at: message.created_at,
         event_id_from: None,
         event_id_to: None,
@@ -2028,7 +2032,8 @@ impl TeamManager {
                     m.status,
                     m.created_at,
                     m.delivered_at,
-                    r.team_id
+                    r.team_id,
+                    r.input_json
                 FROM team_actor_messages m
                 INNER JOIN team_runs r ON r.id = m.run_id
                 WHERE m.id > ?1
@@ -2049,8 +2054,12 @@ impl TeamManager {
             for row in rows {
                 last_id = row.get("id");
                 let team_id: String = row.get("team_id");
+                let input_json: String = row.get("input_json");
+                let run_input: Value = serde_json::from_str(&input_json)?;
                 let message = parse_team_actor_message_row(&row)?;
-                documents.push(team_actor_message_archive_document(&team_id, &message));
+                documents.push(team_actor_message_archive_document(
+                    &team_id, &message, &run_input,
+                ));
                 report.team_actor_messages += 1;
             }
             archive.append_documents(&documents).await?;

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -162,10 +162,25 @@ fn team_conversation_message_archive_document(
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct MessageArchiveScopeFallback {
+    conversation_id: Option<String>,
+    task_id: Option<String>,
+}
+
+impl MessageArchiveScopeFallback {
+    fn from_run_input(run_input: &Value) -> Self {
+        Self {
+            conversation_id: message_archive_payload_string(run_input, "conversation_id"),
+            task_id: message_archive_payload_string(run_input, "task_id"),
+        }
+    }
+}
+
 fn team_run_event_archive_document(
     team_id: &str,
     event: &TeamRunEventRecord,
-    run_input: &Value,
+    scope: &MessageArchiveScopeFallback,
 ) -> MessageDocument {
     let body_text = message_archive_body_text(&event.payload);
     let redacted_payload = redact_sensitive_json(&event.payload);
@@ -179,9 +194,9 @@ fn team_run_event_archive_document(
         team_id: Some(team_id.to_string()),
         run_id: Some(event.run_id.clone()),
         conversation_id: message_archive_payload_string(&event.payload, "conversation_id")
-            .or_else(|| message_archive_payload_string(run_input, "conversation_id")),
+            .or_else(|| scope.conversation_id.clone()),
         task_id: message_archive_payload_string(&event.payload, "task_id")
-            .or_else(|| message_archive_payload_string(run_input, "task_id")),
+            .or_else(|| scope.task_id.clone()),
         agent_id: None,
         session_id: None,
         body_text: if body_text.is_empty() {
@@ -200,7 +215,7 @@ fn team_run_event_archive_document(
 fn team_actor_message_archive_document(
     team_id: &str,
     message: &TeamActorMessageRecord,
-    run_input: &Value,
+    scope: &MessageArchiveScopeFallback,
 ) -> MessageDocument {
     let redacted_payload = redact_sensitive_json(&message.payload);
     MessageDocument {
@@ -223,9 +238,9 @@ fn team_actor_message_archive_document(
                 "conversation_id",
             ],
         )
-        .or_else(|| message_archive_payload_string(run_input, "conversation_id")),
+        .or_else(|| scope.conversation_id.clone()),
         task_id: message_archive_payload_string(&message.payload, "task_id")
-            .or_else(|| message_archive_payload_string(run_input, "task_id")),
+            .or_else(|| scope.task_id.clone()),
         agent_id: Some(message.to_actor_id.clone()),
         session_id: None,
         body_text: message_archive_body_text(&message.payload),
@@ -1909,6 +1924,67 @@ impl TeamManager {
         archive.search(query).await
     }
 
+    async fn message_archive_table_max_id(&self, table_name: &str) -> anyhow::Result<i64> {
+        let sql = match table_name {
+            "team_conversation_messages" => {
+                "SELECT COALESCE(MAX(id), 0) FROM team_conversation_messages"
+            }
+            "team_run_events" => "SELECT COALESCE(MAX(id), 0) FROM team_run_events",
+            "team_actor_messages" => "SELECT COALESCE(MAX(id), 0) FROM team_actor_messages",
+            _ => anyhow::bail!("unsupported archive migration table: {table_name}"),
+        };
+        Ok(sqlx::query_scalar::<_, i64>(sql)
+            .fetch_one(&self.db)
+            .await?)
+    }
+
+    async fn message_archive_task_conversation_id(
+        &self,
+        team_id: &str,
+        task_id: &str,
+    ) -> anyhow::Result<Option<String>> {
+        Ok(sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT id
+            FROM team_conversations
+            WHERE team_id = ?1 AND task_id = ?2
+            LIMIT 1
+            "#,
+        )
+        .bind(team_id)
+        .bind(task_id)
+        .fetch_optional(&self.db)
+        .await?)
+    }
+
+    async fn message_archive_scope_for_payload(
+        &self,
+        team_id: &str,
+        payload: &Value,
+        base_scope: &MessageArchiveScopeFallback,
+        task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
+    ) -> anyhow::Result<MessageArchiveScopeFallback> {
+        let task_id = message_archive_payload_string(payload, "task_id")
+            .or_else(|| base_scope.task_id.clone());
+        let mut conversation_id = base_scope.conversation_id.clone();
+        if conversation_id.is_none() {
+            if let Some(task_id) = task_id.as_deref() {
+                let cache_key = (team_id.to_string(), task_id.to_string());
+                if !task_conversation_cache.contains_key(&cache_key) {
+                    let resolved = self
+                        .message_archive_task_conversation_id(team_id, task_id)
+                        .await?;
+                    task_conversation_cache.insert(cache_key.clone(), resolved);
+                }
+                conversation_id = task_conversation_cache.get(&cache_key).cloned().flatten();
+            }
+        }
+        Ok(MessageArchiveScopeFallback {
+            conversation_id,
+            task_id,
+        })
+    }
+
     pub async fn migrate_team_messages_to_archive(
         &self,
         batch_size: usize,
@@ -1919,6 +1995,15 @@ impl TeamManager {
         let mut report = TeamMessageArchiveMigrationReport::default();
         let batch_size = batch_size.clamp(1, 1000);
         let batch_limit = i64::try_from(batch_size)?;
+        let max_conversation_message_id = self
+            .message_archive_table_max_id("team_conversation_messages")
+            .await?;
+        let max_run_event_id = self.message_archive_table_max_id("team_run_events").await?;
+        let max_actor_message_id = self
+            .message_archive_table_max_id("team_actor_messages")
+            .await?;
+        let mut run_scope_cache: HashMap<String, MessageArchiveScopeFallback> = HashMap::new();
+        let mut task_conversation_cache: HashMap<(String, String), Option<String>> = HashMap::new();
 
         let mut last_id = 0_i64;
         loop {
@@ -1936,12 +2021,13 @@ impl TeamManager {
                     c.team_id
                 FROM team_conversation_messages m
                 INNER JOIN team_conversations c ON c.id = m.conversation_id
-                WHERE m.id > ?1
+                WHERE m.id > ?1 AND m.id <= ?2
                 ORDER BY m.id ASC
-                LIMIT ?2
+                LIMIT ?3
                 "#,
             )
             .bind(last_id)
+            .bind(max_conversation_message_id)
             .bind(batch_limit)
             .fetch_all(&self.db)
             .await?;
@@ -1986,12 +2072,14 @@ impl TeamManager {
                 FROM team_run_events e
                 INNER JOIN team_runs r ON r.id = e.run_id
                 WHERE e.id > ?1
-                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?2
+                  AND e.id <= ?2
+                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?3
                 ORDER BY e.id ASC
-                LIMIT ?3
+                LIMIT ?4
                 "#,
             )
             .bind(last_id)
+            .bind(max_run_event_id)
             .bind(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
             .bind(batch_limit)
             .fetch_all(&self.db)
@@ -2002,13 +2090,30 @@ impl TeamManager {
             let mut documents = Vec::with_capacity(rows.len());
             for row in rows {
                 last_id = row.get("id");
+                let run_id: String = row.get("run_id");
                 let team_id: String = row.get("team_id");
-                let input_json: String = row.get("input_json");
-                let run_input: Value = serde_json::from_str(&input_json)?;
+                if !run_scope_cache.contains_key(&run_id) {
+                    let input_json: String = row.get("input_json");
+                    let run_input: Value = serde_json::from_str(&input_json)?;
+                    run_scope_cache.insert(
+                        run_id.clone(),
+                        MessageArchiveScopeFallback::from_run_input(&run_input),
+                    );
+                }
+                let base_scope = run_scope_cache
+                    .get(&run_id)
+                    .expect("run scope is cached before use")
+                    .clone();
                 let event = parse_run_event_row(&row)?;
-                documents.push(team_run_event_archive_document(
-                    &team_id, &event, &run_input,
-                ));
+                let scope = self
+                    .message_archive_scope_for_payload(
+                        &team_id,
+                        &event.payload,
+                        &base_scope,
+                        &mut task_conversation_cache,
+                    )
+                    .await?;
+                documents.push(team_run_event_archive_document(&team_id, &event, &scope));
                 report.team_run_events += 1;
             }
             archive.append_documents(&documents).await?;
@@ -2037,12 +2142,14 @@ impl TeamManager {
                 FROM team_actor_messages m
                 INNER JOIN team_runs r ON r.id = m.run_id
                 WHERE m.id > ?1
-                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?2
+                  AND m.id <= ?2
+                  AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?3
                 ORDER BY m.id ASC
-                LIMIT ?3
+                LIMIT ?4
                 "#,
             )
             .bind(last_id)
+            .bind(max_actor_message_id)
             .bind(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
             .bind(batch_limit)
             .fetch_all(&self.db)
@@ -2053,12 +2160,31 @@ impl TeamManager {
             let mut documents = Vec::with_capacity(rows.len());
             for row in rows {
                 last_id = row.get("id");
+                let run_id: String = row.get("run_id");
                 let team_id: String = row.get("team_id");
-                let input_json: String = row.get("input_json");
-                let run_input: Value = serde_json::from_str(&input_json)?;
+                if !run_scope_cache.contains_key(&run_id) {
+                    let input_json: String = row.get("input_json");
+                    let run_input: Value = serde_json::from_str(&input_json)?;
+                    run_scope_cache.insert(
+                        run_id.clone(),
+                        MessageArchiveScopeFallback::from_run_input(&run_input),
+                    );
+                }
+                let base_scope = run_scope_cache
+                    .get(&run_id)
+                    .expect("run scope is cached before use")
+                    .clone();
                 let message = parse_team_actor_message_row(&row)?;
+                let scope = self
+                    .message_archive_scope_for_payload(
+                        &team_id,
+                        &message.payload,
+                        &base_scope,
+                        &mut task_conversation_cache,
+                    )
+                    .await?;
                 documents.push(team_actor_message_archive_document(
-                    &team_id, &message, &run_input,
+                    &team_id, &message, &scope,
                 ));
                 report.team_actor_messages += 1;
             }

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -38,6 +38,19 @@ use uuid::Uuid;
 
 pub use mailbox::{SendActorMessageInput, TeamRemoteRelayWorkerSettings};
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TeamMessageArchiveMigrationReport {
+    pub team_conversation_messages: usize,
+    pub team_run_events: usize,
+    pub team_actor_messages: usize,
+}
+
+impl TeamMessageArchiveMigrationReport {
+    pub fn total_documents(&self) -> usize {
+        self.team_conversation_messages + self.team_run_events + self.team_actor_messages
+    }
+}
+
 use self::codec::{
     parse_run_event_row, parse_team_actor_message_row, parse_team_conversation_message_row,
     parse_team_conversation_row, parse_team_definition_row, parse_team_member_continuity_state_row,
@@ -147,6 +160,73 @@ fn team_conversation_message_archive_document(
         event_id_to: None,
         chunk_count: None,
     }
+}
+
+fn team_run_event_archive_document(team_id: &str, event: &TeamRunEventRecord) -> MessageDocument {
+    let body_text = message_archive_body_text(&event.payload);
+    MessageDocument {
+        document_id: format!("team_run_event:{}:{}", event.run_id, event.event_id),
+        source_kind: MessageDocumentKind::TeamRunEvent,
+        source_id: event.event_id.to_string(),
+        logical_message_id: None,
+        authority_message_id: Some(event.event_id),
+        correlation_id: message_archive_payload_string(&event.payload, "correlation_id"),
+        team_id: Some(team_id.to_string()),
+        run_id: Some(event.run_id.clone()),
+        conversation_id: message_archive_payload_string(&event.payload, "conversation_id"),
+        task_id: message_archive_payload_string(&event.payload, "task_id"),
+        agent_id: None,
+        session_id: None,
+        body_text: if body_text.is_empty() {
+            event.event_type.clone()
+        } else {
+            body_text
+        },
+        payload_json: Some(event.payload.to_string()),
+        created_at: event.ts,
+        event_id_from: Some(event.event_id),
+        event_id_to: Some(event.event_id),
+        chunk_count: None,
+    }
+}
+
+fn team_actor_message_archive_document(
+    team_id: &str,
+    message: &TeamActorMessageRecord,
+) -> MessageDocument {
+    MessageDocument {
+        document_id: format!(
+            "team_actor_message:{}:{}",
+            message.run_id, message.message_id
+        ),
+        source_kind: MessageDocumentKind::TeamActorMessage,
+        source_id: message.message_id.to_string(),
+        logical_message_id: None,
+        authority_message_id: Some(message.message_id),
+        correlation_id: message_archive_payload_string(&message.payload, "correlation_id"),
+        team_id: Some(team_id.to_string()),
+        run_id: Some(message.run_id.clone()),
+        conversation_id: message_archive_payload_string(&message.payload, "task_conversation_id")
+            .or_else(|| message_archive_payload_string(&message.payload, "conversation_id")),
+        task_id: message_archive_payload_string(&message.payload, "task_id"),
+        agent_id: Some(message.to_actor_id.clone()),
+        session_id: None,
+        body_text: message_archive_body_text(&message.payload),
+        payload_json: Some(message.payload.to_string()),
+        created_at: message.created_at,
+        event_id_from: None,
+        event_id_to: None,
+        chunk_count: None,
+    }
+}
+
+fn message_archive_payload_string(payload: &Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn message_archive_body_text(payload: &Value) -> String {
@@ -1795,6 +1875,115 @@ impl TeamManager {
             return Ok(Vec::new());
         };
         archive.search(query).await
+    }
+
+    pub async fn migrate_team_messages_to_archive(
+        &self,
+        batch_size: usize,
+    ) -> anyhow::Result<TeamMessageArchiveMigrationReport> {
+        let Some(archive) = self.message_archive.as_ref() else {
+            anyhow::bail!("message archive is not configured");
+        };
+        let mut report = TeamMessageArchiveMigrationReport::default();
+        let mut documents = Vec::new();
+
+        let conversation_rows = sqlx::query(
+            r#"
+            SELECT
+                m.id,
+                m.conversation_id,
+                m.task_id,
+                m.from_actor_id,
+                m.to_actor_id,
+                m.route,
+                m.payload_json,
+                m.created_at,
+                c.team_id
+            FROM team_conversation_messages m
+            INNER JOIN team_conversations c ON c.id = m.conversation_id
+            ORDER BY m.id ASC
+            "#,
+        )
+        .fetch_all(&self.db)
+        .await?;
+        for row in conversation_rows {
+            let conversation = TeamConversationRecord {
+                id: row.get("conversation_id"),
+                team_id: row.get("team_id"),
+                task_id: row.get("task_id"),
+                mode: String::new(),
+                topic: None,
+                created_at: 0,
+                updated_at: 0,
+            };
+            let message = parse_team_conversation_message_row(&row)?;
+            documents.push(team_conversation_message_archive_document(
+                &conversation,
+                &message,
+            ));
+            report.team_conversation_messages += 1;
+        }
+
+        let run_event_rows = sqlx::query(
+            r#"
+            SELECT
+                e.id,
+                e.run_id,
+                e.step_id,
+                e.event_type,
+                e.ts,
+                e.payload_json,
+                r.team_id
+            FROM team_run_events e
+            INNER JOIN team_runs r ON r.id = e.run_id
+            ORDER BY e.id ASC
+            "#,
+        )
+        .fetch_all(&self.db)
+        .await?;
+        for row in run_event_rows {
+            let team_id: String = row.get("team_id");
+            let event = parse_run_event_row(&row)?;
+            documents.push(team_run_event_archive_document(&team_id, &event));
+            report.team_run_events += 1;
+        }
+
+        let actor_message_rows = sqlx::query(
+            r#"
+            SELECT
+                m.id,
+                m.run_id,
+                m.from_actor_id,
+                m.from_peer_id,
+                m.to_actor_id,
+                m.to_peer_id,
+                m.channel,
+                m.transport,
+                m.route_json,
+                m.payload_json,
+                m.status,
+                m.created_at,
+                m.delivered_at,
+                r.team_id
+            FROM team_actor_messages m
+            INNER JOIN team_runs r ON r.id = m.run_id
+            ORDER BY m.id ASC
+            "#,
+        )
+        .fetch_all(&self.db)
+        .await?;
+        for row in actor_message_rows {
+            let team_id: String = row.get("team_id");
+            let message = parse_team_actor_message_row(&row)?;
+            documents.push(team_actor_message_archive_document(&team_id, &message));
+            report.team_actor_messages += 1;
+        }
+
+        let batch_size = batch_size.clamp(1, 1000);
+        for chunk in documents.chunks(batch_size) {
+            archive.append_documents(chunk).await?;
+        }
+        Ok(report)
     }
 
     pub async fn create_run(

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -38,7 +38,7 @@ use uuid::Uuid;
 
 pub use mailbox::{SendActorMessageInput, TeamRemoteRelayWorkerSettings};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct TeamMessageArchiveMigrationReport {
     pub team_conversation_messages: usize,
     pub team_run_events: usize,

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -180,6 +180,9 @@ impl TeamManager {
             })
             .await
             .map_err(map_actor_mailbox_store_error)?;
+        if result.created {
+            self.spawn_archive_team_actor_message(&result.message);
+        }
         if result.created
             && should_emit_human_visible_reply
             && let Some((team_id, task_id, conversation_id)) =

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -983,6 +983,7 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             json!({
                 "task_id": task.id,
                 "conversation_id": conversation.id,
+                "api_key": "run-input-secret",
             }),
         )
         .await
@@ -1000,8 +1001,6 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             payload: json!({
                 "type": "chat_message",
                 "text": "migrate actor mailbox message",
-                "task_id": task.id,
-                "channel_conversation_id": conversation.id,
                 "authority_message_id": conversation_message.message_id,
                 "correlation_id": "corr-migration-actor"
             }),
@@ -1009,6 +1008,65 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
         })
         .await
         .expect("send actor message");
+    sqlx::query(
+        r#"
+        INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
+        VALUES (?1, NULL, ?2, ?3, ?4)
+        "#,
+    )
+    .bind(&run.id)
+    .bind("run_secret_event")
+    .bind(Utc::now().timestamp())
+    .bind(
+        json!({
+            "text": "raw run secret event",
+            "authority_message_id": conversation_message.message_id,
+            "api_key": "run-event-secret"
+        })
+        .to_string(),
+    )
+    .execute(&seed_manager.db)
+    .await
+    .expect("insert raw run event");
+    let raw_actor_message_id = sqlx::query(
+        r#"
+        INSERT INTO team_actor_messages (
+            run_id,
+            from_actor_id,
+            from_peer_id,
+            to_actor_id,
+            to_peer_id,
+            channel,
+            transport,
+            route_json,
+            payload_json,
+            status,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?9, ?10)
+        "#,
+    )
+    .bind(&run.id)
+    .bind("coordinator")
+    .bind(ACTOR_MAIN_PEER_ID)
+    .bind("worker-1")
+    .bind(ACTOR_MAIN_PEER_ID)
+    .bind("all")
+    .bind("local")
+    .bind(
+        json!({
+            "type": "chat_message",
+            "text": "raw actor secret message",
+            "api_key": "actor-message-secret"
+        })
+        .to_string(),
+    )
+    .bind("pending")
+    .bind(Utc::now().timestamp())
+    .execute(&seed_manager.db)
+    .await
+    .expect("insert raw actor message")
+    .last_insert_rowid();
     let hidden_run = seed_manager
         .ensure_shared_thread_mailbox_run(&team.id, &task.id, &conversation.id)
         .await
@@ -1047,12 +1105,12 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
         .expect("migrate team messages");
 
     assert_eq!(report.team_conversation_messages, 1);
-    assert_eq!(report.team_run_events, 2);
-    assert_eq!(report.team_actor_messages, 1);
-    assert_eq!(report.total_documents(), 4);
+    assert_eq!(report.team_run_events, 3);
+    assert_eq!(report.team_actor_messages, 2);
+    assert_eq!(report.total_documents(), 6);
 
     let documents = archive.documents.lock().await.clone();
-    assert_eq!(documents.len(), 4);
+    assert_eq!(documents.len(), 6);
     assert!(documents.iter().any(|document| {
         document.document_id
             == format!(
@@ -1078,9 +1136,22 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             && document.source_kind == MessageDocumentKind::TeamRunEvent
             && document.team_id.as_deref() == Some(team.id.as_str())
             && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.authority_message_id.is_none()
             && document.conversation_id.as_deref() == Some(conversation.id.as_str())
             && document.task_id.as_deref() == Some(task.id.as_str())
             && document.body_text == "run_submitted"
+            && document
+                .payload_json
+                .as_deref()
+                .is_some_and(|payload| !payload.contains("run-input-secret"))
+    }));
+    assert!(documents.iter().any(|document| {
+        document.body_text == "raw run secret event"
+            && document.source_kind == MessageDocumentKind::TeamRunEvent
+            && document.authority_message_id == Some(conversation_message.message_id)
+            && document.payload_json.as_deref().is_some_and(|payload| {
+                payload.contains("[redacted]") && !payload.contains("run-event-secret")
+            })
     }));
     assert!(documents.iter().any(|document| {
         document.document_id
@@ -1090,9 +1161,21 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             && document.run_id.as_deref() == Some(run.id.as_str())
             && document.authority_message_id == Some(conversation_message.message_id)
             && document.conversation_id.as_deref() == Some(conversation.id.as_str())
+            && document.task_id.as_deref() == Some(task.id.as_str())
             && document.agent_id.as_deref() == Some("worker-1")
             && document.correlation_id.as_deref() == Some("corr-migration-actor")
             && document.body_text == "migrate actor mailbox message"
+    }));
+    assert!(documents.iter().any(|document| {
+        document.document_id == format!("team_actor_message:{}:{}", run.id, raw_actor_message_id)
+            && document.source_kind == MessageDocumentKind::TeamActorMessage
+            && document.authority_message_id.is_none()
+            && document.conversation_id.as_deref() == Some(conversation.id.as_str())
+            && document.task_id.as_deref() == Some(task.id.as_str())
+            && document.body_text == "raw actor secret message"
+            && document.payload_json.as_deref().is_some_and(|payload| {
+                payload.contains("[redacted]") && !payload.contains("actor-message-secret")
+            })
     }));
     assert!(
         documents

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1001,13 +1001,39 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
                 "type": "chat_message",
                 "text": "migrate actor mailbox message",
                 "task_id": task.id,
-                "task_conversation_id": conversation.id,
+                "channel_conversation_id": conversation.id,
+                "authority_message_id": conversation_message.message_id,
                 "correlation_id": "corr-migration-actor"
             }),
             idempotency_key: None,
         })
         .await
         .expect("send actor message");
+    let hidden_run = seed_manager
+        .ensure_shared_thread_mailbox_run(&team.id, &task.id, &conversation.id)
+        .await
+        .expect("create hidden shared-thread mailbox run");
+    seed_manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &hidden_run.id,
+            from_actor_id: "coordinator",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker-1",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "all",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type": "chat_message",
+                "text": "hidden shared-thread mailbox message",
+                "task_id": task.id,
+                "channel_conversation_id": conversation.id,
+                "authority_message_id": conversation_message.message_id,
+            }),
+            idempotency_key: None,
+        })
+        .await
+        .expect("send hidden actor message");
 
     let archive = Arc::new(RecordingMessageArchive::default());
     let archive_manager = TeamManager::new_with_event_dbs_and_message_archive(
@@ -1052,6 +1078,8 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             && document.source_kind == MessageDocumentKind::TeamRunEvent
             && document.team_id.as_deref() == Some(team.id.as_str())
             && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.conversation_id.as_deref() == Some(conversation.id.as_str())
+            && document.task_id.as_deref() == Some(task.id.as_str())
             && document.body_text == "run_submitted"
     }));
     assert!(documents.iter().any(|document| {
@@ -1060,10 +1088,17 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             && document.source_kind == MessageDocumentKind::TeamActorMessage
             && document.team_id.as_deref() == Some(team.id.as_str())
             && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.authority_message_id == Some(conversation_message.message_id)
+            && document.conversation_id.as_deref() == Some(conversation.id.as_str())
             && document.agent_id.as_deref() == Some("worker-1")
             && document.correlation_id.as_deref() == Some("corr-migration-actor")
             && document.body_text == "migrate actor mailbox message"
     }));
+    assert!(
+        documents
+            .iter()
+            .all(|document| document.run_id.as_deref() != Some(hidden_run.id.as_str()))
+    );
 }
 
 #[test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1127,7 +1127,7 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             .iter()
             .filter(|document| document.source_kind == MessageDocumentKind::TeamRunEvent)
             .count(),
-        2
+        3
     );
     assert!(documents.iter().any(|document| {
         document

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -932,6 +932,140 @@ async fn append_task_conversation_message_dual_writes_created_rows_to_archive() 
     assert_eq!(document.created_at, first.created_at);
 }
 
+#[tokio::test]
+async fn migrate_team_messages_to_archive_covers_team_message_tables() {
+    let db = setup_test_db().await;
+    let seed_manager = TeamManager::new(db.clone());
+
+    let team = seed_manager
+        .create_team(TeamDefinitionConfig {
+            name: "team-message-archive-migration".to_string(),
+            description: Some("team for archive migration".to_string()),
+            spec: json!({
+                "entrypoint":"coordinator_plan",
+                "members":[
+                    {"member_id":"coordinator"},
+                    {"member_id":"worker-1","role":"worker"}
+                ]
+            }),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = seed_manager
+        .create_task(
+            &team.id,
+            "Archive migration",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let conversation_message = seed_manager
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({
+                "type": "chat_message",
+                "text": "migrate conversation message",
+                "correlation_id": "corr-migration-conversation"
+            }),
+        )
+        .await
+        .expect("append conversation message");
+    let run = seed_manager
+        .create_run(
+            &team.id,
+            Some(task.id.as_str()),
+            json!({
+                "task_id": task.id,
+                "conversation_id": conversation.id,
+            }),
+        )
+        .await
+        .expect("create run");
+    let actor_message = seed_manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "coordinator",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker-1",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "all",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type": "chat_message",
+                "text": "migrate actor mailbox message",
+                "task_id": task.id,
+                "task_conversation_id": conversation.id,
+                "correlation_id": "corr-migration-actor"
+            }),
+            idempotency_key: None,
+        })
+        .await
+        .expect("send actor message");
+
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let archive_manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db,
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+    let report = archive_manager
+        .migrate_team_messages_to_archive(2)
+        .await
+        .expect("migrate team messages");
+
+    assert_eq!(report.team_conversation_messages, 1);
+    assert_eq!(report.team_run_events, 2);
+    assert_eq!(report.team_actor_messages, 1);
+    assert_eq!(report.total_documents(), 4);
+
+    let documents = archive.documents.lock().await.clone();
+    assert_eq!(documents.len(), 4);
+    assert!(documents.iter().any(|document| {
+        document.document_id
+            == format!(
+                "team_conversation_message:{}:{}",
+                conversation_message.conversation_id, conversation_message.message_id
+            )
+            && document.source_kind == MessageDocumentKind::TeamConversationMessage
+            && document.team_id.as_deref() == Some(team.id.as_str())
+            && document.correlation_id.as_deref() == Some("corr-migration-conversation")
+            && document.body_text == "migrate conversation message"
+    }));
+    assert_eq!(
+        documents
+            .iter()
+            .filter(|document| document.source_kind == MessageDocumentKind::TeamRunEvent)
+            .count(),
+        2
+    );
+    assert!(documents.iter().any(|document| {
+        document
+            .document_id
+            .starts_with(format!("team_run_event:{}:", run.id).as_str())
+            && document.source_kind == MessageDocumentKind::TeamRunEvent
+            && document.team_id.as_deref() == Some(team.id.as_str())
+            && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.body_text == "run_submitted"
+    }));
+    assert!(documents.iter().any(|document| {
+        document.document_id
+            == format!("team_actor_message:{}:{}", run.id, actor_message.message_id)
+            && document.source_kind == MessageDocumentKind::TeamActorMessage
+            && document.team_id.as_deref() == Some(team.id.as_str())
+            && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.agent_id.as_deref() == Some("worker-1")
+            && document.correlation_id.as_deref() == Some("corr-migration-actor")
+            && document.body_text == "migrate actor mailbox message"
+    }));
+}
+
 #[test]
 fn message_archive_body_text_does_not_index_structured_payload_fallback() {
     assert_eq!(

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -60,6 +60,7 @@ struct TailAppendingMessageArchive {
     db: SqlitePool,
     conversation_id: String,
     task_id: String,
+    run_id: Option<String>,
     inserted: Mutex<bool>,
     documents: Mutex<Vec<MessageDocument>>,
 }
@@ -105,6 +106,50 @@ impl MessageArchiveStore for TailAppendingMessageArchive {
             .bind(Utc::now().timestamp())
             .execute(&self.db)
             .await?;
+            if let Some(run_id) = self.run_id.as_deref() {
+                sqlx::query(
+                    r#"
+                    INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
+                    VALUES (?1, NULL, ?2, ?3, ?4)
+                    "#,
+                )
+                .bind(run_id)
+                .bind("live_tail_event")
+                .bind(Utc::now().timestamp())
+                .bind(json!({"text":"live tail run event"}).to_string())
+                .execute(&self.db)
+                .await?;
+                sqlx::query(
+                    r#"
+                    INSERT INTO team_actor_messages (
+                        run_id,
+                        from_actor_id,
+                        from_peer_id,
+                        to_actor_id,
+                        to_peer_id,
+                        channel,
+                        transport,
+                        route_json,
+                        payload_json,
+                        status,
+                        created_at
+                    )
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?9, ?10)
+                    "#,
+                )
+                .bind(run_id)
+                .bind("coordinator")
+                .bind(ACTOR_MAIN_PEER_ID)
+                .bind("worker-1")
+                .bind(ACTOR_MAIN_PEER_ID)
+                .bind("all")
+                .bind("local")
+                .bind(json!({"type":"chat_message","text":"live tail actor message"}).to_string())
+                .bind("pending")
+                .bind(Utc::now().timestamp())
+                .execute(&self.db)
+                .await?;
+            }
         }
         Ok(())
     }
@@ -991,6 +1036,137 @@ async fn append_task_conversation_message_dual_writes_created_rows_to_archive() 
 }
 
 #[tokio::test]
+async fn send_actor_message_dual_writes_created_rows_to_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "actor-message-archive-team".to_string(),
+            description: Some("team for actor message archive dual-write".to_string()),
+            spec: json!({
+                "entrypoint":"coordinator_plan",
+                "members":[
+                    {"member_id":"coordinator"},
+                    {"member_id":"worker-1","role":"worker"}
+                ]
+            }),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "Archive actor message",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let source_message = manager
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({"type":"chat_message","text":"source actor archive message"}),
+        )
+        .await
+        .expect("append source message");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some(task.id.as_str()),
+            json!({
+                "task_id": task.id,
+            }),
+        )
+        .await
+        .expect("create run");
+
+    let first = manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "coordinator",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker-1",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "all",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type": "chat_message",
+                "text": "live actor archive message",
+                "authority_message_id": source_message.message_id,
+                "correlation_id": "corr-live-actor"
+            }),
+            idempotency_key: Some("actor-archive-msg-1"),
+        })
+        .await
+        .expect("send first actor message");
+    let retry = manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "coordinator",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker-1",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "all",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type": "chat_message",
+                "text": "live actor archive message",
+                "authority_message_id": source_message.message_id,
+                "correlation_id": "corr-live-actor"
+            }),
+            idempotency_key: Some("actor-archive-msg-1"),
+        })
+        .await
+        .expect("send retry actor message");
+    assert_eq!(retry.message_id, first.message_id);
+
+    let documents = wait_for_archive_documents(&archive, 2).await;
+    let actor_documents: Vec<_> = documents
+        .iter()
+        .filter(|document| document.source_kind == MessageDocumentKind::TeamActorMessage)
+        .collect();
+    assert_eq!(
+        actor_documents.len(),
+        1,
+        "idempotent retries should not dual-write duplicate actor archive documents"
+    );
+    let document = actor_documents[0];
+    assert_eq!(
+        document.document_id,
+        format!("team_actor_message:{}:{}", run.id, first.message_id)
+    );
+    assert_eq!(document.source_id, first.message_id.to_string());
+    assert_eq!(
+        document.authority_message_id,
+        Some(source_message.message_id)
+    );
+    assert_eq!(document.correlation_id.as_deref(), Some("corr-live-actor"));
+    assert_eq!(document.team_id.as_deref(), Some(team.id.as_str()));
+    assert_eq!(document.run_id.as_deref(), Some(run.id.as_str()));
+    assert_eq!(
+        document.conversation_id.as_deref(),
+        Some(conversation.id.as_str())
+    );
+    assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
+    assert_eq!(document.agent_id.as_deref(), Some("worker-1"));
+    assert_eq!(document.body_text, "live actor archive message");
+    assert_eq!(document.created_at, first.created_at);
+}
+
+#[tokio::test]
 async fn migrate_team_messages_to_archive_covers_team_message_tables() {
     let db = setup_test_db().await;
     let seed_manager = TeamManager::new(db.clone());
@@ -1290,6 +1466,7 @@ async fn migrate_team_messages_to_archive_uses_start_snapshot_for_conversation_r
         db: db.clone(),
         conversation_id: conversation.id.clone(),
         task_id: task.id.clone(),
+        run_id: None,
         inserted: Mutex::new(false),
         documents: Mutex::new(Vec::new()),
     });
@@ -1321,6 +1498,142 @@ async fn migrate_team_messages_to_archive_uses_start_snapshot_for_conversation_r
     .await
     .expect("count conversation messages");
     assert_eq!(stored_count, 3);
+}
+
+#[tokio::test]
+async fn migrate_team_messages_to_archive_uses_start_snapshot_for_run_and_actor_rows() {
+    let db = setup_test_db().await;
+    let seed_manager = TeamManager::new(db.clone());
+
+    let team = seed_manager
+        .create_team(TeamDefinitionConfig {
+            name: "team-message-archive-run-actor-snapshot".to_string(),
+            description: Some("team for run and actor archive migration snapshot".to_string()),
+            spec: json!({
+                "entrypoint":"coordinator_plan",
+                "members":[
+                    {"member_id":"coordinator"},
+                    {"member_id":"worker-1","role":"worker"}
+                ]
+            }),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = seed_manager
+        .create_task(
+            &team.id,
+            "Archive run and actor snapshot",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let run = seed_manager
+        .create_run(
+            &team.id,
+            Some(task.id.as_str()),
+            json!({
+                "task_id": task.id,
+            }),
+        )
+        .await
+        .expect("create run");
+    sqlx::query(
+        r#"
+        INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
+        VALUES (?1, NULL, ?2, ?3, ?4)
+        "#,
+    )
+    .bind(&run.id)
+    .bind("snapshot_run_event")
+    .bind(Utc::now().timestamp())
+    .bind(json!({"text":"snapshot run event"}).to_string())
+    .execute(&seed_manager.db)
+    .await
+    .expect("insert snapshot run event");
+    sqlx::query(
+        r#"
+        INSERT INTO team_actor_messages (
+            run_id,
+            from_actor_id,
+            from_peer_id,
+            to_actor_id,
+            to_peer_id,
+            channel,
+            transport,
+            route_json,
+            payload_json,
+            status,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?9, ?10)
+        "#,
+    )
+    .bind(&run.id)
+    .bind("coordinator")
+    .bind(ACTOR_MAIN_PEER_ID)
+    .bind("worker-1")
+    .bind(ACTOR_MAIN_PEER_ID)
+    .bind("all")
+    .bind("local")
+    .bind(json!({"type":"chat_message","text":"snapshot actor message"}).to_string())
+    .bind("pending")
+    .bind(Utc::now().timestamp())
+    .execute(&seed_manager.db)
+    .await
+    .expect("insert snapshot actor message");
+
+    let archive = Arc::new(TailAppendingMessageArchive {
+        db: db.clone(),
+        conversation_id: conversation.id.clone(),
+        task_id: task.id.clone(),
+        run_id: Some(run.id.clone()),
+        inserted: Mutex::new(false),
+        documents: Mutex::new(Vec::new()),
+    });
+    let archive_manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let report = archive_manager
+        .migrate_team_messages_to_archive(1)
+        .await
+        .expect("migrate team messages");
+
+    assert_eq!(report.team_conversation_messages, 0);
+    assert_eq!(report.team_run_events, 2);
+    assert_eq!(report.team_actor_messages, 1);
+    assert_eq!(report.total_documents(), 3);
+    let documents = archive.documents.lock().await.clone();
+    assert_eq!(documents.len(), 3);
+    assert!(
+        documents
+            .iter()
+            .all(|document| document.body_text != "live tail run event")
+    );
+    assert!(
+        documents
+            .iter()
+            .all(|document| document.body_text != "live tail actor message")
+    );
+    let stored_run_event_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM team_run_events WHERE run_id = ?1")
+            .bind(&run.id)
+            .fetch_one(&db)
+            .await
+            .expect("count run events");
+    let stored_actor_message_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM team_actor_messages WHERE run_id = ?1")
+            .bind(&run.id)
+            .fetch_one(&db)
+            .await
+            .expect("count actor messages");
+    assert_eq!(stored_run_event_count, 3);
+    assert_eq!(stored_actor_message_count, 2);
 }
 
 #[test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -56,6 +56,64 @@ impl MessageArchiveStore for RecordingMessageArchive {
     }
 }
 
+struct TailAppendingMessageArchive {
+    db: SqlitePool,
+    conversation_id: String,
+    task_id: String,
+    inserted: Mutex<bool>,
+    documents: Mutex<Vec<MessageDocument>>,
+}
+
+#[async_trait]
+impl MessageArchiveStore for TailAppendingMessageArchive {
+    async fn ensure_ready(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn append_documents(&self, documents: &[MessageDocument]) -> anyhow::Result<()> {
+        self.documents.lock().await.extend_from_slice(documents);
+        let should_insert = {
+            let mut inserted = self.inserted.lock().await;
+            if *inserted {
+                false
+            } else {
+                *inserted = true;
+                true
+            }
+        };
+        if should_insert {
+            sqlx::query(
+                r#"
+                INSERT INTO team_conversation_messages (
+                    conversation_id,
+                    task_id,
+                    from_actor_id,
+                    to_actor_id,
+                    route,
+                    payload_json,
+                    created_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "#,
+            )
+            .bind(&self.conversation_id)
+            .bind(&self.task_id)
+            .bind("user")
+            .bind("coordinator")
+            .bind("to_coordinator")
+            .bind(json!({"type":"chat_message","text":"live tail message"}).to_string())
+            .bind(Utc::now().timestamp())
+            .execute(&self.db)
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn search(&self, _query: &MessageSearchQuery) -> anyhow::Result<Vec<MessageSearchHit>> {
+        Ok(Vec::new())
+    }
+}
+
 struct PendingMessageArchive;
 
 #[async_trait]
@@ -982,7 +1040,6 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             Some(task.id.as_str()),
             json!({
                 "task_id": task.id,
-                "conversation_id": conversation.id,
                 "api_key": "run-input-secret",
             }),
         )
@@ -1182,6 +1239,88 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
             .iter()
             .all(|document| document.run_id.as_deref() != Some(hidden_run.id.as_str()))
     );
+}
+
+#[tokio::test]
+async fn migrate_team_messages_to_archive_uses_start_snapshot_for_conversation_rows() {
+    let db = setup_test_db().await;
+    let seed_manager = TeamManager::new(db.clone());
+
+    let team = seed_manager
+        .create_team(TeamDefinitionConfig {
+            name: "team-message-archive-snapshot".to_string(),
+            description: Some("team for archive migration snapshot".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = seed_manager
+        .create_task(
+            &team.id,
+            "Archive snapshot",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    seed_manager
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({"type":"chat_message","text":"snapshot message one"}),
+        )
+        .await
+        .expect("append first message");
+    seed_manager
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            Some("coordinator"),
+            "to_coordinator",
+            json!({"type":"chat_message","text":"snapshot message two"}),
+        )
+        .await
+        .expect("append second message");
+
+    let archive = Arc::new(TailAppendingMessageArchive {
+        db: db.clone(),
+        conversation_id: conversation.id.clone(),
+        task_id: task.id.clone(),
+        inserted: Mutex::new(false),
+        documents: Mutex::new(Vec::new()),
+    });
+    let archive_manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let report = archive_manager
+        .migrate_team_messages_to_archive(1)
+        .await
+        .expect("migrate team messages");
+
+    assert_eq!(report.team_conversation_messages, 2);
+    assert_eq!(report.total_documents(), 2);
+    let documents = archive.documents.lock().await.clone();
+    assert_eq!(documents.len(), 2);
+    assert!(
+        documents
+            .iter()
+            .all(|document| document.body_text != "live tail message")
+    );
+    let stored_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM team_conversation_messages WHERE conversation_id = ?1",
+    )
+    .bind(&conversation.id)
+    .fetch_one(&db)
+    .await
+    .expect("count conversation messages");
+    assert_eq!(stored_count, 3);
 }
 
 #[test]

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -30,9 +30,10 @@ pub(crate) use manager::TEAM_TASK_DETAIL_MESSAGE_LIMIT_MAX;
 #[allow(unused_imports)]
 pub use manager::{
     SendActorMessageInput, TeamContextLookupError, TeamContextRecord, TeamConversationStreamEvent,
-    TeamManager, TeamMemoryFlushRequest, TeamRemoteRelayWorkerSettings, TeamRunContextFingerprint,
-    TeamRunContextStreamEvent, TeamRuntimeRecord, TeamRuntimeStatus, TeamTaskAssignmentUpdate,
-    TeamTaskContextPatch, TeamTaskListQuery,
+    TeamManager, TeamMemoryFlushRequest, TeamMessageArchiveMigrationReport,
+    TeamRemoteRelayWorkerSettings, TeamRunContextFingerprint, TeamRunContextStreamEvent,
+    TeamRuntimeRecord, TeamRuntimeStatus, TeamTaskAssignmentUpdate, TeamTaskContextPatch,
+    TeamTaskListQuery,
 };
 pub(crate) use permission_review::resolve_team_permission_review_target;
 pub use permission_review::{


### PR DESCRIPTION
## Summary

- Add `TeamManager::migrate_team_messages_to_archive` for historical Team SQLite message rows.
- Convert Team conversation messages, run events, and actor mailbox messages into canonical archive documents.
- Make LanceDB archive appends idempotent by upserting on `document_id`.
- Record the rollout checkpoint in the message archive journal and feature spec source list.

## Purpose

This continues the message archive rollout by covering existing Team SQLite history, not only new dual-written conversation messages. The migration keeps Team relational state in SQLite while projecting message-shaped history into the pluggable archive/search plane.

## Related Issue

- Follow-up for the P0+ message archive and LanceDB rollout in `docs/todo.md`.

## Testing

```bash
cargo test -p agenthub-message-archive lancedb_archive_upserts_documents_by_document_id -- --nocapture
cargo test --lib migrate_team_messages_to_archive_covers_team_message_tables -- --nocapture
cargo fmt --all --check
git diff --check
```
