### PR TITLE
docs: RBAC multi-user specification (P0)

### DIFF
--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -2,107 +2,114 @@
 
 ## Problem
 
-AgentHub currently has a minimal role system: `root` for the superuser and `device` for node
-join. There is no `member` role for regular human users beyond the first admin. Every
-authenticated user can see, modify, start, stop, and delete any agent or team in the system.
+AgentHub currently has two roles: `root` (superuser) and `device` (node join). There is no
+graduated access control for regular human users. Every authenticated user can see, modify, start,
+stop, and delete any agent or team.
 
-This is not tenable beyond single-user homelab use:
-
-- there is no way to grant a teammate access to only their team without also exposing all other
-  teams and agents;
-- there is no way to prevent accidental (or malicious) deletion of another user's agents;
-- the only authorization boundary is "logged in or not";
-- Team members have per-Team roles (`coordinator`, `worker`) but those are runtime semantic labels,
-  not access-control roles.
-
-We need a proper role-based access control model that supports multiple human users sharing one
-AgentHub instance, without introducing multi-tenancy (tenant isolation, separate DBs, org
-hierarchies). This is a **single-instance, multi-user** model.
+This is not tenable beyond single-user homelab use. We need a proper role hierarchy that supports
+multiple human users with different privilege levels, without introducing multi-tenancy.
 
 ## Scope
 
-- User identity and authentication hardening.
-- New `member` role for regular human users (alongside existing `root` and `device`).
+- Four-tier human role hierarchy: root → maintainer → member → visitor.
+- Keep existing `device` role for node registration (unchanged).
 - Per-resource (Agent, Team, Node) ownership and access control.
-- API authorization middleware gating all mutable endpoints.
+- API authorization middleware gating all endpoints.
 - Frontend UI gating for role-restricted actions.
-- Default migration path from the current model.
 - Audit logging for role changes and destructive actions.
 
 ## Non-Goals
 
-- Multi-tenancy: no workspace/org isolation, no tenant-scoped data partitioning, no per-tenant
-  billing.
-- Fine-grained attribute-based access control (ABAC).
-- OIDC / OAuth2 / external identity provider integration (this is a future add-on, not v1).
-- Row-level security inside Agent workspaces (file permissions are out of scope).
-- Replacing Team member roles (`coordinator`, `worker`) with RBAC roles — those remain runtime
-  semantic roles.
-- Changing `root` or `device` role semantics — these are existing and remain stable.
+- Multi-tenancy (no org isolation, no per-tenant billing).
+- OIDC / OAuth2 / external identity provider integration.
+- Fine-grained ABAC or per-file permissions inside workspaces.
+- Replacing Team agent roles (`coordinator`, `worker`) — those remain runtime semantic labels.
 
 ## Threat Model
 
-The primary threats this spec addresses:
-
 | Threat | Mitigation |
 |--------|------------|
-| Authenticated user deletes another user's agent | Resource-level ownership + role check |
-| Authenticated user starts/stops another user's agent | Same |
-| Authenticated user reads another user's Team conversation | Team access control |
-| Authenticated user joins a node that hosts other users' agents | Node-level `root` gate |
-| Privilege escalation via API without frontend | Server-side enforcement, not UI-only |
-| Token reuse / session hijacking | Token scoping to user, session revocation |
+| Unauthorized agent deletion / start / stop | Resource ownership + role hierarchy |
+| Unauthorized Team access | Team membership + role gate |
+| Privilege escalation via API | Server-side middleware, not UI-only |
+| Token reuse / hijacking | Session scoping to user, revocation |
+| Visitor modifying resources | Write operations gated at API layer |
 
 ## Architecture
 
-### 1) User Model
+### 1) Role Hierarchy
 
-Users are the human actors (plus Node devices). Each user has exactly one role.
+```
+root (管理员)
+ ├── maintainer (维护员)
+ │    ├── member (员工)
+ │    └── visitor (访客)
+ └── device (节点注册, system role, no WebUI login)
+```
 
-**Existing roles (unchanged):**
+Roles are hierarchical: a higher role includes all permissions of lower roles.
 
-| Role | Description | Added in |
-|------|-------------|----------|
-| `root` | Superuser. Full access to all resources. Create/manage nodes, agents, teams, and users. | Existing (`auth/mod.rs`) |
-| `device` | Node registration identity. Used by `agenthub join`. Cannot login via WebUI. | Existing (`api/join.rs`) |
-
-**New role (this spec):**
-
-| Role | Description |
-|------|-------------|
-| `member` | Regular human user. Access only to resources they own or are Team members of. |
+| Role | 中文 | Description |
+|------|------|-------------|
+| `root` | 管理员 | Superuser. Full access. Manage nodes, users, all resources. Create/delete other roots. |
+| `maintainer` | 维护员 | Team/resource manager. Create/manage agents and teams. Manage team membership. Cannot manage nodes or users. |
+| `member` | 员工 | Regular user. Create agents and teams. Full access to own resources. Read-only access to teams they are invited to. |
+| `visitor` | 访客 | Read-only user. Cannot create resources. Can only view teams they're explicitly invited to. |
+| `device` | 节点 | System role for `agenthub join`. No WebUI login. Unchanged from current behavior. |
 
 **Constraints:**
 
-- The bootstrap user (first user created) is always `root`.
-- There must always be at least one `root` user. Deleting the last root is rejected.
-- `device` users cannot authenticate via the WebUI (no passkey/password login flow).
-- `member` users cannot register passkeys or use the WebUI login if passkey is enabled and they
-  have no credential — they must be created by a `root` user.
+- The bootstrap user (first created) is always `root`.
+- There must always be at least one `root`. Deleting the last root is rejected.
+- A user cannot change their own role (prevents self-promotion and self-demotion).
+- `device` users cannot authenticate via WebUI.
+- `visitor` users cannot create agents, teams, or send messages.
 
-**DB schema (additive changes):**
+### 2) Permission Matrix
 
-```sql
--- Existing table (unchanged columns)
--- CREATE TABLE users (id, username, display_name, role, password_hash, created_at);
+| Action | root | maintainer | member | visitor |
+|--------|------|------------|--------|---------|
+| **User management** | | | | |
+| Create/delete users | ✅ | - | - | - |
+| Change user roles | ✅ | - | - | - |
+| View all users | ✅ | ✅ | - | - |
+| **Node management** | | | | |
+| Register/remove nodes | ✅ | - | - | - |
+| View nodes | ✅ | ✅ | ✅ | - |
+| **Agent operations** | | | | |
+| Create agent | ✅ | ✅ | ✅ | - |
+| View own agents | ✅ | ✅ | ✅ | ✅ |
+| View any agent | ✅ | ✅ | - | - |
+| Start/stop own agent | ✅ | ✅ | ✅ | - |
+| Start/stop any agent | ✅ | ✅ | - | - |
+| Delete own agent | ✅ | ✅ | ✅ | - |
+| Delete any agent | ✅ | ✅ | - | - |
+| **Team operations** | | | | |
+| Create team | ✅ | ✅ | ✅ | - |
+| View own teams | ✅ | ✅ | ✅ | ✅ |
+| View any team | ✅ | ✅ | - | - |
+| Invite members to own team | ✅ | ✅ | ✅ (owner) | - |
+| Invite members to any team | ✅ | ✅ | - | - |
+| Send conversation messages | ✅ | ✅ | ✅ (own/member-of) | - |
+| Delete own team | ✅ | ✅ | ✅ (owner) | - |
+| Delete any team | ✅ | ✅ | - | - |
+| Start/stop team runtime | ✅ | ✅ | ✅ (own/member-of) | - |
+| **Admin page** | | | | |
+| View admin dashboard | ✅ | - | - | - |
+| View system config | ✅ | - | - | - |
 
--- New columns
-ALTER TABLE users ADD COLUMN disabled_at TEXT;  -- soft-disable
+**Key rules:**
 
--- Existing auth_sessions stays, but session.user_id must be populated
-```
+- `root` can do everything, everywhere.
+- `maintainer` can manage all agents and teams (create, delete, start, stop) but cannot touch nodes or users.
+- `member` has full access to their own resources. For teams they don't own, they can view and
+  participate in conversations (if invited), but cannot manage membership or delete.
+- `visitor` is strictly read-only. Can view agents they own and teams they're invited to. Cannot
+  create, modify, or delete anything. Cannot send messages.
 
-**API changes for registration:**
+### 3) Resource Ownership
 
-`POST /api/auth/register` already accepts `role` parameter (from `api/auth.rs:106`).
-Currently it defaults to `"device"` when `role` is absent. We add `"member"` as a valid role
-and require `root` authorization to create another `root` user.
-
-### 2) Resource Ownership Model
-
-Every resource has an `owner_user_id`. Additionally, Teams have a `members` list.
-
-**New DB columns:**
+Every Agent and Team has an `owner_user_id`.
 
 ```sql
 ALTER TABLE agents ADD COLUMN owner_user_id TEXT REFERENCES users(id);
@@ -112,190 +119,140 @@ CREATE TABLE team_members (
     user_id TEXT NOT NULL REFERENCES users(id),
     PRIMARY KEY (team_id, user_id)
 );
-CREATE INDEX idx_agents_owner ON agents(owner_user_id);
-CREATE INDEX idx_teams_owner ON teams(owner_user_id);
-CREATE INDEX idx_team_members_user ON team_members(user_id);
 ```
 
-**Ownership rules:**
-
-- The user who creates a resource is its owner.
-- Ownership can be transferred by a `root` user.
-- `root` users implicitly have access to all resources (but are not the owner).
-
-**Team membership rules:**
-
-- A Team has one owner plus zero or more human members.
-- Team members can view and interact with the Team's conversation, runs, and tasks.
-- Only the owner or a `root` user can delete the Team or manage its membership.
-- The Team's agent members (coordinator, workers) are AI agents, not human users. Their
-  authentication is via internal gRPC tokens, not user sessions.
-
-### 3) Permission Matrix
-
-| Action | root | member (owner) | member (team member) | member (unrelated) |
-|--------|------|----------------|----------------------|--------------------|
-| Create agent | ✅ | ✅ | - | ✅ |
-| View own agent | ✅ | ✅ | - | - |
-| View any agent | ✅ | - | - | - |
-| Start/stop own agent | ✅ | ✅ | - | - |
-| Start/stop any agent | ✅ | - | - | - |
-| Delete own agent | ✅ | ✅ | - | - |
-| Delete any agent | ✅ | - | - | - |
-| Create team | ✅ | ✅ | - | ✅ |
-| View own team | ✅ | ✅ | ✅ | - |
-| View any team | ✅ | - | - | - |
-| Manage team membership | ✅ | ✅ | - | - |
-| Delete team | ✅ | ✅ | - | - |
-| Manage nodes | ✅ | - | - | - |
-| Manage users | ✅ | - | - | - |
-| View admin page | ✅ | - | - | - |
-
-**Frontend gating:**
-
-- The `Admin` route is only accessible to `root` users.
-- Team/Agent lists are filtered to show only resources the user can access.
-- Destructive action buttons are hidden (not just disabled) when the user lacks permission.
+**Ownership on create:**
+- `POST /api/agents` → sets `owner_user_id = current user.id`
+- `POST /api/teams` → sets `owner_user_id = current user.id`
 
 ### 4) API Authorization Middleware
 
-All mutable API endpoints must validate permissions server-side.
-
-Existing middleware in `api/authz.rs` already has `require_admin`:
+Existing middleware (`api/authz.rs:27`):
 
 ```rust
-// Existing (api/authz.rs:27)
 pub fn require_admin(user: &UserRecord) -> Result<(), ApiError> {
-    if user.role != "root" {
-        return Err(ApiError::unauthorized("root role required"));
-    }
+    if user.role != "root" { return Err(ApiError::unauthorized("root role required")); }
     Ok(())
 }
 ```
 
-**New middleware to add:**
+**New middleware:**
 
 ```rust
-pub fn require_resource_owner(
-    user: &UserRecord,
-    resource_owner_id: &str,
-) -> Result<(), ApiError> {
-    if user.role == "root" || user.id == resource_owner_id {
+pub fn require_maintainer(user: &UserRecord) -> Result<(), ApiError> {
+    if user.role != "root" && user.role != "maintainer" {
+        return Err(ApiError::unauthorized("maintainer role or above required"));
+    }
+    Ok(())
+}
+
+pub fn require_resource_owner(user: &UserRecord, owner_id: &str) -> Result<(), ApiError> {
+    if user.role == "root" || user.role == "maintainer" || user.id == owner_id {
         Ok(())
     } else {
         Err(ApiError::forbidden("you do not have access to this resource"))
     }
 }
 
-pub fn require_team_access(
-    user: &UserRecord,
-    team_owner_id: &str,
-    team_member_ids: &[String],
-) -> Result<(), ApiError> {
-    if user.role == "root" || user.id == team_owner_id || team_member_ids.contains(&user.id) {
-        Ok(())
-    } else {
-        Err(ApiError::forbidden("you do not have access to this team"))
+pub fn require_not_visitor(user: &UserRecord) -> Result<(), ApiError> {
+    if user.role == "visitor" {
+        return Err(ApiError::forbidden("visitors cannot perform write operations"));
     }
+    Ok(())
 }
 ```
 
-**Changes to existing endpoints:**
+**Endpoint gating:**
 
-| Endpoint | Current | Required |
-|----------|---------|----------|
-| `POST /api/agents` | `require_user` | `require_user` (ownership auto-set) |
-| `GET /api/agents/:id` | `require_user` | Owner or root |
-| `POST /api/agents/:id/input` | `require_user` | Owner or root |
-| `DELETE /api/agents/:id` | `require_user` | Owner or root |
-| `POST /api/agents/:id/start` | `require_user` | Owner or root |
-| `POST /api/agents/:id/stop` | `require_user` | Owner or root |
-| `GET /api/teams/:id` | `require_user` | Owner, member, or root |
-| `DELETE /api/teams/:id` | `require_user` | Owner or root |
-| `POST /api/teams/:id/runtime` | `require_user` | Owner, member, or root |
-| `POST /api/teams/:id/start` | `require_user` | Owner, member, or root |
-| `POST /api/teams/:id/stop` | `require_user` | Owner, member, or root |
-| `POST /api/agent_nodes` | `require_admin` (root) | `require_admin` (unchanged) |
-| `GET /api/admin/*` | `require_user` | `require_admin` (root) |
+| Endpoint | Required role |
+|----------|---------------|
+| `POST /api/agents` | `require_not_visitor` |
+| `GET /api/agents` | filtered by visibility |
+| `GET /api/agents/:id` | `require_resource_owner` (root/maintainer see all) |
+| `POST /api/agents/:id/start` | `require_resource_owner` |
+| `POST /api/agents/:id/stop` | `require_resource_owner` |
+| `DELETE /api/agents/:id` | `require_resource_owner` |
+| `POST /api/teams` | `require_not_visitor` |
+| `GET /api/teams` | filtered by user visibility |
+| `GET /api/teams/:id` | owner/member/root/maintainer |
+| `DELETE /api/teams/:id` | `require_resource_owner` + `require_maintainer` for non-owned |
+| `POST /api/teams/:id/start` | owner/member/root/maintainer |
+| `POST /api/teams/:id/stop` | owner/member/root/maintainer |
+| `POST /api/agent_nodes` | `require_admin` (root only) |
+| `GET /api/admin/*` | `require_admin` (root only) |
+| `POST /api/auth/register` (with role=root) | `require_admin` |
+| `POST /api/auth/register` (with role=maintainer) | `require_admin` |
 
-**Read-only endpoints** (GET list, status, etc.) should also filter to user-visible resources.
+### 5) Visitor-Specific Guards
 
-### 5) Session And Token Security
+- `require_not_visitor` is applied to ALL write endpoints (POST, PUT, DELETE, PATCH).
+- Visitors cannot send Team conversation messages — the message send endpoint gates on
+  `require_not_visitor`.
+- Visitors cannot create agents — gated on agent create endpoint.
+- Visitors cannot start/stop runs — gated on runtime endpoints.
 
-Current state: bearer token in `auth_sessions`. Tokens are validated via `AuthService::validate_session`.
+### 6) Session And Token Security
 
-**Improvements:**
+- Tokens scoped to `user_id` (already tracked via `validate_session`).
+- Logout invalidates session server-side.
+- `GET /api/auth/sessions` → list current user's sessions.
+- `DELETE /api/auth/sessions/:id` → revoke a session.
+- `root` can view/revoke all sessions via admin API.
 
-- Session tokens must be associated with a specific `user_id` (already tracked via `validate_session` → `UserRecord`).
-- On logout, invalidate the session server-side.
-- `GET /api/auth/sessions` returns the current user's active sessions.
-- `DELETE /api/auth/sessions/:id` allows a user to revoke a specific session.
-- `root` can view and revoke any user's sessions via `GET /api/admin/sessions`.
-- Token validation should be constant-time to avoid timing side-channels.
+### 7) Migration Path
 
-### 6) Migration Path
+**Phase 1: Schema + Backfill**
 
-**Phase 1: Schema migration (non-destructive)**
-
-- Add `owner_user_id` to agents and teams tables.
+- Add `owner_user_id` to agents, teams (nullable initially).
 - Add `team_members` table.
-- Add `disabled_at` to users table.
-- Add `member` as valid role in registration endpoint.
-- All existing agents/teams get `owner_user_id = <first root user id>`.
+- Add `disabled_at` to users.
+- Add `maintainer`, `member`, `visitor` as valid role values in registration.
+- Backfill: all existing users keep `root`. All existing agents/teams get `owner_user_id` from
+  first root.
 
 **Phase 2: API Authorization**
 
-- Apply `require_resource_owner` / `require_team_access` to all CRUD endpoints.
-- Apply `require_admin` to admin and node endpoints.
-- Add user-scoped session listing and revocation.
+- Apply role middleware to all endpoints.
+- Filter list endpoints by user visibility.
 
 **Phase 3: Frontend Gating**
 
-- Filter agent/team lists by user visibility.
-- Conditionally render action buttons.
-- Hide admin route from non-root users.
+- Conditional rendering based on role.
+- Admin route for root only.
+- Visitor gets simplified read-only UI.
 
-**Phase 4: User Management**
+**Phase 4: User Management UI**
 
-- Admin user CRUD UI.
-- Profile / session management.
-- Audit log viewer.
+- Admin page: list users, create user, change role.
+- Self-service: profile, session management.
 
-### 7) Audit Logging
+### 8) Audit Logging
 
 | Event | Fields |
 |-------|--------|
 | `user.created` | actor_id, target_user_id, role |
 | `user.role_changed` | actor_id, target_user_id, old_role, new_role |
-| `user.disabled` | actor_id, target_user_id |
+| `user.disabled` / `user.enabled` | actor_id, target_user_id |
 | `resource.deleted` | actor_id, resource_type, resource_id, resource_name |
-| `auth.login` | user_id, method (passkey/password) |
-| `auth.login_failed` | username, method, reason |
-| `auth.session_revoked` | actor_id, target_user_id, session_id |
+| `auth.login` / `auth.login_failed` | user_id, method |
 
-### 8) Security Review Checklist
+### 9) Security Review Checklist
 
-- [ ] All mutable API endpoints have server-side authorization checks.
-- [ ] Read endpoints filter results by user visibility.
-- [ ] Token validation is constant-time.
-- [ ] Session tokens are scoped to `user_id`.
-- [ ] Logout invalidates the session server-side.
-- [ ] Cannot delete the last `root` user.
-- [ ] Cannot change your own role (prevents self-demotion attack).
-- [ ] `owner_user_id` cannot be changed by non-root, non-owner users.
-- [ ] Team member list cannot be modified by non-owner, non-root users.
-- [ ] `device` users cannot login via WebUI.
-- [ ] `member` users cannot create `root` users.
-- [ ] Audit log is append-only from the application layer.
-- [ ] Database migrations are backward-compatible.
+- [ ] All write endpoints have `require_not_visitor`.
+- [ ] Admin endpoints have `require_admin` (root only).
+- [ ] Node management is root-only.
+- [ ] `require_resource_owner` allows root + maintainer bypass.
+- [ ] Visitors cannot send messages or create resources.
+- [ ] Cannot delete last root.
+- [ ] Cannot self-promote or self-demote.
+- [ ] `device` users cannot WebUI login.
+- [ ] Audit log is append-only.
 
 ## Validation Matrix
 
-- Rust unit tests for `require_resource_owner` and `require_team_access` edge cases.
-- Integration tests for each endpoint with different roles.
-- Frontend unit tests for conditional rendering.
-- E2E: root creates member, member logs in, member can only see own resources.
-- E2E: member cannot access admin route.
+- Unit tests for each middleware helper.
+- Integration tests for each endpoint × role combination.
+- E2E: root creates maintainer → maintainer creates member → member creates agent.
+- E2E: visitor cannot create agent, cannot send message.
 - E2E: member cannot delete another user's agent.
-- E2E: device user cannot login via WebUI.
-- Manual: passkey + password login flows with different roles.
+- E2E: maintainer can delete any agent but cannot access admin page.

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -78,8 +78,8 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 | View nodes | ✅ | ✅ | ✅ | - |
 | **Agent operations** | | | | |
 | Create agent | ✅ | ✅ | ✅ | - |
-| View own agents | ✅ | ✅ | ✅ | ✅ |
-| View any agent | ✅ | ✅ | - | - |
+| View own agents (meta + full) | ✅ | ✅ | ✅ | ✅ |
+| View any agent (meta only) | ✅ | ✅ | ✅ | ✅ |
 | Send input to own agent | ✅ | ✅ | ✅ | - |
 | Send input to any agent | ✅ | ✅ | - | - |
 | Start/stop own agent | ✅ | ✅ | ✅ | - |
@@ -108,7 +108,7 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
   agents they created themselves. For teams they don't own, they can view and participate in
   conversations (if invited), but cannot manage membership or delete.
 - `visitor` is strictly read-only. **Cannot create agents. Cannot manage any agents.**
-  Can view agents they own and teams they're invited to. Cannot create, modify, or delete
+  Can view all agent metadata. Cannot send input to any agent. Cannot create, modify, or delete
   anything. Cannot send messages.
 
 ### 3) Resource Ownership
@@ -189,11 +189,13 @@ pub fn require_not_visitor(user: &UserRecord) -> Result<(), ApiError> {
 
 ### 5) Visitor-Specific Guards
 
-- `require_not_visitor` is applied to ALL write endpoints (POST, PUT, DELETE, PATCH).
-- Visitors cannot send Team conversation messages — the message send endpoint gates on
-  `require_not_visitor`.
-- Visitors cannot create agents — gated on agent create endpoint.
-- Visitors cannot start/stop runs — gated on runtime endpoints.
+- `GET` endpoints for agents/teams return metadata for all resources to visitors (no filtering by
+  ownership). Visitors can browse and discover what's running.
+- `require_not_visitor` middleware is applied to ALL write endpoints (POST, PUT, DELETE, PATCH).
+- Visitors cannot send Team conversation messages.
+- Visitors cannot create agents.
+- Visitors cannot start/stop runs.
+- Visitors cannot send input to any agent (even ones they own).
 
 ### 6) Session And Token Security
 

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -1,0 +1,318 @@
+# RBAC Multi-User Specification
+
+## Problem
+
+AgentHub currently treats all authenticated users as equivalent. The `role` field on users is a
+flat string (`root` or absent) that only gates two operations: agent node management and agent
+creation on a specific node. Every authenticated user can see, modify, start, stop, and delete any
+agent or team in the system.
+
+This is not tenable beyond single-user homelab use:
+
+- there is no way to grant a teammate access to only their team without also exposing all other
+  teams and agents;
+- there is no way to prevent accidental (or malicious) deletion of another user's agents;
+- the only authorization boundary is "logged in or not";
+- Team members have per-Team roles (`coordinator`, `worker`) but those are runtime semantic labels,
+  not access-control roles.
+
+We need a proper role-based access control model that supports multiple human users sharing one
+AgentHub instance, without introducing multi-tenancy (tenant isolation, separate DBs, org
+hierarchies). This is a **single-instance, multi-user** model.
+
+## Scope
+
+- User identity and authentication hardening.
+- Role definitions and permission model.
+- Per-resource (Agent, Team, Node) ownership and access control.
+- API authorization middleware gating all mutable endpoints.
+- Frontend UI gating for role-restricted actions.
+- Default migration path from the current flat model.
+- Audit logging for role changes and destructive actions.
+
+## Non-Goals
+
+- Multi-tenancy: no workspace/org isolation, no tenant-scoped data partitioning, no per-tenant
+  billing.
+- Fine-grained attribute-based access control (ABAC).
+- OIDC / OAuth2 / external identity provider integration (this is a future add-on, not v1).
+- Row-level security inside Agent workspaces (file permissions are out of scope).
+- Replacing Team member roles (`coordinator`, `worker`) with RBAC roles — those remain runtime
+  semantic roles.
+
+## Threat Model
+
+The primary threats this spec addresses:
+
+| Threat | Mitigation |
+|--------|------------|
+| Authenticated user deletes another user's agent | Resource-level ownership + RBAC |
+| Authenticated user starts/stops another user's agent | Same |
+| Authenticated user reads another user's Team conversation | Team access control |
+| Authenticated user joins a node that hosts other users' agents | Node-level admin gate |
+| Privilege escalation via API without frontend | Server-side enforcement, not UI-only |
+| Token reuse / session hijacking | Token scoping to user, session revocation |
+
+## Architecture
+
+### 1) User Model
+
+Users are the human actors. Each user has exactly one role.
+
+```
+User {
+  id: UUID,
+  username: String (unique),
+  display_name: String,
+  role: "admin" | "member",
+  password_hash: Option<String>,
+  passkey_credential_id: Option<String>,
+  created_at: Timestamp,
+  updated_at: Timestamp,
+  disabled_at: Option<Timestamp>,
+}
+```
+
+**Roles:**
+
+| Role | Description |
+|------|-------------|
+| `admin` | Full access. Create/delete users, manage nodes, all agents and teams. Equivalent to current `root`. |
+| `member` | Access only to resources they own or are a member of. Cannot manage nodes or users. |
+
+**Constraints:**
+
+- The **first user** created (bootstrap) is always `admin`.
+- There must always be at least one `admin` user. Deleting the last admin is rejected.
+- `disabled_at` is a soft-delete: the user cannot authenticate, but their resource ownership
+  records are preserved.
+- Username is the human-facing identifier, independent of the UUID primary key.
+
+### 2) Resource Ownership Model
+
+Every resource has an `owner_user_id`. Additionally, Teams have a `members` list.
+
+```
+Agent {
+  ...
+  owner_user_id: UUID (FK → users.id),
+}
+
+Team {
+  ...
+  owner_user_id: UUID (FK → users.id),
+}
+
+TeamMember {
+  team_id: UUID,
+  user_id: UUID,
+}
+```
+
+**Ownership rules:**
+
+- The user who creates a resource is its owner.
+- Ownership can be transferred by an admin or the current owner.
+- `admin` users implicitly have access to all resources (but do not become the owner).
+
+**Team membership rules:**
+
+- A Team has one owner plus zero or more members.
+- Team members can view and interact with the Team's conversation, runs, and tasks.
+- Only the owner or an admin can delete the Team or manage its membership.
+- The Team's agent members (coordinator, workers) are AI agents, not human users. Their
+  authentication is via internal gRPC tokens, not user sessions.
+
+### 3) Permission Matrix
+
+| Action | admin | member (owner) | member (team member) | member (unrelated) |
+|--------|-------|----------------|----------------------|--------------------|
+| Create agent | ✅ | ✅ | - | ✅ |
+| View own agent | ✅ | ✅ | - | - |
+| View any agent | ✅ | - | - | - |
+| Start/stop own agent | ✅ | ✅ | - | - |
+| Start/stop any agent | ✅ | - | - | - |
+| Delete own agent | ✅ | ✅ | - | - |
+| Delete any agent | ✅ | - | - | - |
+| Create team | ✅ | ✅ | - | ✅ |
+| View own team | ✅ | ✅ | ✅ | - |
+| View any team | ✅ | - | - | - |
+| Manage team membership | ✅ | ✅ | - | - |
+| Delete team | ✅ | ✅ | - | - |
+| Manage nodes | ✅ | - | - | - |
+| Manage users | ✅ | - | - | - |
+| View admin page | ✅ | - | - | - |
+
+**Frontend gating:**
+
+- The `Admin` route is only accessible to `admin` users.
+- Team/Agent lists are filtered to show only resources the user can access.
+- Destructive action buttons are hidden (not just disabled) when the user lacks permission.
+
+### 4) API Authorization Middleware
+
+All mutable API endpoints must validate permissions server-side.
+
+**Pattern:**
+
+```
+fn require_resource_owner(
+    user: &UserRecord,
+    resource_owner_id: &str,
+) -> Result<(), ApiError> {
+    if user.role == "admin" || user.id == resource_owner_id {
+        Ok(())
+    } else {
+        Err(ApiError::forbidden("you do not have access to this resource"))
+    }
+}
+```
+
+**Changes to existing endpoints:**
+
+| Endpoint | Current | Required |
+|----------|---------|----------|
+| `POST /api/agents` | Any authenticated | Any authenticated (ownership auto-set) |
+| `GET /api/agents/:id` | Any | Owner or admin |
+| `POST /api/agents/:id/input` | Any | Owner or admin |
+| `DELETE /api/agents/:id` | Any | Owner or admin |
+| `POST /api/agents/:id/start` | Any | Owner or admin |
+| `POST /api/agents/:id/stop` | Any | Owner or admin |
+| `GET /api/teams/:id` | Any | Owner, member, or admin |
+| `DELETE /api/teams/:id` | Any | Owner or admin |
+| `POST /api/teams/:id/runtime` | Any | Owner, member, or admin |
+| `POST /api/teams/:id/start` | Any | Owner, member, or admin |
+| `POST /api/teams/:id/stop` | Any | Owner, member, or admin |
+| `POST /api/agent_nodes` | `root` only | `admin` only |
+| `GET /api/admin/*` | Any | `admin` only |
+
+**Read-only endpoints** (GET list, status, etc.) should also filter to user-visible resources
+rather than returning all resources to every authenticated user.
+
+### 5) Session And Token Security
+
+Current state: a single bearer token per session, stored in `auth_sessions`. Tokens are not scoped
+to a user — the user is looked up from the token at validation time.
+
+**Improvements:**
+
+- Session tokens must be associated with a specific `user_id`.
+- On login, issue a new session token. On logout, invalidate it.
+- `GET /api/auth/sessions` returns the current user's active sessions.
+- `DELETE /api/auth/sessions/:id` allows a user to revoke a specific session.
+- Admin can view and revoke any user's sessions via `GET /api/admin/sessions`.
+- Token validation should be constant-time to avoid timing side-channels.
+- CSRF: existing token-in-header pattern is sufficient for an SPA; no cookies needed.
+
+### 6) Migration Path
+
+The current DB has users with optional `role` and no resource ownership.
+
+**Phase 1: Schema migration (non-destructive)**
+
+```sql
+ALTER TABLE users ADD COLUMN disabled_at TEXT;
+ALTER TABLE agents ADD COLUMN owner_user_id TEXT;
+ALTER TABLE teams ADD COLUMN owner_user_id TEXT;
+CREATE TABLE team_members (
+    team_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    PRIMARY KEY (team_id, user_id)
+);
+CREATE INDEX idx_agents_owner ON agents(owner_user_id);
+CREATE INDEX idx_teams_owner ON teams(owner_user_id);
+CREATE INDEX idx_team_members_user ON team_members(user_id);
+```
+
+**Phase 2: Data backfill**
+
+- All existing users with `role = 'root'` get `role = 'admin'`.
+- All other existing users get `role = 'member'`.
+- All existing agents and teams get `owner_user_id = <first admin user id>`.
+- The first admin user is added as a member of all existing teams.
+
+**Phase 3: Enforce RBAC at API boundary**
+
+- Activate authorization middleware on all mutable endpoints.
+- Frontend gates activate.
+
+**Phase 4: Add user management UI**
+
+- Admin page: list users, create user, disable user, change role.
+- Profile page: change display name, view sessions, revoke sessions.
+
+### 7) Audit Logging
+
+| Event | Fields |
+|-------|--------|
+| `user.created` | actor_id, target_user_id, role |
+| `user.role_changed` | actor_id, target_user_id, old_role, new_role |
+| `user.disabled` | actor_id, target_user_id |
+| `user.enabled` | actor_id, target_user_id |
+| `resource.deleted` | actor_id, resource_type, resource_id, resource_name |
+| `auth.login` | user_id, method (passkey/password) |
+| `auth.login_failed` | username, method, reason |
+| `auth.session_revoked` | actor_id, target_user_id, session_id |
+
+Audit events are stored in SQLite and exposed to admin users via the admin page.
+
+### 8) Frontend Changes
+
+- `AuthState` type gains `user_id`, `username`, and `role` fields.
+- All list views (agents, teams) filter server-side by user visibility.
+- The `Admin` route checks `role === "admin"` before mounting.
+- Delete/start/stop buttons are conditionally rendered.
+- New "Users" tab on the Admin page for user management.
+- Profile dropdown shows current user info and logout option.
+- Error messages for 403 responses should be user-friendly ("You don't have access to this team").
+
+### 9) Security Review Checklist
+
+- [ ] All mutable API endpoints have server-side authorization checks.
+- [ ] Read endpoints filter results by user visibility.
+- [ ] Token validation is constant-time.
+- [ ] Session tokens are scoped to `user_id`.
+- [ ] Logout invalidates the session server-side.
+- [ ] Cannot delete the last admin user.
+- [ ] Cannot change your own role (prevents self-demotion attack).
+- [ ] `owner_user_id` cannot be changed by non-admin, non-owner users.
+- [ ] Team member list cannot be modified by non-owner, non-admin users.
+- [ ] Audit log is append-only from the application layer.
+- [ ] Database migrations are backward-compatible.
+
+## Rollout Phases
+
+### Phase 1: Schema + Backfill (this PR)
+
+- DB migration to add `owner_user_id`, `team_members`, `disabled_at`.
+- Backfill script assigns existing resources to admin.
+- No authorization enforcement yet — purely additive.
+
+### Phase 2: API Authorization
+
+- Add `require_resource_owner` and `require_admin` middleware helpers.
+- Apply to all CRUD endpoints for agents and teams.
+- Apply to node management endpoints.
+- Add user-scoped session tokens.
+
+### Phase 3: Frontend Gating
+
+- Filter agent/team lists server-side by visibility.
+- Conditionally render action buttons.
+- Gate admin route.
+
+### Phase 4: User Management
+
+- Admin user CRUD UI.
+- Profile / session management.
+- Audit log viewer.
+
+## Validation Matrix
+
+- Rust unit tests for `require_resource_owner` edge cases.
+- Integration tests for each endpoint with different roles.
+- Frontend unit tests for conditional rendering.
+- E2E: admin creates user, user logs in, user can only see own resources.
+- E2E: member cannot access admin route.
+- E2E: owner cannot delete another user's agent.
+- Manual: passkey + password login flows with different roles.

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -80,6 +80,8 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 | Create agent | ✅ | ✅ | ✅ | - |
 | View own agents | ✅ | ✅ | ✅ | ✅ |
 | View any agent | ✅ | ✅ | - | - |
+| Send input to own agent | ✅ | ✅ | ✅ | - |
+| Send input to any agent | ✅ | ✅ | - | - |
 | Start/stop own agent | ✅ | ✅ | ✅ | - |
 | Start/stop any agent | ✅ | ✅ | - | - |
 | Delete own agent | ✅ | ✅ | ✅ | - |
@@ -102,10 +104,12 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 
 - `root` can do everything, everywhere.
 - `maintainer` can manage all agents and teams (create, delete, start, stop) but cannot touch nodes or users.
-- `member` has full access to their own resources. For teams they don't own, they can view and
-  participate in conversations (if invited), but cannot manage membership or delete.
-- `visitor` is strictly read-only. Can view agents they own and teams they're invited to. Cannot
-  create, modify, or delete anything. Cannot send messages.
+- `member` can create agents and teams. Can only manage (start, stop, delete, send input to)
+  agents they created themselves. For teams they don't own, they can view and participate in
+  conversations (if invited), but cannot manage membership or delete.
+- `visitor` is strictly read-only. **Cannot create agents. Cannot manage any agents.**
+  Can view agents they own and teams they're invited to. Cannot create, modify, or delete
+  anything. Cannot send messages.
 
 ### 3) Resource Ownership
 

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -53,8 +53,8 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 |------|------|-------------|
 | `root` | 管理员 | Superuser. Full access. Manage nodes, users, all resources. Create/delete other roots. |
 | `maintainer` | 维护员 | Team/resource manager. Create/manage agents and teams. Manage team membership. Cannot manage nodes or users. |
-| `member` | 员工 | Regular user. Create agents and teams. Full access to own resources. Read-only access to teams they are invited to. |
-| `visitor` | 访客 | Read-only user. Cannot create resources. Can only view teams they're explicitly invited to. |
+| `member` | 员工 | Regular user. Create agents and teams. Full access to own agents. Can chat in invited teams. Cannot manage other users' agents. |
+| `visitor` | 访客 | Read-only user. Cannot create resources. Can browse all agent metadata. Cannot send messages or interact with agents. |
 | `device` | 节点 | System role for `agenthub join`. No WebUI login. Unchanged from current behavior. |
 
 **Constraints:**

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -53,7 +53,7 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 |------|------|-------------|
 | `root` | 管理员 | Superuser. Full access. Manage nodes, users, all resources. Create/delete other roots. |
 | `maintainer` | 维护员 | Team/resource manager. Create/manage agents and teams. Manage team membership. Cannot manage nodes or users. |
-| `member` | 员工 | Regular user. Create agents and teams. Full access to own agents. Can chat in invited teams. Cannot manage other users' agents. |
+| `member` | 员工 | Regular user. Create agents and teams. Can deeply interact (send input, view full details) only with agents they created. Can chat in invited teams. Can view metadata of all agents. |
 | `visitor` | 访客 | Read-only user. Cannot create resources. Can browse all agent metadata. Cannot send messages or interact with agents. |
 | `device` | 节点 | System role for `agenthub join`. No WebUI login. Unchanged from current behavior. |
 
@@ -104,9 +104,9 @@ Roles are hierarchical: a higher role includes all permissions of lower roles.
 
 - `root` can do everything, everywhere.
 - `maintainer` can manage all agents and teams (create, delete, start, stop) but cannot touch nodes or users.
-- `member` can create agents and teams. Can only manage (start, stop, delete, send input to)
-  agents they created themselves. For teams they don't own, they can view and participate in
-  conversations (if invited), but cannot manage membership or delete.
+- `member` can create agents and teams. Can only deeply interact (send input, start/stop, delete)
+  with agents they created themselves. Can view metadata of all agents. Can chat in invited teams.
+  Cannot manage other users' agents in any way.
 - `visitor` is strictly read-only. **Cannot create agents. Cannot manage any agents.**
   Can view all agent metadata. Cannot send input to any agent. Cannot create, modify, or delete
   anything. Cannot send messages.
@@ -172,7 +172,8 @@ pub fn require_not_visitor(user: &UserRecord) -> Result<(), ApiError> {
 |----------|---------------|
 | `POST /api/agents` | `require_not_visitor` |
 | `GET /api/agents` | filtered by visibility |
-| `GET /api/agents/:id` | `require_resource_owner` (root/maintainer see all) |
+| `GET /api/agents/:id` | metadata always returned; full detail (ACP, terminal, history) only for owner / root / maintainer |
+| `POST /api/agents/:id/input` | owner / root / maintainer only (member cannot send input to others' agents) |
 | `POST /api/agents/:id/start` | `require_resource_owner` |
 | `POST /api/agents/:id/stop` | `require_resource_owner` |
 | `DELETE /api/agents/:id` | `require_resource_owner` |

--- a/docs/features/rbac-multi-user.md
+++ b/docs/features/rbac-multi-user.md
@@ -2,10 +2,9 @@
 
 ## Problem
 
-AgentHub currently treats all authenticated users as equivalent. The `role` field on users is a
-flat string (`root` or absent) that only gates two operations: agent node management and agent
-creation on a specific node. Every authenticated user can see, modify, start, stop, and delete any
-agent or team in the system.
+AgentHub currently has a minimal role system: `root` for the superuser and `device` for node
+join. There is no `member` role for regular human users beyond the first admin. Every
+authenticated user can see, modify, start, stop, and delete any agent or team in the system.
 
 This is not tenable beyond single-user homelab use:
 
@@ -23,11 +22,11 @@ hierarchies). This is a **single-instance, multi-user** model.
 ## Scope
 
 - User identity and authentication hardening.
-- Role definitions and permission model.
+- New `member` role for regular human users (alongside existing `root` and `device`).
 - Per-resource (Agent, Team, Node) ownership and access control.
 - API authorization middleware gating all mutable endpoints.
 - Frontend UI gating for role-restricted actions.
-- Default migration path from the current flat model.
+- Default migration path from the current model.
 - Audit logging for role changes and destructive actions.
 
 ## Non-Goals
@@ -39,6 +38,7 @@ hierarchies). This is a **single-instance, multi-user** model.
 - Row-level security inside Agent workspaces (file permissions are out of scope).
 - Replacing Team member roles (`coordinator`, `worker`) with RBAC roles — those remain runtime
   semantic roles.
+- Changing `root` or `device` role semantics — these are existing and remain stable.
 
 ## Threat Model
 
@@ -46,10 +46,10 @@ The primary threats this spec addresses:
 
 | Threat | Mitigation |
 |--------|------------|
-| Authenticated user deletes another user's agent | Resource-level ownership + RBAC |
+| Authenticated user deletes another user's agent | Resource-level ownership + role check |
 | Authenticated user starts/stops another user's agent | Same |
 | Authenticated user reads another user's Team conversation | Team access control |
-| Authenticated user joins a node that hosts other users' agents | Node-level admin gate |
+| Authenticated user joins a node that hosts other users' agents | Node-level `root` gate |
 | Privilege escalation via API without frontend | Server-side enforcement, not UI-only |
 | Token reuse / session hijacking | Token scoping to user, session revocation |
 
@@ -57,76 +57,84 @@ The primary threats this spec addresses:
 
 ### 1) User Model
 
-Users are the human actors. Each user has exactly one role.
+Users are the human actors (plus Node devices). Each user has exactly one role.
 
-```
-User {
-  id: UUID,
-  username: String (unique),
-  display_name: String,
-  role: "admin" | "member",
-  password_hash: Option<String>,
-  passkey_credential_id: Option<String>,
-  created_at: Timestamp,
-  updated_at: Timestamp,
-  disabled_at: Option<Timestamp>,
-}
-```
+**Existing roles (unchanged):**
 
-**Roles:**
+| Role | Description | Added in |
+|------|-------------|----------|
+| `root` | Superuser. Full access to all resources. Create/manage nodes, agents, teams, and users. | Existing (`auth/mod.rs`) |
+| `device` | Node registration identity. Used by `agenthub join`. Cannot login via WebUI. | Existing (`api/join.rs`) |
+
+**New role (this spec):**
 
 | Role | Description |
 |------|-------------|
-| `admin` | Full access. Create/delete users, manage nodes, all agents and teams. Equivalent to current `root`. |
-| `member` | Access only to resources they own or are a member of. Cannot manage nodes or users. |
+| `member` | Regular human user. Access only to resources they own or are Team members of. |
 
 **Constraints:**
 
-- The **first user** created (bootstrap) is always `admin`.
-- There must always be at least one `admin` user. Deleting the last admin is rejected.
-- `disabled_at` is a soft-delete: the user cannot authenticate, but their resource ownership
-  records are preserved.
-- Username is the human-facing identifier, independent of the UUID primary key.
+- The bootstrap user (first user created) is always `root`.
+- There must always be at least one `root` user. Deleting the last root is rejected.
+- `device` users cannot authenticate via the WebUI (no passkey/password login flow).
+- `member` users cannot register passkeys or use the WebUI login if passkey is enabled and they
+  have no credential — they must be created by a `root` user.
+
+**DB schema (additive changes):**
+
+```sql
+-- Existing table (unchanged columns)
+-- CREATE TABLE users (id, username, display_name, role, password_hash, created_at);
+
+-- New columns
+ALTER TABLE users ADD COLUMN disabled_at TEXT;  -- soft-disable
+
+-- Existing auth_sessions stays, but session.user_id must be populated
+```
+
+**API changes for registration:**
+
+`POST /api/auth/register` already accepts `role` parameter (from `api/auth.rs:106`).
+Currently it defaults to `"device"` when `role` is absent. We add `"member"` as a valid role
+and require `root` authorization to create another `root` user.
 
 ### 2) Resource Ownership Model
 
 Every resource has an `owner_user_id`. Additionally, Teams have a `members` list.
 
-```
-Agent {
-  ...
-  owner_user_id: UUID (FK → users.id),
-}
+**New DB columns:**
 
-Team {
-  ...
-  owner_user_id: UUID (FK → users.id),
-}
-
-TeamMember {
-  team_id: UUID,
-  user_id: UUID,
-}
+```sql
+ALTER TABLE agents ADD COLUMN owner_user_id TEXT REFERENCES users(id);
+ALTER TABLE teams ADD COLUMN owner_user_id TEXT REFERENCES users(id);
+CREATE TABLE team_members (
+    team_id TEXT NOT NULL REFERENCES teams(id),
+    user_id TEXT NOT NULL REFERENCES users(id),
+    PRIMARY KEY (team_id, user_id)
+);
+CREATE INDEX idx_agents_owner ON agents(owner_user_id);
+CREATE INDEX idx_teams_owner ON teams(owner_user_id);
+CREATE INDEX idx_team_members_user ON team_members(user_id);
 ```
 
 **Ownership rules:**
 
 - The user who creates a resource is its owner.
-- Ownership can be transferred by an admin or the current owner.
-- `admin` users implicitly have access to all resources (but do not become the owner).
+- Ownership can be transferred by a `root` user.
+- `root` users implicitly have access to all resources (but are not the owner).
 
 **Team membership rules:**
 
-- A Team has one owner plus zero or more members.
+- A Team has one owner plus zero or more human members.
 - Team members can view and interact with the Team's conversation, runs, and tasks.
-- Only the owner or an admin can delete the Team or manage its membership.
+- Only the owner or a `root` user can delete the Team or manage its membership.
 - The Team's agent members (coordinator, workers) are AI agents, not human users. Their
   authentication is via internal gRPC tokens, not user sessions.
 
 ### 3) Permission Matrix
 
-| Action | admin | member (owner) | member (team member) | member (unrelated) |
-|--------|-------|----------------|----------------------|--------------------|
+| Action | root | member (owner) | member (team member) | member (unrelated) |
+|--------|------|----------------|----------------------|--------------------|
 | Create agent | ✅ | ✅ | - | ✅ |
 | View own agent | ✅ | ✅ | - | - |
 | View any agent | ✅ | - | - | - |
@@ -145,7 +153,7 @@ TeamMember {
 
 **Frontend gating:**
 
-- The `Admin` route is only accessible to `admin` users.
+- The `Admin` route is only accessible to `root` users.
 - Team/Agent lists are filtered to show only resources the user can access.
 - Destructive action buttons are hidden (not just disabled) when the user lacks permission.
 
@@ -153,17 +161,41 @@ TeamMember {
 
 All mutable API endpoints must validate permissions server-side.
 
-**Pattern:**
+Existing middleware in `api/authz.rs` already has `require_admin`:
 
+```rust
+// Existing (api/authz.rs:27)
+pub fn require_admin(user: &UserRecord) -> Result<(), ApiError> {
+    if user.role != "root" {
+        return Err(ApiError::unauthorized("root role required"));
+    }
+    Ok(())
+}
 ```
-fn require_resource_owner(
+
+**New middleware to add:**
+
+```rust
+pub fn require_resource_owner(
     user: &UserRecord,
     resource_owner_id: &str,
 ) -> Result<(), ApiError> {
-    if user.role == "admin" || user.id == resource_owner_id {
+    if user.role == "root" || user.id == resource_owner_id {
         Ok(())
     } else {
         Err(ApiError::forbidden("you do not have access to this resource"))
+    }
+}
+
+pub fn require_team_access(
+    user: &UserRecord,
+    team_owner_id: &str,
+    team_member_ids: &[String],
+) -> Result<(), ApiError> {
+    if user.role == "root" || user.id == team_owner_id || team_member_ids.contains(&user.id) {
+        Ok(())
+    } else {
+        Err(ApiError::forbidden("you do not have access to this team"))
     }
 }
 ```
@@ -172,74 +204,62 @@ fn require_resource_owner(
 
 | Endpoint | Current | Required |
 |----------|---------|----------|
-| `POST /api/agents` | Any authenticated | Any authenticated (ownership auto-set) |
-| `GET /api/agents/:id` | Any | Owner or admin |
-| `POST /api/agents/:id/input` | Any | Owner or admin |
-| `DELETE /api/agents/:id` | Any | Owner or admin |
-| `POST /api/agents/:id/start` | Any | Owner or admin |
-| `POST /api/agents/:id/stop` | Any | Owner or admin |
-| `GET /api/teams/:id` | Any | Owner, member, or admin |
-| `DELETE /api/teams/:id` | Any | Owner or admin |
-| `POST /api/teams/:id/runtime` | Any | Owner, member, or admin |
-| `POST /api/teams/:id/start` | Any | Owner, member, or admin |
-| `POST /api/teams/:id/stop` | Any | Owner, member, or admin |
-| `POST /api/agent_nodes` | `root` only | `admin` only |
-| `GET /api/admin/*` | Any | `admin` only |
+| `POST /api/agents` | `require_user` | `require_user` (ownership auto-set) |
+| `GET /api/agents/:id` | `require_user` | Owner or root |
+| `POST /api/agents/:id/input` | `require_user` | Owner or root |
+| `DELETE /api/agents/:id` | `require_user` | Owner or root |
+| `POST /api/agents/:id/start` | `require_user` | Owner or root |
+| `POST /api/agents/:id/stop` | `require_user` | Owner or root |
+| `GET /api/teams/:id` | `require_user` | Owner, member, or root |
+| `DELETE /api/teams/:id` | `require_user` | Owner or root |
+| `POST /api/teams/:id/runtime` | `require_user` | Owner, member, or root |
+| `POST /api/teams/:id/start` | `require_user` | Owner, member, or root |
+| `POST /api/teams/:id/stop` | `require_user` | Owner, member, or root |
+| `POST /api/agent_nodes` | `require_admin` (root) | `require_admin` (unchanged) |
+| `GET /api/admin/*` | `require_user` | `require_admin` (root) |
 
-**Read-only endpoints** (GET list, status, etc.) should also filter to user-visible resources
-rather than returning all resources to every authenticated user.
+**Read-only endpoints** (GET list, status, etc.) should also filter to user-visible resources.
 
 ### 5) Session And Token Security
 
-Current state: a single bearer token per session, stored in `auth_sessions`. Tokens are not scoped
-to a user — the user is looked up from the token at validation time.
+Current state: bearer token in `auth_sessions`. Tokens are validated via `AuthService::validate_session`.
 
 **Improvements:**
 
-- Session tokens must be associated with a specific `user_id`.
-- On login, issue a new session token. On logout, invalidate it.
+- Session tokens must be associated with a specific `user_id` (already tracked via `validate_session` → `UserRecord`).
+- On logout, invalidate the session server-side.
 - `GET /api/auth/sessions` returns the current user's active sessions.
 - `DELETE /api/auth/sessions/:id` allows a user to revoke a specific session.
-- Admin can view and revoke any user's sessions via `GET /api/admin/sessions`.
+- `root` can view and revoke any user's sessions via `GET /api/admin/sessions`.
 - Token validation should be constant-time to avoid timing side-channels.
-- CSRF: existing token-in-header pattern is sufficient for an SPA; no cookies needed.
 
 ### 6) Migration Path
 
-The current DB has users with optional `role` and no resource ownership.
-
 **Phase 1: Schema migration (non-destructive)**
 
-```sql
-ALTER TABLE users ADD COLUMN disabled_at TEXT;
-ALTER TABLE agents ADD COLUMN owner_user_id TEXT;
-ALTER TABLE teams ADD COLUMN owner_user_id TEXT;
-CREATE TABLE team_members (
-    team_id TEXT NOT NULL,
-    user_id TEXT NOT NULL,
-    PRIMARY KEY (team_id, user_id)
-);
-CREATE INDEX idx_agents_owner ON agents(owner_user_id);
-CREATE INDEX idx_teams_owner ON teams(owner_user_id);
-CREATE INDEX idx_team_members_user ON team_members(user_id);
-```
+- Add `owner_user_id` to agents and teams tables.
+- Add `team_members` table.
+- Add `disabled_at` to users table.
+- Add `member` as valid role in registration endpoint.
+- All existing agents/teams get `owner_user_id = <first root user id>`.
 
-**Phase 2: Data backfill**
+**Phase 2: API Authorization**
 
-- All existing users with `role = 'root'` get `role = 'admin'`.
-- All other existing users get `role = 'member'`.
-- All existing agents and teams get `owner_user_id = <first admin user id>`.
-- The first admin user is added as a member of all existing teams.
+- Apply `require_resource_owner` / `require_team_access` to all CRUD endpoints.
+- Apply `require_admin` to admin and node endpoints.
+- Add user-scoped session listing and revocation.
 
-**Phase 3: Enforce RBAC at API boundary**
+**Phase 3: Frontend Gating**
 
-- Activate authorization middleware on all mutable endpoints.
-- Frontend gates activate.
+- Filter agent/team lists by user visibility.
+- Conditionally render action buttons.
+- Hide admin route from non-root users.
 
-**Phase 4: Add user management UI**
+**Phase 4: User Management**
 
-- Admin page: list users, create user, disable user, change role.
-- Profile page: change display name, view sessions, revoke sessions.
+- Admin user CRUD UI.
+- Profile / session management.
+- Audit log viewer.
 
 ### 7) Audit Logging
 
@@ -248,71 +268,34 @@ CREATE INDEX idx_team_members_user ON team_members(user_id);
 | `user.created` | actor_id, target_user_id, role |
 | `user.role_changed` | actor_id, target_user_id, old_role, new_role |
 | `user.disabled` | actor_id, target_user_id |
-| `user.enabled` | actor_id, target_user_id |
 | `resource.deleted` | actor_id, resource_type, resource_id, resource_name |
 | `auth.login` | user_id, method (passkey/password) |
 | `auth.login_failed` | username, method, reason |
 | `auth.session_revoked` | actor_id, target_user_id, session_id |
 
-Audit events are stored in SQLite and exposed to admin users via the admin page.
-
-### 8) Frontend Changes
-
-- `AuthState` type gains `user_id`, `username`, and `role` fields.
-- All list views (agents, teams) filter server-side by user visibility.
-- The `Admin` route checks `role === "admin"` before mounting.
-- Delete/start/stop buttons are conditionally rendered.
-- New "Users" tab on the Admin page for user management.
-- Profile dropdown shows current user info and logout option.
-- Error messages for 403 responses should be user-friendly ("You don't have access to this team").
-
-### 9) Security Review Checklist
+### 8) Security Review Checklist
 
 - [ ] All mutable API endpoints have server-side authorization checks.
 - [ ] Read endpoints filter results by user visibility.
 - [ ] Token validation is constant-time.
 - [ ] Session tokens are scoped to `user_id`.
 - [ ] Logout invalidates the session server-side.
-- [ ] Cannot delete the last admin user.
+- [ ] Cannot delete the last `root` user.
 - [ ] Cannot change your own role (prevents self-demotion attack).
-- [ ] `owner_user_id` cannot be changed by non-admin, non-owner users.
-- [ ] Team member list cannot be modified by non-owner, non-admin users.
+- [ ] `owner_user_id` cannot be changed by non-root, non-owner users.
+- [ ] Team member list cannot be modified by non-owner, non-root users.
+- [ ] `device` users cannot login via WebUI.
+- [ ] `member` users cannot create `root` users.
 - [ ] Audit log is append-only from the application layer.
 - [ ] Database migrations are backward-compatible.
 
-## Rollout Phases
-
-### Phase 1: Schema + Backfill (this PR)
-
-- DB migration to add `owner_user_id`, `team_members`, `disabled_at`.
-- Backfill script assigns existing resources to admin.
-- No authorization enforcement yet — purely additive.
-
-### Phase 2: API Authorization
-
-- Add `require_resource_owner` and `require_admin` middleware helpers.
-- Apply to all CRUD endpoints for agents and teams.
-- Apply to node management endpoints.
-- Add user-scoped session tokens.
-
-### Phase 3: Frontend Gating
-
-- Filter agent/team lists server-side by visibility.
-- Conditionally render action buttons.
-- Gate admin route.
-
-### Phase 4: User Management
-
-- Admin user CRUD UI.
-- Profile / session management.
-- Audit log viewer.
-
 ## Validation Matrix
 
-- Rust unit tests for `require_resource_owner` edge cases.
+- Rust unit tests for `require_resource_owner` and `require_team_access` edge cases.
 - Integration tests for each endpoint with different roles.
 - Frontend unit tests for conditional rendering.
-- E2E: admin creates user, user logs in, user can only see own resources.
+- E2E: root creates member, member logs in, member can only see own resources.
 - E2E: member cannot access admin route.
-- E2E: owner cannot delete another user's agent.
+- E2E: member cannot delete another user's agent.
+- E2E: device user cannot login via WebUI.
 - Manual: passkey + password login flows with different roles.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive specification for Role-Based Access Control with multi-user support.

## Role hierarchy (4 human tiers + 1 system)

```
root (管理员) → maintainer (维护员) → member (员工) → visitor (访客)
                                                      + device (节点)
```

| Role | Chinese | Summary |
|------|---------|---------|
| `root` | 管理员 | Full access. Manage nodes, users, all resources. |
| `maintainer` | 维护员 | Manage all agents/teams. Cannot manage nodes/users. |
| `member` | 员工 | Create agents. Can only deeply interact with own agents. View meta of all. Chat in invited teams. |
| `visitor` | 访客 | Read-only. Browse all agent meta. Cannot create, manage, or interact. |
| `device` | 节点 | System role for node registration. No WebUI login. Unchanged. |

## Agent permissions at a glance

| | root | maintainer | member | visitor |
|--|------|------------|--------|---------|
| Create agent | ✅ | ✅ | ✅ | ❌ |
| View all agent meta | ✅ | ✅ | ✅ | ✅ |
| Deep interact with own agent | ✅ | ✅ | ✅ | ❌ |
| Deep interact with others | ✅ | ✅ | ❌ | ❌ |

## Threat model covered

- Unauthorized agent deletion / start / stop
- Unauthorized Team access
- Privilege escalation via API
- Session hijacking / reuse
- Visitor write protection

## Migration

Four-phase: schema + backfill → API authorization → frontend gates → user management UI

## File

- `docs/features/rbac-multi-user.md`