### PR TITLE
feat(team): create team shell before first agent

### DIFF
--- a/docs/features/team-create-flow.md
+++ b/docs/features/team-create-flow.md
@@ -219,3 +219,4 @@ Explicit anti-goals:
 
 - `docs/journal/2026-02-19-team-create-dual-entry-modes.md`
 - `docs/journal/2026-02-19-team-create-wizard-manual-spec-flow.md`
+- `docs/journal/2026-05-06-team-create-shell-first.md`

--- a/docs/journal/2026-05-06-team-create-shell-first.md
+++ b/docs/journal/2026-05-06-team-create-shell-first.md
@@ -1,0 +1,42 @@
+# Team Create Shell First
+
+## Summary
+
+Team creation now stops at the Team shell. It no longer opens the first coordinator-agent forge
+modal immediately after `Create Team` succeeds.
+
+## Background
+
+The canonical Team create flow keeps `Create Team` mission-first and moves coordinator assignment
+to the first explicit `Add Agent` action. The UI already made the add-agent role fixed
+(`coordinator` for an empty Team, `worker` after a coordinator exists), but the create action still
+opened the coordinator forge modal automatically.
+
+## Scope
+
+- Keep the `Create Team` action limited to creating an empty Team spec.
+- Reset the create/forge draft state after creation.
+- Leave the operator on the new Team detail page with a direct next-step hint.
+- Preserve the existing `Add First Coordinator Agent` and `Copy Existing Agent` entry points as the
+  places where first-agent coordinator semantics are shown.
+
+## Key Decisions
+
+- Do not auto-open the forge modal after creating a Team shell.
+- Do not fabricate a draft coordinator member during Team creation.
+- Keep role assignment inside the add-agent flow, where the selected Team state determines whether
+  the fixed role is `coordinator` or `worker`.
+
+## Validation
+
+```bash
+npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx src/pages/team/team_management_modals.test.tsx
+git diff --check
+npm --prefix web run lint
+npm --prefix web run build
+```
+
+## Follow-Ups
+
+- Add a browser-level small-screen pass for the full create-shell, add-first-agent, and add-worker
+  sequence before closing the broader P0+ Team create-flow item.

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -307,7 +307,7 @@ describe("useTeamManagementActions", () => {
     }
   });
 
-  it("creates a team and immediately opens the first coordinator forge flow", async () => {
+  it("creates a team shell without opening the first coordinator forge flow", async () => {
     mockedApi.createTeam.mockResolvedValueOnce({
       id: "team-2",
       name: "New Team",
@@ -344,9 +344,9 @@ describe("useTeamManagementActions", () => {
           newTeamDescription: "",
           coordinatorPrompt: "lead",
           showCreateTeamModal: false,
-          showForgeAgentForm: true,
+          showForgeAgentForm: false,
           showCopyExistingAgentModal: false,
-          forgeAgentName: "new-team-coordinator",
+          forgeAgentName: "",
           forgeAgentPresetId: "codex",
           forgeAgentWorktreeMode: "use_existing",
           forgeAgentWorktreeRepo: "",
@@ -355,10 +355,9 @@ describe("useTeamManagementActions", () => {
           forgeAgentWorktreeError: null,
         })
       );
-      expect(params.setTeamMemberDraft).toHaveBeenCalledWith(
-        expect.objectContaining({
-          role: "coordinator",
-        })
+      expect(params.setTeamMemberDraft).not.toHaveBeenCalled();
+      expect(params.setWarning).toHaveBeenCalledWith(
+        "Team created. Add the first agent to make it the coordinator."
       );
       expect(params.navigateToTeamDetail).toHaveBeenCalledWith("team-2");
     } finally {

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -728,21 +728,11 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       setSelectedTeamId(created.id);
       clearTeamCreateDraft();
       patchTeamCreate({
-        newTeamName: initial.newTeamName,
-        newTeamDescription: initial.newTeamDescription,
+        ...initial,
         coordinatorPrompt: teamPromptDefaults.coordinator_prompt,
         showCreateTeamModal: false,
-        showForgeAgentForm: false,
-        showCopyExistingAgentModal: false,
-        forgeAgentName: initial.forgeAgentName,
-        forgeAgentWorkdir: initial.forgeAgentWorkdir,
         forgeAgentPresetId: DEFAULT_AGENT_PRESET_ID,
-        forgeAgentWorktreeMode: initial.forgeAgentWorktreeMode,
-        forgeAgentWorktreeRepo: initial.forgeAgentWorktreeRepo,
-        forgeAgentWorktreeRef: initial.forgeAgentWorktreeRef,
         forgeAgentCodeMode: true,
-        forgeAgentWorktreeError: null,
-        forgeAgentBusy: initial.forgeAgentBusy,
       });
       setWarning("Team created. Add the first agent to make it the coordinator.");
       navigateToTeamDetail(created.id);

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -724,36 +724,27 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
         spec: buildEmptyTeamSpec(),
       });
       const initial = createInitialTeamCreateState();
-      const defaults = resolveTeamForgeDefaults({
-        teamName: created.name,
-        teamSpec: created.spec,
-        role: resolveInitialTeamMemberRole(false),
-        workerCount: 0,
-        defaultWorktreeRoot: forgeDefaultWorktreeRoot,
-        agentPresetId: DEFAULT_AGENT_PRESET_ID,
-        promptDefaults: teamPromptDefaults,
-      });
       setTeams((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
       setSelectedTeamId(created.id);
       clearTeamCreateDraft();
-      setTeamMemberDraft(defaults.draft);
       patchTeamCreate({
         newTeamName: initial.newTeamName,
         newTeamDescription: initial.newTeamDescription,
         coordinatorPrompt: teamPromptDefaults.coordinator_prompt,
         showCreateTeamModal: false,
-        showForgeAgentForm: true,
+        showForgeAgentForm: false,
         showCopyExistingAgentModal: false,
-        forgeAgentName: defaults.agentName,
-        forgeAgentWorkdir: defaults.agentWorkdir,
+        forgeAgentName: initial.forgeAgentName,
+        forgeAgentWorkdir: initial.forgeAgentWorkdir,
         forgeAgentPresetId: DEFAULT_AGENT_PRESET_ID,
-        forgeAgentWorktreeMode: defaults.worktreeMode,
-        forgeAgentWorktreeRepo: defaults.worktreeRepo,
-        forgeAgentWorktreeRef: defaults.worktreeRef,
+        forgeAgentWorktreeMode: initial.forgeAgentWorktreeMode,
+        forgeAgentWorktreeRepo: initial.forgeAgentWorktreeRepo,
+        forgeAgentWorktreeRef: initial.forgeAgentWorktreeRef,
         forgeAgentCodeMode: true,
         forgeAgentWorktreeError: null,
         forgeAgentBusy: initial.forgeAgentBusy,
       });
+      setWarning("Team created. Add the first agent to make it the coordinator.");
       navigateToTeamDetail(created.id);
     } catch (err) {
       setError(parseErrorMessage(err));
@@ -763,13 +754,11 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
   }, [
     newTeamDescription,
     newTeamName,
-    forgeDefaultWorktreeRoot,
     navigateToTeamDetail,
     patchTeamCreate,
     setBusy,
     setError,
     setSelectedTeamId,
-    setTeamMemberDraft,
     setTeams,
     setWarning,
     teamPromptDefaults,

--- a/web/tests/e2e/team_page_setup.e2e.ts
+++ b/web/tests/e2e/team_page_setup.e2e.ts
@@ -62,24 +62,12 @@ test("team create flow stores mission metadata before member setup", async ({ pa
   });
   await expect(page).toHaveURL(/\/teams\/.+/);
   await expect.poll(() => isTeamDetailReady(page)).toBe(true);
-  const forgeDialog = page.getByRole("dialog").filter({
-    has: page.getByRole("button", { name: "Create Coordinator Agent", exact: true }),
-  });
-  await expect(forgeDialog).toBeVisible();
-  await expect(forgeDialog.getByText("Assigned Role", { exact: true })).toBeVisible();
-  await expect(forgeDialog.getByText("Coordinator", { exact: true })).toBeVisible();
   await expect(
-    forgeDialog.getByText(
-      "This team does not have a coordinator yet, so the first added agent becomes the coordinator automatically.",
-      { exact: true }
-    )
+    page.getByText("Team created. Add the first agent to make it the coordinator.", {
+      exact: true,
+    })
   ).toBeVisible();
-  await expect(
-    forgeDialog.getByText(
-      "The first agent added to a Team becomes the coordinator. Add workers after this first agent exists.",
-      { exact: true }
-    )
-  ).toBeVisible();
+  await expectAddAgentEntryVisible(page, "quest-team");
 
   const payload = fixture.getCreatePayload();
   expect(payload).not.toBeNull();
@@ -403,9 +391,7 @@ test("team setup keeps add agent wording after the first member binds", async ({
     name: teamName,
     goal: "Bind coordinator in-place before worker setup.",
   });
-  await expect(
-    page.getByRole("button", { name: "Create Coordinator Agent", exact: true })
-  ).toBeVisible();
+  await expectAddAgentEntryVisible(page, teamName);
 
   await createTeamMemberFromModal(page, {
     teamName,


### PR DESCRIPTION
## Summary

- Stop auto-opening the first coordinator-agent forge modal after `Create Team` succeeds.
- Keep Team creation limited to creating an empty Team shell and resetting create/forge draft state.
- Leave the operator on the new Team detail page with a direct next-step hint to add the first coordinator agent.
- Record the rollout checkpoint in the Team create-flow spec journal.

## Tests

- `npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx src/pages/team/team_management_modals.test.tsx`
- `git diff --check`
- `npm --prefix web run lint`
- `npm --prefix web run build`

## Related

- Continues the P0+ Team create-flow simplification backlog.
