### PR TITLE
feat(team): simplify add agent choices

### DIFF
--- a/docs/journal/2026-05-06-team-create-mission-first-add-agent.md
+++ b/docs/journal/2026-05-06-team-create-mission-first-add-agent.md
@@ -1,0 +1,37 @@
+# Team Create Mission-First Add Agent Cleanup
+
+## Summary
+
+This checkpoint tightens the default Team setup flow after shell-first Team creation. The empty-Team setup surface now presents the two intended participant paths, `Create New Agent` and `Copy Existing Agent`, while the first added agent remains the coordinator by default.
+
+## Background
+
+The canonical contract in `docs/features/team-create-flow.md` says Team creation should collect mission and identity first, then add participants afterward. It also says the default add-agent surface should avoid a coordinator/worker role switch and should keep copy semantics separate from a later move flow.
+
+## Scope
+
+- Rename the default new-agent entry from role-specific add labels to `Create New Agent`.
+- Keep the create-agent modal title role-aware, but make its action label generic and its body describe a fixed Team assignment rather than a role-selection ceremony.
+- Rename the existing-agent path to `Copy Existing Agent`.
+- Remove the disabled `Move to Team (later)` action from the copy modal so move does not appear as a third default add-agent path.
+- Keep the move warning as non-actionable context because ownership transfer still needs separate runtime and history guardrails.
+
+## Key Decisions
+
+- The two default add-agent paths are product choices, not role-management choices.
+- The modal can still show whether the created/copied agent will become coordinator or worker, but the user does not choose that assignment in the default flow.
+- Copy remains configuration-only for now; move is explicitly not part of the default modal action set.
+
+## Validation
+
+```bash
+cd web && npm exec vitest -- run src/pages/team_setup_panel.test.tsx src/pages/team/team_management_modals.test.tsx src/pages/team_panels.test.tsx
+cd web && npm run lint
+cd web && npm exec tsc -- --noEmit
+cd web && npm run build
+```
+
+## Follow-Ups
+
+- Browser-check the create Team shell, first coordinator creation, and later worker creation on a narrow viewport before closing the full `P0+` Team create-flow backlog item.
+- Keep the separate Team adoption work focused on copy-first behavior, optional workspace-content copy, memory/context seeding, and guarded move semantics.

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -187,8 +187,8 @@ describe("Team management modals", () => {
     expect(html).toContain("Coordinator Profile");
     expect(html).toContain("Managed automatically");
     expect(html).toContain("What should this agent help with?");
-    expect(html).toContain("keeps role assignment fixed");
-    expect(html).toContain("Assigned Role");
+    expect(html).toContain("keeps Team assignment fixed");
+    expect(html).toContain("Team Assignment");
     expect(html).toContain("Coordinator");
     expect(html).toContain(
       "This team does not have a coordinator yet, so the first added agent becomes the coordinator automatically."
@@ -230,8 +230,8 @@ describe("Team management modals", () => {
             infoStripGridClassName: "info-grid",
           }}
           modalProps={{
-            title: "Add Worker Agent",
-            confirmLabel: "Create Worker Agent",
+            title: "Create new worker agent",
+            confirmLabel: "Create Agent",
             agentPresetLabel: "Runtime",
             agentPresetSummaryLabel: "Model",
             showCommandSummary: false,
@@ -301,9 +301,9 @@ describe("Team management modals", () => {
       </MantineProvider>
     );
 
-    expect(html).toContain("Add Existing Agent");
+    expect(html).toContain("Copy Existing Agent");
     expect(html).toContain("Alpha");
-    expect(html).toContain("Copy an existing agent into this team.");
+    expect(html).toContain("Copy an existing agent into this Team.");
     expect(html).toContain("Search existing agents");
     expect(html).toContain("Source Agent");
     expect(html).toContain("Copy semantics");
@@ -346,8 +346,7 @@ describe("Team management modals", () => {
     expect(html).toContain("new Team-owned worker agent");
     expect(html).toContain("Copy keeps the source agent unchanged");
     expect(html).toContain("Move semantics are not enabled yet");
-    expect(html).toContain("Move to Team (later)");
-    expect(html).toContain('disabled="">Move to Team (later)');
+    expect(html).not.toContain("Move to Team (later)");
   });
 
   it("renders the copy-existing-agent empty-filter fallback", () => {

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -464,14 +464,14 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
         <div className={chrome.modalHeaderClassName}>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
-              <span className={chrome.badgeClassName}>Add Existing Agent</span>
+              <span className={chrome.badgeClassName}>Copy Existing Agent</span>
               <AlphaBadge />
             </div>
             <h3
               id="team-copy-existing-agent-title"
               className="mt-2 text-[18px] font-semibold tracking-tight text-black"
             >
-              Copy an existing agent into this team.
+              Copy an existing agent into this Team.
             </h3>
             <p className="mt-2 max-w-2xl text-[13px] leading-5 text-black/70">
               AgentHub will create a new Team-owned {copyRoleLabel} agent from the selected source
@@ -578,15 +578,6 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             Cancel
           </ActionButton>
           <ActionButton
-            className={chrome.mutedButtonClassName}
-            disabled
-            size="md"
-            tone="secondary"
-            type="button"
-          >
-            Move to Team (later)
-          </ActionButton>
-          <ActionButton
             className={chrome.accentButtonClassName}
             onClick={() => onCopy(selectedAgentId)}
             disabled={busy || !selectedAgentId}
@@ -641,7 +632,7 @@ export const TeamForgeAgentDialog = React.memo(function TeamForgeAgentDialog({
         <SurfaceCard className="mt-4 rounded-[14px] border border-ui-border bg-ui-surface-soft px-3.5 py-3 shadow-none">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="min-w-0">
-              <p className={chrome.infoStripLabelClassName}>Assigned Role</p>
+              <p className={chrome.infoStripLabelClassName}>Team Assignment</p>
               <p className="mt-1 text-[12px] leading-5 text-ui-text-secondary">
                 {selectedTeamHasCoordinator
                   ? "This team already has a coordinator, so new agents join as workers by default."
@@ -653,7 +644,7 @@ export const TeamForgeAgentDialog = React.memo(function TeamForgeAgentDialog({
             </span>
           </div>
           <p className="mt-3 text-[11px] leading-5 text-ui-text-muted">
-            The default Add Agent flow keeps role assignment fixed so the modal only asks for
+            The default Add Agent flow keeps Team assignment fixed so the modal only asks for
             description and workspace settings.
           </p>
         </SurfaceCard>
@@ -693,8 +684,8 @@ export const TeamForgeAgentDialog = React.memo(function TeamForgeAgentDialog({
           }
         />
         <Alert className="mt-4" radius="md" color="blue" variant="light" title="Managed automatically">
-          AgentHub injects the role-specific system prompt and Team skills automatically for the
-          selected role. The default Add Agent flow only asks for a description and workspace
+          AgentHub injects the assignment-specific system prompt and Team skills automatically.
+          The default Add Agent flow only asks for a description and workspace
           settings.
         </Alert>
         {!selectedTeamHasCoordinator ? (

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1342,9 +1342,7 @@ export function TeamPage(props: TeamPageProps) {
     }
     return null;
   }, [selectedTeam, selectedTeamHasConfiguredMembers]);
-  const teamMemberForgeLabel = selectedTeamHasCoordinator
-    ? "Add Worker Agent"
-    : "Add First Coordinator Agent";
+  const teamMemberForgeLabel = "Create New Agent";
   const teamMemberCopyExistingLabel = "Copy Existing Agent";
   const copyExistingTeamAgentCandidates = useMemo(() => {
     const selectedMemberIds = new Set(selectedTeamMembers.map((member) => member.member_id));
@@ -3794,10 +3792,10 @@ export function TeamPage(props: TeamPageProps) {
   );
   const forgeModalProps = useMemo(
     () => ({
-      title: selectedTeamHasCoordinator ? "Add Worker Agent" : "Add First Coordinator Agent",
-      confirmLabel: selectedTeamHasCoordinator
-        ? "Create Worker Agent"
-        : "Create Coordinator Agent",
+      title: selectedTeamHasCoordinator
+        ? "Create new worker agent"
+        : "Create first coordinator agent",
+      confirmLabel: "Create Agent",
       agentPresetLabel: "Runtime",
       agentPresetSummaryLabel: "Preset",
       commandSummaryLabel: "Launch command",

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -1075,7 +1075,7 @@ describe("team panels interactions", () => {
             onOpenCurrentMachine={onOpenCurrentMachine}
             onOpenTeamMemberForge={onOpenTeamMemberForge}
             onOpenTeamMemberCopyExisting={onOpenTeamMemberCopyExisting}
-            teamMemberForgeLabel="Add Worker Agent"
+            teamMemberForgeLabel="Create New Agent"
             teamMemberCopyExistingLabel="Copy Existing Agent"
             onStartTeamRuntime={onStartTeamRuntime}
             onStopTeamRuntime={onStopTeamRuntime}
@@ -1101,8 +1101,8 @@ describe("team panels interactions", () => {
     await waitForCondition(() => document.body.textContent?.includes("Current Machine (main)") ?? false);
     clickElement(findInteractiveByText(document.body, "Current Machine (main)"));
     clickMenuTrigger(findButtonByAriaLabel(container, "Open controls for Team One"));
-    await waitForCondition(() => document.body.textContent?.includes("Add Worker Agent") ?? false);
-    clickElement(findInteractiveByText(document.body, "Add Worker Agent"));
+    await waitForCondition(() => document.body.textContent?.includes("Create New Agent") ?? false);
+    clickElement(findInteractiveByText(document.body, "Create New Agent"));
     clickMenuTrigger(findButtonByAriaLabel(container, "Open controls for Team One"));
     await waitForCondition(() => document.body.textContent?.includes("Copy Existing Agent") ?? false);
     expect(document.body.textContent).toContain("Alpha");

--- a/web/src/pages/team_setup_panel.test.tsx
+++ b/web/src/pages/team_setup_panel.test.tsx
@@ -9,7 +9,7 @@ describe("TeamSetupPanel", () => {
       <MantineProvider>
         <TeamSetupPanel
           description="Own query debugging"
-          forgeLabel="Add First Coordinator Agent"
+          forgeLabel="Create New Agent"
           copyExistingLabel="Copy Existing Agent"
           onForge={vi.fn()}
           onCopyExisting={vi.fn()}
@@ -18,11 +18,12 @@ describe("TeamSetupPanel", () => {
     );
 
     expect(html).toContain("No agents have joined this team yet.");
-    expect(html).toContain("Add First Coordinator Agent");
+    expect(html).toContain("Create New Agent");
     expect(html).toContain("Copy Existing Agent");
     expect(html).toContain("Alpha");
-    expect(html).toContain("until you add the first coordinator agent");
-    expect(html).toContain("This first agent becomes the coordinator.");
+    expect(html).toContain("Choose one of the two agent paths below");
+    expect(html).toContain("The first added agent becomes the coordinator");
+    expect(html).toContain("Create a new Team-owned agent or copy an existing agent configuration.");
     expect(html).toContain("Create the first coordinator agent");
   });
 });

--- a/web/src/pages/team_setup_panel.tsx
+++ b/web/src/pages/team_setup_panel.tsx
@@ -38,7 +38,7 @@ export function TeamSetupPanel({
             </h3>
           </div>
         }
-        subtitle="The team goal is saved, but runtime and runs stay blocked until you add the first coordinator agent."
+        subtitle="The team goal is saved. Choose one of the two agent paths below; the first added agent becomes the coordinator automatically."
         className="border-b-0 pb-0"
         titleClassName="text-base font-normal"
         subtitleClassName="max-w-2xl text-[13px] leading-5 text-ui-text-secondary"
@@ -77,8 +77,8 @@ export function TeamSetupPanel({
           <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
             <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>First Agent</p>
             <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>
-              Add the first agent with a short description and a workspace. This first agent
-              becomes the coordinator.
+              Create a new Team-owned agent or copy an existing agent configuration. The first
+              added agent becomes the coordinator.
             </p>
           </div>
           <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -28,9 +28,9 @@ export function selectedTeamMenuLocator(page: import("@playwright/test").Page) {
 }
 
 const TEAM_ADD_AGENT_ENTRY_LABEL_PATTERN =
-  /^(Add First Coordinator Agent|Add Worker Agent|Add Agent)$/;
+  /^(Create New Agent|Add First Coordinator Agent|Add Worker Agent|Add Agent)$/;
 const TEAM_CREATE_AGENT_CONFIRM_LABEL_PATTERN =
-  /^(Create Coordinator Agent|Create Worker Agent|Create Agent)$/;
+  /^(Create Agent|Create Coordinator Agent|Create Worker Agent)$/;
 const TEAM_MEMBER_NAME_LABEL_PATTERN = /^(Name|Agent name)$/;
 const TEAM_MEMBER_DESCRIPTION_LABEL_PATTERN = /^(Description|Identity)$/;
 const TEAM_MEMBER_RUNTIME_LABEL_PATTERN = /^(Runtime|Role model)$/;

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -113,16 +113,16 @@ test("team setup actions stay reachable after mobile shell-first creation", asyn
     hasText: "No agents have joined this team yet.",
   });
   await expect(setupPanel.getByRole("button", { name: "Copy Existing Agent" })).toBeVisible();
-  await expect(setupPanel.getByRole("button", { name: "Add First Coordinator Agent" })).toBeVisible();
+  await expect(setupPanel.getByRole("button", { name: "Create New Agent" })).toBeVisible();
 
   await setupPanel.getByRole("button", { name: "Copy Existing Agent" }).click();
   const dialog = page
     .locator("[role='dialog']")
-    .filter({ hasText: "Copy an existing agent into this team." })
+    .filter({ hasText: "Copy an existing agent into this Team." })
     .last();
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Copy keeps the source agent unchanged.")).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Move to Team (later)" })).toBeDisabled();
+  await expect(dialog.getByRole("button", { name: "Move to Team (later)" })).toHaveCount(0);
 
   const dialogBox = await dialog.boundingBox();
   const viewportWidth = await page.evaluate(() => document.documentElement.clientWidth);

--- a/web/tests/e2e/team_page_setup.e2e.ts
+++ b/web/tests/e2e/team_page_setup.e2e.ts
@@ -15,6 +15,7 @@ import {
   mockTeamPageApis,
   openAdvancedView,
   openMainTeamAction,
+  openSelectedTeamMenu,
   openTeamFromSelector,
   selectAgentFromSidebar,
   selectTeamChannelFromSidebar,
@@ -128,7 +129,7 @@ test("team member setup adds the first agent and appends more agents through spe
   ]);
 });
 
-test("team adoption copy keeps move disabled and creates a team-owned coordinator", async ({
+test("team adoption copy keeps move out of the default action path and creates a team-owned coordinator", async ({
   page,
 }) => {
   const fixture = await mockTeamPageApis(page);
@@ -143,14 +144,13 @@ test("team adoption copy keeps move disabled and creates a team-owned coordinato
   await page.getByRole("button", { name: "Copy Existing Agent" }).click();
   const dialog = page
     .locator("[role='dialog']")
-    .filter({ hasText: "Copy an existing agent into this team." })
+    .filter({ hasText: "Copy an existing agent into this Team." })
     .last();
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("The original agent remains unchanged.")).toBeVisible();
 
   const moveButton = dialog.getByRole("button", { name: "Move to Team (later)" });
-  await expect(moveButton).toBeVisible();
-  await expect(moveButton).toBeDisabled();
+  await expect(moveButton).toHaveCount(0);
 
   const copyButton = dialog.getByRole("button", { name: "Copy into Team" });
   await expect(copyButton).toBeEnabled();
@@ -435,6 +435,7 @@ test("team setup keeps add agent wording after the first member binds", async ({
     goal: "Bind coordinator in-place before worker setup.",
   });
   await expectAddAgentEntryVisible(page, teamName);
+  await expect(page.getByRole("button", { name: "Create New Agent" })).toBeVisible();
 
   await createTeamMemberFromModal(page, {
     teamName,
@@ -444,6 +445,9 @@ test("team setup keeps add agent wording after the first member binds", async ({
 
   await openTeamFromSelector(page, teamName);
   await expectAddAgentEntryVisible(page, teamName);
+  await openSelectedTeamMenu(page);
+  await expect(page.getByRole("menuitem", { name: "Create New Agent" })).toBeVisible();
+  await page.keyboard.press("Escape");
   const updates = fixture.getUpdateSpecPayloads();
   expect(updates).toHaveLength(1);
   expect(updates[0]?.payload.spec.members[0]?.member_id).toBe("agent-forge-1");


### PR DESCRIPTION
## Summary

- simplify the default Team add-agent entry to the two intended paths: `Create New Agent` and `Copy Existing Agent`
- keep coordinator/worker assignment fixed by Team state instead of presenting add-agent as role selection
- remove the disabled `Move to Team (later)` action from the copy modal so copy and move remain separate flows
- record the rollout checkpoint in `docs/journal/2026-05-06-team-create-mission-first-add-agent.md`

## Purpose

This advances the `P0+` Team creation backlog item by keeping `Create Team` mission-first and making the follow-up add-agent path less role-ceremonial. The first added agent still becomes coordinator; later agents still default to worker.

## Related Issues

- None

## Testing

```bash
cd web && npm exec vitest -- run src/pages/team_setup_panel.test.tsx src/pages/team/team_management_modals.test.tsx src/pages/team_panels.test.tsx
cd web && npm run lint
cd web && npm exec tsc -- --noEmit
cd web && npm run build
```
