### PR TITLE
test(team): centralize channel sidebar selectors

### DIFF
--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -7,6 +7,17 @@ import {
   teamChannelSidebarEntry,
 } from "./team_page_helpers";
 
+test("team channel sidebar helper does not select prefixed channel ids", async ({ page }) => {
+  await page.setContent(`
+    <aside class="teams-sidebar">
+      <button type="button"># all-archive archived lane</button>
+      <button type="button"># all default lane</button>
+    </aside>
+  `);
+
+  await expect(teamChannelSidebarEntry(page, "all")).toHaveText("# all default lane");
+});
+
 test("team channels shows #all by default in sidebar", async ({ page }) => {
   const fixture = await mockTeamPageApis(page);
   const teamId = "team-ch-default";

--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -3,6 +3,8 @@ import {
   gotoTeams,
   mockTeamPageApis,
   openTeamFromSelector,
+  selectTeamChannelFromSidebar,
+  teamChannelSidebarEntry,
 } from "./team_page_helpers";
 
 test("team channels shows #all by default in sidebar", async ({ page }) => {
@@ -28,12 +30,9 @@ test("team channels shows #all by default in sidebar", async ({ page }) => {
   await gotoTeams(page);
   await openTeamFromSelector(page, "Default Channel Team");
 
-  // The sidebar should show "# all" as the default channel
-  const allChannel = page.locator("button").filter({ hasText: "# all" });
-  await expect(allChannel.first()).toBeVisible();
+  await expect(teamChannelSidebarEntry(page, "all")).toBeVisible();
 
-  // Clicking "# all" should keep us in the channels lens
-  await allChannel.first().click();
+  await selectTeamChannelFromSidebar(page, "all");
   await expect(page).toHaveURL(/lens=channels/);
 });
 
@@ -77,20 +76,16 @@ test("team channels create, switch and delete custom channel", async ({ page }) 
   // Submit
   await page.locator('button[type="submit"]').filter({ hasText: "Create channel" }).click();
 
-  // The new channel should appear in the sidebar
-  const reviewChannel = page.locator("button").filter({ hasText: "# review" });
-  await expect(reviewChannel.first()).toBeVisible();
+  const reviewChannel = teamChannelSidebarEntry(page, "review");
+  await expect(reviewChannel).toBeVisible();
 
-  // Switch to the new channel
-  await reviewChannel.first().click();
+  await selectTeamChannelFromSidebar(page, "review");
   await expect(page).toHaveURL(/channel=review/);
 
-  // Switch back to # all
-  const allChannel = page.locator("button").filter({ hasText: "# all" });
-  await allChannel.first().click();
+  await selectTeamChannelFromSidebar(page, "all");
 
   // Delete the custom channel (hover to reveal delete button)
-  await reviewChannel.first().hover();
+  await reviewChannel.hover();
   const deleteButton = page.getByLabel("Delete channel review");
   await expect(deleteButton).toBeVisible();
 
@@ -99,7 +94,7 @@ test("team channels create, switch and delete custom channel", async ({ page }) 
   await deleteButton.click();
 
   // The channel should be removed
-  await expect(reviewChannel.first()).toBeHidden();
+  await expect(reviewChannel).toBeHidden();
 });
 
 test("team channels navigates to channel via url and opens thread", async ({ page }) => {
@@ -175,16 +170,15 @@ test("non-default channel delete requires confirmation", async ({ page }) => {
   await page.getByLabel("Channel ID").fill("staging");
   await page.locator('button[type="submit"]').filter({ hasText: "Create channel" }).click();
 
-  // Verify the channel appears
-  const stagingChannel = page.locator("button").filter({ hasText: "# staging" });
-  await expect(stagingChannel.first()).toBeVisible();
+  const stagingChannel = teamChannelSidebarEntry(page, "staging");
+  await expect(stagingChannel).toBeVisible();
 
   // Cancel the delete dialog should keep the channel
-  await stagingChannel.first().hover();
+  await stagingChannel.hover();
   const deleteButton = page.getByLabel("Delete channel staging");
   page.once("dialog", (dialog) => dialog.dismiss());
   await deleteButton.click();
 
   // Channel should still be visible
-  await expect(stagingChannel.first()).toBeVisible();
+  await expect(stagingChannel).toBeVisible();
 });

--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -17,6 +17,9 @@ test("team channel sidebar helper does not select prefixed channel ids", async (
   `);
 
   await expect(teamChannelSidebarEntry(page, "all")).toHaveText("# all default lane");
+  expect(() => teamChannelSidebarEntry(page, "# all")).toThrow(
+    "Expected a raw channel id without the display prefix"
+  );
 });
 
 test("team channels shows #all by default in sidebar", async ({ page }) => {

--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -11,6 +11,7 @@ test("team channel sidebar helper does not select prefixed channel ids", async (
   await page.setContent(`
     <aside class="teams-sidebar">
       <button type="button"># all-archive archived lane</button>
+      <button type="button">Kanban Human task requests belong in # all.</button>
       <button type="button"># all default lane</button>
     </aside>
   `);

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -481,11 +481,18 @@ export function teamChannelSidebarEntry(
   page: import("@playwright/test").Page,
   channelId: string
 ) {
+  const channelNamePattern = new RegExp(
+    `^\\s*#\\s+${escapeRegExp(channelId)}(?:\\s|$)`
+  );
   return page
     .locator(".teams-sidebar")
     .locator("button")
-    .filter({ hasText: `# ${channelId}` })
+    .filter({ hasText: channelNamePattern })
     .first();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export async function openMainTeamAction(

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -89,7 +89,7 @@ export async function restoreTeamAddAgentContext(
     await showTeamsPanelButton.click();
   }
 
-  const conversationSubject = page.getByRole("button", { name: "# all", exact: true });
+  const conversationSubject = teamChannelSidebarEntry(page, "all");
   if (await conversationSubject.isVisible().catch(() => false)) {
     await conversationSubject.click();
     await page.waitForTimeout(150);
@@ -481,6 +481,7 @@ export function teamChannelSidebarEntry(
   page: import("@playwright/test").Page,
   channelId: string
 ) {
+  assertRawChannelId(channelId);
   const channelNamePattern = new RegExp(
     `#\\s*${escapeRegExp(channelId)}(?:\\s|$)`
   );
@@ -488,6 +489,14 @@ export function teamChannelSidebarEntry(
     .locator(".teams-sidebar")
     .getByRole("button", { name: channelNamePattern })
     .first();
+}
+
+function assertRawChannelId(channelId: string): void {
+  if (channelId.trim().startsWith("#")) {
+    throw new Error(
+      `Expected a raw channel id without the display prefix, got ${JSON.stringify(channelId)}`
+    );
+  }
 }
 
 function escapeRegExp(value: string): string {
@@ -555,10 +564,7 @@ export async function openMainTeamAction(
   }
 
   if (allowSidebarReset) {
-    const sidebarConversationEntry = page
-      .locator(".teams-sidebar")
-      .locator("button", { hasText: "# all" })
-      .first();
+    const sidebarConversationEntry = teamChannelSidebarEntry(page, "all");
     if ((await sidebarConversationEntry.count()) > 0) {
       await expect(sidebarConversationEntry).toBeVisible();
       await sidebarConversationEntry.click();

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -472,13 +472,20 @@ export async function selectTeamChannelFromSidebar(
   page: import("@playwright/test").Page,
   channelId: string
 ): Promise<void> {
-  const sidebar = page.locator(".teams-sidebar");
-  const channelEntry = sidebar
+  const channelEntry = teamChannelSidebarEntry(page, channelId);
+  await expect(channelEntry).toBeVisible();
+  await channelEntry.click();
+}
+
+export function teamChannelSidebarEntry(
+  page: import("@playwright/test").Page,
+  channelId: string
+) {
+  return page
+    .locator(".teams-sidebar")
     .locator("button")
     .filter({ hasText: `# ${channelId}` })
     .first();
-  await expect(channelEntry).toBeVisible();
-  await channelEntry.click();
 }
 
 export async function openMainTeamAction(

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -482,12 +482,11 @@ export function teamChannelSidebarEntry(
   channelId: string
 ) {
   const channelNamePattern = new RegExp(
-    `^\\s*#\\s+${escapeRegExp(channelId)}(?:\\s|$)`
+    `#\\s*${escapeRegExp(channelId)}(?:\\s|$)`
   );
   return page
     .locator(".teams-sidebar")
-    .locator("button")
-    .filter({ hasText: channelNamePattern })
+    .getByRole("button", { name: channelNamePattern })
     .first();
 }
 


### PR DESCRIPTION
## Summary

- Add a semantic `teamChannelSidebarEntry(page, channelId)` helper for Team channel sidebar buttons.
- Update channel E2E tests to select channels by channel id instead of spelling rendered labels like `# all` at call sites.

## Purpose

This keeps channel navigation tests aligned with the domain object being selected and avoids mixing the generic primary sidebar entry helper with channel-specific display labels.

## Related Issues

- Follow-up to PR #510 review cleanup.

## Testing

- `cd web && npm exec tsc -- --noEmit`
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `git diff --check`
- `cd web && PLAYWRIGHT_NO_WEBSERVER=1 npx playwright test tests/e2e/team_page_channels.e2e.ts`
