### PR TITLE
feat(archive): migrate agent events into message archive

### DIFF
--- a/crates/agenthub-message-archive/src/acp.rs
+++ b/crates/agenthub-message-archive/src/acp.rs
@@ -52,15 +52,17 @@ struct OpenAggregate {
     created_at: i64,
 }
 
-pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessage> {
-    let mut sorted = rows.to_vec();
-    sorted.sort_by_key(|row| row.event_id);
+#[derive(Debug, Default)]
+pub struct AcpChunkAccumulator {
+    // Keep only open logical messages, not every historical event row.
+    // Final ordering is made deterministic when the accumulator is finished.
+    open: HashMap<AggregateKey, OpenAggregate>,
+}
 
-    let mut open = HashMap::<AggregateKey, OpenAggregate>::new();
-
-    for row in sorted {
+impl AcpChunkAccumulator {
+    pub fn push_row(&mut self, row: AcpEventRow) -> bool {
         let Some(parsed) = parse_chunk_event(&row.message) else {
-            continue;
+            return false;
         };
 
         let key = AggregateKey {
@@ -70,7 +72,7 @@ pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessag
             message_id: parsed.message_id.clone(),
         };
 
-        match open.get_mut(&key) {
+        match self.open.get_mut(&key) {
             Some(active) => {
                 active.first_event_id = active.first_event_id.min(row.event_id);
                 active.last_event_id = active.last_event_id.max(row.event_id);
@@ -78,7 +80,7 @@ pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessag
                 active.chunks.push(parsed);
             }
             None => {
-                open.insert(
+                self.open.insert(
                     key,
                     OpenAggregate {
                         agent_id: row.agent_id,
@@ -93,32 +95,47 @@ pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessag
                 );
             }
         }
+        true
     }
 
-    let mut out: Vec<_> = open
-        .into_values()
-        .map(|mut aggregate| {
-            aggregate.chunks.sort_by_key(|chunk| chunk.chunk_index);
-            let text = aggregate
-                .chunks
-                .iter()
-                .map(|chunk| chunk.text.as_str())
-                .collect::<String>();
-            AcpAggregatedMessage {
-                logical_message_id: aggregate.message_id,
-                message_kind: aggregate.message_kind,
-                agent_id: aggregate.agent_id,
-                session_id: aggregate.session_id,
-                text,
-                created_at: aggregate.created_at,
-                first_event_id: aggregate.first_event_id,
-                last_event_id: aggregate.last_event_id,
-                chunk_count: aggregate.chunks.len().try_into().unwrap_or(u32::MAX),
-            }
-        })
-        .collect();
-    out.sort_by_key(|message| message.first_event_id);
-    out
+    pub fn finish(self) -> Vec<AcpAggregatedMessage> {
+        let mut out: Vec<_> = self
+            .open
+            .into_values()
+            .map(|mut aggregate| {
+                aggregate.chunks.sort_by_key(|chunk| chunk.chunk_index);
+                let text = aggregate
+                    .chunks
+                    .iter()
+                    .map(|chunk| chunk.text.as_str())
+                    .collect::<String>();
+                AcpAggregatedMessage {
+                    logical_message_id: aggregate.message_id,
+                    message_kind: aggregate.message_kind,
+                    agent_id: aggregate.agent_id,
+                    session_id: aggregate.session_id,
+                    text,
+                    created_at: aggregate.created_at,
+                    first_event_id: aggregate.first_event_id,
+                    last_event_id: aggregate.last_event_id,
+                    chunk_count: aggregate.chunks.len().try_into().unwrap_or(u32::MAX),
+                }
+            })
+            .collect();
+        out.sort_by_key(|message| message.first_event_id);
+        out
+    }
+}
+
+pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessage> {
+    let mut sorted = rows.to_vec();
+    sorted.sort_by_key(|row| row.event_id);
+
+    let mut accumulator = AcpChunkAccumulator::default();
+    for row in sorted {
+        accumulator.push_row(row);
+    }
+    accumulator.finish()
 }
 
 pub fn is_aggregatable_acp_chunk(raw: &str) -> bool {

--- a/crates/agenthub-message-archive/src/acp.rs
+++ b/crates/agenthub-message-archive/src/acp.rs
@@ -121,6 +121,10 @@ pub fn aggregate_acp_chunk_rows(rows: &[AcpEventRow]) -> Vec<AcpAggregatedMessag
     out
 }
 
+pub fn is_aggregatable_acp_chunk(raw: &str) -> bool {
+    parse_chunk_event(raw).is_some()
+}
+
 fn parse_chunk_event(raw: &str) -> Option<ParsedChunkEvent> {
     let value: Value = serde_json::from_str(raw).ok()?;
     let obj = value.as_object()?;
@@ -155,7 +159,7 @@ fn parse_chunk_index(value: Option<&Value>) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AcpEventRow, aggregate_acp_chunk_rows};
+    use super::{AcpEventRow, aggregate_acp_chunk_rows, is_aggregatable_acp_chunk};
 
     #[test]
     fn aggregates_consecutive_agent_message_chunks() {
@@ -252,6 +256,19 @@ mod tests {
 
         let aggregated = aggregate_acp_chunk_rows(&rows);
         assert!(aggregated.is_empty());
+    }
+
+    #[test]
+    fn identifies_only_parseable_message_chunks_as_aggregatable() {
+        assert!(is_aggregatable_acp_chunk(
+            r#"{"type":"agent_message","text":"hel","chunk":true,"message_id":"m1","chunk_index":0}"#
+        ));
+        assert!(!is_aggregatable_acp_chunk(
+            r#"{"type":"agent_message","text":"hel","chunk":true,"chunk_index":0}"#
+        ));
+        assert!(!is_aggregatable_acp_chunk(
+            r#"{"type":"tool_call","text":"search","chunk":true,"message_id":"m1","chunk_index":0}"#
+        ));
     }
 
     #[test]

--- a/crates/agenthub-message-archive/src/lib.rs
+++ b/crates/agenthub-message-archive/src/lib.rs
@@ -3,7 +3,9 @@ mod factory;
 mod lance;
 mod model;
 
-pub use acp::{AcpAggregatedMessage, AcpEventRow, aggregate_acp_chunk_rows};
+pub use acp::{
+    AcpAggregatedMessage, AcpEventRow, aggregate_acp_chunk_rows, is_aggregatable_acp_chunk,
+};
 pub use factory::{MessageArchiveStoreRef, open_message_archive_store};
 pub use lance::LanceDbMessageArchive;
 pub use model::{

--- a/crates/agenthub-message-archive/src/lib.rs
+++ b/crates/agenthub-message-archive/src/lib.rs
@@ -4,7 +4,8 @@ mod lance;
 mod model;
 
 pub use acp::{
-    AcpAggregatedMessage, AcpEventRow, aggregate_acp_chunk_rows, is_aggregatable_acp_chunk,
+    AcpAggregatedMessage, AcpChunkAccumulator, AcpEventRow, aggregate_acp_chunk_rows,
+    is_aggregatable_acp_chunk,
 };
 pub use factory::{MessageArchiveStoreRef, open_message_archive_store};
 pub use lance::LanceDbMessageArchive;

--- a/docs/features/message-archive-lancedb.md
+++ b/docs/features/message-archive-lancedb.md
@@ -278,6 +278,10 @@ actor-scoped archive filters find messages delivered to that actor.
   SQLite transaction commits so archive search does not observe rolled-back flush attempts. The
   remaining tx-heavy step lifecycle insertion paths still require follow-up consolidation before
   run-event search can be fully continuous without rerunning migration.
+- Historical agent event migration replays both main/global `agent_events` rows and per-agent
+  `AgentEventDbRouter` rows. Parseable ACP message chunks become `aggregated_acp_message`
+  documents, while non-chunk or malformed ACP rows fall back to raw `agent_event` documents with
+  the same deterministic source identity.
 
 ### 6) Multi-Database Extensibility Contract
 
@@ -303,7 +307,8 @@ actor-scoped archive filters find messages delivered to that actor.
   - Team conversation messages
   - Team run events
   - Team actor messages
-  - raw ACP event replay into aggregated archive documents
+  - main/global and per-agent raw ACP event replay into aggregated archive documents
+  - malformed or non-chunk ACP fallback into raw `agent_event` archive documents
 - Focused Team manager test for live Team conversation message dual-write without duplicating
   archive documents on idempotent retries.
 - Focused Team manager tests for live Team run-event dual-write on run submission and public

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -42,6 +42,8 @@ pub struct MigrateTeamMessagesArchiveResponse {
     pub team_conversation_messages: usize,
     pub team_run_events: usize,
     pub team_actor_messages: usize,
+    pub agent_events: usize,
+    pub aggregated_acp_messages: usize,
     pub total_documents: usize,
 }
 
@@ -352,10 +354,12 @@ async fn migrate_team_messages_archive(
     };
     let total_documents = report.total_documents();
     let detail = format!(
-        "team_conversation_messages={},team_run_events={},team_actor_messages={},total_documents={}",
+        "team_conversation_messages={},team_run_events={},team_actor_messages={},agent_events={},aggregated_acp_messages={},total_documents={}",
         report.team_conversation_messages,
         report.team_run_events,
         report.team_actor_messages,
+        report.agent_events,
+        report.aggregated_acp_messages,
         total_documents
     );
     let _ = state
@@ -373,6 +377,8 @@ async fn migrate_team_messages_archive(
         team_conversation_messages: report.team_conversation_messages,
         team_run_events: report.team_run_events,
         team_actor_messages: report.team_actor_messages,
+        agent_events: report.agent_events,
+        aggregated_acp_messages: report.aggregated_acp_messages,
         total_documents,
     }))
 }
@@ -612,6 +618,8 @@ mod tests {
         assert_eq!(body["team_conversation_messages"], 1);
         assert_eq!(body["team_run_events"], 0);
         assert_eq!(body["team_actor_messages"], 0);
+        assert_eq!(body["agent_events"], 0);
+        assert_eq!(body["aggregated_acp_messages"], 0);
         assert_eq!(body["total_documents"], 1);
 
         let row = sqlx::query(
@@ -634,6 +642,9 @@ mod tests {
                 .as_deref()
                 .is_some_and(|value| value.contains("total_documents=1"))
         );
+        assert!(detail.as_deref().is_some_and(|value| {
+            value.contains("agent_events=0") && value.contains("aggregated_acp_messages=0")
+        }));
     }
 
     #[tokio::test]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -80,9 +80,8 @@ use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use agenthub_db::AgentEventDbRouter;
 use agenthub_message_archive::{
-    AcpAggregatedMessage, AcpEventRow, MessageArchiveStoreRef, MessageDocument,
-    MessageDocumentKind, MessageSearchHit, MessageSearchQuery, aggregate_acp_chunk_rows,
-    is_aggregatable_acp_chunk,
+    AcpAggregatedMessage, AcpChunkAccumulator, AcpEventRow, MessageArchiveStoreRef,
+    MessageDocument, MessageDocumentKind, MessageSearchHit, MessageSearchQuery,
 };
 use agenthub_team_actor::{ACTOR_MAIN_PEER_ID, canonical_json};
 
@@ -364,7 +363,24 @@ impl AgentEventArchiveMigrationCounts {
     }
 }
 
-fn agent_event_archive_document(row: &AgentEventArchiveRow) -> MessageDocument {
+#[derive(Debug, Clone, Default)]
+struct AgentEventArchiveScope {
+    team_id: Option<String>,
+    run_id: Option<String>,
+    conversation_id: Option<String>,
+    task_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AgentEventArchiveSnapshot {
+    main_max_id: i64,
+    per_agent_max_ids: Vec<(String, i64)>,
+}
+
+fn agent_event_archive_document(
+    row: &AgentEventArchiveRow,
+    scope: Option<&AgentEventArchiveScope>,
+) -> MessageDocument {
     let parsed_message = serde_json::from_str::<Value>(row.message.as_str()).ok();
     let body_text = parsed_message
         .as_ref()
@@ -401,10 +417,10 @@ fn agent_event_archive_document(row: &AgentEventArchiveRow) -> MessageDocument {
         correlation_id: parsed_message
             .as_ref()
             .and_then(|payload| message_archive_payload_string(payload, "correlation_id")),
-        team_id: None,
-        run_id: None,
-        conversation_id: None,
-        task_id: None,
+        team_id: scope.and_then(|scope| scope.team_id.clone()),
+        run_id: scope.and_then(|scope| scope.run_id.clone()),
+        conversation_id: scope.and_then(|scope| scope.conversation_id.clone()),
+        task_id: scope.and_then(|scope| scope.task_id.clone()),
         agent_id: Some(row.agent_id.clone()),
         session_id: Some(row.session_id.clone()),
         body_text,
@@ -416,7 +432,10 @@ fn agent_event_archive_document(row: &AgentEventArchiveRow) -> MessageDocument {
     }
 }
 
-fn aggregated_acp_message_archive_document(message: &AcpAggregatedMessage) -> MessageDocument {
+fn aggregated_acp_message_archive_document(
+    message: &AcpAggregatedMessage,
+    scope: Option<&AgentEventArchiveScope>,
+) -> MessageDocument {
     MessageDocument {
         document_id: format!(
             "aggregated_acp_message:{}:{}:{}:{}",
@@ -430,10 +449,10 @@ fn aggregated_acp_message_archive_document(message: &AcpAggregatedMessage) -> Me
         logical_message_id: Some(message.logical_message_id.clone()),
         authority_message_id: None,
         correlation_id: None,
-        team_id: None,
-        run_id: None,
-        conversation_id: None,
-        task_id: None,
+        team_id: scope.and_then(|scope| scope.team_id.clone()),
+        run_id: scope.and_then(|scope| scope.run_id.clone()),
+        conversation_id: scope.and_then(|scope| scope.conversation_id.clone()),
+        task_id: scope.and_then(|scope| scope.task_id.clone()),
         agent_id: Some(message.agent_id.clone()),
         session_id: Some(message.session_id.clone()),
         body_text: message.text.clone(),
@@ -2303,32 +2322,62 @@ impl TeamManager {
         &self,
         archive: &MessageArchiveStoreRef,
         batch_size: usize,
+        snapshot: &AgentEventArchiveSnapshot,
     ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
         let mut counts = AgentEventArchiveMigrationCounts::default();
         counts.add(
-            migrate_main_agent_events_to_archive(&self.db, archive, batch_size)
-                .await
-                .context("migrate main agent_events to message archive")?,
+            migrate_main_agent_events_to_archive(
+                &self.db,
+                archive,
+                batch_size,
+                snapshot.main_max_id,
+            )
+            .await
+            .context("migrate main agent_events to message archive")?,
         );
 
+        for (agent_id, max_id) in &snapshot.per_agent_max_ids {
+            let pool = self.event_dbs.pool_for_agent(&agent_id).await?;
+            counts.add(
+                migrate_per_agent_events_to_archive(
+                    &self.db, &pool, archive, agent_id, batch_size, *max_id,
+                )
+                .await
+                .with_context(|| {
+                    format!("migrate per-agent agent_events for agent_id={agent_id}")
+                })?,
+            );
+        }
+        Ok(counts)
+    }
+
+    async fn message_archive_agent_event_snapshot(
+        &self,
+    ) -> anyhow::Result<AgentEventArchiveSnapshot> {
+        let main_max_id =
+            sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
+                .fetch_one(&self.db)
+                .await?;
         let agent_ids = sqlx::query_scalar::<_, String>("SELECT id FROM agents ORDER BY id ASC")
             .fetch_all(&self.db)
             .await?;
+        let mut per_agent_max_ids = Vec::new();
         for agent_id in agent_ids {
             let db_path = self.event_dbs.db_path_for_agent(&agent_id);
             if !tokio::fs::try_exists(&db_path).await? {
                 continue;
             }
             let pool = self.event_dbs.pool_for_agent(&agent_id).await?;
-            counts.add(
-                migrate_per_agent_events_to_archive(&pool, archive, &agent_id, batch_size)
-                    .await
-                    .with_context(|| {
-                        format!("migrate per-agent agent_events for agent_id={agent_id}")
-                    })?,
-            );
+            let max_id =
+                sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
+                    .fetch_one(&pool)
+                    .await?;
+            per_agent_max_ids.push((agent_id, max_id));
         }
-        Ok(counts)
+        Ok(AgentEventArchiveSnapshot {
+            main_max_id,
+            per_agent_max_ids,
+        })
     }
 
     pub async fn migrate_team_messages_to_archive(
@@ -2348,6 +2397,7 @@ impl TeamManager {
         let max_actor_message_id = self
             .message_archive_table_max_id("team_actor_messages")
             .await?;
+        let agent_event_snapshot = self.message_archive_agent_event_snapshot().await?;
         let mut run_scope_cache: HashMap<String, MessageArchiveScopeFallback> = HashMap::new();
         let mut task_conversation_cache: HashMap<(String, String), Option<String>> = HashMap::new();
 
@@ -2538,7 +2588,7 @@ impl TeamManager {
         }
 
         let agent_event_counts = self
-            .migrate_agent_events_to_archive(archive, batch_size)
+            .migrate_agent_events_to_archive(archive, batch_size, &agent_event_snapshot)
             .await?;
         report.agent_events = agent_event_counts.agent_events;
         report.aggregated_acp_messages = agent_event_counts.aggregated_acp_messages;
@@ -5483,21 +5533,33 @@ async fn migrate_main_agent_events_to_archive(
     db: &SqlitePool,
     archive: &MessageArchiveStoreRef,
     batch_size: usize,
-) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
-    migrate_agent_event_rows_to_archive(db, archive, batch_size, AgentEventArchiveSource::Main)
-        .await
-}
-
-async fn migrate_per_agent_events_to_archive(
-    db: &SqlitePool,
-    archive: &MessageArchiveStoreRef,
-    agent_id: &str,
-    batch_size: usize,
+    max_id: i64,
 ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
     migrate_agent_event_rows_to_archive(
         db,
+        db,
         archive,
         batch_size,
+        max_id,
+        AgentEventArchiveSource::Main,
+    )
+    .await
+}
+
+async fn migrate_per_agent_events_to_archive(
+    main_db: &SqlitePool,
+    event_db: &SqlitePool,
+    archive: &MessageArchiveStoreRef,
+    agent_id: &str,
+    batch_size: usize,
+    max_id: i64,
+) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
+    migrate_agent_event_rows_to_archive(
+        main_db,
+        event_db,
+        archive,
+        batch_size,
+        max_id,
         AgentEventArchiveSource::PerAgent { agent_id },
     )
     .await
@@ -5510,35 +5572,59 @@ enum AgentEventArchiveSource<'a> {
 }
 
 async fn migrate_agent_event_rows_to_archive(
-    db: &SqlitePool,
+    main_db: &SqlitePool,
+    event_db: &SqlitePool,
     archive: &MessageArchiveStoreRef,
     batch_size: usize,
+    max_id: i64,
     source: AgentEventArchiveSource<'_>,
 ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
-    let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
-        .fetch_one(db)
-        .await?;
     let mut last_id = 0_i64;
-    let mut chunk_rows = Vec::new();
+    let mut chunk_accumulator = AcpChunkAccumulator::default();
     let mut counts = AgentEventArchiveMigrationCounts::default();
     let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
+    let mut scope_cache = HashMap::<(String, String), Option<AgentEventArchiveScope>>::new();
+    let mut task_conversation_cache = HashMap::<(String, String), Option<String>>::new();
 
     loop {
-        let rows = fetch_agent_event_archive_rows(db, source, last_id, max_id, batch_limit).await?;
+        let rows =
+            fetch_agent_event_archive_rows(event_db, source, last_id, max_id, batch_limit).await?;
         if rows.is_empty() {
             break;
         }
         let mut documents = Vec::new();
         for row in rows {
             last_id = row.event_id;
-            collect_agent_event_archive_row(row, &mut documents, &mut chunk_rows, &mut counts);
+            let scope = agent_event_archive_scope_for_row(
+                main_db,
+                &row,
+                &mut scope_cache,
+                &mut task_conversation_cache,
+            )
+            .await?;
+            collect_agent_event_archive_row(
+                row,
+                scope.as_ref(),
+                &mut documents,
+                &mut chunk_accumulator,
+                &mut counts,
+            );
         }
         if !documents.is_empty() {
             archive.append_documents(&documents).await?;
         }
     }
 
-    append_aggregated_acp_documents(archive, &chunk_rows, batch_size, &mut counts).await?;
+    append_aggregated_acp_documents(
+        main_db,
+        archive,
+        chunk_accumulator,
+        batch_size,
+        &mut scope_cache,
+        &mut task_conversation_cache,
+        &mut counts,
+    )
+    .await?;
     Ok(counts)
 }
 
@@ -5604,35 +5690,117 @@ async fn fetch_agent_event_archive_rows(
 
 fn collect_agent_event_archive_row(
     row: AgentEventArchiveRow,
+    scope: Option<&AgentEventArchiveScope>,
     documents: &mut Vec<MessageDocument>,
-    chunk_rows: &mut Vec<AcpEventRow>,
+    chunk_accumulator: &mut AcpChunkAccumulator,
     counts: &mut AgentEventArchiveMigrationCounts,
 ) {
-    if is_aggregatable_acp_chunk(row.message.as_str()) {
-        chunk_rows.push(AcpEventRow {
-            event_id: row.event_id,
-            agent_id: row.agent_id,
-            session_id: row.session_id,
-            ts: row.ts,
-            message: row.message,
-        });
+    if chunk_accumulator.push_row(AcpEventRow {
+        event_id: row.event_id,
+        agent_id: row.agent_id.clone(),
+        session_id: row.session_id.clone(),
+        ts: row.ts,
+        message: row.message.clone(),
+    }) {
         return;
     }
 
-    documents.push(agent_event_archive_document(&row));
+    documents.push(agent_event_archive_document(&row, scope));
     counts.agent_events += 1;
 }
 
+async fn agent_event_archive_scope_for_row(
+    db: &SqlitePool,
+    row: &AgentEventArchiveRow,
+    scope_cache: &mut HashMap<(String, String), Option<AgentEventArchiveScope>>,
+    task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
+) -> anyhow::Result<Option<AgentEventArchiveScope>> {
+    let cache_key = (row.agent_id.clone(), row.session_id.clone());
+    if let Some(scope) = scope_cache.get(&cache_key) {
+        return Ok(scope.clone());
+    }
+    let scope = agent_event_archive_scope_for_session(
+        db,
+        &row.agent_id,
+        &row.session_id,
+        task_conversation_cache,
+    )
+    .await?;
+    scope_cache.insert(cache_key, scope.clone());
+    Ok(scope)
+}
+
+async fn agent_event_archive_scope_for_session(
+    db: &SqlitePool,
+    agent_id: &str,
+    session_id: &str,
+    task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
+) -> anyhow::Result<Option<AgentEventArchiveScope>> {
+    let row = sqlx::query(
+        r#"
+        SELECT r.team_id, r.id AS run_id, r.input_json
+        FROM team_steps s
+        INNER JOIN team_runs r ON r.id = s.run_id
+        WHERE s.member_id = ?1 AND s.remote_task_id = ?2
+        ORDER BY COALESCE(s.started_at, 0) DESC, COALESCE(s.ended_at, 0) DESC, s.attempt DESC, s.id DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(agent_id)
+    .bind(session_id)
+    .fetch_optional(db)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let team_id: String = row.get("team_id");
+    let run_id: String = row.get("run_id");
+    let input_json: String = row.get("input_json");
+    let run_input: Value = serde_json::from_str(&input_json)?;
+    let base_scope = MessageArchiveScopeFallback::from_run_input(&run_input);
+    let scope = message_archive_scope_for_payload_db(
+        db,
+        &team_id,
+        &Value::Null,
+        &base_scope,
+        task_conversation_cache,
+    )
+    .await?;
+    Ok(Some(AgentEventArchiveScope {
+        team_id: Some(team_id),
+        run_id: Some(run_id),
+        conversation_id: scope.conversation_id,
+        task_id: scope.task_id,
+    }))
+}
+
 async fn append_aggregated_acp_documents(
+    db: &SqlitePool,
     archive: &MessageArchiveStoreRef,
-    rows: &[AcpEventRow],
+    accumulator: AcpChunkAccumulator,
     batch_size: usize,
+    scope_cache: &mut HashMap<(String, String), Option<AgentEventArchiveScope>>,
+    task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
     counts: &mut AgentEventArchiveMigrationCounts,
 ) -> anyhow::Result<()> {
-    let documents = aggregate_acp_chunk_rows(rows)
-        .iter()
-        .map(aggregated_acp_message_archive_document)
-        .collect::<Vec<_>>();
+    let mut documents = Vec::new();
+    for message in accumulator.finish() {
+        let row = AgentEventArchiveRow {
+            event_id: message.first_event_id,
+            agent_id: message.agent_id.clone(),
+            session_id: message.session_id.clone(),
+            ts: message.created_at,
+            stream: "acp".to_string(),
+            message: String::new(),
+        };
+        let scope =
+            agent_event_archive_scope_for_row(db, &row, scope_cache, task_conversation_cache)
+                .await?;
+        documents.push(aggregated_acp_message_archive_document(
+            &message,
+            scope.as_ref(),
+        ));
+    }
     counts.aggregated_acp_messages += documents.len();
     for chunk in documents.chunks(batch_size.clamp(1, 1000)) {
         archive.append_documents(chunk).await?;

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2337,7 +2337,7 @@ impl TeamManager {
         );
 
         for (agent_id, max_id) in &snapshot.per_agent_max_ids {
-            let pool = self.event_dbs.pool_for_agent(&agent_id).await?;
+            let pool = self.event_dbs.pool_for_agent(agent_id).await?;
             counts.add(
                 migrate_per_agent_events_to_archive(
                     &self.db, &pool, archive, agent_id, batch_size, *max_id,

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -5583,7 +5583,7 @@ async fn migrate_agent_event_rows_to_archive(
     let mut chunk_accumulator = AcpChunkAccumulator::default();
     let mut counts = AgentEventArchiveMigrationCounts::default();
     let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
-    let mut scope_cache = HashMap::<(String, String), Option<AgentEventArchiveScope>>::new();
+    let mut scope_cache = HashMap::<(String, String, i64), Option<AgentEventArchiveScope>>::new();
     let mut task_conversation_cache = HashMap::<(String, String), Option<String>>::new();
 
     loop {
@@ -5695,13 +5695,15 @@ fn collect_agent_event_archive_row(
     chunk_accumulator: &mut AcpChunkAccumulator,
     counts: &mut AgentEventArchiveMigrationCounts,
 ) {
-    if chunk_accumulator.push_row(AcpEventRow {
-        event_id: row.event_id,
-        agent_id: row.agent_id.clone(),
-        session_id: row.session_id.clone(),
-        ts: row.ts,
-        message: row.message.clone(),
-    }) {
+    if row.stream == "acp"
+        && chunk_accumulator.push_row(AcpEventRow {
+            event_id: row.event_id,
+            agent_id: row.agent_id.clone(),
+            session_id: row.session_id.clone(),
+            ts: row.ts,
+            message: row.message.clone(),
+        })
+    {
         return;
     }
 
@@ -5712,10 +5714,10 @@ fn collect_agent_event_archive_row(
 async fn agent_event_archive_scope_for_row(
     db: &SqlitePool,
     row: &AgentEventArchiveRow,
-    scope_cache: &mut HashMap<(String, String), Option<AgentEventArchiveScope>>,
+    scope_cache: &mut HashMap<(String, String, i64), Option<AgentEventArchiveScope>>,
     task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
 ) -> anyhow::Result<Option<AgentEventArchiveScope>> {
-    let cache_key = (row.agent_id.clone(), row.session_id.clone());
+    let cache_key = (row.agent_id.clone(), row.session_id.clone(), row.event_id);
     if let Some(scope) = scope_cache.get(&cache_key) {
         return Ok(scope.clone());
     }
@@ -5723,6 +5725,7 @@ async fn agent_event_archive_scope_for_row(
         db,
         &row.agent_id,
         &row.session_id,
+        row.ts,
         task_conversation_cache,
     )
     .await?;
@@ -5734,6 +5737,7 @@ async fn agent_event_archive_scope_for_session(
     db: &SqlitePool,
     agent_id: &str,
     session_id: &str,
+    event_ts: i64,
     task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
 ) -> anyhow::Result<Option<AgentEventArchiveScope>> {
     let row = sqlx::query(
@@ -5741,13 +5745,19 @@ async fn agent_event_archive_scope_for_session(
         SELECT r.team_id, r.id AS run_id, r.input_json
         FROM team_steps s
         INNER JOIN team_runs r ON r.id = s.run_id
-        WHERE s.member_id = ?1 AND s.remote_task_id = ?2
+        WHERE s.member_id = ?1
+          AND s.remote_task_id = ?2
+          AND COALESCE(s.started_at, r.started_at, r.created_at, 0) <= ?3
+          AND (s.ended_at IS NULL OR s.ended_at >= ?3)
+          AND trim(COALESCE(json_extract(r.input_json, '$.bootstrap_kind'), '')) != ?4
         ORDER BY COALESCE(s.started_at, 0) DESC, COALESCE(s.ended_at, 0) DESC, s.attempt DESC, s.id DESC
         LIMIT 1
         "#,
     )
     .bind(agent_id)
     .bind(session_id)
+    .bind(event_ts)
+    .bind(TEAM_SHARED_THREAD_MAILBOX_RUN_BOOTSTRAP_KIND)
     .fetch_optional(db)
     .await?;
     let Some(row) = row else {
@@ -5779,7 +5789,7 @@ async fn append_aggregated_acp_documents(
     archive: &MessageArchiveStoreRef,
     accumulator: AcpChunkAccumulator,
     batch_size: usize,
-    scope_cache: &mut HashMap<(String, String), Option<AgentEventArchiveScope>>,
+    scope_cache: &mut HashMap<(String, String, i64), Option<AgentEventArchiveScope>>,
     task_conversation_cache: &mut HashMap<(String, String), Option<String>>,
     counts: &mut AgentEventArchiveMigrationCounts,
 ) -> anyhow::Result<()> {

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -19,6 +19,7 @@ use agenthub_team_domain::{
     continuity_note_relative_path, extract_context_artifact_path,
 };
 use agenthub_text::truncate_chars;
+use anyhow::Context;
 use chrono::Utc;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -43,11 +44,17 @@ pub struct TeamMessageArchiveMigrationReport {
     pub team_conversation_messages: usize,
     pub team_run_events: usize,
     pub team_actor_messages: usize,
+    pub agent_events: usize,
+    pub aggregated_acp_messages: usize,
 }
 
 impl TeamMessageArchiveMigrationReport {
     pub fn total_documents(&self) -> usize {
-        self.team_conversation_messages + self.team_run_events + self.team_actor_messages
+        self.team_conversation_messages
+            + self.team_run_events
+            + self.team_actor_messages
+            + self.agent_events
+            + self.aggregated_acp_messages
     }
 }
 
@@ -73,8 +80,9 @@ use crate::internal::client::InternalGrpcPeerClientConfig;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use agenthub_db::AgentEventDbRouter;
 use agenthub_message_archive::{
-    MessageArchiveStoreRef, MessageDocument, MessageDocumentKind, MessageSearchHit,
-    MessageSearchQuery,
+    AcpAggregatedMessage, AcpEventRow, MessageArchiveStoreRef, MessageDocument,
+    MessageDocumentKind, MessageSearchHit, MessageSearchQuery, aggregate_acp_chunk_rows,
+    is_aggregatable_acp_chunk,
 };
 use agenthub_team_actor::{ACTOR_MAIN_PEER_ID, canonical_json};
 
@@ -330,6 +338,120 @@ fn team_actor_message_archive_document(
         event_id_from: None,
         event_id_to: None,
         chunk_count: None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AgentEventArchiveRow {
+    event_id: i64,
+    agent_id: String,
+    session_id: String,
+    ts: i64,
+    stream: String,
+    message: String,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct AgentEventArchiveMigrationCounts {
+    agent_events: usize,
+    aggregated_acp_messages: usize,
+}
+
+impl AgentEventArchiveMigrationCounts {
+    fn add(&mut self, other: AgentEventArchiveMigrationCounts) {
+        self.agent_events += other.agent_events;
+        self.aggregated_acp_messages += other.aggregated_acp_messages;
+    }
+}
+
+fn agent_event_archive_document(row: &AgentEventArchiveRow) -> MessageDocument {
+    let parsed_message = serde_json::from_str::<Value>(row.message.as_str()).ok();
+    let body_text = parsed_message
+        .as_ref()
+        .map(message_archive_body_text)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            parsed_message
+                .as_ref()
+                .and_then(|payload| payload.get("type"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| row.message.trim().to_string());
+    let payload_json = parsed_message
+        .as_ref()
+        .map(redact_sensitive_json)
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "stream": row.stream.as_str(),
+                "message": row.message.as_str(),
+            })
+        })
+        .to_string();
+
+    MessageDocument {
+        document_id: format!(
+            "agent_event:{}:{}:{}",
+            row.agent_id, row.session_id, row.event_id
+        ),
+        source_kind: MessageDocumentKind::AgentEvent,
+        source_id: row.event_id.to_string(),
+        logical_message_id: None,
+        authority_message_id: None,
+        correlation_id: parsed_message
+            .as_ref()
+            .and_then(|payload| message_archive_payload_string(payload, "correlation_id")),
+        team_id: None,
+        run_id: None,
+        conversation_id: None,
+        task_id: None,
+        agent_id: Some(row.agent_id.clone()),
+        session_id: Some(row.session_id.clone()),
+        body_text,
+        payload_json: Some(payload_json),
+        created_at: row.ts,
+        event_id_from: Some(row.event_id),
+        event_id_to: Some(row.event_id),
+        chunk_count: None,
+    }
+}
+
+fn aggregated_acp_message_archive_document(message: &AcpAggregatedMessage) -> MessageDocument {
+    MessageDocument {
+        document_id: format!(
+            "aggregated_acp_message:{}:{}:{}:{}",
+            message.agent_id, message.session_id, message.logical_message_id, message.message_kind
+        ),
+        source_kind: MessageDocumentKind::AggregatedAcpMessage,
+        source_id: format!(
+            "{}:{}:{}:{}",
+            message.agent_id, message.session_id, message.logical_message_id, message.message_kind
+        ),
+        logical_message_id: Some(message.logical_message_id.clone()),
+        authority_message_id: None,
+        correlation_id: None,
+        team_id: None,
+        run_id: None,
+        conversation_id: None,
+        task_id: None,
+        agent_id: Some(message.agent_id.clone()),
+        session_id: Some(message.session_id.clone()),
+        body_text: message.text.clone(),
+        payload_json: Some(
+            serde_json::json!({
+                "type": message.message_kind.as_str(),
+                "message_id": message.logical_message_id.as_str(),
+                "text": message.text.as_str(),
+                "event_id_from": message.first_event_id,
+                "event_id_to": message.last_event_id,
+                "chunk_count": message.chunk_count,
+            })
+            .to_string(),
+        ),
+        created_at: message.created_at,
+        event_id_from: Some(message.first_event_id),
+        event_id_to: Some(message.last_event_id),
+        chunk_count: Some(message.chunk_count),
     }
 }
 
@@ -2177,6 +2299,38 @@ impl TeamManager {
             .await?)
     }
 
+    async fn migrate_agent_events_to_archive(
+        &self,
+        archive: &MessageArchiveStoreRef,
+        batch_size: usize,
+    ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
+        let mut counts = AgentEventArchiveMigrationCounts::default();
+        counts.add(
+            migrate_main_agent_events_to_archive(&self.db, archive, batch_size)
+                .await
+                .context("migrate main agent_events to message archive")?,
+        );
+
+        let agent_ids = sqlx::query_scalar::<_, String>("SELECT id FROM agents ORDER BY id ASC")
+            .fetch_all(&self.db)
+            .await?;
+        for agent_id in agent_ids {
+            let db_path = self.event_dbs.db_path_for_agent(&agent_id);
+            if !tokio::fs::try_exists(&db_path).await? {
+                continue;
+            }
+            let pool = self.event_dbs.pool_for_agent(&agent_id).await?;
+            counts.add(
+                migrate_per_agent_events_to_archive(&pool, archive, &agent_id, batch_size)
+                    .await
+                    .with_context(|| {
+                        format!("migrate per-agent agent_events for agent_id={agent_id}")
+                    })?,
+            );
+        }
+        Ok(counts)
+    }
+
     pub async fn migrate_team_messages_to_archive(
         &self,
         batch_size: usize,
@@ -2382,6 +2536,12 @@ impl TeamManager {
             }
             archive.append_documents(&documents).await?;
         }
+
+        let agent_event_counts = self
+            .migrate_agent_events_to_archive(archive, batch_size)
+            .await?;
+        report.agent_events = agent_event_counts.agent_events;
+        report.aggregated_acp_messages = agent_event_counts.aggregated_acp_messages;
         Ok(report)
     }
 
@@ -5317,6 +5477,163 @@ impl TeamManager {
             .map(|member| member.role);
         Ok(role)
     }
+}
+
+async fn migrate_main_agent_events_to_archive(
+    db: &SqlitePool,
+    archive: &MessageArchiveStoreRef,
+    batch_size: usize,
+) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
+    let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
+        .fetch_one(db)
+        .await?;
+    let mut last_id = 0_i64;
+    let mut chunk_rows = Vec::new();
+    let mut counts = AgentEventArchiveMigrationCounts::default();
+    let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
+
+    loop {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, agent_id, session_id, ts, stream, message
+            FROM agent_events
+            WHERE id > ?1 AND id <= ?2
+            ORDER BY id ASC
+            LIMIT ?3
+            "#,
+        )
+        .bind(last_id)
+        .bind(max_id)
+        .bind(batch_limit)
+        .fetch_all(db)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        let mut documents = Vec::new();
+        for row in rows {
+            last_id = row.get("id");
+            collect_agent_event_archive_row(
+                AgentEventArchiveRow {
+                    event_id: row.get("id"),
+                    agent_id: row.get("agent_id"),
+                    session_id: row.get("session_id"),
+                    ts: row.get("ts"),
+                    stream: row.get("stream"),
+                    message: decode_message_from_storage(
+                        row.get::<Vec<u8>, _>("message").as_slice(),
+                    ),
+                },
+                &mut documents,
+                &mut chunk_rows,
+                &mut counts,
+            );
+        }
+        if !documents.is_empty() {
+            archive.append_documents(&documents).await?;
+        }
+    }
+
+    append_aggregated_acp_documents(archive, &chunk_rows, batch_size, &mut counts).await?;
+    Ok(counts)
+}
+
+async fn migrate_per_agent_events_to_archive(
+    db: &SqlitePool,
+    archive: &MessageArchiveStoreRef,
+    agent_id: &str,
+    batch_size: usize,
+) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
+    let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
+        .fetch_one(db)
+        .await?;
+    let mut last_id = 0_i64;
+    let mut chunk_rows = Vec::new();
+    let mut counts = AgentEventArchiveMigrationCounts::default();
+    let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
+
+    loop {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, session_id, ts, stream, message
+            FROM agent_events
+            WHERE id > ?1 AND id <= ?2
+            ORDER BY id ASC
+            LIMIT ?3
+            "#,
+        )
+        .bind(last_id)
+        .bind(max_id)
+        .bind(batch_limit)
+        .fetch_all(db)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        let mut documents = Vec::new();
+        for row in rows {
+            last_id = row.get("id");
+            collect_agent_event_archive_row(
+                AgentEventArchiveRow {
+                    event_id: row.get("id"),
+                    agent_id: agent_id.to_string(),
+                    session_id: row.get("session_id"),
+                    ts: row.get("ts"),
+                    stream: row.get("stream"),
+                    message: decode_message_from_storage(
+                        row.get::<Vec<u8>, _>("message").as_slice(),
+                    ),
+                },
+                &mut documents,
+                &mut chunk_rows,
+                &mut counts,
+            );
+        }
+        if !documents.is_empty() {
+            archive.append_documents(&documents).await?;
+        }
+    }
+
+    append_aggregated_acp_documents(archive, &chunk_rows, batch_size, &mut counts).await?;
+    Ok(counts)
+}
+
+fn collect_agent_event_archive_row(
+    row: AgentEventArchiveRow,
+    documents: &mut Vec<MessageDocument>,
+    chunk_rows: &mut Vec<AcpEventRow>,
+    counts: &mut AgentEventArchiveMigrationCounts,
+) {
+    if is_aggregatable_acp_chunk(row.message.as_str()) {
+        chunk_rows.push(AcpEventRow {
+            event_id: row.event_id,
+            agent_id: row.agent_id,
+            session_id: row.session_id,
+            ts: row.ts,
+            message: row.message,
+        });
+        return;
+    }
+
+    documents.push(agent_event_archive_document(&row));
+    counts.agent_events += 1;
+}
+
+async fn append_aggregated_acp_documents(
+    archive: &MessageArchiveStoreRef,
+    rows: &[AcpEventRow],
+    batch_size: usize,
+    counts: &mut AgentEventArchiveMigrationCounts,
+) -> anyhow::Result<()> {
+    let documents = aggregate_acp_chunk_rows(rows)
+        .iter()
+        .map(aggregated_acp_message_archive_document)
+        .collect::<Vec<_>>();
+    counts.aggregated_acp_messages += documents.len();
+    for chunk in documents.chunks(batch_size.clamp(1, 1000)) {
+        archive.append_documents(chunk).await?;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -5484,58 +5484,8 @@ async fn migrate_main_agent_events_to_archive(
     archive: &MessageArchiveStoreRef,
     batch_size: usize,
 ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
-    let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
-        .fetch_one(db)
-        .await?;
-    let mut last_id = 0_i64;
-    let mut chunk_rows = Vec::new();
-    let mut counts = AgentEventArchiveMigrationCounts::default();
-    let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
-
-    loop {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, agent_id, session_id, ts, stream, message
-            FROM agent_events
-            WHERE id > ?1 AND id <= ?2
-            ORDER BY id ASC
-            LIMIT ?3
-            "#,
-        )
-        .bind(last_id)
-        .bind(max_id)
-        .bind(batch_limit)
-        .fetch_all(db)
-        .await?;
-        if rows.is_empty() {
-            break;
-        }
-        let mut documents = Vec::new();
-        for row in rows {
-            last_id = row.get("id");
-            collect_agent_event_archive_row(
-                AgentEventArchiveRow {
-                    event_id: row.get("id"),
-                    agent_id: row.get("agent_id"),
-                    session_id: row.get("session_id"),
-                    ts: row.get("ts"),
-                    stream: row.get("stream"),
-                    message: decode_message_from_storage(
-                        row.get::<Vec<u8>, _>("message").as_slice(),
-                    ),
-                },
-                &mut documents,
-                &mut chunk_rows,
-                &mut counts,
-            );
-        }
-        if !documents.is_empty() {
-            archive.append_documents(&documents).await?;
-        }
-    }
-
-    append_aggregated_acp_documents(archive, &chunk_rows, batch_size, &mut counts).await?;
-    Ok(counts)
+    migrate_agent_event_rows_to_archive(db, archive, batch_size, AgentEventArchiveSource::Main)
+        .await
 }
 
 async fn migrate_per_agent_events_to_archive(
@@ -5543,6 +5493,27 @@ async fn migrate_per_agent_events_to_archive(
     archive: &MessageArchiveStoreRef,
     agent_id: &str,
     batch_size: usize,
+) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
+    migrate_agent_event_rows_to_archive(
+        db,
+        archive,
+        batch_size,
+        AgentEventArchiveSource::PerAgent { agent_id },
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AgentEventArchiveSource<'a> {
+    Main,
+    PerAgent { agent_id: &'a str },
+}
+
+async fn migrate_agent_event_rows_to_archive(
+    db: &SqlitePool,
+    archive: &MessageArchiveStoreRef,
+    batch_size: usize,
+    source: AgentEventArchiveSource<'_>,
 ) -> anyhow::Result<AgentEventArchiveMigrationCounts> {
     let max_id = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM agent_events")
         .fetch_one(db)
@@ -5553,41 +5524,14 @@ async fn migrate_per_agent_events_to_archive(
     let batch_limit = i64::try_from(batch_size.clamp(1, 1000))?;
 
     loop {
-        let rows = sqlx::query(
-            r#"
-            SELECT id, session_id, ts, stream, message
-            FROM agent_events
-            WHERE id > ?1 AND id <= ?2
-            ORDER BY id ASC
-            LIMIT ?3
-            "#,
-        )
-        .bind(last_id)
-        .bind(max_id)
-        .bind(batch_limit)
-        .fetch_all(db)
-        .await?;
+        let rows = fetch_agent_event_archive_rows(db, source, last_id, max_id, batch_limit).await?;
         if rows.is_empty() {
             break;
         }
         let mut documents = Vec::new();
         for row in rows {
-            last_id = row.get("id");
-            collect_agent_event_archive_row(
-                AgentEventArchiveRow {
-                    event_id: row.get("id"),
-                    agent_id: agent_id.to_string(),
-                    session_id: row.get("session_id"),
-                    ts: row.get("ts"),
-                    stream: row.get("stream"),
-                    message: decode_message_from_storage(
-                        row.get::<Vec<u8>, _>("message").as_slice(),
-                    ),
-                },
-                &mut documents,
-                &mut chunk_rows,
-                &mut counts,
-            );
+            last_id = row.event_id;
+            collect_agent_event_archive_row(row, &mut documents, &mut chunk_rows, &mut counts);
         }
         if !documents.is_empty() {
             archive.append_documents(&documents).await?;
@@ -5596,6 +5540,66 @@ async fn migrate_per_agent_events_to_archive(
 
     append_aggregated_acp_documents(archive, &chunk_rows, batch_size, &mut counts).await?;
     Ok(counts)
+}
+
+async fn fetch_agent_event_archive_rows(
+    db: &SqlitePool,
+    source: AgentEventArchiveSource<'_>,
+    last_id: i64,
+    max_id: i64,
+    batch_limit: i64,
+) -> anyhow::Result<Vec<AgentEventArchiveRow>> {
+    let rows = match source {
+        AgentEventArchiveSource::Main => sqlx::query(
+            r#"
+                SELECT id, agent_id, session_id, ts, stream, message
+                FROM agent_events
+                WHERE id > ?1 AND id <= ?2
+                ORDER BY id ASC
+                LIMIT ?3
+                "#,
+        )
+        .bind(last_id)
+        .bind(max_id)
+        .bind(batch_limit)
+        .fetch_all(db)
+        .await?
+        .into_iter()
+        .map(|row| AgentEventArchiveRow {
+            event_id: row.get("id"),
+            agent_id: row.get("agent_id"),
+            session_id: row.get("session_id"),
+            ts: row.get("ts"),
+            stream: row.get("stream"),
+            message: decode_message_from_storage(row.get::<Vec<u8>, _>("message").as_slice()),
+        })
+        .collect(),
+        AgentEventArchiveSource::PerAgent { agent_id } => sqlx::query(
+            r#"
+                SELECT id, session_id, ts, stream, message
+                FROM agent_events
+                WHERE id > ?1 AND id <= ?2
+                ORDER BY id ASC
+                LIMIT ?3
+                "#,
+        )
+        .bind(last_id)
+        .bind(max_id)
+        .bind(batch_limit)
+        .fetch_all(db)
+        .await?
+        .into_iter()
+        .map(|row| AgentEventArchiveRow {
+            event_id: row.get("id"),
+            agent_id: agent_id.to_string(),
+            session_id: row.get("session_id"),
+            ts: row.get("ts"),
+            stream: row.get("stream"),
+            message: decode_message_from_storage(row.get::<Vec<u8>, _>("message").as_slice()),
+        })
+        .collect(),
+    };
+    Ok(rows)
 }
 
 fn collect_agent_event_archive_row(

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1840,9 +1840,9 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
     sqlx::query(
         r#"
         INSERT INTO team_steps (
-            id, run_id, step_key, member_id, remote_task_id, status, attempt, depends_on_json, input_json, started_at
+            id, run_id, step_key, member_id, remote_task_id, status, attempt, depends_on_json, input_json, started_at, ended_at
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, NULL, ?8)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, NULL, ?8, ?9)
         "#,
     )
     .bind("archive-step")
@@ -1853,29 +1853,162 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
     .bind("working")
     .bind("[]")
     .bind(1_i64)
+    .bind(22_i64)
     .execute(&db)
     .await
     .expect("insert archive step");
+    sqlx::query(
+        r#"
+        INSERT INTO team_runs (id, team_id, context_id, status, input_json, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind("archive-shared-mailbox-run")
+    .bind("archive-team")
+    .bind("archive-task")
+    .bind("working")
+    .bind(
+        json!({
+            "bootstrap_kind": "shared_thread_mailbox",
+            "task_id": "archive-task",
+            "conversation_id": "archive-conversation"
+        })
+        .to_string(),
+    )
+    .bind(23_i64)
+    .execute(&db)
+    .await
+    .expect("insert shared mailbox run");
+    sqlx::query(
+        r#"
+        INSERT INTO team_steps (
+            id, run_id, step_key, member_id, remote_task_id, status, attempt, depends_on_json, input_json, started_at, ended_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, NULL, ?8, ?9)
+        "#,
+    )
+    .bind("archive-shared-mailbox-step")
+    .bind("archive-shared-mailbox-run")
+    .bind("planner_step")
+    .bind("planner")
+    .bind("per-agent-session")
+    .bind("working")
+    .bind("[]")
+    .bind(23_i64)
+    .bind(25_i64)
+    .execute(&db)
+    .await
+    .expect("insert shared mailbox step");
+    sqlx::query(
+        r#"
+        INSERT INTO team_tasks (id, team_id, title, status, created_by_actor_id, assigned_member_id, context_json, created_at, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8)
+        "#,
+    )
+    .bind("archive-task-2")
+    .bind("archive-team")
+    .bind("Archive ACP 2")
+    .bind("open")
+    .bind("user")
+    .bind(json!({}).to_string())
+    .bind(30_i64)
+    .bind(30_i64)
+    .execute(&db)
+    .await
+    .expect("insert second archive task");
+    sqlx::query(
+        r#"
+        INSERT INTO team_conversations (id, team_id, task_id, mode, topic, created_at, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        "#,
+    )
+    .bind("archive-conversation-2")
+    .bind("archive-team")
+    .bind("archive-task-2")
+    .bind("group_chat")
+    .bind("Archive ACP 2")
+    .bind(30_i64)
+    .bind(30_i64)
+    .execute(&db)
+    .await
+    .expect("insert second archive conversation");
+    sqlx::query(
+        r#"
+        INSERT INTO team_runs (id, team_id, context_id, status, input_json, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind("archive-run-2")
+    .bind("archive-team")
+    .bind("archive-task-2")
+    .bind("working")
+    .bind(
+        json!({"task_id":"archive-task-2","conversation_id":"archive-conversation-2"}).to_string(),
+    )
+    .bind(30_i64)
+    .execute(&db)
+    .await
+    .expect("insert second archive run");
+    sqlx::query(
+        r#"
+        INSERT INTO team_steps (
+            id, run_id, step_key, member_id, remote_task_id, status, attempt, depends_on_json, input_json, started_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, NULL, ?8)
+        "#,
+    )
+    .bind("archive-step-2")
+    .bind("archive-run-2")
+    .bind("planner_step")
+    .bind("planner")
+    .bind("per-agent-session")
+    .bind("working")
+    .bind("[]")
+    .bind(30_i64)
+    .execute(&db)
+    .await
+    .expect("insert second archive step");
 
     let event_db = event_dbs
         .pool_for_agent("planner")
         .await
         .expect("open planner event db");
-    for (seq, ts, message) in [
+    for (seq, ts, stream, message) in [
         (
             "1",
             20_i64,
+            "acp",
             r#"{"type":"agent_message","text":"lo","chunk":true,"message_id":"msg-1","chunk_index":1}"#,
         ),
         (
             "2",
             21_i64,
+            "acp",
             r#"{"type":"agent_message","text":"hel","chunk":true,"message_id":"msg-1","chunk_index":0}"#,
         ),
         (
             "3",
             22_i64,
+            "acp",
             r#"{"type":"agent_message","text":"fallback malformed chunk","chunk":true,"chunk_index":2,"api_key":"per-agent-secret"}"#,
+        ),
+        (
+            "4",
+            23_i64,
+            "stdout",
+            r#"{"type":"agent_message","text":"stdout raw chunk","chunk":true,"message_id":"stdout-msg","chunk_index":0}"#,
+        ),
+        (
+            "5",
+            24_i64,
+            "acp",
+            r#"{"type":"tool_call","text":"hidden mailbox event"}"#,
+        ),
+        (
+            "6",
+            31_i64,
+            "acp",
+            r#"{"type":"tool_call","text":"second run event"}"#,
         ),
     ] {
         sqlx::query(
@@ -1887,7 +2020,7 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
         .bind("per-agent-session")
         .bind(seq)
         .bind(ts)
-        .bind("acp")
+        .bind(stream)
         .bind(message)
         .execute(&event_db)
         .await
@@ -1902,12 +2035,12 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
         .await
         .expect("migrate agent events");
 
-    assert_eq!(report.agent_events, 2);
+    assert_eq!(report.agent_events, 5);
     assert_eq!(report.aggregated_acp_messages, 1);
-    assert_eq!(report.total_documents(), 3);
+    assert_eq!(report.total_documents(), 6);
 
     let documents = archive.documents.lock().await.clone();
-    assert_eq!(documents.len(), 3);
+    assert_eq!(documents.len(), 6);
     assert!(documents.iter().any(|document| {
         document.source_kind == MessageDocumentKind::AgentEvent
             && document.document_id == "agent_event:planner:main-session:1"
@@ -1927,6 +2060,28 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
             && document.payload_json.as_deref().is_some_and(|payload| {
                 payload.contains("[redacted]") && !payload.contains("per-agent-secret")
             })
+    }));
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AgentEvent
+            && document.document_id == "agent_event:planner:per-agent-session:4"
+            && document.logical_message_id.is_none()
+            && document.team_id.is_none()
+            && document.body_text == "stdout raw chunk"
+    }));
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AgentEvent
+            && document.document_id == "agent_event:planner:per-agent-session:5"
+            && document.team_id.is_none()
+            && document.body_text == "hidden mailbox event"
+    }));
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AgentEvent
+            && document.document_id == "agent_event:planner:per-agent-session:6"
+            && document.team_id.as_deref() == Some("archive-team")
+            && document.run_id.as_deref() == Some("archive-run-2")
+            && document.conversation_id.as_deref() == Some("archive-conversation-2")
+            && document.task_id.as_deref() == Some("archive-task-2")
+            && document.body_text == "second run event"
     }));
     assert!(documents.iter().any(|document| {
         document.source_kind == MessageDocumentKind::AggregatedAcpMessage

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1775,6 +1775,88 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
     .await
     .expect("insert main agent event");
 
+    sqlx::query(
+        r#"
+        INSERT INTO team_definitions (id, name, description, spec_json, owner_user_id, created_at, updated_at)
+        VALUES (?1, ?2, NULL, ?3, NULL, ?4, ?5)
+        "#,
+    )
+    .bind("archive-team")
+    .bind("archive-team")
+    .bind(json!({"entrypoint":"coordinator_plan","members":[{"member_id":"planner"}]}).to_string())
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert archive team");
+    sqlx::query(
+        r#"
+        INSERT INTO team_tasks (id, team_id, title, status, created_by_actor_id, assigned_member_id, context_json, created_at, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8)
+        "#,
+    )
+    .bind("archive-task")
+    .bind("archive-team")
+    .bind("Archive ACP")
+    .bind("open")
+    .bind("user")
+    .bind(json!({}).to_string())
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert archive task");
+    sqlx::query(
+        r#"
+        INSERT INTO team_conversations (id, team_id, task_id, mode, topic, created_at, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        "#,
+    )
+    .bind("archive-conversation")
+    .bind("archive-team")
+    .bind("archive-task")
+    .bind("group_chat")
+    .bind("Archive ACP")
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert archive conversation");
+    sqlx::query(
+        r#"
+        INSERT INTO team_runs (id, team_id, context_id, status, input_json, created_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind("archive-run")
+    .bind("archive-team")
+    .bind("archive-task")
+    .bind("working")
+    .bind(json!({"task_id":"archive-task","conversation_id":"archive-conversation"}).to_string())
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert archive run");
+    sqlx::query(
+        r#"
+        INSERT INTO team_steps (
+            id, run_id, step_key, member_id, remote_task_id, status, attempt, depends_on_json, input_json, started_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, NULL, ?8)
+        "#,
+    )
+    .bind("archive-step")
+    .bind("archive-run")
+    .bind("planner_step")
+    .bind("planner")
+    .bind("per-agent-session")
+    .bind("working")
+    .bind("[]")
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert archive step");
+
     let event_db = event_dbs
         .pool_for_agent("planner")
         .await
@@ -1837,6 +1919,10 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
     assert!(documents.iter().any(|document| {
         document.source_kind == MessageDocumentKind::AgentEvent
             && document.document_id == "agent_event:planner:per-agent-session:3"
+            && document.team_id.as_deref() == Some("archive-team")
+            && document.run_id.as_deref() == Some("archive-run")
+            && document.conversation_id.as_deref() == Some("archive-conversation")
+            && document.task_id.as_deref() == Some("archive-task")
             && document.body_text == "fallback malformed chunk"
             && document.payload_json.as_deref().is_some_and(|payload| {
                 payload.contains("[redacted]") && !payload.contains("per-agent-secret")
@@ -1848,6 +1934,10 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
                 == "aggregated_acp_message:planner:per-agent-session:msg-1:agent_message"
             && document.source_id == "planner:per-agent-session:msg-1:agent_message"
             && document.logical_message_id.as_deref() == Some("msg-1")
+            && document.team_id.as_deref() == Some("archive-team")
+            && document.run_id.as_deref() == Some("archive-run")
+            && document.conversation_id.as_deref() == Some("archive-conversation")
+            && document.task_id.as_deref() == Some("archive-task")
             && document.agent_id.as_deref() == Some("planner")
             && document.session_id.as_deref() == Some("per-agent-session")
             && document.body_text == "hello"
@@ -1855,6 +1945,59 @@ async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregat
             && document.event_id_to == Some(2)
             && document.chunk_count == Some(2)
     }));
+}
+
+#[tokio::test]
+async fn migrate_team_messages_to_archive_skips_missing_per_agent_event_db() {
+    let db = setup_test_db().await;
+    let event_dbs = AgentEventDbRouter::new(std::env::temp_dir().join(format!(
+        "agenthub-archive-missing-eventdb-{}",
+        uuid::Uuid::new_v4()
+    )));
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, source, status, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 0, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind("idle-agent")
+    .bind("idle-agent")
+    .bind(std::env::temp_dir().to_string_lossy().to_string())
+    .bind("codex")
+    .bind("[]")
+    .bind("use_existing")
+    .bind("manual")
+    .bind("stopped")
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert idle agent");
+
+    let idle_event_db_path = event_dbs.db_path_for_agent("idle-agent");
+    assert!(
+        !idle_event_db_path.exists(),
+        "test must start without a per-agent event db"
+    );
+
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let archive_manager =
+        TeamManager::new_with_event_dbs_and_message_archive(db, event_dbs, Some(archive.clone()));
+    let report = archive_manager
+        .migrate_team_messages_to_archive(2)
+        .await
+        .expect("migrate with missing per-agent event db");
+
+    assert_eq!(report.agent_events, 0);
+    assert_eq!(report.aggregated_acp_messages, 0);
+    assert!(
+        !idle_event_db_path.exists(),
+        "migration should not create empty per-agent event db files"
+    );
+    let documents = archive.documents.lock().await.clone();
+    assert!(documents.is_empty());
 }
 
 #[tokio::test]

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -1718,6 +1718,146 @@ async fn migrate_team_messages_to_archive_covers_team_message_tables() {
 }
 
 #[tokio::test]
+async fn migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregation() {
+    let db = setup_test_db().await;
+    let event_dbs = AgentEventDbRouter::new(std::env::temp_dir().join(format!(
+        "agenthub-archive-acp-eventdb-{}",
+        uuid::Uuid::new_v4()
+    )));
+
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, source, status, created_at, updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 0, ?7, ?8, ?9, ?10)
+        "#,
+    )
+    .bind("planner")
+    .bind("planner")
+    .bind(std::env::temp_dir().to_string_lossy().to_string())
+    .bind("codex")
+    .bind("[]")
+    .bind("use_existing")
+    .bind("manual")
+    .bind("running")
+    .bind(1_i64)
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert planner agent");
+    sqlx::query(
+        r#"
+        INSERT INTO agent_sessions (id, agent_id, status, started_at, ended_at)
+        VALUES (?1, ?2, ?3, ?4, NULL)
+        "#,
+    )
+    .bind("main-session")
+    .bind("planner")
+    .bind("running")
+    .bind(1_i64)
+    .execute(&db)
+    .await
+    .expect("insert main session");
+    sqlx::query(
+        r#"
+        INSERT INTO agent_events (agent_id, session_id, seq, ts, stream, message)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "#,
+    )
+    .bind("planner")
+    .bind("main-session")
+    .bind("1")
+    .bind(10_i64)
+    .bind("acp")
+    .bind(r#"{"type":"tool_call","text":"main raw event","api_key":"main-secret"}"#)
+    .execute(&db)
+    .await
+    .expect("insert main agent event");
+
+    let event_db = event_dbs
+        .pool_for_agent("planner")
+        .await
+        .expect("open planner event db");
+    for (seq, ts, message) in [
+        (
+            "1",
+            20_i64,
+            r#"{"type":"agent_message","text":"lo","chunk":true,"message_id":"msg-1","chunk_index":1}"#,
+        ),
+        (
+            "2",
+            21_i64,
+            r#"{"type":"agent_message","text":"hel","chunk":true,"message_id":"msg-1","chunk_index":0}"#,
+        ),
+        (
+            "3",
+            22_i64,
+            r#"{"type":"agent_message","text":"fallback malformed chunk","chunk":true,"chunk_index":2,"api_key":"per-agent-secret"}"#,
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO agent_events (session_id, seq, ts, stream, message)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+        )
+        .bind("per-agent-session")
+        .bind(seq)
+        .bind(ts)
+        .bind("acp")
+        .bind(message)
+        .execute(&event_db)
+        .await
+        .expect("insert per-agent event");
+    }
+
+    let archive = Arc::new(RecordingMessageArchive::default());
+    let archive_manager =
+        TeamManager::new_with_event_dbs_and_message_archive(db, event_dbs, Some(archive.clone()));
+    let report = archive_manager
+        .migrate_team_messages_to_archive(2)
+        .await
+        .expect("migrate agent events");
+
+    assert_eq!(report.agent_events, 2);
+    assert_eq!(report.aggregated_acp_messages, 1);
+    assert_eq!(report.total_documents(), 3);
+
+    let documents = archive.documents.lock().await.clone();
+    assert_eq!(documents.len(), 3);
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AgentEvent
+            && document.document_id == "agent_event:planner:main-session:1"
+            && document.body_text == "main raw event"
+            && document.payload_json.as_deref().is_some_and(|payload| {
+                payload.contains("[redacted]") && !payload.contains("main-secret")
+            })
+    }));
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AgentEvent
+            && document.document_id == "agent_event:planner:per-agent-session:3"
+            && document.body_text == "fallback malformed chunk"
+            && document.payload_json.as_deref().is_some_and(|payload| {
+                payload.contains("[redacted]") && !payload.contains("per-agent-secret")
+            })
+    }));
+    assert!(documents.iter().any(|document| {
+        document.source_kind == MessageDocumentKind::AggregatedAcpMessage
+            && document.document_id
+                == "aggregated_acp_message:planner:per-agent-session:msg-1:agent_message"
+            && document.source_id == "planner:per-agent-session:msg-1:agent_message"
+            && document.logical_message_id.as_deref() == Some("msg-1")
+            && document.agent_id.as_deref() == Some("planner")
+            && document.session_id.as_deref() == Some("per-agent-session")
+            && document.body_text == "hello"
+            && document.event_id_from == Some(1)
+            && document.event_id_to == Some(2)
+            && document.chunk_count == Some(2)
+    }));
+}
+
+#[tokio::test]
 async fn migrate_team_messages_to_archive_uses_start_snapshot_for_conversation_rows() {
     let db = setup_test_db().await;
     let seed_manager = TeamManager::new(db.clone());


### PR DESCRIPTION
## Summary

- migrate historical main/global `agent_events` rows into raw `agent_event` archive documents
- migrate existing per-agent `AgentEventDbRouter` rows into the archive without creating empty per-agent DBs
- aggregate parseable ACP message chunks into deterministic `aggregated_acp_message` documents while preserving malformed/non-chunk fallback as raw `agent_event` documents
- update the message archive spec and focused migration coverage

## Purpose

This closes the historical ACP replay gap in the P0+ message archive rollout. Team message migration already covered Team conversation/run/mailbox tables; this extends the same operator-triggered migration path to agent event history and preserves the logical-message aggregation contract for chunked ACP output.

## Related Issues

- None

## Testing

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p agenthub-message-archive identifies_only_parseable_message_chunks_as_aggregatable -- --nocapture`
- `cargo test -p agenthub migrate_team_messages_to_archive_replays_agent_events_with_acp_aggregation -- --nocapture`
- `cargo test -p agenthub migrate_team_messages_to_archive_covers_team_message_tables -- --nocapture`
