### PR TITLE
test(team): cover existing-agent adoption boundary

### DIFF
--- a/docs/journal/2026-05-06-team-adoption-move-deferred.md
+++ b/docs/journal/2026-05-06-team-adoption-move-deferred.md
@@ -35,7 +35,21 @@ npm --prefix web run lint
 npm --prefix web run build
 ```
 
+## 2026-05-06 Browser Coverage Follow-Up
+
+The Team setup E2E path now covers the copy-first adoption boundary:
+
+- an empty Team can open `Copy Existing Agent` from the setup panel;
+- `Move to Team (later)` is visible but disabled;
+- `Copy into Team` creates a new Team-owned coordinator member;
+- the original source agent remains available in the mocked agent list.
+
+Additional validation:
+
+```bash
+npm --prefix web run e2e -- tests/e2e/team_page_setup.e2e.ts --grep "team adoption copy keeps move disabled"
+```
+
 ## Follow-Ups
 
 - Define stopped-only runtime and ownership-transfer guards before enabling `Move to Team`.
-- Add browser-level coverage for copy-first adoption and the disabled move boundary.

--- a/web/tests/e2e/team_page_setup.e2e.ts
+++ b/web/tests/e2e/team_page_setup.e2e.ts
@@ -128,6 +128,49 @@ test("team member setup adds the first agent and appends more agents through spe
   ]);
 });
 
+test("team adoption copy keeps move disabled and creates a team-owned coordinator", async ({
+  page,
+}) => {
+  const fixture = await mockTeamPageApis(page);
+  const teamName = "adoption-copy-team";
+
+  await gotoTeams(page);
+  await createTeamFromModal(page, {
+    name: teamName,
+    goal: "Adopt an existing agent through copy semantics.",
+  });
+
+  await page.getByRole("button", { name: "Copy Existing Agent" }).click();
+  const dialog = page
+    .locator("[role='dialog']")
+    .filter({ hasText: "Copy an existing agent into this team." })
+    .last();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("The original agent remains unchanged.")).toBeVisible();
+
+  const moveButton = dialog.getByRole("button", { name: "Move to Team (later)" });
+  await expect(moveButton).toBeVisible();
+  await expect(moveButton).toBeDisabled();
+
+  const copyButton = dialog.getByRole("button", { name: "Copy into Team" });
+  await expect(copyButton).toBeEnabled();
+  await copyButton.click();
+  await expect(dialog).toBeHidden();
+
+  const updates = fixture.getUpdateSpecPayloads();
+  expect(updates).toHaveLength(1);
+  const [member] = updates[0]?.payload.spec.members ?? [];
+  expect(updates[0]?.payload.spec.coordinator_member_id).toBe("agent-forge-4");
+  expect(member).toMatchObject({
+    member_id: "agent-forge-4",
+    role: "coordinator",
+    description: "Copied from existing agent Coordinator Agent.",
+    model: "Codex",
+  });
+  expect(fixture.agents.some((agent) => agent.id === "agent-coordinator-1")).toBe(true);
+  expect(fixture.agents.some((agent) => agent.id === "agent-forge-4")).toBe(true);
+});
+
 test("team create modal only captures mission metadata and points member setup to the next step", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- Add Playwright coverage for the Add Existing Agent adoption boundary.
- Assert `Move to Team (later)` is visible but disabled.
- Assert `Copy into Team` creates a new Team-owned coordinator while preserving the source agent.
- Record the browser-coverage follow-up in the Team adoption journal.

## Purpose

This closes the browser-level coverage gap left by the P0+ Team adoption copy/move split. Copy remains the only executable adoption path; move stays explicitly deferred until runtime and ownership-transfer guardrails are defined.

## Related Issues

- None

## Testing

- `PLAYWRIGHT_NO_WEBSERVER=1 npm --prefix web run e2e -- tests/e2e/team_page_setup.e2e.ts --grep "team adoption copy keeps move disabled"`
- `npm --prefix web run lint`
- `cd web && ./node_modules/.bin/tsc --noEmit`
- `npm --prefix web run build`
- `git diff --check`
