### PR TITLE
fix(team): clean up conflicted agent copies

### DIFF
--- a/docs/journal/2026-05-06-team-copy-conflict-cleanup.md
+++ b/docs/journal/2026-05-06-team-copy-conflict-cleanup.md
@@ -1,0 +1,39 @@
+# Team Copy Conflict Cleanup
+
+## Summary
+
+Copying an existing agent into a Team now best-effort deletes the newly created Team-owned copy when
+the follow-up Team spec update fails with a conflict.
+
+## Background
+
+The adoption copy path creates a new Team-owned agent first, then appends that agent to the Team
+spec. If the Team spec update races another edit and returns `409`, leaving the created copy around
+violates the copy rollout's ownership boundary by producing an unattached Team-forged agent.
+
+## Scope
+
+- Apply the same conflict cleanup shape already used by the Team forge path.
+- Keep source-agent copy semantics unchanged.
+- Do not implement `move existing agent to Team`.
+
+## Key Decisions
+
+- Cleanup only runs after a copied agent was created and the Team spec update reports `409`.
+- Cleanup remains best-effort so a delete failure does not hide the original conflict error.
+- The copy modal stays open on conflict so the operator can retry after refreshing state.
+
+## Validation
+
+```bash
+npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx
+git diff --check
+npm --prefix web run lint
+npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit
+npm --prefix web run build
+```
+
+## Follow-Ups
+
+- Continue the Team adoption backlog with explicit workspace-content copy, memory/context seeding,
+  and move-ownership guardrails as separate opt-in slices.

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -576,6 +576,41 @@ describe("useTeamManagementActions", () => {
     }
   });
 
+  it("cleans up a copied agent when the team spec update conflicts", async () => {
+    mockedApi.createAgent.mockResolvedValueOnce({
+      id: "agent-copy-conflict",
+      name: "source-agent-worker-1",
+      workdir: "/repo/source",
+      command: "agenthub-codex-acp",
+      args: [],
+      worktree_mode: "use_existing",
+      worktree_repo: null,
+      worktree_ref: null,
+      code_mode: true,
+      status: "stopped",
+      created_at: 1,
+      updated_at: 1,
+    } as never);
+    mockedApi.updateTeamSpec.mockRejectedValueOnce(
+      Object.assign(new Error("team spec changed"), { status: 409 })
+    );
+    mockedApi.deleteAgent.mockResolvedValueOnce(undefined as never);
+
+    const params = createParams();
+    const mounted = await mountHook(params);
+    try {
+      await act(async () => {
+        await mounted.getSnapshot()?.onCopyExistingTeamAgent("agent-source-1");
+      });
+
+      expect(mockedApi.deleteAgent).toHaveBeenCalledWith("token-1", "agent-copy-conflict");
+      expect(params.setError).toHaveBeenCalledWith("team spec changed");
+      expect(params.setShowCopyExistingAgentModal).not.toHaveBeenCalledWith(false);
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
   it("surfaces an error when the selected copy source is missing", async () => {
     const params = createParams({
       agents: [],

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -645,6 +645,39 @@ describe("useTeamManagementActions", () => {
     }
   });
 
+  it("does not clean up a copied agent for non-conflict team spec failures", async () => {
+    mockedApi.createAgent.mockResolvedValueOnce({
+      id: "agent-copy-server-error",
+      name: "source-agent-worker-1",
+      workdir: "/repo/source",
+      command: "agenthub-codex-acp",
+      args: [],
+      worktree_mode: "use_existing",
+      worktree_repo: null,
+      worktree_ref: null,
+      code_mode: true,
+      status: "stopped",
+      created_at: 1,
+      updated_at: 1,
+    } as never);
+    mockedApi.updateTeamSpec.mockRejectedValueOnce(
+      Object.assign(new Error("server error"), { status: 500 })
+    );
+
+    const params = createParams();
+    const mounted = await mountHook(params);
+    try {
+      await act(async () => {
+        await mounted.getSnapshot()?.onCopyExistingTeamAgent("agent-source-1");
+      });
+
+      expect(mockedApi.deleteAgent).not.toHaveBeenCalled();
+      expect(params.setError).toHaveBeenCalledWith("server error");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
   it("surfaces an error when the selected copy source is missing", async () => {
     const params = createParams({
       agents: [],

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -611,6 +611,40 @@ describe("useTeamManagementActions", () => {
     }
   });
 
+  it("keeps the original copy conflict error when cleanup deletion fails", async () => {
+    mockedApi.createAgent.mockResolvedValueOnce({
+      id: "agent-copy-delete-fails",
+      name: "source-agent-worker-1",
+      workdir: "/repo/source",
+      command: "agenthub-codex-acp",
+      args: [],
+      worktree_mode: "use_existing",
+      worktree_repo: null,
+      worktree_ref: null,
+      code_mode: true,
+      status: "stopped",
+      created_at: 1,
+      updated_at: 1,
+    } as never);
+    mockedApi.updateTeamSpec.mockRejectedValueOnce(
+      Object.assign(new Error("team spec changed"), { status: 409 })
+    );
+    mockedApi.deleteAgent.mockRejectedValueOnce(new Error("delete failed"));
+
+    const params = createParams();
+    const mounted = await mountHook(params);
+    try {
+      await act(async () => {
+        await mounted.getSnapshot()?.onCopyExistingTeamAgent("agent-source-1");
+      });
+
+      expect(mockedApi.deleteAgent).toHaveBeenCalledWith("token-1", "agent-copy-delete-fails");
+      expect(params.setError).toHaveBeenCalledWith("team spec changed");
+    } finally {
+      mounted.cleanup();
+    }
+  });
+
   it("surfaces an error when the selected copy source is missing", async () => {
     const params = createParams({
       agents: [],

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -553,6 +553,7 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
     setBusy("copy-team-agent");
     setError(null);
     setWarning(null);
+    let createdAgentId: string | null = null;
     try {
       const created = await api.createAgent(token, {
         name: copiedAgentName,
@@ -566,6 +567,7 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
         worktree_ref: copiedWorktreeRef,
         code_mode: sourceAgent.code_mode,
       });
+      createdAgentId = created.id;
       const updated = await api.updateTeamSpec(token, selectedTeam.id, {
         spec: appendTeamMemberToSpec(
           selectedTeam.spec,
@@ -585,6 +587,17 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       setShowCopyExistingAgentModal(false);
       void refreshTeamRuntime(updated.id).catch(() => undefined);
     } catch (err) {
+      const status =
+        typeof (err as { status?: unknown })?.status === "number"
+          ? ((err as { status: number }).status as number)
+          : null;
+      if (createdAgentId && status === 409) {
+        try {
+          await api.deleteAgent(token, createdAgentId);
+        } catch {
+          // Best-effort cleanup only. Ambiguous failures should not mask the original conflict.
+        }
+      }
       setError(parseErrorMessage(err));
     } finally {
       setBusy(null);

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -470,10 +470,7 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       setTeamMemberDraft(null);
       void refreshTeamRuntime(updated.id).catch(() => undefined);
     } catch (err) {
-      const status =
-        typeof (err as { status?: unknown })?.status === "number"
-          ? ((err as { status: number }).status as number)
-          : null;
+      const status = (err as { status?: number })?.status ?? null;
       if (createdAgentId && status === 409) {
         try {
           await api.deleteAgent(token, createdAgentId);
@@ -598,7 +595,7 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
           // Best-effort cleanup only. Ambiguous failures should not mask the original conflict.
         }
       }
-      setError(parseErrorMessage(err));
+      setError(formatTeamForgeWorktreeError(err) ?? parseErrorMessage(err));
     } finally {
       setBusy(null);
     }

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -584,16 +584,8 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       setShowCopyExistingAgentModal(false);
       void refreshTeamRuntime(updated.id).catch(() => undefined);
     } catch (err) {
-      const status =
-        typeof (err as { status?: unknown })?.status === "number"
-          ? ((err as { status: number }).status as number)
-          : null;
-      if (createdAgentId && status === 409) {
-        try {
-          await api.deleteAgent(token, createdAgentId);
-        } catch {
-          // Best-effort cleanup only. Ambiguous failures should not mask the original conflict.
-        }
+      if (createdAgentId && (err as { status?: number })?.status === 409) {
+        void api.deleteAgent(token, createdAgentId).catch(() => undefined);
       }
       setError(formatTeamForgeWorktreeError(err) ?? parseErrorMessage(err));
     } finally {


### PR DESCRIPTION
## Summary

- Best-effort delete a newly created Team-owned copy when `updateTeamSpec` returns a conflict.
- Add a focused hook regression test for the conflict cleanup path.
- Record the adoption-copy cleanup boundary in a journal note.

## Purpose

The Team adoption copy flow creates a new Team-owned agent before appending it to the Team spec. If
the spec update races another edit, the copy should not leave an unattached Team-forged agent behind.

## Related Issues

- None.

## Testing

- `npm --prefix web run test -- src/pages/team/use_team_management_actions.test.tsx`
- `git diff --check`
- `npm --prefix web run lint`
- `npm --prefix web exec -- tsc -p web/tsconfig.json --noEmit`
- `npm --prefix web run build`
