### PR TITLE
fix(team): clarify adoption copy boundary

### DIFF
--- a/docs/journal/2026-05-06-team-adoption-move-deferred.md
+++ b/docs/journal/2026-05-06-team-adoption-move-deferred.md
@@ -35,7 +35,7 @@ before it can be enabled.
 npm --prefix web run test -- src/pages/team/team_management_modals.test.tsx
 git diff --check
 npm --prefix web run lint
-cd web && npm exec tsc -- --noEmit
+npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit
 npm --prefix web run build
 ```
 

--- a/docs/journal/2026-05-06-team-adoption-move-deferred.md
+++ b/docs/journal/2026-05-06-team-adoption-move-deferred.md
@@ -2,8 +2,8 @@
 
 ## Summary
 
-`Add Existing Agent` now keeps `Copy into Team` as the only executable adoption path while showing
-`Move to Team` as explicitly deferred.
+`Add Existing Agent` now keeps `Copy into Team` as the only executable adoption path while
+documenting `Move to Team` as explicitly deferred.
 
 ## Background
 
@@ -16,15 +16,18 @@ before it can be enabled.
 
 - Keep copy as the active Add Existing Agent action.
 - Add visible move semantics explaining why transfer is not enabled yet.
-- Render a disabled `Move to Team (later)` action so copy and move are not collapsed into one
-  ambiguous import path.
+- Keep move as non-actionable explanatory copy instead of a default add-agent action.
+- Make the default copy boundary explicit: copied configuration does not clone workspace contents,
+  runtime history, active sessions, or workspace-local memory/context.
 
 ## Key Decisions
 
 - Do not add move behavior in this slice.
 - Do not mutate source agents from the Add Existing Agent flow.
-- Keep the disabled move action in the same modal as copy so operators see the product boundary at
-  the decision point.
+- Keep move semantics in the same modal as copy so operators see the product boundary at the
+  decision point, without presenting move as a selectable action.
+- Keep workspace-content copy, memory/context seeding, and ownership transfer as separate opt-in
+  follow-ups rather than implicit side effects of configuration copy.
 
 ## Validation
 
@@ -32,6 +35,7 @@ before it can be enabled.
 npm --prefix web run test -- src/pages/team/team_management_modals.test.tsx
 git diff --check
 npm --prefix web run lint
+cd web && npm exec tsc -- --noEmit
 npm --prefix web run build
 ```
 
@@ -40,7 +44,9 @@ npm --prefix web run build
 The Team setup E2E path now covers the copy-first adoption boundary:
 
 - an empty Team can open `Copy Existing Agent` from the setup panel;
-- `Move to Team (later)` is visible but disabled;
+- `Move to Team (later)` is not shown as a default action;
+- the modal explains that move semantics are not enabled yet;
+- the modal explains that the default copy path is configuration-only;
 - `Copy into Team` creates a new Team-owned coordinator member;
 - the original source agent remains available in the mocked agent list.
 
@@ -53,3 +59,5 @@ npm --prefix web run e2e -- tests/e2e/team_page_setup.e2e.ts --grep "team adopti
 ## Follow-Ups
 
 - Define stopped-only runtime and ownership-transfer guards before enabling `Move to Team`.
+- Separately evaluate explicit workspace-content copy and memory/context seeding before any
+  non-configuration adoption mode is enabled.

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -308,6 +308,9 @@ describe("Team management modals", () => {
     expect(html).toContain("Source Agent");
     expect(html).toContain("Copy semantics");
     expect(html).toContain("Copy into Team");
+    expect(html).toContain("Configuration copy only");
+    expect(html).toContain("does not clone workspace contents");
+    expect(html).toContain("workspace-local memory/context");
   });
 
   it("renders the copy-existing-agent dialog as a semantic list with selection state", () => {

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -553,6 +553,11 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             Copy keeps the source agent unchanged. AgentHub creates a new Team-owned{" "}
             {copyRoleLabel} agent with copied runtime settings and fresh Team membership.
           </Alert>
+          <Alert radius="md" color="blue" variant="light" title="Configuration copy only">
+            The default copy path does not clone workspace contents, runtime history, active
+            sessions, or workspace-local memory/context. Those must remain explicit opt-in
+            follow-ups.
+          </Alert>
           <Alert
             radius="md"
             color="yellow"


### PR DESCRIPTION
## Summary

- Clarify that `Copy into Team` is configuration-only by default.
- Keep workspace contents, runtime history, active sessions, and workspace-local memory/context out of the implicit copy path.
- Update the Team adoption journal so it no longer describes `Move to Team (later)` as a disabled default action.

## Purpose

This keeps Team adoption aligned with the copy-vs-move contract: copying an existing agent into a Team remains safe and non-mutating, while workspace-content copy, memory/context seeding, and ownership transfer stay explicit future flows.

## Related Issue

None.

## Testing

```bash
npm --prefix web run test -- src/pages/team/team_management_modals.test.tsx
git diff --check
npm --prefix web run lint
npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit
npm --prefix web run build
```
