### PR TITLE
feat(archive): dual-write live team run events

### DIFF
--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -271,9 +271,11 @@ actor-scoped archive filters find messages delivered to that actor.
   not distinguish newly inserted archive rows from idempotent updates; archive backends need an
   inserted/updated write-result contract before the admin API can expose that distinction.
 - Live Team actor mailbox sends dual-write created rows to the archive with the same canonical
-  document identity as migration. Team run-event live dual-write still requires a follow-up
-  consolidation of the multiple event insertion paths before run-event search can be fully
-  continuous without rerunning migration.
+  document identity as migration.
+- Live Team run-event dual-write covers new run submissions and the public run-event append path,
+  including actor mailbox run-event appends. The remaining tx-heavy step lifecycle insertion paths
+  still require follow-up consolidation before run-event search can be fully continuous without
+  rerunning migration.
 
 ### 6) Multi-Database Extensibility Contract
 
@@ -302,6 +304,8 @@ actor-scoped archive filters find messages delivered to that actor.
   - raw ACP event replay into aggregated archive documents
 - Focused Team manager test for live Team conversation message dual-write without duplicating
   archive documents on idempotent retries.
+- Focused Team manager tests for live Team run-event dual-write on run submission and public
+  run-event appends.
 - Focused Team API test for Team-scoped archive search:
   - route uses the archive abstraction
   - route forces path Team scope into `MessageSearchQuery`

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -272,10 +272,10 @@ actor-scoped archive filters find messages delivered to that actor.
   inserted/updated write-result contract before the admin API can expose that distinction.
 - Live Team actor mailbox sends dual-write created rows to the archive with the same canonical
   document identity as migration.
-- Live Team run-event dual-write covers new run submissions and the public run-event append path,
-  including actor mailbox run-event appends. The remaining tx-heavy step lifecycle insertion paths
-  still require follow-up consolidation before run-event search can be fully continuous without
-  rerunning migration.
+- Live Team run-event dual-write covers new run submissions, the public run-event append path, and
+  actor mailbox run-event appends. The remaining tx-heavy insertion paths still require follow-up
+  consolidation before run-event search can be fully continuous without rerunning migration; this
+  includes step lifecycle writes and memory-flush events emitted through `append_run_event_tx`.
 
 ### 6) Multi-Database Extensibility Contract
 

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -177,6 +177,87 @@ impl MessageArchiveScopeFallback {
     }
 }
 
+async fn message_archive_task_conversation_id_db(
+    db: &SqlitePool,
+    team_id: &str,
+    task_id: &str,
+) -> anyhow::Result<Option<String>> {
+    Ok(sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT id
+        FROM team_conversations
+        WHERE team_id = ?1 AND task_id = ?2
+        LIMIT 1
+        "#,
+    )
+    .bind(team_id)
+    .bind(task_id)
+    .fetch_optional(db)
+    .await?)
+}
+
+async fn message_archive_scope_for_payload_db(
+    db: &SqlitePool,
+    team_id: &str,
+    payload: &Value,
+    base_scope: &MessageArchiveScopeFallback,
+    task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
+) -> anyhow::Result<MessageArchiveScopeFallback> {
+    let task_id =
+        message_archive_payload_string(payload, "task_id").or_else(|| base_scope.task_id.clone());
+    let mut conversation_id = base_scope.conversation_id.clone();
+    if conversation_id.is_none()
+        && let Some(task_id) = task_id.as_deref()
+    {
+        let cache_key = (team_id.to_string(), task_id.to_string());
+        if !task_conversation_cache.contains_key(&cache_key) {
+            let resolved = message_archive_task_conversation_id_db(db, team_id, task_id).await?;
+            task_conversation_cache.insert(cache_key.clone(), resolved);
+        }
+        conversation_id = task_conversation_cache.get(&cache_key).cloned().flatten();
+    }
+    Ok(MessageArchiveScopeFallback {
+        conversation_id,
+        task_id,
+    })
+}
+
+async fn team_run_event_archive_document_for_db(
+    db: &SqlitePool,
+    event: &TeamRunEventRecord,
+) -> anyhow::Result<Option<MessageDocument>> {
+    let row = sqlx::query(
+        r#"
+        SELECT team_id, input_json
+        FROM team_runs
+        WHERE id = ?1
+        "#,
+    )
+    .bind(&event.run_id)
+    .fetch_one(db)
+    .await?;
+    let team_id: String = row.get("team_id");
+    let input_json: String = row.get("input_json");
+    let run_input: Value = serde_json::from_str(&input_json)?;
+    if message_archive_payload_string(&run_input, "bootstrap_kind").as_deref()
+        == Some(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
+    {
+        return Ok(None);
+    }
+    let base_scope = MessageArchiveScopeFallback::from_run_input(&run_input);
+    let scope = message_archive_scope_for_payload_db(
+        db,
+        &team_id,
+        &event.payload,
+        &base_scope,
+        &mut HashMap::new(),
+    )
+    .await?;
+    Ok(Some(team_run_event_archive_document(
+        &team_id, event, &scope,
+    )))
+}
+
 fn team_run_event_archive_document(
     team_id: &str,
     event: &TeamRunEventRecord,
@@ -1918,6 +1999,66 @@ impl TeamManager {
         )))
     }
 
+    pub(super) fn spawn_archive_team_run_event(&self, event: &TeamRunEventRecord) {
+        if self.message_archive.is_none() {
+            return;
+        }
+        let manager = self.clone();
+        let event = event.clone();
+        let run_id = event.run_id.clone();
+        let event_id = event.event_id;
+
+        tokio::spawn(async move {
+            match manager.team_run_event_archive_document(&event).await {
+                Ok(Some(document)) => {
+                    let Some(archive) = manager.message_archive.as_ref().cloned() else {
+                        return;
+                    };
+                    match tokio::time::timeout(
+                        MESSAGE_ARCHIVE_APPEND_TIMEOUT,
+                        archive.append_documents(&[document]),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            tracing::warn!(
+                                error = ?error,
+                                run_id = %run_id,
+                                event_id,
+                                "failed to dual-write team run event to archive"
+                            );
+                        }
+                        Err(_) => {
+                            tracing::warn!(
+                                run_id = %run_id,
+                                event_id,
+                                timeout_ms = MESSAGE_ARCHIVE_APPEND_TIMEOUT.as_millis(),
+                                "timed out dual-writing team run event to archive"
+                            );
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = ?error,
+                        run_id = %run_id,
+                        event_id,
+                        "failed to build team run event archive document"
+                    );
+                }
+            }
+        });
+    }
+
+    async fn team_run_event_archive_document(
+        &self,
+        event: &TeamRunEventRecord,
+    ) -> anyhow::Result<Option<MessageDocument>> {
+        team_run_event_archive_document_for_db(&self.db, event).await
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn append_channel_replica_message(
         &self,
@@ -2346,7 +2487,7 @@ impl TeamManager {
             "status": team_run_status_to_str(&status),
             "continuity_mode": continuity_mode,
         });
-        sqlx::query(
+        let submitted_event_result = sqlx::query(
             r#"
             INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
             VALUES (?1, NULL, ?2, ?3, ?4)
@@ -2358,6 +2499,14 @@ impl TeamManager {
         .bind(payload.to_string())
         .execute(&mut *tx)
         .await?;
+        let submitted_event = TeamRunEventRecord {
+            event_id: submitted_event_result.last_insert_rowid(),
+            run_id: run_id.clone(),
+            step_id: None,
+            event_type: "run_submitted".to_string(),
+            ts: now,
+            payload,
+        };
         insert_materialized_run_steps_tx(&mut tx, &run_id, &materialized_steps, now).await?;
         sync_linked_task_status_tx(
             &mut tx,
@@ -2369,6 +2518,7 @@ impl TeamManager {
         )
         .await?;
         tx.commit().await?;
+        self.spawn_archive_team_run_event(&submitted_event);
 
         Ok(TeamRunRecord {
             id: run_id,
@@ -4613,7 +4763,7 @@ impl TeamManager {
         payload: Value,
     ) -> anyhow::Result<()> {
         let ts = Utc::now().timestamp();
-        sqlx::query(
+        let result = sqlx::query(
             r#"
             INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
             VALUES (?1, NULL, ?2, ?3, ?4)
@@ -4625,6 +4775,15 @@ impl TeamManager {
         .bind(payload.to_string())
         .execute(&self.db)
         .await?;
+        let event = TeamRunEventRecord {
+            event_id: result.last_insert_rowid(),
+            run_id: run_id.to_string(),
+            step_id: None,
+            event_type: event_type.to_string(),
+            ts,
+            payload,
+        };
+        self.spawn_archive_team_run_event(&event);
         Ok(())
     }
 

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -1986,14 +1986,14 @@ impl TeamManager {
             return Ok(None);
         }
         let base_scope = MessageArchiveScopeFallback::from_run_input(&run_input);
-        let scope = self
-            .message_archive_scope_for_payload(
-                &team_id,
-                &message.payload,
-                &base_scope,
-                &mut HashMap::new(),
-            )
-            .await?;
+        let scope = message_archive_scope_for_payload_db(
+            &self.db,
+            &team_id,
+            &message.payload,
+            &base_scope,
+            &mut HashMap::new(),
+        )
+        .await?;
         Ok(Some(team_actor_message_archive_document(
             &team_id, message, &scope,
         )))
@@ -2168,53 +2168,6 @@ impl TeamManager {
             .await?)
     }
 
-    async fn message_archive_task_conversation_id(
-        &self,
-        team_id: &str,
-        task_id: &str,
-    ) -> anyhow::Result<Option<String>> {
-        Ok(sqlx::query_scalar::<_, String>(
-            r#"
-            SELECT id
-            FROM team_conversations
-            WHERE team_id = ?1 AND task_id = ?2
-            LIMIT 1
-            "#,
-        )
-        .bind(team_id)
-        .bind(task_id)
-        .fetch_optional(&self.db)
-        .await?)
-    }
-
-    async fn message_archive_scope_for_payload(
-        &self,
-        team_id: &str,
-        payload: &Value,
-        base_scope: &MessageArchiveScopeFallback,
-        task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
-    ) -> anyhow::Result<MessageArchiveScopeFallback> {
-        let task_id = message_archive_payload_string(payload, "task_id")
-            .or_else(|| base_scope.task_id.clone());
-        let mut conversation_id = base_scope.conversation_id.clone();
-        if conversation_id.is_none()
-            && let Some(task_id) = task_id.as_deref()
-        {
-            let cache_key = (team_id.to_string(), task_id.to_string());
-            if !task_conversation_cache.contains_key(&cache_key) {
-                let resolved = self
-                    .message_archive_task_conversation_id(team_id, task_id)
-                    .await?;
-                task_conversation_cache.insert(cache_key.clone(), resolved);
-            }
-            conversation_id = task_conversation_cache.get(&cache_key).cloned().flatten();
-        }
-        Ok(MessageArchiveScopeFallback {
-            conversation_id,
-            task_id,
-        })
-    }
-
     pub async fn migrate_team_messages_to_archive(
         &self,
         batch_size: usize,
@@ -2335,14 +2288,14 @@ impl TeamManager {
                     .expect("run scope is cached before use")
                     .clone();
                 let event = parse_run_event_row(&row)?;
-                let scope = self
-                    .message_archive_scope_for_payload(
-                        &team_id,
-                        &event.payload,
-                        &base_scope,
-                        &mut task_conversation_cache,
-                    )
-                    .await?;
+                let scope = message_archive_scope_for_payload_db(
+                    &self.db,
+                    &team_id,
+                    &event.payload,
+                    &base_scope,
+                    &mut task_conversation_cache,
+                )
+                .await?;
                 documents.push(team_run_event_archive_document(&team_id, &event, &scope));
                 report.team_run_events += 1;
             }
@@ -2405,14 +2358,14 @@ impl TeamManager {
                     .expect("run scope is cached before use")
                     .clone();
                 let message = parse_team_actor_message_row(&row)?;
-                let scope = self
-                    .message_archive_scope_for_payload(
-                        &team_id,
-                        &message.payload,
-                        &base_scope,
-                        &mut task_conversation_cache,
-                    )
-                    .await?;
+                let scope = message_archive_scope_for_payload_db(
+                    &self.db,
+                    &team_id,
+                    &message.payload,
+                    &base_scope,
+                    &mut task_conversation_cache,
+                )
+                .await?;
                 documents.push(team_actor_message_archive_document(
                     &team_id, &message, &scope,
                 ));

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use agenthub_message_archive::MessageArchiveStoreRef;
@@ -17,6 +18,7 @@ use serde_json::{Map, Value};
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Error as SqlxError, Executor, QueryBuilder, Row, Sqlite, SqlitePool};
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use uuid::Uuid;
 
 use super::codec::{
@@ -38,6 +40,15 @@ const TEAM_SHARED_THREAD_BOOTSTRAP_SOURCE: &str = "server_canonical_reply";
 const TEAM_SPECIAL_USER_ACTOR_ALIAS: &str = "user";
 const TEAM_SPECIAL_USER_ACTOR_PREFIX: &str = "user:";
 const SQLITE_READONLY_BASE_CODE: i32 = 8;
+const MAILBOX_RUN_EVENT_ARCHIVE_MAX_CONCURRENCY: usize = 4;
+
+static MAILBOX_RUN_EVENT_ARCHIVE_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+fn mailbox_run_event_archive_semaphore() -> Arc<Semaphore> {
+    MAILBOX_RUN_EVENT_ARCHIVE_SEMAPHORE
+        .get_or_init(|| Arc::new(Semaphore::new(MAILBOX_RUN_EVENT_ARCHIVE_MAX_CONCURRENCY)))
+        .clone()
+}
 
 #[derive(Debug, Clone)]
 struct CanonicalChatReply {
@@ -1398,9 +1409,18 @@ impl ActorMailboxStore for SqlActorMailboxStore {
         };
         if let Some(archive) = self.message_archive.as_ref().cloned() {
             let db = self.db.clone();
+            let semaphore = mailbox_run_event_archive_semaphore();
             let run_id = event.run_id.clone();
             let event_id = event.event_id;
             tokio::spawn(async move {
+                let Ok(_permit) = semaphore.acquire_owned().await else {
+                    tracing::warn!(
+                        run_id = %run_id,
+                        event_id,
+                        "failed to acquire mailbox run event archive permit"
+                    );
+                    return;
+                };
                 match team_run_event_archive_document_for_db(&db, &event).await {
                     Ok(Some(document)) => {
                         match tokio::time::timeout(

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -1409,14 +1409,14 @@ impl ActorMailboxStore for SqlActorMailboxStore {
         };
         if let Some(archive) = self.message_archive.as_ref().cloned() {
             let db = self.db.clone();
-            let semaphore = mailbox_run_event_archive_semaphore();
+            let permit = mailbox_run_event_archive_semaphore()
+                .acquire_owned()
+                .await
+                .expect("mailbox run event archive semaphore stays open");
             let run_id = event.run_id.clone();
             let event_id = event.event_id;
             tokio::spawn(async move {
-                let _permit = semaphore
-                    .acquire_owned()
-                    .await
-                    .expect("mailbox run event archive semaphore stays open");
+                let _permit = permit;
                 match team_run_event_archive_document_for_db(&db, &event).await {
                     Ok(Some(document)) => {
                         match tokio::time::timeout(

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use agenthub_message_archive::MessageArchiveStoreRef;
 use agenthub_team_actor::{
     ACTOR_MAIN_PEER_ID, ACTOR_NODE_PEER_ID, AckActorMessageCommand, AckActorMessageResult,
     ActorAckRequest, ActorAckResponse, ActorInboxRequest, ActorInboxResponse, ActorMailbox,
@@ -25,12 +26,12 @@ use super::codec::{
 use super::{
     TEAM_SHARED_THREAD_BOOTSTRAP_KIND, TEAM_SHARED_THREAD_TITLE, TeamConversationStreamEvent,
     TeamManager, TeamMemberSpecView, fetch_canonical_shared_thread_target, parse_team_member_specs,
-    redact_sensitive_json,
+    redact_sensitive_json, team_run_event_archive_document_for_db,
 };
 use crate::agent::normalize_target_node_id;
 use crate::team::{
     TeamActorMessageRecord, TeamActorMessageStatus, TeamActorMessageTransport,
-    TeamConversationMessageRecord,
+    TeamConversationMessageRecord, TeamRunEventRecord,
 };
 
 const TEAM_SHARED_THREAD_BOOTSTRAP_SOURCE: &str = "server_canonical_reply";
@@ -308,6 +309,7 @@ impl TeamManager {
     fn actor_mailbox(&self) -> ActorMailbox<SqlActorMailboxStore> {
         ActorMailbox::new(SqlActorMailboxStore {
             db: self.db.clone(),
+            message_archive: self.message_archive.clone(),
         })
     }
 
@@ -850,6 +852,7 @@ impl ActorMailboxService for TeamActorMailboxService {
             .unwrap_or_else(|| vec![TeamActorMessageStatus::Pending]);
         let snapshot = SqlActorMailboxStore {
             db: self.manager.db.clone(),
+            message_archive: None,
         }
         .read_inbox_snapshot(&ListActorInboxQuery {
             run_id: run_id.to_string(),
@@ -910,6 +913,7 @@ impl ActorMailboxService for TeamActorMailboxService {
 #[derive(Clone)]
 struct SqlActorMailboxStore {
     db: SqlitePool,
+    message_archive: Option<MessageArchiveStoreRef>,
 }
 
 #[derive(Debug, Error)]
@@ -1372,7 +1376,7 @@ impl ActorMailboxStore for SqlActorMailboxStore {
         ts: i64,
         payload: Value,
     ) -> Result<(), Self::Error> {
-        sqlx::query(
+        let result = sqlx::query(
             r#"
             INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
             VALUES (?1, NULL, ?2, ?3, ?4)
@@ -1384,6 +1388,58 @@ impl ActorMailboxStore for SqlActorMailboxStore {
         .bind(payload.to_string())
         .execute(&self.db)
         .await?;
+        let event = TeamRunEventRecord {
+            event_id: result.last_insert_rowid(),
+            run_id: run_id.to_string(),
+            step_id: None,
+            event_type: event_type.to_string(),
+            ts,
+            payload,
+        };
+        if let Some(archive) = self.message_archive.as_ref().cloned() {
+            let db = self.db.clone();
+            let run_id = event.run_id.clone();
+            let event_id = event.event_id;
+            tokio::spawn(async move {
+                match team_run_event_archive_document_for_db(&db, &event).await {
+                    Ok(Some(document)) => {
+                        match tokio::time::timeout(
+                            super::MESSAGE_ARCHIVE_APPEND_TIMEOUT,
+                            archive.append_documents(&[document]),
+                        )
+                        .await
+                        {
+                            Ok(Ok(())) => {}
+                            Ok(Err(error)) => {
+                                tracing::warn!(
+                                    error = ?error,
+                                    run_id = %run_id,
+                                    event_id,
+                                    "failed to dual-write team actor mailbox run event to archive"
+                                );
+                            }
+                            Err(_) => {
+                                tracing::warn!(
+                                    run_id = %run_id,
+                                    event_id,
+                                    timeout_ms = super::MESSAGE_ARCHIVE_APPEND_TIMEOUT.as_millis(),
+                                    "timed out dual-writing team actor mailbox run event to archive"
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            error = ?error,
+                            run_id = %run_id,
+                            event_id,
+                            "failed to build team actor mailbox run event archive document"
+                        );
+                    }
+                }
+            });
+        }
         Ok(())
     }
 }

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -1413,14 +1413,10 @@ impl ActorMailboxStore for SqlActorMailboxStore {
             let run_id = event.run_id.clone();
             let event_id = event.event_id;
             tokio::spawn(async move {
-                let Ok(_permit) = semaphore.acquire_owned().await else {
-                    tracing::warn!(
-                        run_id = %run_id,
-                        event_id,
-                        "failed to acquire mailbox run event archive permit"
-                    );
-                    return;
-                };
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("mailbox run event archive semaphore stays open");
                 match team_run_event_archive_document_for_db(&db, &event).await {
                     Ok(Some(document)) => {
                         match tokio::time::timeout(

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1164,13 +1164,98 @@ async fn send_actor_message_dual_writes_created_rows_to_archive() {
     assert_eq!(document.agent_id.as_deref(), Some("worker-1"));
     assert_eq!(document.body_text, "live actor archive message");
     assert_eq!(document.created_at, first.created_at);
-    assert!(documents.iter().any(|document| {
+    let sent_run_event_documents: Vec<_> = documents
+        .iter()
+        .filter(|document| {
+            document.source_kind == MessageDocumentKind::TeamRunEvent
+                && document.run_id.as_deref() == Some(run.id.as_str())
+                && document.body_text == "actor_message_sent"
+        })
+        .collect();
+    assert_eq!(
+        sent_run_event_documents.len(),
+        1,
+        "idempotent retries should not dual-write duplicate actor_message_sent archive documents"
+    );
+    assert!(sent_run_event_documents.iter().any(|document| {
         document.source_kind == MessageDocumentKind::TeamRunEvent
             && document.run_id.as_deref() == Some(run.id.as_str())
             && document.body_text == "actor_message_sent"
             && document.conversation_id.as_deref() == Some(conversation.id.as_str())
             && document.task_id.as_deref() == Some(task.id.as_str())
     }));
+}
+
+#[tokio::test]
+async fn append_run_event_skips_shared_thread_mailbox_runs_in_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "shared-thread-run-event-archive-team".to_string(),
+            description: Some("team for shared-thread run event archive skip".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "Shared thread archive skip",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let shared_run = manager
+        .ensure_shared_thread_mailbox_run(&team.id, &task.id, &conversation.id)
+        .await
+        .expect("ensure shared thread mailbox run");
+
+    manager
+        .append_run_event(
+            &shared_run.id,
+            "shared_thread_live_event",
+            json!({
+                "text": "hidden shared thread event",
+                "task_id": task.id,
+                "conversation_id": conversation.id,
+            }),
+        )
+        .await
+        .expect("append shared thread run event");
+
+    let events = manager
+        .list_run_events(&shared_run.id, 10, None)
+        .await
+        .expect("list shared thread run events");
+    let live_event = events
+        .iter()
+        .find(|event| event.event_type == "shared_thread_live_event")
+        .expect("shared thread live event");
+    assert!(
+        manager
+            .team_run_event_archive_document(live_event)
+            .await
+            .expect("build shared thread run event archive document")
+            .is_none(),
+        "shared-thread mailbox run events should not build archive documents"
+    );
+
+    sleep(Duration::from_millis(50)).await;
+    let documents = archive.documents.lock().await.clone();
+    assert!(
+        documents.is_empty(),
+        "shared-thread mailbox run events should stay out of message archive"
+    );
 }
 
 #[tokio::test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1133,7 +1133,7 @@ async fn send_actor_message_dual_writes_created_rows_to_archive() {
         .expect("send retry actor message");
     assert_eq!(retry.message_id, first.message_id);
 
-    let documents = wait_for_archive_documents(&archive, 2).await;
+    let documents = wait_for_archive_documents(&archive, 4).await;
     let actor_documents: Vec<_> = documents
         .iter()
         .filter(|document| document.source_kind == MessageDocumentKind::TeamActorMessage)
@@ -1164,6 +1164,149 @@ async fn send_actor_message_dual_writes_created_rows_to_archive() {
     assert_eq!(document.agent_id.as_deref(), Some("worker-1"));
     assert_eq!(document.body_text, "live actor archive message");
     assert_eq!(document.created_at, first.created_at);
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::TeamRunEvent
+            && document.run_id.as_deref() == Some(run.id.as_str())
+            && document.body_text == "actor_message_sent"
+            && document.conversation_id.as_deref() == Some(conversation.id.as_str())
+            && document.task_id.as_deref() == Some(task.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn create_run_dual_writes_submission_event_to_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "run-event-archive-team".to_string(),
+            description: Some("team for run event archive dual-write".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "Archive run event",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+
+    let run = manager
+        .create_run(
+            &team.id,
+            Some(task.id.as_str()),
+            json!({
+                "task_id": task.id,
+            }),
+        )
+        .await
+        .expect("create run");
+
+    let documents = wait_for_archive_documents(&archive, 1).await;
+    let document = documents
+        .iter()
+        .find(|document| document.source_kind == MessageDocumentKind::TeamRunEvent)
+        .expect("run event archive document");
+    assert_eq!(
+        document.document_id,
+        format!("team_run_event:{}:{}", run.id, document.source_id)
+    );
+    assert_eq!(document.team_id.as_deref(), Some(team.id.as_str()));
+    assert_eq!(document.run_id.as_deref(), Some(run.id.as_str()));
+    assert_eq!(
+        document.conversation_id.as_deref(),
+        Some(conversation.id.as_str())
+    );
+    assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
+    assert_eq!(document.body_text, "run_submitted");
+    assert!(
+        document
+            .payload_json
+            .as_deref()
+            .is_some_and(|payload| payload.contains("inherit_recent"))
+    );
+}
+
+#[tokio::test]
+async fn append_run_event_dual_writes_created_event_to_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "append-run-event-archive-team".to_string(),
+            description: Some("team for appended run event archive dual-write".to_string()),
+            spec: json!({"entrypoint":"coordinator_plan","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "Archive appended run event",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some(task.id.as_str()),
+            json!({
+                "task_id": task.id,
+            }),
+        )
+        .await
+        .expect("create run");
+
+    manager
+        .append_run_event(
+            &run.id,
+            "custom_live_event",
+            json!({
+                "text": "custom live run event",
+                "authority_message_id": 42,
+                "correlation_id": "corr-live-run"
+            }),
+        )
+        .await
+        .expect("append run event");
+
+    let documents = wait_for_archive_documents(&archive, 2).await;
+    let document = documents
+        .iter()
+        .find(|document| document.body_text == "custom live run event")
+        .expect("custom run event archive document");
+    assert_eq!(document.source_kind, MessageDocumentKind::TeamRunEvent);
+    assert_eq!(document.authority_message_id, Some(42));
+    assert_eq!(document.correlation_id.as_deref(), Some("corr-live-run"));
+    assert_eq!(document.team_id.as_deref(), Some(team.id.as_str()));
+    assert_eq!(document.run_id.as_deref(), Some(run.id.as_str()));
+    assert_eq!(
+        document.conversation_id.as_deref(),
+        Some(conversation.id.as_str())
+    );
+    assert_eq!(document.task_id.as_deref(), Some(task.id.as_str()));
 }
 
 #[tokio::test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -194,6 +194,21 @@ async fn wait_for_archive_documents(
     .expect("archive documents should be appended")
 }
 
+async fn assert_archive_documents_stay_empty(archive: &RecordingMessageArchive) {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let documents = archive.documents.lock().await.clone();
+            assert!(
+                documents.is_empty(),
+                "archive should remain empty, got documents: {documents:?}"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect_err("archive should remain empty for the full assertion window");
+}
+
 async fn setup_test_db() -> SqlitePool {
     let options = SqliteConnectOptions::new()
         .filename(":memory:")
@@ -1250,12 +1265,69 @@ async fn append_run_event_skips_shared_thread_mailbox_runs_in_archive() {
         "shared-thread mailbox run events should not build archive documents"
     );
 
-    sleep(Duration::from_millis(50)).await;
-    let documents = archive.documents.lock().await.clone();
-    assert!(
-        documents.is_empty(),
-        "shared-thread mailbox run events should stay out of message archive"
+    assert_archive_documents_stay_empty(&archive).await;
+}
+
+#[tokio::test]
+async fn actor_mailbox_run_event_skips_shared_thread_mailbox_runs_in_archive() {
+    let db = setup_test_db().await;
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
     );
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "shared-thread-mailbox-archive-team".to_string(),
+            description: Some("team for shared-thread mailbox archive skip".to_string()),
+            spec: json!({
+                "entrypoint":"coordinator_plan",
+                "members":[
+                    {"member_id":"coordinator"},
+                    {"member_id":"worker-1","role":"worker"}
+                ]
+            }),
+        })
+        .await
+        .expect("create team");
+    let (task, conversation) = manager
+        .create_task(
+            &team.id,
+            "Shared thread mailbox archive skip",
+            "user",
+            json!({}),
+            "group_chat",
+            None,
+        )
+        .await
+        .expect("create task");
+    let shared_run = manager
+        .ensure_shared_thread_mailbox_run(&team.id, &task.id, &conversation.id)
+        .await
+        .expect("ensure shared thread mailbox run");
+
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &shared_run.id,
+            from_actor_id: "coordinator",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "worker-1",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "all",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type": "chat_message",
+                "text": "hidden shared thread mailbox event",
+            }),
+            idempotency_key: Some("shared-thread-mailbox-archive-msg-1"),
+        })
+        .await
+        .expect("send shared thread mailbox actor message");
+
+    assert_archive_documents_stay_empty(&archive).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add best-effort archive dual-write for live Team run events created by run submission.
- Add best-effort archive dual-write for public run-event appends, including actor mailbox run-event appends.
- Keep the message archive spec explicit about the remaining tx-heavy step lifecycle follow-up.

## Purpose

This continues the P0+ message archive rollout after the Team history migration. New run-event search documents now cover the main live entry points instead of depending only on rerunning migration.

## Related Issues

- Follow-up to the message archive LanceDB rollout.

## Testing

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p agenthub dual_writes -- --nocapture`

## Notes

The remaining direct SQL inserts inside step lifecycle transactions are intentionally left as a follow-up consolidation slice. This PR keeps the diff bounded and records that boundary in `docs/features/message-archive-lancedb.md`.
