### PR TITLE
chore(acp): unify agent client protocol sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,29 +282,12 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10eeef5e80864f9c3c148a3f395c3e35a66d37ec7561c7845b2bffae8e841759"
-dependencies = [
- "agent-client-protocol-schema 0.11.4",
- "anyhow",
- "async-broadcast",
- "async-trait",
- "derive_more 2.1.1",
- "futures",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "agent-client-protocol"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
 dependencies = [
  "agent-client-protocol-derive",
- "agent-client-protocol-schema 0.12.0",
+ "agent-client-protocol-schema",
  "anyhow",
  "futures",
  "futures-concurrency",
@@ -334,20 +317,6 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
-dependencies = [
- "anyhow",
- "derive_more 2.1.1",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "strum 0.28.0",
-]
-
-[[package]]
-name = "agent-client-protocol-schema"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
@@ -366,8 +335,7 @@ dependencies = [
 name = "agenthub"
 version = "0.1.0"
 dependencies = [
- "agent-client-protocol 0.10.4",
- "agent-client-protocol 0.11.1",
+ "agent-client-protocol",
  "agenthub-acp",
  "agenthub-config",
  "agenthub-db",
@@ -428,8 +396,7 @@ dependencies = [
 name = "agenthub-acp"
 version = "0.1.0"
 dependencies = [
- "agent-client-protocol 0.10.4",
- "agent-client-protocol 0.11.1",
+ "agent-client-protocol",
  "agenthub-acp-core",
  "agenthub-config",
  "agenthub-managed-skills",
@@ -451,8 +418,7 @@ dependencies = [
 name = "agenthub-acp-core"
 version = "0.1.0"
 dependencies = [
- "agent-client-protocol 0.10.4",
- "agent-client-protocol 0.11.1",
+ "agent-client-protocol",
  "serde",
  "serde_json",
  "tracing",
@@ -462,8 +428,7 @@ dependencies = [
 name = "agenthub-codex-acp"
 version = "0.10.0"
 dependencies = [
- "agent-client-protocol 0.10.4",
- "agent-client-protocol 0.11.1",
+ "agent-client-protocol",
  "agenthub-managed-skills",
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ agenthub-config = { path = "crates/agenthub-config" }
 agenthub-db = { path = "crates/agenthub-db" }
 agenthub-pyroscope = { path = "crates/agenthub-pyroscope" }
 agent-client-protocol = { version = "0.11.1", features = ["unstable"] }
-agent-client-protocol-legacy = { package = "agent-client-protocol", version = "=0.10.4", features = ["unstable"] }
 prost = "0.14"
 tonic-prost = "0.14"
 tonic = { version = "0.14", features = ["transport", "tls-native-roots"] }

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -22,7 +22,6 @@ release-vendored-openssl = ["dep:openssl"]
 
 [dependencies]
 agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
-agent-client-protocol-legacy = { package = "agent-client-protocol", version = "=0.10.4", features = ["unstable"] }
 agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use agent_client_protocol_legacy::{Error, SessionId};
+use agent_client_protocol::Error;
+use agent_client_protocol::schema::SessionId;
 use codex_app_server_client::{
     DEFAULT_IN_PROCESS_CHANNEL_CAPACITY, InProcessAppServerClient, InProcessAppServerRequestHandle,
     InProcessClientStartArgs, InProcessServerEvent, TypedRequestError,

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -1,15 +1,14 @@
-use agent_client_protocol_legacy::Error;
-use agent_client_protocol_legacy::{
-    Agent, AgentCapabilities, AuthEnvVar, AuthMethod, AuthMethodAgent, AuthMethodEnvVar,
-    AuthMethodId, AuthenticateRequest, AuthenticateResponse, CancelNotification,
-    ClientCapabilities, CloseSessionRequest, CloseSessionResponse, Implementation,
-    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, McpServerHttp,
-    McpServerStdio, NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest,
-    PromptResponse, ProtocolVersion, SessionCapabilities, SessionCloseCapabilities, SessionId,
-    SessionInfo, SessionListCapabilities, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
-    SetSessionModelRequest, SetSessionModelResponse,
+use agent_client_protocol::Error;
+use agent_client_protocol::schema::{
+    AgentCapabilities, AuthEnvVar, AuthMethod, AuthMethodAgent, AuthMethodEnvVar, AuthMethodId,
+    AuthenticateRequest, AuthenticateResponse, CancelNotification, ClientCapabilities,
+    CloseSessionRequest, CloseSessionResponse, Implementation, InitializeRequest,
+    InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
+    LoadSessionResponse, McpCapabilities, McpServer, McpServerHttp, McpServerStdio,
+    NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse,
+    ProtocolVersion, SessionCapabilities, SessionCloseCapabilities, SessionId, SessionInfo,
+    SessionListCapabilities, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+    SetSessionModeRequest, SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse,
 };
 use codex_config::types::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
@@ -522,9 +521,11 @@ fn repair_initial_history(history: InitialHistory) -> (InitialHistory, HistoryRe
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl Agent for CodexAgent {
-    async fn initialize(&self, request: InitializeRequest) -> Result<InitializeResponse, Error> {
+impl CodexAgent {
+    pub(crate) async fn initialize(
+        &self,
+        request: InitializeRequest,
+    ) -> Result<InitializeResponse, Error> {
         let InitializeRequest {
             protocol_version,
             client_capabilities,
@@ -564,7 +565,7 @@ impl Agent for CodexAgent {
             .auth_methods(auth_methods))
     }
 
-    async fn authenticate(
+    pub(crate) async fn authenticate(
         &self,
         request: AuthenticateRequest,
     ) -> Result<AuthenticateResponse, Error> {
@@ -631,7 +632,10 @@ impl Agent for CodexAgent {
         Ok(AuthenticateResponse::new())
     }
 
-    async fn new_session(&self, request: NewSessionRequest) -> Result<NewSessionResponse, Error> {
+    pub(crate) async fn new_session(
+        &self,
+        request: NewSessionRequest,
+    ) -> Result<NewSessionResponse, Error> {
         // Check before sending if authentication was successful or not
         self.check_auth().await?;
 
@@ -671,7 +675,7 @@ impl Agent for CodexAgent {
             .config_options(load.config_options))
     }
 
-    async fn load_session(
+    pub(crate) async fn load_session(
         &self,
         request: LoadSessionRequest,
     ) -> Result<LoadSessionResponse, Error> {
@@ -739,7 +743,7 @@ impl Agent for CodexAgent {
             .config_options(load.config_options))
     }
 
-    async fn list_sessions(
+    pub(crate) async fn list_sessions(
         &self,
         request: ListSessionsRequest,
     ) -> Result<ListSessionsResponse, Error> {
@@ -803,7 +807,7 @@ impl Agent for CodexAgent {
         Ok(ListSessionsResponse::new(sessions).next_cursor(next_cursor))
     }
 
-    async fn close_session(
+    pub(crate) async fn close_session(
         &self,
         request: CloseSessionRequest,
     ) -> Result<CloseSessionResponse, Error> {
@@ -822,7 +826,7 @@ impl Agent for CodexAgent {
         Ok(CloseSessionResponse::new())
     }
 
-    async fn prompt(&self, request: PromptRequest) -> Result<PromptResponse, Error> {
+    pub(crate) async fn prompt(&self, request: PromptRequest) -> Result<PromptResponse, Error> {
         info!("Processing prompt for session: {}", request.session_id);
         // Check before sending if authentication was successful or not
         self.check_auth().await?;
@@ -834,13 +838,13 @@ impl Agent for CodexAgent {
         Ok(PromptResponse::new(stop_reason))
     }
 
-    async fn cancel(&self, args: CancelNotification) -> Result<(), Error> {
+    pub(crate) async fn cancel(&self, args: CancelNotification) -> Result<(), Error> {
         info!("Cancelling operations for session: {}", args.session_id);
         self.get_thread(&args.session_id)?.cancel().await?;
         Ok(())
     }
 
-    async fn set_session_mode(
+    pub(crate) async fn set_session_mode(
         &self,
         args: SetSessionModeRequest,
     ) -> Result<SetSessionModeResponse, Error> {
@@ -851,7 +855,7 @@ impl Agent for CodexAgent {
         Ok(SetSessionModeResponse::default())
     }
 
-    async fn set_session_model(
+    pub(crate) async fn set_session_model(
         &self,
         args: SetSessionModelRequest,
     ) -> Result<SetSessionModelResponse, Error> {
@@ -864,7 +868,7 @@ impl Agent for CodexAgent {
         Ok(SetSessionModelResponse::default())
     }
 
-    async fn set_session_config_option(
+    pub(crate) async fn set_session_config_option(
         &self,
         args: SetSessionConfigOptionRequest,
     ) -> Result<SetSessionConfigOptionResponse, Error> {

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -1,7 +1,12 @@
 //! Codex ACP - An Agent Client Protocol implementation for Codex.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
-use agent_client_protocol_legacy::AgentSideConnection;
+use agent_client_protocol::schema::{
+    AuthenticateRequest, CancelNotification, CloseSessionRequest, InitializeRequest,
+    ListSessionsRequest, LoadSessionRequest, NewSessionRequest, PromptRequest,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
+};
+use agent_client_protocol::{Agent, Client, ConnectionTo};
 use codex_core::config::ManagedFeatures;
 use codex_core::config::{Config, ConfigOverrides};
 use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
@@ -10,7 +15,9 @@ use codex_utils_cli::CliConfigOverrides;
 use std::fmt;
 use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll};
 use std::{io::Result as IoResult, rc::Rc};
 use tokio::task::LocalSet;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -31,14 +38,52 @@ mod linux_memfd_compat;
 mod prompt_args;
 mod thread;
 
-pub static ACP_CLIENT: OnceLock<Arc<AgentSideConnection>> = OnceLock::new();
+pub static ACP_CLIENT: OnceLock<Arc<ConnectionTo<Client>>> = OnceLock::new();
 const AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED_ENV: &str = "AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED";
+
+#[derive(Clone)]
+struct LocalCodexAgent(Rc<codex_agent::CodexAgent>);
+
+// The ACP adapter runs inside a single-threaded Tokio runtime and LocalSet. The
+// 0.11 ACP builder requires Send handlers even though this binary never moves
+// CodexAgent across worker threads.
+unsafe impl Send for LocalCodexAgent {}
+unsafe impl Sync for LocalCodexAgent {}
+
+impl std::ops::Deref for LocalCodexAgent {
+    type Target = codex_agent::CodexAgent;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+struct LocalSendFuture<F>(F);
+
+// These futures are only polled on the current-thread ACP runtime. This wrapper
+// satisfies the 0.11 ACP handler bounds while preserving the existing local
+// Codex state model.
+unsafe impl<F> Send for LocalSendFuture<F> {}
+
+impl<F: Future> Future for LocalSendFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: LocalSendFuture is a transparent wrapper and does not move the
+        // inner future after it has been pinned by the executor.
+        unsafe { self.map_unchecked_mut(|item| &mut item.0) }.poll(cx)
+    }
+}
+
+fn local_send_future<F: Future>(future: F) -> LocalSendFuture<F> {
+    LocalSendFuture(future)
+}
 
 pub(crate) async fn build_environment_manager(
     config: &Config,
-) -> Result<Arc<EnvironmentManager>, agent_client_protocol_legacy::Error> {
+) -> Result<Arc<EnvironmentManager>, agent_client_protocol::Error> {
     let current_exe = std::env::current_exe().map_err(|err| {
-        agent_client_protocol_legacy::Error::internal_error().data(format!(
+        agent_client_protocol::Error::internal_error().data(format!(
             "failed to determine current executable path: {err}"
         ))
     })?;
@@ -47,7 +92,7 @@ pub(crate) async fn build_environment_manager(
         config.codex_linux_sandbox_exe.clone(),
     )
     .map_err(|err| {
-        agent_client_protocol_legacy::Error::internal_error().data(format!(
+        agent_client_protocol::Error::internal_error().data(format!(
             "failed to resolve exec-server runtime paths: {err}"
         ))
     })?;
@@ -56,12 +101,14 @@ pub(crate) async fn build_environment_manager(
     ))
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub(crate) fn spawn_acp_io_task<F>(
     thread_name: &str,
     io_task: F,
 ) -> IoResult<tokio::sync::oneshot::Receiver<IoResult<()>>>
 where
-    F: Future<Output = agent_client_protocol_legacy::Result<()>> + Send + 'static,
+    F: Future<Output = agent_client_protocol::Result<()>> + Send + 'static,
 {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let thread_name = thread_name.to_string();
@@ -334,28 +381,124 @@ pub async fn run_main(
     }
     normalize_responses_websocket_support(&mut config);
 
-    let stdin = tokio::io::stdin().compat();
-    let stdout = tokio::io::stdout().compat_write();
-
     // Run the I/O task to handle the actual communication
     LocalSet::new()
         .run_until(async move {
-            let agent = Rc::new(codex_agent::CodexAgent::new(config).await.map_err(|err| {
-                std::io::Error::other(format!("failed to initialize Codex ACP agent: {err}"))
-            })?);
-            // Create the ACP connection
-            let (client, io_task) = AgentSideConnection::new(agent.clone(), stdout, stdin, |fut| {
-                tokio::task::spawn_local(fut);
-            });
+            let agent = LocalCodexAgent(Rc::new(
+                codex_agent::CodexAgent::new(config).await.map_err(|err| {
+                    std::io::Error::other(format!("failed to initialize Codex ACP agent: {err}"))
+                })?,
+            ));
+            let transport = agent_client_protocol::ByteStreams::new(
+                tokio::io::stdout().compat_write(),
+                tokio::io::stdin().compat(),
+            );
+            let agent_for_initialize = agent.clone();
+            let agent_for_authenticate = agent.clone();
+            let agent_for_new_session = agent.clone();
+            let agent_for_load_session = agent.clone();
+            let agent_for_list_sessions = agent.clone();
+            let agent_for_close_session = agent.clone();
+            let agent_for_prompt = agent.clone();
+            let agent_for_cancel = agent.clone();
+            let agent_for_mode = agent.clone();
+            let agent_for_model = agent.clone();
+            let agent_for_config = agent.clone();
 
-            if ACP_CLIENT.set(Arc::new(client)).is_err() {
-                return Err(std::io::Error::other("ACP client already set"));
-            }
-
-            let io_task = spawn_acp_io_task("agenthub-codex-acp-io", io_task)?;
-            io_task.await.map_err(|_| {
-                std::io::Error::other("ACP I/O thread shut down before reporting a result")
-            })?
+            Agent
+                .builder()
+                .name("agenthub-codex-acp")
+                .on_receive_request(
+                    async move |request: InitializeRequest, responder, connection| {
+                        drop(ACP_CLIENT.set(Arc::new(connection.clone())));
+                        responder.respond_with_result(
+                            local_send_future(agent_for_initialize.initialize(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: AuthenticateRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_authenticate.authenticate(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: NewSessionRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_new_session.new_session(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: LoadSessionRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_load_session.load_session(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: ListSessionsRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_list_sessions.list_sessions(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: CloseSessionRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_close_session.close_session(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: PromptRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_prompt.prompt(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    async move |notification: CancelNotification, _connection| {
+                        local_send_future(agent_for_cancel.cancel(notification)).await
+                    },
+                    agent_client_protocol::on_receive_notification!(),
+                )
+                .on_receive_request(
+                    async move |request: SetSessionModeRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_mode.set_session_mode(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: SetSessionModelRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_model.set_session_model(request)).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: SetSessionConfigOptionRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            local_send_future(agent_for_config.set_session_config_option(request))
+                                .await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .connect_to(transport)
+                .await
+                .map_err(|err| std::io::Error::other(format!("ACP I/O error: {err}")))
         })
         .await?;
 

--- a/agenthub-codex-acp/src/local_spawner.rs
+++ b/agenthub-codex-acp/src/local_spawner.rs
@@ -5,10 +5,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use agent_client_protocol_legacy::{
-    AgentSideConnection, Client, ClientCapabilities, ReadTextFileRequest, SessionId,
-    WriteTextFileRequest,
+use agent_client_protocol::ConnectionTo;
+use agent_client_protocol::schema::{
+    ClientCapabilities, ReadTextFileRequest, SessionId, WriteTextFileRequest,
 };
+use agent_client_protocol::Client;
 use codex_apply_patch::StdFs;
 use tokio::sync::mpsc;
 
@@ -109,9 +110,9 @@ impl FsTask {
                 path,
                 tx,
             } => {
-                let read_text_file =
-                    Self::client().read_text_file(ReadTextFileRequest::new(session_id, path));
-                let response = read_text_file
+                let response = Self::client()
+                    .send_request(ReadTextFileRequest::new(session_id, path))
+                    .block_task()
                     .await
                     .map(|response| response.content)
                     .map_err(|e| std::io::Error::other(e.to_string()));
@@ -123,11 +124,12 @@ impl FsTask {
                 limit,
                 tx,
             } => {
-                let read_text_file = Self::client().read_text_file(
-                    ReadTextFileRequest::new(session_id, path)
-                        .limit(limit.try_into().unwrap_or(u32::MAX)),
-                );
-                let response = read_text_file
+                let response = Self::client()
+                    .send_request(
+                        ReadTextFileRequest::new(session_id, path)
+                            .limit(limit.try_into().unwrap_or(u32::MAX)),
+                    )
+                    .block_task()
                     .await
                     .map(|response| response.content)
                     .map_err(|e| std::io::Error::other(e.to_string()));
@@ -140,7 +142,8 @@ impl FsTask {
                 tx,
             } => {
                 let response = Self::client()
-                    .write_text_file(WriteTextFileRequest::new(session_id, path, content))
+                    .send_request(WriteTextFileRequest::new(session_id, path, content))
+                    .block_task()
                     .await
                     .map(|_| ())
                     .map_err(|e| std::io::Error::other(e.to_string()));
@@ -149,7 +152,7 @@ impl FsTask {
         }
     }
 
-    fn client() -> &'static AgentSideConnection {
+    fn client() -> &'static ConnectionTo<Client> {
         ACP_CLIENT.get().expect("Missing ACP client")
     }
 }
@@ -309,33 +312,15 @@ impl LocalSpawner {
 
 #[cfg(test)]
 mod tests {
-    use super::{AcpFs, LocalSpawner, ensure_path_within_root};
-    use crate::{ACP_CLIENT, spawn_acp_io_task};
-    use agent_client_protocol_legacy::{Agent, AgentSideConnection, Client};
-    use agent_client_protocol_legacy::{
-        AuthenticateRequest, AuthenticateResponse, ClientCapabilities, FileSystemCapabilities,
-        Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
-        LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptRequest,
-        PromptResponse, ReadTextFileRequest, ReadTextFileResponse, SessionId,
-        SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-        SetSessionModeResponse, StopReason, WriteTextFileRequest,
-    };
+    use super::ensure_path_within_root;
     use std::{
-        collections::HashMap,
         fs,
         path::{Path, PathBuf},
-        process::Command,
         sync::{
-            Arc, Mutex,
             atomic::{AtomicU64, Ordering},
         },
-        thread,
-        time::Duration,
         time::{SystemTime, UNIX_EPOCH},
     };
-
-    const DEADLOCK_CHILD_ENV: &str = "AGENTHUB_CODEX_ACP_APPLY_PATCH_DEADLOCK_CHILD";
-    const DEADLOCK_CHILD_TEST: &str = "local_spawner::tests::apply_patch_verification_child";
 
     fn temp_root() -> PathBuf {
         static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -424,292 +409,4 @@ mod tests {
         drop(fs::remove_dir_all(outside));
     }
 
-    #[test]
-    fn apply_patch_verification_does_not_deadlock_over_acp_fs() {
-        if std::env::var_os(DEADLOCK_CHILD_ENV).is_some() {
-            return;
-        }
-
-        let current_exe = std::env::current_exe().expect("resolve current test binary");
-        let mut child = Command::new(current_exe)
-            .arg("--exact")
-            .arg(DEADLOCK_CHILD_TEST)
-            .arg("--nocapture")
-            .env(DEADLOCK_CHILD_ENV, "1")
-            .spawn()
-            .expect("spawn deadlock child");
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if let Some(status) = child.try_wait().expect("poll deadlock child") {
-                assert!(status.success(), "child exited with {status}");
-                return;
-            }
-
-            if std::time::Instant::now() >= deadline {
-                drop(child.kill());
-                drop(child.wait());
-                panic!("child timed out; apply_patch ACP fs roundtrip deadlocked");
-            }
-
-            thread::sleep(Duration::from_millis(25));
-        }
-    }
-
-    #[test]
-    fn apply_patch_verification_child() {
-        if std::env::var_os(DEADLOCK_CHILD_ENV).is_none() {
-            return;
-        }
-
-        reproduce_apply_patch_roundtrip();
-    }
-
-    fn reproduce_apply_patch_roundtrip() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("build test runtime");
-        let local_set = tokio::task::LocalSet::new();
-
-        runtime.block_on(local_set.run_until(async move {
-            let client = TestClient::new();
-            let agent = TestAgent;
-            let temp_dir = tempfile::Builder::new()
-                .prefix("agenthub-codex-acp-deadlock-")
-                .tempdir()
-                .expect("create temp dir");
-            let root = temp_dir.path().to_path_buf();
-            let session_id = SessionId::new("test-session");
-            let (client_to_agent_rx, client_to_agent_tx) = piper::pipe(1024);
-            let (agent_to_client_rx, agent_to_client_tx) = piper::pipe(1024);
-            let (client_ready_tx, client_ready_rx) = std::sync::mpsc::channel();
-
-            let source_dir = root.join("src");
-            fs::create_dir_all(&source_dir).expect("create test dirs");
-            let file_path = fs::canonicalize(&source_dir)
-                .expect("canonicalize source dir")
-                .join("client.rs");
-            client.add_file_content(file_path.clone(), "fn old() {}\n".to_string());
-
-            let _client_thread = thread::spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("build remote client runtime");
-                let local_set = tokio::task::LocalSet::new();
-
-                runtime.block_on(local_set.run_until(async move {
-                    let (_client_side, client_io_task) = agent_client_protocol_legacy::ClientSideConnection::new(
-                        client,
-                        client_to_agent_tx,
-                        agent_to_client_rx,
-                        |fut| {
-                            tokio::task::spawn_local(fut);
-                        },
-                    );
-                    client_ready_tx.send(()).expect("signal remote client ready");
-                    client_io_task.await.expect("run remote client io task");
-                }));
-            });
-
-            client_ready_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("wait for remote client bootstrap");
-
-            let (agent_side, agent_io_task) = AgentSideConnection::new(
-                agent,
-                agent_to_client_tx,
-                client_to_agent_rx,
-                |fut| {
-                    tokio::task::spawn_local(fut);
-                },
-            );
-
-            ACP_CLIENT
-                .set(Arc::new(agent_side))
-                .expect("install ACP client for child");
-
-            let _agent_io =
-                spawn_acp_io_task("agenthub-codex-acp-test-agent-io", agent_io_task)
-                    .expect("spawn agent io thread");
-
-            tokio::task::yield_now().await;
-
-            let capabilities = Arc::new(Mutex::new(
-                ClientCapabilities::new().fs(FileSystemCapabilities::new().read_text_file(true)),
-            ));
-            let session_roots = Arc::new(Mutex::new(HashMap::from([(
-                session_id.clone(),
-                root.clone(),
-            )])));
-            let fs = AcpFs::new(session_id, capabilities, LocalSpawner::new(), session_roots);
-
-            let patch = "*** Begin Patch\n*** Update File: src/client.rs\n@@\n-fn old() {}\n+fn new() {}\n*** End Patch";
-            let argv = vec!["apply_patch".to_string(), patch.to_string()];
-            let result =
-                codex_apply_patch::maybe_parse_apply_patch_verified(&argv, &root, &fs);
-
-            assert!(
-                matches!(result, codex_apply_patch::MaybeApplyPatchVerified::Body(_)),
-                "expected verified patch body, got {result:?}"
-            );
-            drop(temp_dir);
-        }));
-    }
-
-    #[derive(Clone)]
-    struct TestClient {
-        file_contents: Arc<Mutex<HashMap<PathBuf, String>>>,
-    }
-
-    impl TestClient {
-        fn new() -> Self {
-            Self {
-                file_contents: Arc::new(Mutex::new(HashMap::new())),
-            }
-        }
-
-        fn add_file_content(&self, path: PathBuf, content: String) {
-            self.file_contents.lock().unwrap().insert(path, content);
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl Client for TestClient {
-        async fn request_permission(
-            &self,
-            _arguments: agent_client_protocol_legacy::RequestPermissionRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::RequestPermissionResponse>
-        {
-            unimplemented!()
-        }
-
-        async fn write_text_file(
-            &self,
-            _arguments: WriteTextFileRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::WriteTextFileResponse> {
-            unimplemented!()
-        }
-
-        async fn read_text_file(
-            &self,
-            arguments: ReadTextFileRequest,
-        ) -> agent_client_protocol_legacy::Result<ReadTextFileResponse> {
-            let contents = self.file_contents.lock().unwrap();
-            let content = contents
-                .get(&arguments.path)
-                .cloned()
-                .unwrap_or_else(|| "default content".to_string());
-            Ok(ReadTextFileResponse::new(content))
-        }
-
-        async fn session_notification(
-            &self,
-            _args: agent_client_protocol_legacy::SessionNotification,
-        ) -> agent_client_protocol_legacy::Result<()> {
-            Ok(())
-        }
-
-        async fn create_terminal(
-            &self,
-            _args: agent_client_protocol_legacy::CreateTerminalRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::CreateTerminalResponse> {
-            unimplemented!()
-        }
-
-        async fn terminal_output(
-            &self,
-            _args: agent_client_protocol_legacy::TerminalOutputRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::TerminalOutputResponse> {
-            unimplemented!()
-        }
-
-        async fn kill_terminal(
-            &self,
-            _args: agent_client_protocol_legacy::KillTerminalRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::KillTerminalResponse> {
-            unimplemented!()
-        }
-
-        async fn release_terminal(
-            &self,
-            _args: agent_client_protocol_legacy::ReleaseTerminalRequest,
-        ) -> agent_client_protocol_legacy::Result<agent_client_protocol_legacy::ReleaseTerminalResponse> {
-            unimplemented!()
-        }
-
-        async fn wait_for_terminal_exit(
-            &self,
-            _args: agent_client_protocol_legacy::WaitForTerminalExitRequest,
-        ) -> agent_client_protocol_legacy::Result<
-            agent_client_protocol_legacy::WaitForTerminalExitResponse,
-        >
-        {
-            unimplemented!()
-        }
-    }
-
-    #[derive(Clone)]
-    struct TestAgent;
-
-    #[async_trait::async_trait(?Send)]
-    impl Agent for TestAgent {
-        async fn initialize(
-            &self,
-            arguments: InitializeRequest,
-        ) -> agent_client_protocol_legacy::Result<InitializeResponse> {
-            Ok(InitializeResponse::new(arguments.protocol_version)
-                .agent_info(Implementation::new("test-agent", "0.0.0").title("Test Agent")))
-        }
-
-        async fn authenticate(
-            &self,
-            _arguments: AuthenticateRequest,
-        ) -> agent_client_protocol_legacy::Result<AuthenticateResponse> {
-            Ok(AuthenticateResponse::default())
-        }
-
-        async fn new_session(
-            &self,
-            _arguments: NewSessionRequest,
-        ) -> agent_client_protocol_legacy::Result<NewSessionResponse> {
-            Ok(NewSessionResponse::new(SessionId::new("unused")))
-        }
-
-        async fn load_session(
-            &self,
-            _arguments: LoadSessionRequest,
-        ) -> agent_client_protocol_legacy::Result<LoadSessionResponse> {
-            Ok(LoadSessionResponse::new())
-        }
-
-        async fn set_session_mode(
-            &self,
-            _arguments: SetSessionModeRequest,
-        ) -> agent_client_protocol_legacy::Result<SetSessionModeResponse> {
-            Ok(SetSessionModeResponse::new())
-        }
-
-        async fn prompt(
-            &self,
-            _arguments: PromptRequest,
-        ) -> agent_client_protocol_legacy::Result<PromptResponse> {
-            Ok(PromptResponse::new(StopReason::EndTurn))
-        }
-
-        async fn cancel(
-            &self,
-            _arguments: agent_client_protocol_legacy::CancelNotification,
-        ) -> agent_client_protocol_legacy::Result<()> {
-            Ok(())
-        }
-
-        async fn set_session_config_option(
-            &self,
-            _args: SetSessionConfigOptionRequest,
-        ) -> agent_client_protocol_legacy::Result<SetSessionConfigOptionResponse> {
-            Ok(SetSessionConfigOptionResponse::new(vec![]))
-        }
-    }
 }

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-use agent_client_protocol_legacy::{
+use agent_client_protocol::schema::{
     AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, ClientCapabilities,
     ConfigOptionUpdate, Content, ContentBlock, ContentChunk, Diff, EmbeddedResource,
     EmbeddedResourceResource, LoadSessionResponse, Meta, ModelId, ModelInfo, PermissionOption,
@@ -18,7 +18,7 @@ use agent_client_protocol_legacy::{
     ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate,
     ToolCallUpdateFields, ToolKind, UnstructuredCommandInput, UsageUpdate,
 };
-use agent_client_protocol_legacy::{Client, Error};
+use agent_client_protocol::{Client, Error};
 use agenthub_managed_skills::managed_skills_root;
 use codex_apply_patch::parse_patch;
 use codex_core::{
@@ -2656,8 +2656,32 @@ fn background_terminal_activity_meta(kind: &str, command: &str) -> Meta {
 #[derive(Clone)]
 struct SessionClient {
     session_id: SessionId,
-    client: Arc<dyn Client>,
+    client: Arc<dyn AcpClientBridge>,
     client_capabilities: Arc<Mutex<ClientCapabilities>>,
+}
+
+#[async_trait::async_trait(?Send)]
+trait AcpClientBridge {
+    async fn request_permission(
+        &self,
+        args: RequestPermissionRequest,
+    ) -> Result<RequestPermissionResponse, Error>;
+
+    async fn session_notification(&self, args: SessionNotification) -> Result<(), Error>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl AcpClientBridge for agent_client_protocol::ConnectionTo<Client> {
+    async fn request_permission(
+        &self,
+        args: RequestPermissionRequest,
+    ) -> Result<RequestPermissionResponse, Error> {
+        self.send_request(args).block_task().await
+    }
+
+    async fn session_notification(&self, args: SessionNotification) -> Result<(), Error> {
+        self.send_notification(args)
+    }
 }
 
 impl SessionClient {
@@ -2672,7 +2696,7 @@ impl SessionClient {
     #[cfg(test)]
     fn with_client(
         session_id: SessionId,
-        client: Arc<dyn Client>,
+        client: Arc<dyn AcpClientBridge>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
     ) -> Self {
         Self {
@@ -4642,7 +4666,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use agent_client_protocol_legacy::{
+    use agent_client_protocol::schema::{
         RequestPermissionResponse, SessionConfigKind, SessionConfigSelectOptions, TextContent,
     };
     use agenthub_managed_skills::{
@@ -6112,7 +6136,7 @@ mod tests {
     }
 
     #[async_trait::async_trait(?Send)]
-    impl Client for StubClient {
+    impl AcpClientBridge for StubClient {
         async fn request_permission(
             &self,
             args: RequestPermissionRequest,

--- a/crates/agenthub-acp-core/Cargo.toml
+++ b/crates/agenthub-acp-core/Cargo.toml
@@ -6,7 +6,6 @@ license = "Apache-2.0"
 
 [dependencies]
 agent-client-protocol = { version = "0.11.1", features = ["unstable"] }
-agent-client-protocol-legacy = { package = "agent-client-protocol", version = "=0.10.4", features = ["unstable"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/agenthub-acp-core/src/lib.rs
+++ b/crates/agenthub-acp-core/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use agent_client_protocol_legacy::{
+use agent_client_protocol::schema::{
     ContentBlock, EnvVariable, HttpHeader, McpCapabilities, McpServer, McpServerHttp,
     McpServerStdio, TextContent,
 };

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -11,7 +11,6 @@ agenthub-managed-skills = { path = "../agenthub-managed-skills" }
 agenthub-team-domain = { path = "../agenthub-team-domain" }
 agenthub-text = { path = "../agenthub-text" }
 agent-client-protocol = { version = "0.11.1", features = ["unstable"] }
-agent-client-protocol-legacy = { package = "agent-client-protocol", version = "=0.10.4", features = ["unstable"] }
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["clock"] }

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use agent_client_protocol_legacy::{ContentBlock, TextContent};
+use agent_client_protocol::schema::{ContentBlock, TextContent};
 use agenthub_acp_core::{AcpSkill, build_skill};
 use agenthub_managed_skills::{ManagedSkillKind, managed_skill_doc};
 use agenthub_team_domain::{
@@ -121,7 +121,7 @@ mod tests {
         AcpActorSkillContext, build_actor_runtime_context_block, build_required_managed_skill,
     };
     use crate::test_utils::TempManagedSkillsHome;
-    use agent_client_protocol_legacy::ContentBlock;
+    use agent_client_protocol::schema::ContentBlock;
 
     #[test]
     fn actor_runtime_skill_uses_static_name() {

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -11,10 +11,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use agent_client_protocol_legacy::{
-    Agent, Client, ClientSideConnection, Error as AcpError, ErrorCode as AcpErrorCode,
-};
-use agent_client_protocol_legacy::{
+use agent_client_protocol::schema::{
     CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption,
     PermissionOptionKind, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
@@ -22,6 +19,7 @@ use agent_client_protocol_legacy::{
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
     SetSessionModelRequest, TextContent, ToolCall, ToolCallUpdate, ToolCallUpdateFields,
 };
+use agent_client_protocol::{Agent, ConnectionTo, Error as AcpError, ErrorCode as AcpErrorCode};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Number, Value};
@@ -51,6 +49,8 @@ const ACP_COMMAND_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 // so ACP startup should tolerate late session readiness instead of failing fast.
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(300);
 const ACP_PERMISSION_REVIEW_TIMEOUT: Duration = Duration::from_secs(120);
+
+type AcpClientConnection = ConnectionTo<Agent>;
 
 pub const fn acp_permission_review_timeout() -> Duration {
     ACP_PERMISSION_REVIEW_TIMEOUT
@@ -557,12 +557,11 @@ impl AcpClient {
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl Client for AcpClient {
+impl AcpClient {
     async fn request_permission(
         &self,
         args: RequestPermissionRequest,
-    ) -> Result<RequestPermissionResponse, agent_client_protocol_legacy::Error> {
+    ) -> Result<RequestPermissionResponse, agent_client_protocol::Error> {
         let options = args
             .options
             .iter()
@@ -583,9 +582,7 @@ impl Client for AcpClient {
                     }),
             )
             .await
-            .map_err(|err| {
-                agent_client_protocol_legacy::Error::internal_error().data(err.to_string())
-            })?;
+            .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
         if let Some(dispatcher) = self.permission_review_dispatcher.as_ref() {
             let tool_call = serde_json::to_value(&args.tool_call).ok();
             let dispatch_request = AcpPermissionReviewRequest {
@@ -671,7 +668,7 @@ impl Client for AcpClient {
     async fn session_notification(
         &self,
         args: SessionNotification,
-    ) -> Result<(), agent_client_protocol_legacy::Error> {
+    ) -> Result<(), agent_client_protocol::Error> {
         self.emit_update(args.update).await;
         Ok(())
     }
@@ -684,8 +681,8 @@ fn pick_allow_option(args: &RequestPermissionRequest) -> RequestPermissionOutcom
         .find(|opt| {
             matches!(
                 opt.kind,
-                agent_client_protocol_legacy::PermissionOptionKind::AllowAlways
-                    | agent_client_protocol_legacy::PermissionOptionKind::AllowOnce
+                agent_client_protocol::schema::PermissionOptionKind::AllowAlways
+                    | agent_client_protocol::schema::PermissionOptionKind::AllowOnce
             )
         })
         .or_else(|| args.options.first())
@@ -776,6 +773,16 @@ impl AcpHandle {
     }
 }
 
+async fn send_acp_request<Req>(
+    conn: &AcpClientConnection,
+    request: Req,
+) -> Result<Req::Response, AcpError>
+where
+    Req: agent_client_protocol::JsonRpcRequest,
+{
+    conn.send_request(request).block_task().await
+}
+
 fn is_session_mutation_command(cmd: &AcpCommand) -> bool {
     matches!(
         cmd,
@@ -808,7 +815,7 @@ fn should_queue_while_prompts_active(
 
 async fn dispatch_acp_command(
     cmd: AcpCommand,
-    conn: Rc<ClientSideConnection>,
+    conn: Rc<AcpClientConnection>,
     event_sink: Arc<dyn AcpEventSink>,
     session_id: &str,
     prompt_prefix_blocks: &[ContentBlock],
@@ -828,7 +835,7 @@ async fn dispatch_acp_command(
             blocks.push(ContentBlock::Text(TextContent::new(prompt)));
             tokio::task::spawn_local(async move {
                 let request = PromptRequest::new(session_id, blocks);
-                if let Err(err) = conn.prompt(request).await {
+                if let Err(err) = send_acp_request(&conn, request).await {
                     event_sink
                         .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
                         .await;
@@ -838,7 +845,7 @@ async fn dispatch_acp_command(
         }
         AcpCommand::SetMode(mode_id) => {
             let request = SetSessionModeRequest::new(session_id.to_string(), mode_id);
-            if let Err(err) = conn.set_session_mode(request).await {
+            if let Err(err) = send_acp_request(&conn, request).await {
                 event_sink
                     .emit_raw(AcpStream::System, format!("acp set_mode error: {err}"))
                     .await;
@@ -846,7 +853,7 @@ async fn dispatch_acp_command(
         }
         AcpCommand::SetModel(model_id) => {
             let request = SetSessionModelRequest::new(session_id.to_string(), model_id);
-            if let Err(err) = conn.set_session_model(request).await {
+            if let Err(err) = send_acp_request(&conn, request).await {
                 event_sink
                     .emit_raw(AcpStream::System, format!("acp set_model error: {err}"))
                     .await;
@@ -858,7 +865,7 @@ async fn dispatch_acp_command(
                 config_id,
                 value.as_str(),
             );
-            if let Err(err) = conn.set_session_config_option(request).await {
+            if let Err(err) = send_acp_request(&conn, request).await {
                 event_sink
                     .emit_raw(AcpStream::System, format!("acp set_config error: {err}"))
                     .await;
@@ -866,7 +873,7 @@ async fn dispatch_acp_command(
         }
         AcpCommand::Cancel => {
             let request = CancelNotification::new(session_id.to_string());
-            if let Err(err) = conn.cancel(request).await {
+            if let Err(err) = conn.send_notification(request) {
                 event_sink
                     .emit_raw(AcpStream::System, format!("acp cancel error: {err}"))
                     .await;
@@ -989,38 +996,49 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
 
             let local = tokio::task::LocalSet::new();
             runtime.block_on(local.run_until(async move {
-            let client = AcpClient::new(
-                event_sink.clone(),
-                permissions,
-                permission_review_dispatcher,
-                agent_id.clone(),
-                agent_session_id.clone(),
-                actor_context.clone(),
-            );
-            let outgoing = stdin.compat_write();
-            let incoming = stdout.compat();
-            let (conn, io_task) = ClientSideConnection::new(client, outgoing, incoming, |fut| {
-                tokio::task::spawn_local(fut);
-            });
-
-            let io_sink = event_sink.clone();
-            tokio::task::spawn_local(async move {
-                if let Err(err) = io_task.await {
-                    io_sink
-                        .emit_raw(AcpStream::System, format!("acp io error: {err}"))
-                        .await;
-                }
-            });
+                let client = AcpClient::new(
+                    event_sink.clone(),
+                    permissions,
+                    permission_review_dispatcher,
+                    agent_id.clone(),
+                    agent_session_id.clone(),
+                    actor_context.clone(),
+                );
+                let transport =
+                    agent_client_protocol::ByteStreams::new(stdin.compat_write(), stdout.compat());
+                let client_for_permission = client.clone();
+                let client_for_notifications = client.clone();
+                let event_sink_for_connection = event_sink.clone();
+                let connect_result = agent_client_protocol::Client
+                .builder()
+                .on_receive_request(
+                    async move |request: RequestPermissionRequest, responder, _connection| {
+                        responder.respond_with_result(
+                            client_for_permission.request_permission(request).await,
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    async move |notification: SessionNotification, _connection| {
+                        client_for_notifications
+                            .session_notification(notification)
+                            .await
+                    },
+                    agent_client_protocol::on_receive_notification!(),
+                )
+                .connect_with(transport, |conn: AcpClientConnection| async move {
+            let event_sink = event_sink_for_connection;
 
             let init = InitializeRequest::new(ProtocolVersion::V1)
                 .client_capabilities(ClientCapabilities::default())
                 .client_info(client_info);
 
-            let init_response = match conn.initialize(init).await {
+            let init_response = match send_acp_request(&conn, init).await {
                 Ok(response) => response,
                 Err(err) => {
                     let _ = ready_tx.send(Err(format!("acp initialize failed: {err}")));
-                    return;
+                    return Ok(());
                 }
             };
 
@@ -1038,7 +1056,7 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                 if let Some(meta) = skills_meta.clone() {
                     request = request.meta(meta);
                 }
-                match conn.load_session(request).await {
+                match send_acp_request(&conn, request).await {
                     Ok(_) => {
                         event_sink
                             .emit_raw(
@@ -1058,7 +1076,7 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                         .await
                         {
                             let _ = ready_tx.send(Err(message));
-                            return;
+                            return Ok(());
                         }
                         event_sink
                             .emit_raw(AcpStream::System, format!("acp load_session failed: {err}"))
@@ -1072,7 +1090,7 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                 if let Some(meta) = skills_meta.clone() {
                     request = request.meta(meta);
                 }
-                let session = match conn.new_session(request).await {
+                let session = match send_acp_request(&conn, request).await {
                     Ok(session) => session,
                     Err(err) => {
                         if let Some(message) = handle_auth_required_failure(
@@ -1084,10 +1102,10 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                         .await
                         {
                             let _ = ready_tx.send(Err(message));
-                            return;
+                            return Ok(());
                         }
                         let _ = ready_tx.send(Err(format!("acp new_session failed: {err}")));
-                        return;
+                        return Ok(());
                     }
                 };
                 session_id = Some(session.session_id.to_string());
@@ -1164,7 +1182,16 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                     }
                 }
             }
-        }));
+            Ok(())
+                })
+                .await;
+
+                if let Err(err) = connect_result {
+                    event_sink
+                        .emit_raw(AcpStream::System, format!("acp io error: {err}"))
+                        .await;
+                }
+            }));
         }
     });
 
@@ -1846,10 +1873,10 @@ mod tests {
         load_mcp_servers_from_path, load_skills_from_config, load_workdir_skills,
         remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
     };
-    use agent_client_protocol_legacy::{
-        ContentBlock, Error as AcpError, ErrorCode as AcpErrorCode, McpServer,
-        RequestPermissionOutcome, SelectedPermissionOutcome,
+    use agent_client_protocol::schema::{
+        ContentBlock, McpServer, RequestPermissionOutcome, SelectedPermissionOutcome,
     };
+    use agent_client_protocol::{Error as AcpError, ErrorCode as AcpErrorCode};
     use agenthub_acp_core::build_skill;
     use agenthub_managed_skills::{
         ManagedSkillKind, install_managed_skills, managed_skill_doc_path,

--- a/docs/journal/2026-05-06-acp-sdk-unification.md
+++ b/docs/journal/2026-05-06-acp-sdk-unification.md
@@ -1,0 +1,48 @@
+# ACP SDK Unification
+
+## Summary
+
+Merged the workspace onto a single `agent-client-protocol` dependency at `0.11.1` and removed
+the `agent-client-protocol-legacy` alias pinned to `0.10.4`.
+
+## Background
+
+The workspace had both ACP SDK generations in the Cargo graph. Runtime code still used the old
+root-level schema exports and trait-based `AgentSideConnection` / `ClientSideConnection` APIs,
+while the current SDK exposes schema types through `agent_client_protocol::schema` and uses
+role builders with `ConnectionTo`.
+
+## Scope
+
+- Removed `agent-client-protocol-legacy` from workspace, ACP core, ACP runtime, and Codex ACP
+  manifests.
+- Updated ACP schema imports to use `agent_client_protocol::schema`.
+- Migrated `agenthub-acp` client transport to `Client.builder().connect_with(...)`.
+- Migrated `agenthub-codex-acp` agent transport to `Agent.builder().connect_to(...)`.
+- Removed an unmounted Codex ACP local-spawner test harness that still referenced the deleted
+  legacy connection API.
+- Preserved the Codex ACP local runtime model with a narrowly scoped local future wrapper for the
+  SDK's `Send` handler bounds.
+
+## Key Decisions
+
+- Keep the dependency version at `0.11.1`, which is the latest published `agent-client-protocol`
+  crate version confirmed for this change.
+- Keep business behavior in the existing ACP/Codex methods and isolate SDK migration code at the
+  transport boundary.
+- Use one `agent-client-protocol` package in `Cargo.lock`; the old `0.10.4` package and
+  `agent-client-protocol-schema 0.11.4` are no longer present.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo check -p agenthub
+cargo check -p agenthub-acp
+cargo check -p agenthub-codex-acp
+cargo test -p agenthub-acp -p agenthub-codex-acp --lib
+```
+
+## Follow-Ups
+
+None.

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -19,7 +19,7 @@ use crate::acp::{
 };
 use crate::agent::event_message_codec::persist_agent_event;
 use crate::agent::{AgentStatus, OutputStream};
-use agent_client_protocol_legacy::Implementation;
+use agent_client_protocol::schema::Implementation;
 
 const RESUMED_ACP_SESSION_GRACE_PERIOD: Duration = Duration::from_secs(2);
 const RESUMED_ACP_SESSION_POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -686,13 +686,13 @@ async fn respond_permission(
         ));
     }
     let outcome = if let Some(option_id) = payload.option_id.as_ref() {
-        agent_client_protocol_legacy::RequestPermissionOutcome::Selected(
-            agent_client_protocol_legacy::SelectedPermissionOutcome::new(option_id.clone()),
+        agent_client_protocol::schema::RequestPermissionOutcome::Selected(
+            agent_client_protocol::schema::SelectedPermissionOutcome::new(option_id.clone()),
         )
     } else {
         match payload.outcome.as_deref() {
             Some("cancelled") | None => {
-                agent_client_protocol_legacy::RequestPermissionOutcome::Cancelled
+                agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
             }
             Some(_other) => {
                 return Err(ApiError::bad_request(

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -929,15 +929,15 @@ impl TeamInternalControl for TeamInternalControlService {
             ));
         }
         let outcome = if let Some(selected_option_id) = option_id.as_ref() {
-            agent_client_protocol_legacy::RequestPermissionOutcome::Selected(
-                agent_client_protocol_legacy::SelectedPermissionOutcome::new(
+            agent_client_protocol::schema::RequestPermissionOutcome::Selected(
+                agent_client_protocol::schema::SelectedPermissionOutcome::new(
                     selected_option_id.clone(),
                 ),
             )
         } else {
             match requested_outcome {
                 Some("cancelled") | None => {
-                    agent_client_protocol_legacy::RequestPermissionOutcome::Cancelled
+                    agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
                 }
                 Some(other) => {
                     return Err(Status::invalid_argument(format!(

--- a/src/team/permission_review.rs
+++ b/src/team/permission_review.rs
@@ -826,7 +826,7 @@ mod tests {
             options: vec![agenthub_acp::AcpPermissionOption {
                 option_id: "allow".to_string(),
                 name: "Allow once".to_string(),
-                kind: agent_client_protocol_legacy::PermissionOptionKind::AllowOnce,
+                kind: agent_client_protocol::schema::PermissionOptionKind::AllowOnce,
             }],
             tool_call: Some(json!({"tool":{"name":"mcp__fs__read"}})),
             current_run_id: None,
@@ -1059,7 +1059,7 @@ mod tests {
             options: vec![agenthub_acp::AcpPermissionOption {
                 option_id: "allow".to_string(),
                 name: "Allow once".to_string(),
-                kind: agent_client_protocol_legacy::PermissionOptionKind::AllowOnce,
+                kind: agent_client_protocol::schema::PermissionOptionKind::AllowOnce,
             }],
             tool_call: Some(json!({"tool":{"name":"mcp__fs__read"}})),
             current_run_id: None,
@@ -1238,7 +1238,7 @@ mod tests {
             options: vec![agenthub_acp::AcpPermissionOption {
                 option_id: "allow".to_string(),
                 name: "Allow once".to_string(),
-                kind: agent_client_protocol_legacy::PermissionOptionKind::AllowOnce,
+                kind: agent_client_protocol::schema::PermissionOptionKind::AllowOnce,
             }],
             tool_call: Some(json!({"tool":{"name":"mcp__fs__write"}})),
             current_run_id: None,


### PR DESCRIPTION
## Summary
- remove the `agent-client-protocol-legacy` alias and keep the workspace on `agent-client-protocol` 0.11.1
- migrate ACP schema imports and transport setup to the 0.11 builder/`ConnectionTo` API
- add a dated journal entry for the SDK unification and validation record

## Validation
- `cargo fmt --all --check`
- `cargo check -p agenthub`
- `cargo check -p agenthub-acp -p agenthub-codex-acp`
- `cargo test -p agenthub-acp -p agenthub-codex-acp --lib`