### PR TITLE
feat(archive): dual-write memory flush run events

### DIFF
--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -273,9 +273,11 @@ actor-scoped archive filters find messages delivered to that actor.
 - Live Team actor mailbox sends dual-write created rows to the archive with the same canonical
   document identity as migration.
 - Live Team run-event dual-write covers new run submissions, the public run-event append path, and
-  actor mailbox run-event appends. The remaining tx-heavy insertion paths still require follow-up
-  consolidation before run-event search can be fully continuous without rerunning migration; this
-  includes step lifecycle writes and memory-flush events emitted through `append_run_event_tx`.
+  actor mailbox run-event appends.
+- Live memory-flush run events emitted through `append_run_event_tx` dual-write after the enclosing
+  SQLite transaction commits so archive search does not observe rolled-back flush attempts. The
+  remaining tx-heavy step lifecycle insertion paths still require follow-up consolidation before
+  run-event search can be fully continuous without rerunning migration.
 
 ### 6) Multi-Database Extensibility Contract
 
@@ -306,6 +308,8 @@ actor-scoped archive filters find messages delivered to that actor.
   archive documents on idempotent retries.
 - Focused Team manager tests for live Team run-event dual-write on run submission and public
   run-event appends.
+- Focused Team manager tests for memory-flush run-event dual-write after transaction commit,
+  including persisted/noop and failed flush attempts.
 - Focused Team API test for Team-scoped archive search:
   - route uses the archive abstraction
   - route forces path Team scope into `MessageSearchQuery`

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2052,6 +2052,15 @@ impl TeamManager {
         });
     }
 
+    fn spawn_archive_team_run_events(&self, events: Vec<TeamRunEventRecord>) {
+        if self.message_archive.is_none() {
+            return;
+        }
+        for event in events {
+            self.spawn_archive_team_run_event(&event);
+        }
+    }
+
     async fn team_run_event_archive_document(
         &self,
         event: &TeamRunEventRecord,
@@ -3109,8 +3118,8 @@ impl TeamManager {
         event_type: &str,
         ts: i64,
         payload: &Value,
-    ) -> anyhow::Result<()> {
-        sqlx::query(
+    ) -> anyhow::Result<TeamRunEventRecord> {
+        let result = sqlx::query(
             r#"
             INSERT INTO team_run_events (run_id, step_id, event_type, ts, payload_json)
             VALUES (?1, ?2, ?3, ?4, ?5)
@@ -3123,7 +3132,14 @@ impl TeamManager {
         .bind(payload.to_string())
         .execute(&mut **tx)
         .await?;
-        Ok(())
+        Ok(TeamRunEventRecord {
+            event_id: result.last_insert_rowid(),
+            run_id: run_id.to_string(),
+            step_id: step_id.map(str::to_string),
+            event_type: event_type.to_string(),
+            ts,
+            payload: payload.clone(),
+        })
     }
 
     async fn persist_continuity_artifact_tx(
@@ -5011,7 +5027,8 @@ impl TeamManager {
         )
         .await?;
 
-        Self::append_run_event_tx(
+        let mut archive_events = Vec::new();
+        let started_event = Self::append_run_event_tx(
             &mut tx,
             run_id,
             None,
@@ -5027,6 +5044,7 @@ impl TeamManager {
             }),
         )
         .await?;
+        archive_events.push(started_event);
 
         let Some(session_id) = session_id else {
             let context = MemoryFlushFinalizeContext {
@@ -5037,7 +5055,7 @@ impl TeamManager {
                 trigger: normalized.trigger.as_str(),
                 now,
             };
-            let result = finalize_memory_flush_failed_tx(
+            let (result, event) = finalize_memory_flush_failed_tx(
                 &mut tx,
                 &context,
                 "session_mapping_missing",
@@ -5047,6 +5065,8 @@ impl TeamManager {
             )
             .await?;
             tx.commit().await?;
+            archive_events.push(event);
+            self.spawn_archive_team_run_events(archive_events);
             return Ok(result);
         };
 
@@ -5075,8 +5095,10 @@ impl TeamManager {
                 trigger: normalized.trigger.as_str(),
                 now,
             };
-            let result = finalize_memory_flush_noop_tx(&mut tx, &context).await?;
+            let (result, event) = finalize_memory_flush_noop_tx(&mut tx, &context).await?;
             tx.commit().await?;
+            archive_events.push(event);
+            self.spawn_archive_team_run_events(archive_events);
             return Ok(result);
         }
 
@@ -5129,7 +5151,7 @@ impl TeamManager {
                     trigger: normalized.trigger.as_str(),
                     now,
                 };
-                let result = finalize_memory_flush_failed_tx(
+                let (result, event) = finalize_memory_flush_failed_tx(
                     &mut tx,
                     &context,
                     "agent_workdir_missing",
@@ -5139,6 +5161,8 @@ impl TeamManager {
                 )
                 .await?;
                 tx.commit().await?;
+                archive_events.push(event);
+                self.spawn_archive_team_run_events(archive_events);
                 return Ok(result);
             }
             Err(err) => {
@@ -5150,7 +5174,7 @@ impl TeamManager {
                     trigger: normalized.trigger.as_str(),
                     now,
                 };
-                let result = finalize_memory_flush_failed_tx(
+                let (result, event) = finalize_memory_flush_failed_tx(
                     &mut tx,
                     &context,
                     "artifact_write_failed",
@@ -5160,6 +5184,8 @@ impl TeamManager {
                 )
                 .await?;
                 tx.commit().await?;
+                archive_events.push(event);
+                self.spawn_archive_team_run_events(archive_events);
                 return Ok(result);
             }
         };
@@ -5176,7 +5202,7 @@ impl TeamManager {
         .await?;
 
         let pointer_payload = build_context_artifact_pointer_payload(&pointer);
-        Self::append_run_event_tx(
+        let persisted_event = Self::append_run_event_tx(
             &mut tx,
             run_id,
             None,
@@ -5196,8 +5222,10 @@ impl TeamManager {
             }),
         )
         .await?;
+        archive_events.push(persisted_event);
 
         tx.commit().await?;
+        self.spawn_archive_team_run_events(archive_events);
         Ok(TeamMemoryFlushResult {
             status: "persisted".to_string(),
             run_id: run_id.to_string(),
@@ -5537,7 +5565,7 @@ async fn finalize_memory_flush_failed_tx(
     event_range: Option<(i64, i64)>,
     flushed_events: i64,
     error_excerpt: Option<String>,
-) -> anyhow::Result<TeamMemoryFlushResult> {
+) -> anyhow::Result<(TeamMemoryFlushResult, TeamRunEventRecord)> {
     let mut payload = serde_json::Map::new();
     payload.insert(
         "team_id".to_string(),
@@ -5566,7 +5594,7 @@ async fn finalize_memory_flush_failed_tx(
     if let Some(error_excerpt) = error_excerpt {
         payload.insert("error_excerpt".to_string(), Value::String(error_excerpt));
     }
-    TeamManager::append_run_event_tx(
+    let event = TeamManager::append_run_event_tx(
         tx,
         context.run_id,
         None,
@@ -5575,29 +5603,32 @@ async fn finalize_memory_flush_failed_tx(
         &Value::Object(payload),
     )
     .await?;
-    Ok(TeamMemoryFlushResult {
-        status: "failed".to_string(),
-        run_id: context.run_id.to_string(),
-        team_id: context.team_id.to_string(),
-        member_id: context.member_id.to_string(),
-        session_id: context.session_id.map(str::to_string),
-        trigger: context.trigger.to_string(),
-        reason: Some(reason.to_string()),
-        artifact_pointer: None,
-        event_id_from: event_range.map(|(event_id_from, _)| event_id_from),
-        event_id_to: event_range.map(|(_, event_id_to)| event_id_to),
-        flushed_events,
-    })
+    Ok((
+        TeamMemoryFlushResult {
+            status: "failed".to_string(),
+            run_id: context.run_id.to_string(),
+            team_id: context.team_id.to_string(),
+            member_id: context.member_id.to_string(),
+            session_id: context.session_id.map(str::to_string),
+            trigger: context.trigger.to_string(),
+            reason: Some(reason.to_string()),
+            artifact_pointer: None,
+            event_id_from: event_range.map(|(event_id_from, _)| event_id_from),
+            event_id_to: event_range.map(|(_, event_id_to)| event_id_to),
+            flushed_events,
+        },
+        event,
+    ))
 }
 
 async fn finalize_memory_flush_noop_tx(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     context: &MemoryFlushFinalizeContext<'_>,
-) -> anyhow::Result<TeamMemoryFlushResult> {
+) -> anyhow::Result<(TeamMemoryFlushResult, TeamRunEventRecord)> {
     let session_id = context
         .session_id
         .ok_or_else(|| anyhow::anyhow!("session_id is required for noop flush"))?;
-    TeamManager::append_run_event_tx(
+    let event = TeamManager::append_run_event_tx(
         tx,
         context.run_id,
         None,
@@ -5614,19 +5645,22 @@ async fn finalize_memory_flush_noop_tx(
         }),
     )
     .await?;
-    Ok(TeamMemoryFlushResult {
-        status: "noop".to_string(),
-        run_id: context.run_id.to_string(),
-        team_id: context.team_id.to_string(),
-        member_id: context.member_id.to_string(),
-        session_id: Some(session_id.to_string()),
-        trigger: context.trigger.to_string(),
-        reason: Some("no_new_events".to_string()),
-        artifact_pointer: None,
-        event_id_from: None,
-        event_id_to: None,
-        flushed_events: 0,
-    })
+    Ok((
+        TeamMemoryFlushResult {
+            status: "noop".to_string(),
+            run_id: context.run_id.to_string(),
+            team_id: context.team_id.to_string(),
+            member_id: context.member_id.to_string(),
+            session_id: Some(session_id.to_string()),
+            trigger: context.trigger.to_string(),
+            reason: Some("no_new_events".to_string()),
+            artifact_pointer: None,
+            event_id_from: None,
+            event_id_to: None,
+            flushed_events: 0,
+        },
+        event,
+    ))
 }
 
 async fn resolve_memory_flush_session_id_tx(

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -4852,7 +4852,7 @@ async fn flush_run_context_persists_artifact_and_then_noops_with_checkpoint() {
         "memory_flush_noop event should be recorded"
     );
 
-    let documents = wait_for_archive_documents(&archive, 4).await;
+    let documents = wait_for_archive_documents(&archive, 5).await;
     let archived_event_types = documents
         .iter()
         .filter(|document| {
@@ -4868,6 +4868,14 @@ async fn flush_run_context_persists_artifact_and_then_noops_with_checkpoint() {
     assert!(
         archived_event_types.contains(&"memory_flush_started"),
         "memory_flush_started should be archived after transaction commit"
+    );
+    assert_eq!(
+        archived_event_types
+            .iter()
+            .filter(|event_type| **event_type == "memory_flush_started")
+            .count(),
+        2,
+        "each flush attempt should archive its own memory_flush_started event"
     );
     assert!(
         archived_event_types.contains(&"memory_flush_persisted"),

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -4687,7 +4687,12 @@ async fn flush_run_context_persists_artifact_and_then_noops_with_checkpoint() {
         "agenthub-team-flush-eventdb-{}",
         uuid::Uuid::new_v4()
     )));
-    let manager = TeamManager::new_with_event_dbs(db.clone(), event_dbs.clone());
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        event_dbs.clone(),
+        Some(archive.clone()),
+    );
 
     let unique_suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -4847,13 +4852,44 @@ async fn flush_run_context_persists_artifact_and_then_noops_with_checkpoint() {
         "memory_flush_noop event should be recorded"
     );
 
+    let documents = wait_for_archive_documents(&archive, 4).await;
+    let archived_event_types = documents
+        .iter()
+        .filter(|document| {
+            document.source_kind == MessageDocumentKind::TeamRunEvent
+                && document.run_id.as_deref() == Some(run.id.as_str())
+        })
+        .map(|document| document.body_text.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        archived_event_types.contains(&"run_submitted"),
+        "run_submitted should still be archived"
+    );
+    assert!(
+        archived_event_types.contains(&"memory_flush_started"),
+        "memory_flush_started should be archived after transaction commit"
+    );
+    assert!(
+        archived_event_types.contains(&"memory_flush_persisted"),
+        "memory_flush_persisted should be archived after transaction commit"
+    );
+    assert!(
+        archived_event_types.contains(&"memory_flush_noop"),
+        "memory_flush_noop should be archived after transaction commit"
+    );
+
     let _ = std::fs::remove_dir_all(workspace);
 }
 
 #[tokio::test]
 async fn flush_run_context_fails_when_session_mapping_missing() {
     let db = setup_test_db().await;
-    let manager = TeamManager::new(db.clone());
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let manager = TeamManager::new_with_event_dbs_and_message_archive(
+        db.clone(),
+        AgentEventDbRouter::with_default_base_dir(),
+        Some(archive.clone()),
+    );
 
     let team = manager
         .create_team(TeamDefinitionConfig {
@@ -4903,6 +4939,24 @@ async fn flush_run_context_fails_when_session_mapping_missing() {
     assert!(
         event_types.contains(&"memory_flush_failed"),
         "memory_flush_failed event should be recorded"
+    );
+
+    let documents = wait_for_archive_documents(&archive, 3).await;
+    let archived_event_types = documents
+        .iter()
+        .filter(|document| {
+            document.source_kind == MessageDocumentKind::TeamRunEvent
+                && document.run_id.as_deref() == Some(run.id.as_str())
+        })
+        .map(|document| document.body_text.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        archived_event_types.contains(&"memory_flush_started"),
+        "memory_flush_started should be archived for failed flush attempts"
+    );
+    assert!(
+        archived_event_types.contains(&"memory_flush_failed"),
+        "memory_flush_failed should be archived after transaction commit"
     );
 }
 


### PR DESCRIPTION
## Summary

- dual-write memory-flush run events to the message archive after the enclosing SQLite transaction commits
- keep failed/noop/persisted memory-flush archive behavior covered by focused Team manager tests
- update the LanceDB archive spec so memory-flush run events are no longer listed as a remaining live gap

## Purpose

This continues the P0+ message archive rollout after live run-event dual-write landed. Memory-flush events were still emitted through the transaction helper and therefore only visible to archive search after a later migration. This PR makes those events live-searchable without exposing rolled-back transaction attempts.

## Related Issues

- None

## Tests

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p agenthub flush_run_context -- --nocapture`
