### PR TITLE
test(web): cover mobile agents primary flow

### DIFF
--- a/docs/journal/2026-05-06-mobile-agents-primary-flow.md
+++ b/docs/journal/2026-05-06-mobile-agents-primary-flow.md
@@ -1,0 +1,55 @@
+# Mobile Agents Primary Flow
+
+## Summary
+
+Added explicit mobile browser coverage for the Agents primary workbench flow so the small-screen
+contract is no longer represented only by Team and Nodes checks. The same slice also keeps the
+workspace header above the mobile agents backdrop so the compact pane toggle remains clickable after
+opening the agents list.
+
+## Background
+
+`docs/features/frontend-design.md` requires dedicated narrow-screen coverage for Team, Agents, and
+Nodes primary flows. Existing mobile e2e coverage already guarded Team shell proportions, Team
+setup actions, and Nodes list/detail/connect-command surfaces. The remaining obvious gap was a
+browser-level Agents path that proves the agent list and active workbench remain reachable on a
+phone-sized viewport.
+
+## Scope
+
+- Covers `/workspace` on a `390x844` viewport.
+- Uses the existing Team-page e2e fixture because it already provides authenticated root state,
+  agents, nodes, and Team API mocks.
+- Adds agent event and input route mocks specific to the Agents workbench path.
+- Raises the authenticated workspace header above the mobile agents backdrop.
+
+## Key Decisions
+
+- Keep the test focused on primary mobile affordances instead of visual pixel assertions.
+- Treat the header sidebar toggle as the compact pane switch between agent list and active
+  workbench content.
+- Verify a real input submit reaches `/api/agents/:id/input`, not just that the input dock renders.
+- Keep the header at `z-40`, above the `z-20` mobile backdrop and `z-30` agents panel, so the
+  header toggle is not visually available but pointer-blocked.
+
+## Validation
+
+Focused validation:
+
+```bash
+cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MOBILE_ONLY=1 npm exec -- playwright test --project chromium
+npm --prefix web run lint
+npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit
+npm --prefix web run build
+```
+
+The local Playwright run used an already-started Vite dev server on `127.0.0.1:5173`; Chromium had
+to run outside the filesystem sandbox on macOS because the sandbox blocked Chromium's Mach port
+registration.
+
+## Follow-Ups
+
+- Continue broadening small-screen coverage for Team `Conversation <-> Kanban <-> thread` once the
+  remaining channel/thread UX work lands.
+- Keep Chrome DevTools MCP notes attached to PRs that change visible compact layout behavior, not
+  only test coverage.

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -531,7 +531,7 @@ export const ADMIN_VALUE_CLASS = "value break-all text-[14px] font-medium text-n
 export const ADMIN_EMPTY_TEXT_CLASS = "text-sm text-notion-text-muted italic py-4";
 
 export const APP_WORKBENCH_HEADER_CLASS =
-  "flex flex-wrap items-center justify-end gap-2 bg-white px-4 py-2.5 sm:gap-3 sm:px-6 sm:py-3 border-b border-notion-border";
+  "relative z-40 flex flex-wrap items-center justify-end gap-2 bg-white px-4 py-2.5 sm:gap-3 sm:px-6 sm:py-3 border-b border-notion-border";
 
 export const APP_WORKBENCH_HEADER_STATUS_CLASS =
   "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-notion-border/70 bg-notion-sidebar/72 px-2 py-0.5 text-[10px] font-semibold tracking-[0.08em] text-notion-text-muted transition hover:bg-notion-hover";

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from "./coverage";
 import {
   createTeamFromModal,
   gotoTeams,
+  jsonResponse,
   mockTeamPageApis,
   openMainTeamAction,
   openTeamFromSelector,
@@ -89,6 +90,76 @@ test("node detail keeps mobile detail surfaces stacked without horizontal overfl
     .locator('[data-node-team-summary-metrics="true"]')
     .evaluate((element) => window.getComputedStyle(element).gridTemplateColumns);
   expect(summaryMetricColumns.trim().split(/\s+/).length).toBe(1);
+
+  const horizontalOverflow = await page.evaluate(() => {
+    return document.documentElement.scrollWidth - document.documentElement.clientWidth;
+  });
+  expect(horizontalOverflow).toBeLessThanOrEqual(1);
+});
+
+test("agents workbench keeps mobile primary controls reachable", async ({
+  page,
+}) => {
+  await mockTeamPageApis(page);
+  const sentInputs: Array<{
+    agent_id: string;
+    input: string;
+    session_id?: string;
+  }> = [];
+
+  await page.route(/\/api\/agents\/[^/]+\/events(?:\?.*)?$/, async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill(jsonResponse([]));
+  });
+  await page.route(/\/api\/agents\/[^/]+\/input$/, async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    const agentId = decodeURIComponent(
+      request.url().match(/\/api\/agents\/([^/]+)\/input$/)?.[1] ?? ""
+    );
+    const payload = request.postDataJSON() as {
+      input: string;
+      session_id?: string;
+    };
+    sentInputs.push({
+      agent_id: agentId,
+      input: payload.input,
+      session_id: payload.session_id,
+    });
+    await route.fulfill(jsonResponse({ status: "ok" }));
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/workspace", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("button", { name: "Show agents" }).first()).toBeVisible();
+  await expect(page.getByText("Coordinator Agent", { exact: true })).toBeVisible();
+
+  const agentInput = page.getByPlaceholder(/Send input|Type a message \(tap Send/);
+  await expect(agentInput).toBeVisible();
+  await agentInput.fill("Summarize the current workspace state.");
+  await page.getByRole("button", { name: "Send input", exact: true }).click();
+  await expect
+    .poll(() => sentInputs.length, { timeout: 10_000 })
+    .toBe(1);
+  expect(sentInputs[0]).toMatchObject({
+    agent_id: "agent-coordinator-1",
+    input: "Summarize the current workspace state.",
+  });
+
+  await page.getByRole("button", { name: "Show agents" }).first().click();
+  const hideAgentsToggle = page.getByRole("banner").getByRole("button", {
+    name: "Hide agents",
+  });
+  await expect(hideAgentsToggle).toBeVisible();
+  await expect(page.getByText("Worker Agent", { exact: true })).toBeVisible();
+  await hideAgentsToggle.click();
+  await expect(page.getByRole("button", { name: "Show agents" }).first()).toBeVisible();
 
   const horizontalOverflow = await page.evaluate(() => {
     return document.documentElement.scrollWidth - document.documentElement.clientWidth;

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -114,13 +114,14 @@ test("agents workbench keeps mobile primary controls reachable", async ({
     }
     await route.fulfill(jsonResponse([]));
   });
-  await page.route(/\/api\/agents\/[^/]+\/input$/, async (route, request) => {
+  await page.route(/\/api\/agents\/[^/]+\/input(?:\?.*)?$/, async (route, request) => {
     if (request.method() !== "POST") {
       await route.fallback();
       return;
     }
+    const url = new URL(request.url());
     const agentId = decodeURIComponent(
-      request.url().match(/\/api\/agents\/([^/]+)\/input$/)?.[1] ?? ""
+      url.pathname.match(/\/api\/agents\/([^/]+)\/input$/)?.[1] ?? ""
     );
     const payload = request.postDataJSON() as {
       input: string;
@@ -137,7 +138,10 @@ test("agents workbench keeps mobile primary controls reachable", async ({
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/workspace", { waitUntil: "domcontentloaded" });
 
-  await expect(page.getByRole("button", { name: "Show agents" }).first()).toBeVisible();
+  const showAgentsToggle = page.getByRole("banner").getByRole("button", {
+    name: "Show agents",
+  });
+  await expect(showAgentsToggle).toBeVisible();
   await expect(page.getByText("Coordinator Agent", { exact: true })).toBeVisible();
 
   const agentInput = page.getByPlaceholder(/Send input|Type a message \(tap Send/);
@@ -152,14 +156,14 @@ test("agents workbench keeps mobile primary controls reachable", async ({
     input: "Summarize the current workspace state.",
   });
 
-  await page.getByRole("button", { name: "Show agents" }).first().click();
+  await showAgentsToggle.click();
   const hideAgentsToggle = page.getByRole("banner").getByRole("button", {
     name: "Hide agents",
   });
   await expect(hideAgentsToggle).toBeVisible();
   await expect(page.getByText("Worker Agent", { exact: true })).toBeVisible();
   await hideAgentsToggle.click();
-  await expect(page.getByRole("button", { name: "Show agents" }).first()).toBeVisible();
+  await expect(showAgentsToggle).toBeVisible();
 
   const horizontalOverflow = await page.evaluate(() => {
     return document.documentElement.scrollWidth - document.documentElement.clientWidth;


### PR DESCRIPTION
## Summary

- add explicit mobile browser coverage for the Agents primary workbench flow
- verify the compact agents pane can be opened and closed from the workspace header
- keep the workspace header above the mobile agents backdrop so the visible pane toggle remains clickable
- record the rollout checkpoint in `docs/journal/2026-05-06-mobile-agents-primary-flow.md`

## Purpose

This advances the P0+ small-screen backlog item by covering the missing Agents primary flow alongside the existing Team and Nodes mobile e2e checks.

## Related Issues

- None

## Testing

```bash
cd web && PLAYWRIGHT_NO_WEBSERVER=1 PLAYWRIGHT_MOBILE_ONLY=1 npm exec -- playwright test --project chromium
npm --prefix web run lint
npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit
npm --prefix web run build
git diff --check
```
