### PR TITLE
feat(team): show deferred move adoption path

### DIFF
--- a/docs/features/team-agent-adoption.md
+++ b/docs/features/team-agent-adoption.md
@@ -264,3 +264,4 @@ Current status:
 
 - `docs/journal/2026-05-03-team-agent-adoption-contract.md`
 - `docs/journal/2026-05-03-team-add-existing-agent-copy.md`
+- `docs/journal/2026-05-06-team-adoption-move-deferred.md`

--- a/docs/journal/2026-05-06-team-adoption-move-deferred.md
+++ b/docs/journal/2026-05-06-team-adoption-move-deferred.md
@@ -1,0 +1,41 @@
+# Team Adoption Move Deferred
+
+## Summary
+
+`Add Existing Agent` now keeps `Copy into Team` as the only executable adoption path while showing
+`Move to Team` as explicitly deferred.
+
+## Background
+
+The Team adoption contract separates copying an existing agent from moving the original agent into
+Team ownership. Copy is safe for the first rollout because it creates a new Team-owned member and
+leaves the source agent unchanged. Move needs stricter runtime, ownership, and history guardrails
+before it can be enabled.
+
+## Scope
+
+- Keep copy as the active Add Existing Agent action.
+- Add visible move semantics explaining why transfer is not enabled yet.
+- Render a disabled `Move to Team (later)` action so copy and move are not collapsed into one
+  ambiguous import path.
+
+## Key Decisions
+
+- Do not add move behavior in this slice.
+- Do not mutate source agents from the Add Existing Agent flow.
+- Keep the disabled move action in the same modal as copy so operators see the product boundary at
+  the decision point.
+
+## Validation
+
+```bash
+npm --prefix web run test -- src/pages/team/team_management_modals.test.tsx
+git diff --check
+npm --prefix web run lint
+npm --prefix web run build
+```
+
+## Follow-Ups
+
+- Define stopped-only runtime and ownership-transfer guards before enabling `Move to Team`.
+- Add browser-level coverage for copy-first adoption and the disabled move boundary.

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -344,6 +344,10 @@ describe("Team management modals", () => {
     expect(html).toContain("<li");
     expect(html).toContain('aria-pressed="false"');
     expect(html).toContain("new Team-owned worker agent");
+    expect(html).toContain("Copy keeps the source agent unchanged");
+    expect(html).toContain("Move semantics are not enabled yet");
+    expect(html).toContain("Move to Team (later)");
+    expect(html).toContain("Move to Team is deferred until ownership and runtime guardrails land.");
   });
 
   it("renders the copy-existing-agent empty-filter fallback", () => {

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -347,7 +347,6 @@ describe("Team management modals", () => {
     expect(html).toContain("Copy keeps the source agent unchanged");
     expect(html).toContain("Move semantics are not enabled yet");
     expect(html).toContain("Move to Team (later)");
-    expect(html).toContain("Move to Team is deferred until ownership and runtime guardrails land.");
   });
 
   it("renders the copy-existing-agent empty-filter fallback", () => {

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -347,6 +347,7 @@ describe("Team management modals", () => {
     expect(html).toContain("Copy keeps the source agent unchanged");
     expect(html).toContain("Move semantics are not enabled yet");
     expect(html).toContain("Move to Team (later)");
+    expect(html).toContain('disabled="">Move to Team (later)');
   });
 
   it("renders the copy-existing-agent empty-filter fallback", () => {

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -576,7 +576,6 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             disabled
             size="md"
             tone="secondary"
-            title="Move to Team is deferred until ownership and runtime guardrails land."
             type="button"
           >
             Move to Team (later)

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -553,6 +553,11 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             Copy keeps the source agent unchanged. AgentHub creates a new Team-owned{" "}
             {copyRoleLabel} agent with copied runtime settings and fresh Team membership.
           </Alert>
+          <Alert radius="md" color="yellow" variant="light" title="Move semantics are not enabled yet">
+            Moving would transfer the existing agent identity and ownership into this Team. That
+            path needs runtime and history guardrails first, so use copy when you want a safe
+            Team-owned member now.
+          </Alert>
         </div>
 
         <div className={TEAM_CREATE_ACTIONS_BAR_CLASS}>
@@ -565,6 +570,16 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             type="button"
           >
             Cancel
+          </ActionButton>
+          <ActionButton
+            className={chrome.mutedButtonClassName}
+            disabled
+            size="md"
+            tone="secondary"
+            title="Move to Team is deferred until ownership and runtime guardrails land."
+            type="button"
+          >
+            Move to Team (later)
           </ActionButton>
           <ActionButton
             className={chrome.accentButtonClassName}

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -553,7 +553,13 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             Copy keeps the source agent unchanged. AgentHub creates a new Team-owned{" "}
             {copyRoleLabel} agent with copied runtime settings and fresh Team membership.
           </Alert>
-          <Alert radius="md" color="yellow" variant="light" title="Move semantics are not enabled yet">
+          <Alert
+            radius="md"
+            color="yellow"
+            variant="light"
+            title="Move semantics are not enabled yet"
+            icon={<i className="bi bi-exclamation-triangle" aria-hidden="true" />}
+          >
             Moving would transfer the existing agent identity and ownership into this Team. That
             path needs runtime and history guardrails first, so use copy when you want a safe
             Team-owned member now.


### PR DESCRIPTION
## Summary

- Keep `Copy into Team` as the only executable Add Existing Agent adoption action.
- Show a disabled `Move to Team (later)` action with explicit ownership/runtime guardrail wording.
- Record the rollout checkpoint in the Team adoption spec journal.

## Tests

- `npm --prefix web run test -- src/pages/team/team_management_modals.test.tsx`
- `git diff --check`
- `npm --prefix web run lint`
- `npm --prefix web run build`

## Related

- Continues the P0+ Team agent adoption backlog.
