### PR TITLE
docs(team): align runtime thread guidance

### DIFF
--- a/crates/agenthub-managed-skills/src/lib.rs
+++ b/crates/agenthub-managed-skills/src/lib.rs
@@ -361,20 +361,24 @@ Team mailbox commands:
    `agenthub actor send --run-id "<run-id>" --to-actor-id "worker" --text "Please review this patch.\n\n- verify API shape\n- call out blockers"`
 4. Send a channel message:
    `agenthub actor send --run-id "<run-id>" --channel-id "all" --text "@worker Please review this patch.\n\n- verify API shape\n- call out blockers"`
-5. Send a remote direct message:
+5. Open a thread for detailed context rooted in an existing channel message:
+   `agenthub actor team-thread-open --run-id "<run-id>" --shared --root-message-id "<message-id>"`
+6. Reply inside that thread when the topic needs logs, evidence, or detailed follow-up:
+   `agenthub actor team-thread-reply --run-id "<run-id>" --shared --root-message-id "<message-id>" --text-file .agenthubmemory/mailbox/outbox/thread-reply.md`
+7. Send a remote direct message:
    `agenthub actor send --run-id "<run-id>" --to-actor-id "remote-worker" --transport remote --route-json '{"endpoint":"https://..."}' --text "Please review this patch.\n\n- verify API shape\n- call out blockers"`
-6. Send an urgent human notification:
+8. Send an urgent human notification:
    `agenthub actor send --run-id "<run-id>" --to-actor-id "user" --text "Urgent: permission review timed out. Please check Channel for details."`
-7. Force duplicate delivery when business logic requires repeated send:
+9. Force duplicate delivery when business logic requires repeated send:
    `agenthub actor send --run-id "<run-id>" --to-actor-id "worker" --allow-duplicate --text "Reminder:\n\n- update the test evidence\n- reply when done"`
-8. Use explicit idempotency key when coordinating retries across workers:
+10. Use explicit idempotency key when coordinating retries across workers:
    `agenthub actor send --run-id "<run-id>" --to-actor-id "worker" --idempotency-key "stable-key" --text "Reminder:\n\n- update the test evidence\n- reply when done"`
 
 Team context commands:
 
-9. Inspect live team runtime status, roster, identity-card descriptions, and optional run step overlay:
+11. Inspect live team runtime status, roster, identity-card descriptions, and optional run step overlay:
    `agenthub actor team-members`
-10. When you need step-level overlay for a specific run:
+12. When you need step-level overlay for a specific run:
    `agenthub actor team-members --run-id "<run-id>"`
 
 Protocol rules:
@@ -403,6 +407,7 @@ Protocol rules:
 - Prefer `actor send --text` for markdown-rich messages; it preserves formatting better than wrapping prose inside structured fields.
 - For group chat / channel sends, use `channel_id`; the message will still fan out to all relevant teammates even when `@member_id` appears in the text.
 - Treat `@member_id` in channel text as mention metadata for receivers, not as a routing override.
+- Keep channel root messages summary-first. Use `team-thread-open` and `team-thread-reply` for the full context of one rooted topic.
 - Use `to_actor_id = "user"` or `user:<id>` only when you intentionally want a human notification.
 - Use `channel` only when a non-default channel is required.
 - By default, `actor send` auto-generates an idempotency key from message fields to prevent duplicate delivery on retries.
@@ -491,6 +496,74 @@ mod tests {
             worker_executor
                 .contents
                 .contains("important findings, risks, tradeoffs, or decisions")
+        );
+    }
+
+    #[test]
+    fn managed_skills_describe_channel_thread_context_split() {
+        let home = unique_test_temp_dir("agenthub-managed-skills-channel-thread");
+
+        let shared_index =
+            managed_skill_doc(ManagedSkillKind::TeamAgentsIndex, Some(home.as_path()))
+                .expect("build shared team index doc");
+        assert!(
+            shared_index
+                .contents
+                .contains("channel root messages are summary-first")
+        );
+        assert!(
+            shared_index
+                .contents
+                .contains("thread replies are the full-context lane")
+        );
+        assert!(
+            shared_index
+                .contents
+                .contains("agenthub actor team-thread-open")
+        );
+        assert!(
+            shared_index
+                .contents
+                .contains("agenthub actor team-thread-reply")
+        );
+
+        let mailbox = managed_skill_doc(ManagedSkillKind::TeamActorMailbox, Some(home.as_path()))
+            .expect("build mailbox doc");
+        assert!(mailbox.contents.contains("team-thread-open"));
+        assert!(mailbox.contents.contains("team-thread-reply"));
+        assert!(
+            mailbox
+                .contents
+                .contains("open the thread before treating the root message")
+        );
+
+        let runtime = managed_skill_doc(ManagedSkillKind::ActorRuntime, Some(home.as_path()))
+            .expect("build actor runtime doc");
+        assert!(runtime.contents.contains("agenthub actor team-thread-open"));
+        assert!(
+            runtime
+                .contents
+                .contains("agenthub actor team-thread-reply")
+        );
+        assert!(
+            runtime
+                .contents
+                .contains("Keep channel root messages summary-first")
+        );
+
+        let coordinator = managed_skill_doc(
+            ManagedSkillKind::TeamCoordinatorOrchestrator,
+            Some(home.as_path()),
+        )
+        .expect("build coordinator doc");
+        assert!(coordinator.contents.contains("thread-scoped deep context"));
+
+        let worker = managed_skill_doc(ManagedSkillKind::TeamWorkerExecutor, Some(home.as_path()))
+            .expect("build worker doc");
+        assert!(
+            worker
+                .contents
+                .contains("turning the root channel lane into a context dump")
         );
     }
 

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -52,6 +52,12 @@ restating the same rules.
   - `agenthub actor team-tasks` is the canonical path for inspecting the current Team Kanban surface
   - coordinator owns canonical task creation and task lifecycle management for the team
   - channels are for communication/review; Kanban is the canonical task-tracking surface
+- Channel/thread context split:
+  - channel root messages are summary-first entrypoints for one topic, request, review point, or decision
+  - thread replies are the full-context lane for that root topic
+  - use `agenthub actor team-thread-open` before assuming a root channel message contains complete working context
+  - use `agenthub actor team-thread-reply` for long background, evidence, logs, detailed reasoning, or topic-specific follow-up
+  - keep the main channel scannable; do not paste full investigation context into a channel root when a thread can hold it
 - Self-maintenance:
   - each agent may update its own role description/prompt/skill profile through `profile_patch_proposal`
   - use `target="team"` for durable identity-card changes and `target="run"` for temporary run-scoped overrides
@@ -107,6 +113,9 @@ restating the same rules.
     state before using channel messages as the lightweight status broadcast.
 - Channel status messages should actively `@` the relevant agents/people instead of broadcasting
   without ownership context.
+- Channel root messages should carry only the summary needed for broad awareness. If the topic needs
+  deeper context, open the thread and put the detailed follow-up there so only relevant readers pay
+  the full context cost.
 - Findings, debugging experience, reusable heuristics, and newly discovered risks are first-class
   outputs; report them even before implementation completes when they can change team decisions.
 - Large evidence should be summary-first:

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -33,6 +33,8 @@ Shared routing, mention, and human-visible reply policy remain canonical in
   be treated as notification delivery, not as agent identity.
 - `@member_id` in a channel message is mention metadata only; it does not narrow the channel
   broadcast recipient set.
+- Channel root messages are summary-first. Thread replies carry the detailed context for one rooted
+  topic.
 
 ## Routing Surface Contract
 
@@ -42,6 +44,8 @@ Shared routing, mention, and human-visible reply policy remain canonical in
 - Shared channel (`channel_id`) is team-wide delivery. Use it for `shared-channel`.
 - Human mailbox (`to_actor_id = user` / `user:<id>`) is urgent operator-facing notification. Use
   it for `human-notification`.
+- Thread replies are topic-scoped follow-up rooted in an existing channel message. Use
+  `team-thread-open` and `team-thread-reply` when a channel summary needs deeper context.
 - If several specific peers need the same actionable update, either send separate direct mailbox
   messages or use `shared-channel` with explicit `@member_id` mentions; do not pretend channel
   mention metadata is a recipient filter.
@@ -92,9 +96,13 @@ Recommended fields:
    `agenthub actor send --to-actor-id "$TARGET_ACTOR_ID" --payload-file .agenthubmemory/mailbox/outbox/status-update.json`
 6. Broadcast into the shared Team channel while preserving mentions as metadata:
    `agenthub actor send --channel-id all --text-file .agenthubmemory/mailbox/outbox/channel-update.md`
-7. Escalate to human notifications when urgent coordination cannot wait:
+7. Open a thread for topic-specific deep context rooted in an existing channel message:
+   `agenthub actor team-thread-open --channel-id all --root-message-id "$ROOT_MESSAGE_ID"`
+8. Reply inside that thread when long evidence, logs, or detailed follow-up are needed:
+   `agenthub actor team-thread-reply --channel-id all --root-message-id "$ROOT_MESSAGE_ID" --text-file .agenthubmemory/mailbox/outbox/thread-reply.md`
+9. Escalate to human notifications when urgent coordination cannot wait:
    `agenthub actor send --to-actor-id user --text-file .agenthubmemory/mailbox/outbox/human-notification.md`
-8. Direct a single peer when the update does not need channel visibility:
+10. Direct a single peer when the update does not need channel visibility:
    `agenthub actor send --to-actor-id "$PEER_ACTOR_ID" --text-file .agenthubmemory/mailbox/outbox/peer-update.md`
 
 ## Reply Modes
@@ -112,6 +120,11 @@ Recommended fields:
   - if transport requires a chat envelope, keep it minimal and put only the natural-language reply in `text`
   - bad visible reply example: `{"type":"chat_message","current_phase":"Team formation","text":"..."}`
   - good visible reply example: `已收到你的消息。当前 mailbox 收发正常；如果有具体任务，直接发目标、约束和期望输出即可。`
+- Channel/thread replies:
+  - keep new channel root messages concise and summary-first
+  - move long background, logs, detailed reasoning, and topic-specific back-and-forth into the
+    thread rooted at that channel message
+  - open the thread before treating the root message as complete working context
 
 ## Reliability Rules
 

--- a/skills/team/team-agents-index.SKILL.md
+++ b/skills/team/team-agents-index.SKILL.md
@@ -20,6 +20,11 @@ Primary references:
   - coordinator interprets conversation input and compiles internal Team tasks
   - coordinator owns canonical Team task creation/management
   - Kanban is the canonical Team task surface; channels remain communication/review lanes
+- Enforce channel/thread context split:
+  - channel root messages are summary-first entrypoints for one topic
+  - thread replies are the full-context lane for detailed evidence, logs, reasoning, and follow-up
+  - use `agenthub actor team-thread-open` before treating a root channel message as complete context
+  - use `agenthub actor team-thread-reply` for topic-specific deep context
 - Enforce shared routing vocabulary from `skills/team/AGENTS.md`:
   - `coordinator-mailbox`
   - `peer-mailbox`

--- a/skills/team/team-coordinator-orchestrator.SKILL.md
+++ b/skills/team/team-coordinator-orchestrator.SKILL.md
@@ -282,10 +282,15 @@ Use this structure when creating or refreshing coordinator workspace `AGENTS.md`
   - `shared-channel` for human-visible or team-wide progress updates
 - For shared-channel updates, send to the channel mailbox surface and keep `@member_id` mentions as
   ownership metadata; do not treat mentions as a narrowing recipient filter.
+- Keep shared-channel root messages summary-first. If a status update, review point, or human
+  request needs logs, detailed reasoning, or a longer evidence chain, open the thread rooted at that
+  channel message and move the detailed context there.
 - Large evidence handoffs should be summary-first:
   - send a concise summary in the mailbox/channel body
   - attach a stable `detail_ref` / artifact pointer for the full content
   - avoid reposting full logs or copied context into shared-channel updates
+- Treat `agenthub actor team-thread-open` and `agenthub actor team-thread-reply` as the canonical
+  agent-side path for moving one channel topic from broad summary into thread-scoped deep context.
 - If operator attention is urgently required, send a concise human-mailbox notification
   (`to_actor_id = user` / `user:<id>`) as a `human-notification` secondary route in addition to
   the normal coordinator/channel update.

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -199,10 +199,15 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - When posting to a shared channel, use `channel_id` (for example `all`) as the transport target;
   keep `@member_id` in the message body as mention metadata for ownership context rather than as a
   recipient filter.
+- Keep shared-channel root messages summary-first. If your update needs detailed evidence, logs,
+  reasoning, or topic-specific back-and-forth, open the thread rooted at that channel message and
+  continue there instead of turning the root channel lane into a context dump.
 - Large logs, traces, or copied context should be summary-first:
   - send the short summary in mailbox text/payload
   - attach a stable `detail_ref` / artifact pointer for the full content
   - avoid pasting the full body unless the receiver truly cannot access the referenced detail
+- Use `agenthub actor team-thread-open` and `agenthub actor team-thread-reply` when a relevant
+  channel topic needs deeper context than the root summary provides.
 - When posting to a shared channel, explicitly `@` the relevant owner, reviewer, dependency peer,
   or human stakeholder so the update has clear recipients.
 - If a blocker or risk needs immediate operator attention, send a concise human-mailbox


### PR DESCRIPTION
## Summary

- Align Team managed runtime skills with the channel/thread context split from the Team channels spec.
- Document channel root messages as summary-first and thread replies as the deep-context lane.
- Add managed-skill coverage so installed runtime skill docs keep the thread guidance.

## Purpose

This carries the Team channel/thread rollout into the prompt/runtime guidance path. Coordinator and worker sessions now receive consistent guidance across the shared Team index, mailbox protocol, role skills, and actor runtime quick reference.

## Related Issues

- Follow-up for the P0+ Team channel/thread rollout.

## Testing

- `cargo test -p agenthub-managed-skills managed_skills_describe_channel_thread_context_split`
- `cargo test -p agenthub-managed-skills`
- `cargo fmt --all --check`
- `git diff --check`
