### PR TITLE
feat(team): persist channel replica correlation ids

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -624,6 +624,7 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
         CREATE TABLE IF NOT EXISTS team_channel_message_replicas (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             authority_message_id INTEGER NOT NULL,
+            correlation_id TEXT NOT NULL,
             run_id TEXT NOT NULL,
             team_id TEXT NOT NULL,
             conversation_id TEXT NOT NULL,
@@ -1238,6 +1239,28 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     )
     .await;
     create_team_conversation_messages_idempotency_index(&pool).await?;
+    add_column_if_missing(
+        &pool,
+        "ALTER TABLE team_channel_message_replicas ADD COLUMN correlation_id TEXT NOT NULL DEFAULT ''",
+        "team_channel_message_replicas.correlation_id",
+    )
+    .await;
+    if let Err(err) = sqlx::query(
+        r#"
+        UPDATE team_channel_message_replicas
+        SET correlation_id = trim(COALESCE(json_extract(payload_json, '$.correlation_id'), ''))
+        WHERE correlation_id = ''
+          AND trim(COALESCE(json_extract(payload_json, '$.correlation_id'), '')) != ''
+        "#,
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!(
+            "db init: failed to backfill team_channel_message_replicas.correlation_id: {}",
+            err
+        );
+    }
     add_column_if_missing(
         &pool,
         "ALTER TABLE team_actor_messages ADD COLUMN from_peer_id TEXT NOT NULL DEFAULT 'main'",
@@ -3307,6 +3330,95 @@ mod tests {
         assert!(index_sql.contains("conversation_id"));
         assert!(index_sql.contains("from_actor_id"));
         assert!(index_sql.contains("idempotency_key"));
+
+        pool.close().await;
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn init_db_adds_channel_replica_correlation_id_and_backfills_existing_rows() {
+        let dir = unique_temp_dir("db-migrate-channel-replica-correlation");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let db_path = dir.join("agenthub.db");
+        let pool = try_connect(&db_path).await.expect("connect sqlite");
+
+        sqlx::query(
+            r#"
+            CREATE TABLE team_channel_message_replicas (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                authority_message_id INTEGER NOT NULL,
+                run_id TEXT NOT NULL,
+                team_id TEXT NOT NULL,
+                conversation_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                from_actor_id TEXT NOT NULL,
+                source_node_id TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                stored_at INTEGER NOT NULL,
+                UNIQUE(authority_message_id)
+            );
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("create legacy team_channel_message_replicas");
+        sqlx::query(
+            r#"
+            INSERT INTO team_channel_message_replicas (
+                authority_message_id,
+                run_id,
+                team_id,
+                conversation_id,
+                task_id,
+                channel_id,
+                from_actor_id,
+                source_node_id,
+                payload_json,
+                stored_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+        )
+        .bind(42_i64)
+        .bind("run-1")
+        .bind("team-1")
+        .bind("conversation-1")
+        .bind("task-1")
+        .bind("all")
+        .bind("planner")
+        .bind("main")
+        .bind(r#"{"text":"hello","correlation_id":"corr-replica-1"}"#)
+        .bind(1_i64)
+        .execute(&pool)
+        .await
+        .expect("insert legacy replica row");
+        pool.close().await;
+
+        let pool = init_db_at_path(&db_path)
+            .await
+            .expect("init db with channel replica correlation migration");
+        let correlation_id_column: String = sqlx::query_scalar(
+            r#"
+            SELECT name
+            FROM pragma_table_info('team_channel_message_replicas')
+            WHERE name = 'correlation_id'
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read correlation_id column");
+        assert_eq!(correlation_id_column, "correlation_id");
+
+        let correlation_id: String = sqlx::query_scalar(
+            "SELECT correlation_id FROM team_channel_message_replicas WHERE authority_message_id = ?1",
+        )
+        .bind(42_i64)
+        .fetch_one(&pool)
+        .await
+        .expect("read backfilled correlation_id");
+        assert_eq!(correlation_id, "corr-replica-1");
 
         pool.close().await;
         let _ = std::fs::remove_file(&db_path);

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1239,27 +1239,29 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     )
     .await;
     create_team_conversation_messages_idempotency_index(&pool).await?;
-    add_column_if_missing(
-        &pool,
-        "ALTER TABLE team_channel_message_replicas ADD COLUMN correlation_id TEXT NOT NULL DEFAULT ''",
-        "team_channel_message_replicas.correlation_id",
-    )
-    .await;
-    if let Err(err) = sqlx::query(
-        r#"
-        UPDATE team_channel_message_replicas
-        SET correlation_id = trim(COALESCE(json_extract(payload_json, '$.correlation_id'), ''))
-        WHERE correlation_id = ''
-          AND trim(COALESCE(json_extract(payload_json, '$.correlation_id'), '')) != ''
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to backfill team_channel_message_replicas.correlation_id: {}",
-            err
-        );
+    if !sqlite_table_has_column(&pool, "team_channel_message_replicas", "correlation_id").await? {
+        add_column_if_missing(
+            &pool,
+            "ALTER TABLE team_channel_message_replicas ADD COLUMN correlation_id TEXT NOT NULL DEFAULT ''",
+            "team_channel_message_replicas.correlation_id",
+        )
+        .await;
+        if let Err(err) = sqlx::query(
+            r#"
+            UPDATE team_channel_message_replicas
+            SET correlation_id = trim(COALESCE(json_extract(payload_json, '$.correlation_id'), ''))
+            WHERE correlation_id = ''
+              AND trim(COALESCE(json_extract(payload_json, '$.correlation_id'), '')) != ''
+            "#,
+        )
+        .execute(&pool)
+        .await
+        {
+            tracing::warn!(
+                "db init: failed to backfill team_channel_message_replicas.correlation_id: {}",
+                err
+            );
+        }
     }
     add_column_if_missing(
         &pool,

--- a/docs/features/logical-message-metadata-contract.md
+++ b/docs/features/logical-message-metadata-contract.md
@@ -158,7 +158,7 @@ must not be treated as the source of truth when data diverges.
 | --- | --- | --- | --- |
 | `team_conversation_messages` | authority row | `conversation_id`, `authority_message_id`, `correlation_id` | canonical human-visible message content; does not currently persist `run_id` |
 | `team_actor_messages` | authority row | `run_id`, sender/recipient actor ids, effective `idempotency_key` | canonical delivery state |
-| `team_channel_message_replicas` | replica row | `run_id`, `conversation_id`, `authority_message_id`, `correlation_id` | node-relevant channel cache only |
+| `team_channel_message_replicas` | replica row | `run_id`, `conversation_id`, `authority_message_id`, `correlation_id` | node-relevant channel cache only; `correlation_id` is persisted as a first-class projection column |
 | remote relay route metadata | delivery metadata | `source_node_id`, `target_node_id`, optional `broadcast_id`, optional `correlation_id`, effective `idempotency_key` | transport/debug only |
 | archive/search document | projection row | `run_id`, `conversation_id`, `authority_message_id`, `correlation_id`, optional `group_id` | must point back to `main` authority; `group_id` is preserved only when supplied by a live authority source |
 
@@ -200,3 +200,4 @@ rows start populating it.
 - `docs/journal/2026-03-13-team-shared-thread-canonical-replies.md`
 - `docs/journal/2026-05-04-distributed-message-metadata-contract-phase1.md`
 - `docs/journal/2026-05-06-message-archive-group-id-projection.md`
+- `docs/journal/2026-05-06-channel-replica-correlation-projection.md`

--- a/docs/journal/2026-05-06-channel-replica-correlation-projection.md
+++ b/docs/journal/2026-05-06-channel-replica-correlation-projection.md
@@ -1,0 +1,36 @@
+# Channel Replica Correlation Projection
+
+## Summary
+
+This slice promotes `correlation_id` from a payload-only convention into a first-class `team_channel_message_replicas` projection column.
+
+## Background
+
+The logical message metadata contract requires channel replica rows to preserve `run_id`, `conversation_id`, `authority_message_id`, and `correlation_id` so node-local caches remain reconcilable against `main` authority rows. Before this slice, internal gRPC channel replica ingestion validated `correlation_id`, but the replica table only retained it inside `payload_json`.
+
+## Scope
+
+- Add `team_channel_message_replicas.correlation_id` to the fresh SQLite schema.
+- Add legacy migration/backfill from `payload_json.correlation_id`.
+- Persist the validated internal gRPC channel replica `correlation_id` when storing replica rows.
+- Update focused tests to assert the physical projection column.
+
+## Key Decisions
+
+- `team_channel_message_replicas` remains a replica/cache table, not an authority table.
+- The migration uses an empty-string default only to make SQLite legacy-column addition safe; rows with payload-level `correlation_id` are backfilled immediately during `init_db`.
+- Internal gRPC still rejects channel replica payloads without `correlation_id`, so new replica rows should carry a non-empty first-class value.
+
+## Validation
+
+```bash
+cargo test -p agenthub-db init_db_adds_channel_replica_correlation_id_and_backfills_existing_rows -- --nocapture
+cargo test -p agenthub internal_grpc_mailbox_send_persists_channel_replica_history -- --nocapture
+cargo test -p agenthub internal_grpc_mailbox_send_rejects_channel_replica_payload_without_correlation_id -- --nocapture
+cargo fmt --all --check
+```
+
+## Follow-Ups
+
+- Continue the broader distributed metadata P0+ rollout by deciding when `group_id` becomes an authority-layer field instead of projection compatibility metadata.
+- Continue auditing other human-visible/searchable projections for payload-only metadata that should become first-class columns.

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -702,6 +702,7 @@ async fn init_test_schema(db: &SqlitePool) {
         CREATE TABLE team_channel_message_replicas (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             authority_message_id INTEGER NOT NULL,
+            correlation_id TEXT NOT NULL,
             run_id TEXT NOT NULL,
             team_id TEXT NOT NULL,
             conversation_id TEXT NOT NULL,

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -67,6 +67,7 @@ impl TeamInternalControl for TeamInternalControlService {
                 .teams
                 .append_channel_replica_message(
                     replica.authority_message_id,
+                    &replica.correlation_id,
                     run_id,
                     &replica.team_id,
                     &replica.conversation_id,

--- a/src/internal/service/tests/mailbox.rs
+++ b/src/internal/service/tests/mailbox.rs
@@ -332,7 +332,7 @@ async fn internal_grpc_mailbox_send_persists_channel_replica_history() {
 
     let replica = sqlx::query(
             r#"
-            SELECT authority_message_id, run_id, team_id, conversation_id, task_id, channel_id, from_actor_id, source_node_id, payload_json
+            SELECT authority_message_id, correlation_id, run_id, team_id, conversation_id, task_id, channel_id, from_actor_id, source_node_id, payload_json
             FROM team_channel_message_replicas
             WHERE authority_message_id = ?1
             "#,
@@ -344,6 +344,10 @@ async fn internal_grpc_mailbox_send_persists_channel_replica_history() {
     assert_eq!(
         replica.get::<i64, _>("authority_message_id"),
         authority_message_id
+    );
+    assert_eq!(
+        replica.get::<String, _>("correlation_id"),
+        "corr-internal-grpc-replica-1"
     );
     assert_eq!(replica.get::<String, _>("run_id"), run.id);
     assert_eq!(replica.get::<String, _>("channel_id"), "all");

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -2258,6 +2258,7 @@ impl TeamManager {
     pub async fn append_channel_replica_message(
         &self,
         authority_message_id: i64,
+        correlation_id: &str,
         run_id: &str,
         team_id: &str,
         conversation_id: &str,
@@ -2273,6 +2274,7 @@ impl TeamManager {
             r#"
             INSERT OR IGNORE INTO team_channel_message_replicas (
                 authority_message_id,
+                correlation_id,
                 run_id,
                 team_id,
                 conversation_id,
@@ -2283,10 +2285,11 @@ impl TeamManager {
                 payload_json,
                 stored_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
             "#,
         )
         .bind(authority_message_id)
+        .bind(correlation_id)
         .bind(run_id)
         .bind(team_id)
         .bind(conversation_id)

--- a/src/team/manager/tests.rs
+++ b/src/team/manager/tests.rs
@@ -457,6 +457,7 @@ async fn setup_test_db() -> SqlitePool {
         CREATE TABLE team_channel_message_replicas (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             authority_message_id INTEGER NOT NULL,
+            correlation_id TEXT NOT NULL,
             run_id TEXT NOT NULL,
             team_id TEXT NOT NULL,
             conversation_id TEXT NOT NULL,
@@ -3923,9 +3924,9 @@ async fn delete_team_channel_cleans_bootstrap_rows_and_rejects_all() {
     sqlx::query(
         r#"
         INSERT INTO team_channel_message_replicas (
-            authority_message_id, run_id, team_id, conversation_id, task_id, channel_id, from_actor_id, source_node_id, payload_json, stored_at
+            authority_message_id, correlation_id, run_id, team_id, conversation_id, task_id, channel_id, from_actor_id, source_node_id, payload_json, stored_at
         )
-        VALUES (?1, 'run-1', ?2, ?3, ?4, ?5, 'coordinator', 'main', '{"text":"Investigate issue"}', ?6)
+        VALUES (?1, 'corr-delete-replica', 'run-1', ?2, ?3, ?4, ?5, 'coordinator', 'main', '{"text":"Investigate issue","correlation_id":"corr-delete-replica"}', ?6)
         "#,
     )
     .bind(root_message_id)


### PR DESCRIPTION
## Summary

- persist `correlation_id` as a first-class `team_channel_message_replicas` column
- backfill legacy replica rows from `payload_json.correlation_id` during SQLite init
- store the validated internal gRPC channel replica correlation id in the projection row
- record the rollout slice in the logical message metadata spec and journal

## Purpose

This is a focused distributed metadata P0+ slice. Channel replica rows are node-local projections, but they must remain reconcilable against `main` authority rows through explicit `authority_message_id + correlation_id` metadata instead of payload-only conventions.

## Related Issues

- None

## Testing

```bash
cargo test -p agenthub-db init_db_adds_channel_replica_correlation_id_and_backfills_existing_rows -- --nocapture
cargo test -p agenthub internal_grpc_mailbox_send_persists_channel_replica_history -- --nocapture
cargo test -p agenthub internal_grpc_mailbox_send_rejects_channel_replica_payload_without_correlation_id -- --nocapture
cargo fmt --all --check
```
