### PR TITLE
fix(team): keep create team shell-first

### DIFF
--- a/docs/journal/2026-05-03-team-create-first-agent-coordinator.md
+++ b/docs/journal/2026-05-03-team-create-first-agent-coordinator.md
@@ -46,3 +46,23 @@ cd web && npm run build
   ceremony, especially around how existing agents are picked or prefilled
 - add browser-level Team create coverage once the current coordinator-first create-shell wording is
   fully reflected in the main Team flow
+
+## 2026-05-06 Shell-First Follow-Up
+
+`Create Team` now creates only the empty Team shell. After a successful create, the create modal
+closes, the first-agent forge draft is cleared, and the operator lands on the Team detail page where
+the normal `Add Agent` action owns first-agent setup.
+
+This removes the remaining mismatch where Team creation still auto-opened the coordinator forge
+modal even though the product contract had already moved coordinator setup into the first explicit
+add-agent step.
+
+Validation:
+
+```bash
+npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx
+npm --prefix web run lint
+cd web && ./node_modules/.bin/tsc --noEmit
+npm --prefix web run build
+git diff --check
+```

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -307,7 +307,7 @@ describe("useTeamManagementActions", () => {
     }
   });
 
-  it("creates a team and immediately opens the first coordinator forge flow", async () => {
+  it("creates a team shell and leaves first-agent setup to Add Agent", async () => {
     mockedApi.createTeam.mockResolvedValueOnce({
       id: "team-2",
       name: "New Team",
@@ -344,9 +344,9 @@ describe("useTeamManagementActions", () => {
           newTeamDescription: "",
           coordinatorPrompt: "lead",
           showCreateTeamModal: false,
-          showForgeAgentForm: true,
+          showForgeAgentForm: false,
           showCopyExistingAgentModal: false,
-          forgeAgentName: "new-team-coordinator",
+          forgeAgentName: "",
           forgeAgentPresetId: "codex",
           forgeAgentWorktreeMode: "use_existing",
           forgeAgentWorktreeRepo: "",
@@ -355,11 +355,7 @@ describe("useTeamManagementActions", () => {
           forgeAgentWorktreeError: null,
         })
       );
-      expect(params.setTeamMemberDraft).toHaveBeenCalledWith(
-        expect.objectContaining({
-          role: "coordinator",
-        })
-      );
+      expect(params.setTeamMemberDraft).toHaveBeenCalledWith(null);
       expect(params.navigateToTeamDetail).toHaveBeenCalledWith("team-2");
     } finally {
       mounted.cleanup();

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -724,33 +724,24 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
         spec: buildEmptyTeamSpec(),
       });
       const initial = createInitialTeamCreateState();
-      const defaults = resolveTeamForgeDefaults({
-        teamName: created.name,
-        teamSpec: created.spec,
-        role: resolveInitialTeamMemberRole(false),
-        workerCount: 0,
-        defaultWorktreeRoot: forgeDefaultWorktreeRoot,
-        agentPresetId: DEFAULT_AGENT_PRESET_ID,
-        promptDefaults: teamPromptDefaults,
-      });
       setTeams((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
       setSelectedTeamId(created.id);
       clearTeamCreateDraft();
-      setTeamMemberDraft(defaults.draft);
+      setTeamMemberDraft(null);
       patchTeamCreate({
         newTeamName: initial.newTeamName,
         newTeamDescription: initial.newTeamDescription,
         coordinatorPrompt: teamPromptDefaults.coordinator_prompt,
         showCreateTeamModal: false,
-        showForgeAgentForm: true,
+        showForgeAgentForm: false,
         showCopyExistingAgentModal: false,
-        forgeAgentName: defaults.agentName,
-        forgeAgentWorkdir: defaults.agentWorkdir,
-        forgeAgentPresetId: DEFAULT_AGENT_PRESET_ID,
-        forgeAgentWorktreeMode: defaults.worktreeMode,
-        forgeAgentWorktreeRepo: defaults.worktreeRepo,
-        forgeAgentWorktreeRef: defaults.worktreeRef,
-        forgeAgentCodeMode: true,
+        forgeAgentName: initial.forgeAgentName,
+        forgeAgentWorkdir: initial.forgeAgentWorkdir,
+        forgeAgentPresetId: initial.forgeAgentPresetId,
+        forgeAgentWorktreeMode: initial.forgeAgentWorktreeMode,
+        forgeAgentWorktreeRepo: initial.forgeAgentWorktreeRepo,
+        forgeAgentWorktreeRef: initial.forgeAgentWorktreeRef,
+        forgeAgentCodeMode: initial.forgeAgentCodeMode,
         forgeAgentWorktreeError: null,
         forgeAgentBusy: initial.forgeAgentBusy,
       });
@@ -763,7 +754,6 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
   }, [
     newTeamDescription,
     newTeamName,
-    forgeDefaultWorktreeRoot,
     navigateToTeamDetail,
     patchTeamCreate,
     setBusy,


### PR DESCRIPTION
## Summary

- Keep `Create Team` limited to creating an empty Team shell.
- Stop auto-opening the first coordinator forge modal after Team creation succeeds.
- Clear the first-agent draft so the explicit `Add Agent` action owns coordinator setup.
- Record the follow-up in the Team create-flow rollout journal.

## Purpose

This completes the shell-first boundary for the P0+ Team create-flow simplification work. The initial create modal no longer mixes Team identity creation with first-agent setup; the first added agent still becomes coordinator through the normal Add Agent path.

## Related Issues

- None

## Testing

- `npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx`
- `npm --prefix web run lint`
- `cd web && ./node_modules/.bin/tsc --noEmit`
- `npm --prefix web run build`
- `git diff --check`
