### PR TITLE
feat: AgentTimeTriggers collapsible panel

### DIFF
--- a/docs/journal/2026-05-06-agent-time-triggers-panel.md
+++ b/docs/journal/2026-05-06-agent-time-triggers-panel.md
@@ -1,0 +1,55 @@
+# Agent Time Triggers Panel
+
+## Summary
+
+Added a read-only AgentTimeTriggers collapsible panel below the OutputHeader in the agent detail
+view. Operators can now inspect scheduled time triggers that agents created via
+`agent_time_trigger_set` (MCP/CLI) without switching to a debug tab or querying the API directly.
+
+## Background
+
+The backend shipped `agent_time_triggers` persistence and dispatch in March
+(`docs/journal/2026-03-19-team-agent-time-triggers-and-profile-updates.md`), followed by internal
+gRPC and CLI surface hardening. The feature journal explicitly deferred a frontend panel decision.
+This slice closes that gap with a read-only inspection surface.
+
+## Scope
+
+- `web/src/api.ts` — `AgentTimeTriggerRecord` type and `listAgentTimeTriggers` API client
+- `web/src/components/agent_time_triggers_panel.tsx` (new) — collapsible `<details>` panel
+- `web/src/components/agents_route_shell.tsx` — thread `authToken` prop, render panel
+- `web/src/components/agents_root_page.tsx` — pass `auth.token` to shell
+- `web/src/agents_route_shell.test.tsx` — adapt for new `authToken` prop
+
+This slice does not include create/cancel actions from the UI; those remain MCP/CLI-only for now.
+
+## Key Decisions
+
+- **Read-only first**: the panel lists triggers with status, countdown, and message preview but
+  does not expose create or cancel actions. Agents remain in control of their own triggers.
+- **Extensible by kind**: trigger items are labeled by their `kind` field
+  (`triggerKindLabel(kind)`) so future trigger types (e.g. cron-like, event-driven) can be
+  displayed without changing the panel structure.
+- **Collapsible placement**: the panel sits between the OutputHeader and the workbench area,
+  reusing the same `<details>` visual pattern as `OutputHeaderDetails`. It only appears when an
+  agent is selected.
+- **Active-count badge**: a blue pill badge on the summary shows how many triggers are in
+  `scheduled` or `dispatching` state.
+
+## Validation
+
+```bash
+cd web && pnpm exec tsc --noEmit       # clean
+cd web && pnpm run lint                # clean
+cd web && pnpm run build               # 637ms, 1213 modules
+cd web && pnpm exec vitest run src/agents_route_shell.test.tsx  # 7/7 passed
+```
+
+PR: https://github.com/hawkingrei/agenthub/pull/519
+
+## Follow-Ups
+
+- Add inline create/cancel actions to the panel when operator-controlled triggers are needed.
+- Surface triggers in the Team member console so operators see per-member scheduled work without
+  navigating to individual agent pages.
+- Extend `triggerKindLabel` when new trigger kinds land (cron, event-driven, etc.).

--- a/web/src/agents_route_shell.test.tsx
+++ b/web/src/agents_route_shell.test.tsx
@@ -119,6 +119,7 @@ function renderShell(
     <MantineProvider>
       <AgentsRouteShellView
         agentsCollapsed={false}
+        authToken={null}
         workspaceRef={React.createRef<HTMLElement>()}
         workspaceStyle={undefined}
         onAgentsSplitterPointerDown={() => {}}
@@ -138,6 +139,7 @@ function renderRouteShell(
     <MantineProvider>
       <AgentsRouteShell
         agentsCollapsed={false}
+        authToken={null}
         workspaceRef={React.createRef<HTMLElement>()}
         workspaceStyle={undefined}
         onAgentsSplitterPointerDown={() => {}}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -42,6 +42,20 @@ export type AgentRecord = {
   updated_at: number;
 };
 
+export type AgentTimeTriggerRecord = {
+  id: string;
+  agent_id: string;
+  kind: string;
+  created_by_actor_id: string;
+  message_text: string;
+  fire_at: number;
+  status: "scheduled" | "dispatching" | "fired" | "canceled";
+  created_at: number;
+  updated_at: number;
+  fired_at: number | null;
+  last_error: string | null;
+};
+
 export type AgentDiscoveryIdentityRecord = {
   agent_id: string;
   name: string;
@@ -1272,6 +1286,15 @@ export const api = {
     apiFetch<{ status: string }>(`/api/agents/${encodePathSegment(id)}`, token, {
       method: "DELETE",
     }),
+  listAgentTimeTriggers: (
+    token: string,
+    id: string,
+    limit?: number
+  ) =>
+    apiFetch<AgentTimeTriggerRecord[]>(
+      `/api/agents/${encodePathSegment(id)}/triggers${limit != null ? `?limit=${limit}` : ""}`,
+      token
+    ),
   listAcpPermissions: (token: string, id: string, status?: string) => {
     const query = status ? `?status=${encodeURIComponent(status)}` : "";
     return apiFetch<AcpPermissionRecord[]>(

--- a/web/src/components/agent_time_triggers_panel.tsx
+++ b/web/src/components/agent_time_triggers_panel.tsx
@@ -150,7 +150,7 @@ export const AgentTimeTriggersPanel = React.memo(
                     {triggerKindLabel(trigger.kind)}
                   </span>
                   <span className={OUTPUT_HEADER_DETAILS_VALUE_CLASS}>
-                    <span className={resolveTriggerStatusTone(trigger.status)}>
+                    <span className={trigger.last_error ? "text-red-600" : resolveTriggerStatusTone(trigger.status)}>
                       {trigger.status}
                     </span>{" "}
                     · {formatFireAt(trigger.fire_at)}
@@ -165,7 +165,7 @@ export const AgentTimeTriggersPanel = React.memo(
                     {trigger.last_error && (
                       <>
                         <br />
-                        <span className="text-red-600">{trigger.last_error}</span>
+                        <span className="text-red-600">Error: {trigger.last_error}</span>
                       </>
                     )}
                     {trigger.message_text && (

--- a/web/src/components/agent_time_triggers_panel.tsx
+++ b/web/src/components/agent_time_triggers_panel.tsx
@@ -20,13 +20,25 @@ const ACTIVE_TRIGGER_STATUSES = new Set(["scheduled", "dispatching"]);
 function formatFireAt(fireAtUnix: number): string {
   const d = new Date(fireAtUnix * 1000);
   const now = Date.now();
-  const diffSec = Math.max(0, Math.floor((d.getTime() - now) / 1000));
+  const diffSec = Math.floor((d.getTime() - now) / 1000);
 
+  if (diffSec < 0) {
+    const ago = Math.abs(diffSec);
+    if (ago < 60) return "just now";
+    if (ago < 3600) return `${Math.floor(ago / 60)}m ago`;
+    if (ago < 86400) return `${Math.floor(ago / 3600)}h ago`;
+    if (ago < 2592000) return `${Math.floor(ago / 86400)}d ago`;
+    return d.toLocaleDateString();
+  }
   if (diffSec < 60) return "in <1 min";
   if (diffSec < 3600) return `in ${Math.floor(diffSec / 60)}m`;
   if (diffSec < 86400) return `in ${Math.floor(diffSec / 3600)}h`;
   if (diffSec < 2592000) return `in ${Math.floor(diffSec / 86400)}d`;
   return d.toLocaleDateString();
+}
+
+function formatFiredAt(firedAtUnix: number): string {
+  return new Date(firedAtUnix * 1000).toLocaleString();
 }
 
 function triggerKindLabel(kind: string): string {
@@ -142,6 +154,20 @@ export const AgentTimeTriggersPanel = React.memo(
                       {trigger.status}
                     </span>{" "}
                     · {formatFireAt(trigger.fire_at)}
+                    {trigger.fired_at && trigger.status === "fired" && (
+                      <>
+                        <br />
+                        <span className="text-green-700">
+                          fired {formatFiredAt(trigger.fired_at)}
+                        </span>
+                      </>
+                    )}
+                    {trigger.last_error && (
+                      <>
+                        <br />
+                        <span className="text-red-600">{trigger.last_error}</span>
+                      </>
+                    )}
                     {trigger.message_text && (
                       <>
                         <br />

--- a/web/src/components/agent_time_triggers_panel.tsx
+++ b/web/src/components/agent_time_triggers_panel.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { api } from "../api";
+import type { AgentTimeTriggerRecord } from "../api";
+import {
+  OUTPUT_HEADER_DETAILS_ROOT_CLASS,
+  OUTPUT_HEADER_DETAILS_PANEL_CLASS,
+  OUTPUT_HEADER_DETAILS_LIST_CLASS,
+  OUTPUT_HEADER_DETAILS_ITEM_CLASS,
+  OUTPUT_HEADER_DETAILS_LABEL_CLASS,
+  OUTPUT_HEADER_DETAILS_VALUE_CLASS,
+} from "../ui/tailwind_classes";
+
+export type AgentTimeTriggersPanelProps = {
+  agentId: string | null;
+  authToken: string | null;
+};
+
+const ACTIVE_TRIGGER_STATUSES = new Set(["scheduled", "dispatching"]);
+
+function formatFireAt(fireAtUnix: number): string {
+  const d = new Date(fireAtUnix * 1000);
+  const now = Date.now();
+  const diffSec = Math.max(0, Math.floor((d.getTime() - now) / 1000));
+
+  if (diffSec < 60) return "in <1 min";
+  if (diffSec < 3600) return `in ${Math.floor(diffSec / 60)}m`;
+  if (diffSec < 86400) return `in ${Math.floor(diffSec / 3600)}h`;
+  if (diffSec < 2592000) return `in ${Math.floor(diffSec / 86400)}d`;
+  return d.toLocaleDateString();
+}
+
+function triggerKindLabel(kind: string): string {
+  return kind === "time" ? "time" : kind;
+}
+
+function resolveTriggerStatusTone(
+  status: AgentTimeTriggerRecord["status"]
+): string {
+  switch (status) {
+    case "scheduled":
+      return "text-blue-600";
+    case "dispatching":
+      return "text-amber-600";
+    case "fired":
+      return "text-green-600";
+    case "canceled":
+      return "text-slate-400";
+    default:
+      return "text-slate-600";
+  }
+}
+
+export const AgentTimeTriggersPanel = React.memo(
+  function AgentTimeTriggersPanel({
+    agentId,
+    authToken,
+  }: AgentTimeTriggersPanelProps) {
+    const [triggers, setTriggers] = React.useState<
+      AgentTimeTriggerRecord[] | null
+    >(null);
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+      if (!agentId || !authToken) {
+        setTriggers(null);
+        setError(null);
+        return;
+      }
+      let cancelled = false;
+      (async () => {
+        try {
+          setError(null);
+          const records = await api.listAgentTimeTriggers(
+            authToken,
+            agentId,
+            100
+          );
+          if (!cancelled) setTriggers(records);
+        } catch (err) {
+          if (!cancelled) {
+            setError(
+              err instanceof Error ? err.message : "Failed to load triggers"
+            );
+            setTriggers(null);
+          }
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [agentId, authToken]);
+
+    if (!agentId || !authToken) return null;
+    if (error) {
+      return (
+        <details className={OUTPUT_HEADER_DETAILS_ROOT_CLASS}>
+          <summary className="inline-flex cursor-pointer list-none items-center rounded-md border border-transparent bg-transparent px-1 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-notion-text-muted/62 transition hover:bg-notion-hover/65 hover:text-notion-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent/10">
+            Triggers
+          </summary>
+          <div className={OUTPUT_HEADER_DETAILS_PANEL_CLASS}>
+            <div className="px-2 py-1.5 text-[11px] text-red-600">{error}</div>
+          </div>
+        </details>
+      );
+    }
+
+    const loading = triggers === null;
+    const activeCount = loading
+      ? 0
+      : triggers.filter((t) => ACTIVE_TRIGGER_STATUSES.has(t.status)).length;
+
+    return (
+      <details className={OUTPUT_HEADER_DETAILS_ROOT_CLASS}>
+        <summary className="inline-flex cursor-pointer list-none items-center gap-1.5 rounded-md border border-transparent bg-transparent px-1 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-notion-text-muted/62 transition hover:bg-notion-hover/65 hover:text-notion-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent/10">
+          Triggers
+          {activeCount > 0 && (
+            <span className="inline-flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-blue-100 px-1 text-[8px] font-semibold text-blue-700">
+              {activeCount}
+            </span>
+          )}
+        </summary>
+        <div className={OUTPUT_HEADER_DETAILS_PANEL_CLASS}>
+          <div className={OUTPUT_HEADER_DETAILS_LIST_CLASS}>
+            {loading && (
+              <div className="px-2 py-1.5 text-[10px] text-notion-text-muted">
+                Loading...
+              </div>
+            )}
+            {!loading && triggers.length === 0 && (
+              <div className="px-2 py-1.5 text-[10px] text-notion-text-muted">
+                No scheduled triggers
+              </div>
+            )}
+            {!loading &&
+              triggers.map((trigger) => (
+                <div key={trigger.id} className={OUTPUT_HEADER_DETAILS_ITEM_CLASS}>
+                  <span className={OUTPUT_HEADER_DETAILS_LABEL_CLASS}>
+                    {triggerKindLabel(trigger.kind)}
+                  </span>
+                  <span className={OUTPUT_HEADER_DETAILS_VALUE_CLASS}>
+                    <span className={resolveTriggerStatusTone(trigger.status)}>
+                      {trigger.status}
+                    </span>{" "}
+                    · {formatFireAt(trigger.fire_at)}
+                    {trigger.message_text && (
+                      <>
+                        <br />
+                        <span className="opacity-70">
+                          {trigger.message_text.length > 80
+                            ? trigger.message_text.slice(0, 80) + "…"
+                            : trigger.message_text}
+                        </span>
+                      </>
+                    )}
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      </details>
+    );
+  }
+);
+AgentTimeTriggersPanel.displayName = "AgentTimeTriggersPanel";

--- a/web/src/components/agents_root_page.tsx
+++ b/web/src/components/agents_root_page.tsx
@@ -216,6 +216,7 @@ export const AgentsRootPage = React.memo(function AgentsRootPage({
         <AgentsRouteShell
           agentsCollapsed={agentsCollapsed}
           workspaceRef={workspaceRef}
+          authToken={auth?.token ?? null}
           workspaceStyle={workspaceStyle}
           onAgentsSplitterPointerDown={onAgentsSplitterPointerDown}
           agentsPanelProps={agentsPanelProps}

--- a/web/src/components/agents_route_shell.tsx
+++ b/web/src/components/agents_route_shell.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { AgentsPanel, AgentsPanelProps } from "./agents_panel";
 import { AgentsWorkbenchProps } from "./agents_workbench_types";
+import { AgentTimeTriggersPanel } from "./agent_time_triggers_panel";
 import { OutputHeader, OutputHeaderProps } from "./output_header";
 import { OutputErrorBoundary } from "./output_error_boundary";
 import {
@@ -32,6 +33,7 @@ function WorkbenchBodyFallback({ hasAcp }: { hasAcp: boolean }) {
 type AgentsRouteShellViewProps = {
   agentsCollapsed: boolean;
   workspaceRef: React.RefObject<HTMLElement | null>;
+  authToken: string | null;
   workspaceStyle?: React.CSSProperties;
   onAgentsSplitterPointerDown: React.PointerEventHandler<HTMLDivElement>;
   agentsPanelProps: AgentsPanelProps;
@@ -43,6 +45,7 @@ type AgentsRouteShellViewProps = {
 export const AgentsRouteShellView = React.memo(function AgentsRouteShellView({
   agentsCollapsed,
   workspaceRef,
+  authToken,
   workspaceStyle,
   onAgentsSplitterPointerDown,
   agentsPanelProps,
@@ -80,7 +83,15 @@ export const AgentsRouteShellView = React.memo(function AgentsRouteShellView({
             <OutputHeader {...outputHeaderProps} />
           </div>
         ) : null}
-        <div className="flex-1 min-h-0 overflow-hidden relative flex flex-col">
+        {outputHeaderProps.activeAgent ? (
+          <div className="shrink-0 px-3 pt-1">
+            <AgentTimeTriggersPanel
+              agentId={outputHeaderProps.activeAgent.id}
+              authToken={authToken}
+            />
+          </div>
+        ) : null}
+        <div className="flex-1 min-h-0 overflow-hidden relative flex flex-col pt-0.5">
           {workbenchNode}
         </div>
       </div>
@@ -97,6 +108,7 @@ type AgentsRouteShellProps = Omit<AgentsRouteShellViewProps, "workbenchNode"> & 
 export const AgentsRouteShell = React.memo(function AgentsRouteShell({
   agentsCollapsed,
   workspaceRef,
+  authToken,
   workspaceStyle,
   onAgentsSplitterPointerDown,
   agentsPanelProps,
@@ -119,6 +131,7 @@ export const AgentsRouteShell = React.memo(function AgentsRouteShell({
     <AgentsRouteShellView
       agentsCollapsed={agentsCollapsed}
       workspaceRef={workspaceRef}
+      authToken={authToken}
       workspaceStyle={workspaceStyle}
       onAgentsSplitterPointerDown={onAgentsSplitterPointerDown}
       agentsPanelProps={agentsPanelProps}


### PR DESCRIPTION
## Summary

Add a read-only AgentTimeTriggers collapsible panel below the OutputHeader in the agent detail view. Agents can schedule one-shot timed self-reminders via `agent_time_trigger_set` (MCP/CLI), and this panel surfaces the currently scheduled triggers so operators can inspect them.

## Changes

- **api.ts**: Add `AgentTimeTriggerRecord` type and `listAgentTimeTriggers` API client
- **agent_time_triggers_panel.tsx** (new): Collapsible `<details>` panel showing scheduled triggers with status badge, countdown, and message preview. Handles loading/empty/error states. Extensible by `kind` field for future trigger types.
- **agents_route_shell.tsx**: Thread `authToken` prop, render panel between OutputHeader and workbench when agent is selected
- **agents_root_page.tsx**: Pass `auth.token` to `AgentsRouteShell`
- **agents_route_shell.test.tsx**: Adapt tests for new `authToken` prop

## Validation

```bash
cd web && pnpm exec tsc --noEmit    # clean
cd web && pnpm run lint             # clean
cd web && pnpm run build            # 637ms, 1213 modules
cd web && pnpm exec vitest run src/agents_route_shell.test.tsx  # 7/7 passed
```