### PR TITLE
fix(team): restore conversation retention cap

### DIFF
--- a/docs/journal/2026-04-04-team-web-retention-caps.md
+++ b/docs/journal/2026-04-04-team-web-retention-caps.md
@@ -30,3 +30,28 @@
 
 - `cd web && npm run test -- src/pages/team/page_helpers.test.ts src/output_cache.test.ts`
 - `make build-web`
+
+## 2026-05-07 P0 Follow-up
+
+After the P0+ closure work merged, the active TODO still required post-merge
+verification for the Team web retention caps. A follow-up audit found that the
+run-event and member-event caps were still implemented at the shared helper
+layer, but the shared-thread conversation contract had drifted from recent-20
+to recent-60 in both the fetch limit and client retention constant.
+
+This follow-up restores the stable recent-20 contract:
+
+- `TEAM_CONVERSATION_MESSAGE_RETENTION_LIMIT = 20`
+- shared-thread message fetches request `{ limit: 20 }`
+- the existing helper tests continue to cover conversation, run-event, and
+  member-event retention caps
+- the conversation action regression test verifies repeated shared-thread
+  refreshes stay bounded instead of growing client state
+
+Local validation:
+
+- `cd web && npm run test -- src/pages/team/use_team_conversation_actions.test.tsx src/pages/team/page_helpers.test.ts src/pages/team/use_team_actions.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+
+The TODO item should remain open until the follow-up PR records push/PR CI
+evidence after merge.

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -672,6 +672,38 @@ describe("team page helpers", () => {
       title: "Recovered thread",
       status: "in_progress",
     });
+    const sharedTask = buildTask("task-all", 100, 120, {
+      title: DEFAULT_TEAM_THREAD_TITLE,
+      context: { bootstrap_kind: DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND },
+    });
+    const listedTask = buildTask("task-listed", 130, 150, {
+      title: "Listed thread",
+      status: "in_progress",
+    });
+
+    expect(
+      resolveSelectedConversationTask({
+        taskList: [listedTask],
+        selectedTaskId: "",
+        sharedConversation: sharedTask,
+      })
+    ).toEqual(sharedTask);
+
+    expect(
+      resolveSelectedConversationTask({
+        taskList: [listedTask],
+        selectedTaskId: "task-all",
+        sharedConversation: sharedTask,
+      })
+    ).toEqual(sharedTask);
+
+    expect(
+      resolveSelectedConversationTask({
+        taskList: [listedTask],
+        selectedTaskId: "task-listed",
+        sharedConversation: sharedTask,
+      })
+    ).toEqual(listedTask);
 
     expect(
       resolveSelectedConversationTask({
@@ -751,8 +783,29 @@ describe("team page helpers", () => {
 
     expect(
       resolveSelectedConversationLatestRun({
-        selectedConversation: explicitTask,
+        selectedConversation: null,
         selectedConversationDetail: null,
+        sharedConversation: sharedTask,
+        sharedConversationLatestRun: sharedRun,
+      })
+    ).toBeNull();
+
+    expect(
+      resolveSelectedConversationLatestRun({
+        selectedConversation: explicitTask,
+        selectedConversationDetail: {
+          task: buildTask("task-other", 90, 90),
+          conversation: {
+            id: "conv-task-other",
+            team_id: "team-1",
+            task_id: "task-other",
+            mode: "group_chat",
+            topic: "other",
+            created_at: 1,
+            updated_at: 1,
+          },
+          latest_run: explicitRun,
+        },
         sharedConversation: sharedTask,
         sharedConversationLatestRun: sharedRun,
       })
@@ -830,6 +883,44 @@ describe("team page helpers", () => {
         taskList: [sharedTask, explicitTask],
       })
     ).toEqual(explicitTask);
+  });
+
+  it("falls back to selected channel task when channel lane has no active selection", () => {
+    const selectedTask = buildTask("task-review", 120, 140, {
+      title: "Review lane",
+      status: "in_progress",
+      context: { channel_id: "review", bootstrap_kind: "team_channel" },
+    });
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "",
+        selectedConversation: selectedTask,
+        selectedChannelTaskId: "task-review",
+        sharedConversation: null,
+        taskList: [selectedTask],
+      })
+    ).toEqual(selectedTask);
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "review",
+        selectedConversation: null,
+        selectedChannelTaskId: "",
+        sharedConversation: null,
+        taskList: [selectedTask],
+      })
+    ).toBeNull();
+
+    expect(
+      resolveChannelLaneConversationTask({
+        routeChannelId: "review",
+        selectedConversation: null,
+        selectedChannelTaskId: "task-review",
+        sharedConversation: null,
+        taskList: [selectedTask],
+      })
+    ).toEqual(selectedTask);
   });
 
   it("resolves seen-by coverage from delivered mailbox fan-out", () => {

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -1071,6 +1071,19 @@ describe("team page helpers", () => {
     expect(updated?.members.every((member) => member.session_status === "stopped")).toBe(true);
   });
 
+  it("skips optimistic runtime synthesis when no cached runtime or member fallback exists", () => {
+    const updated = updateCachedTeamRuntimeStatus(
+      undefined,
+      "team-1",
+      "Team One",
+      "running",
+      [],
+      () => "running"
+    );
+
+    expect(updated).toBeUndefined();
+  });
+
   it("synthesizes optimistic runtime members when start-team has no cached runtime yet", () => {
     const control: TeamRuntimeControlResponse["members"] = [
       { member_id: "coordinator-agent", session_id: "session-coordinator", action: "started" },
@@ -1104,6 +1117,57 @@ describe("team page helpers", () => {
       "session-coordinator",
       "session-worker",
     ]);
+  });
+
+  it("synthesizes stopped optimistic runtime members without sessions", () => {
+    const updated = updateCachedTeamRuntimeStatus(
+      undefined,
+      "team-1",
+      "Team One",
+      "stopped",
+      [{ member_id: "coordinator-agent", session_id: "session-new", action: "stopped" }],
+      () => "running",
+      [buildMemberStatus({ status: "running" })]
+    );
+
+    expect(updated?.status).toBe("stopped");
+    expect(updated?.members).toHaveLength(1);
+    expect(updated?.members[0]?.session_id).toBeUndefined();
+    expect(updated?.members[0]?.session_status).toBe("stopped");
+    expect(updated?.members[0]?.agent_status).toBe("stopped");
+  });
+
+  it("updates cached runtime sessions for non-stopped optimistic state", () => {
+    const updated = updateCachedTeamRuntimeStatus(
+      buildRuntime({
+        members: [
+          {
+            member_id: "coordinator-agent",
+            display_name: "Coordinator Agent",
+            role: "coordinator",
+            description: "lead",
+            agent_status: "stopped",
+            session_id: undefined,
+            session_status: "stopped",
+            card: {
+              card_id: "card-coordinator",
+              schema_version: "1",
+              description: "lead",
+              capability_tags: [],
+            },
+          },
+        ],
+      }),
+      "team-1",
+      "Team One",
+      "running",
+      [{ member_id: "coordinator-agent", session_id: "session-new", action: "started" }],
+      () => "running"
+    );
+
+    expect(updated?.status).toBe("running");
+    expect(updated?.members[0]?.session_id).toBe("session-new");
+    expect(updated?.members[0]?.session_status).toBe("running");
   });
 
   it("formats timestamps and pretty prints JSON safely", () => {

--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -22,10 +22,13 @@ import {
   DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND,
   formatTs,
   isChannelScopedConversationTask,
+  isCurrentTeamScopedRequest,
   listTeamWorkspaceTasks,
   mergeConversationMessages,
   pickNextWorkerAgentId,
+  removeTeamMemberLookupEntry,
   resolveTaskChannelId,
+  resolveTeamMemberAgentControlState,
   resolveTeamRuntimeControlTone,
   resolveTeamPageNotice,
   resolveTeamRuntimeStatus,
@@ -272,6 +275,56 @@ function buildMemberStatus(
 }
 
 describe("team page helpers", () => {
+  it("matches only the current team-scoped request sequence", () => {
+    const current = { teamId: "team-1", requestSeq: 7 };
+
+    expect(isCurrentTeamScopedRequest(current, "team-1", 7)).toBe(true);
+    expect(isCurrentTeamScopedRequest(current, "", 7)).toBe(false);
+    expect(isCurrentTeamScopedRequest(current, "team-2", 7)).toBe(false);
+    expect(isCurrentTeamScopedRequest(current, "team-1", 8)).toBe(false);
+  });
+
+  it("resolves member agent controls from lifecycle and busy action state", () => {
+    const agent = { id: "agent-1" };
+
+    expect(resolveTeamMemberAgentControlState(agent, "idle", null)).toEqual({
+      canStart: false,
+      canStop: true,
+      canDelete: true,
+    });
+    expect(resolveTeamMemberAgentControlState(agent, "stopped", null)).toEqual({
+      canStart: true,
+      canStop: false,
+      canDelete: true,
+    });
+    expect(
+      resolveTeamMemberAgentControlState(agent, "stopped", "start-team-member-agent")
+    ).toMatchObject({ canStart: false });
+    expect(
+      resolveTeamMemberAgentControlState(agent, "working", "stop-team-member-agent")
+    ).toMatchObject({ canStop: false });
+    expect(
+      resolveTeamMemberAgentControlState(agent, "idle", "delete-team-member-agent")
+    ).toMatchObject({ canDelete: false });
+    expect(resolveTeamMemberAgentControlState(null, "idle", null)).toEqual({
+      canStart: false,
+      canStop: false,
+      canDelete: false,
+    });
+  });
+
+  it("removes member lookup entries without copying when the member is absent", () => {
+    const lookup = { "member-1": "agent-1", "member-2": "agent-2" };
+
+    expect(removeTeamMemberLookupEntry(lookup, "missing-member")).toBe(lookup);
+
+    const next = removeTeamMemberLookupEntry(lookup, "member-1");
+
+    expect(next).not.toBe(lookup);
+    expect(next).toEqual({ "member-2": "agent-2" });
+    expect(lookup).toEqual({ "member-1": "agent-1", "member-2": "agent-2" });
+  });
+
   it("merges conversation messages while preserving unchanged object identity", () => {
     const original = buildConversationMessage(1);
     const prev = [original, buildConversationMessage(2)];

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -27,7 +27,7 @@ function sortRuns(runs: TeamRunRecord[]): TeamRunRecord[] {
 export const DEFAULT_TEAM_THREAD_TITLE = "all";
 export const DEFAULT_TEAM_THREAD_BOOTSTRAP_KIND = "shared_thread";
 export const TEAM_CHANNEL_TASK_BOOTSTRAP_KIND = "team_channel";
-export const TEAM_CONVERSATION_MESSAGE_RETENTION_LIMIT = 60;
+export const TEAM_CONVERSATION_MESSAGE_RETENTION_LIMIT = 20;
 export const TEAM_RUN_EVENT_RETENTION_LIMIT = 100;
 export const TEAM_MEMBER_EVENT_RETENTION_LIMIT = 300;
 

--- a/web/src/pages/team/use_team_conversation_actions.test.tsx
+++ b/web/src/pages/team/use_team_conversation_actions.test.tsx
@@ -310,7 +310,7 @@ describe("useTeamConversationActions", () => {
         "token-1",
         "team-1",
         "task-all",
-        { limit: 60 }
+        { limit: 20 }
       );
       expect(mockedApi.getTeamRunSnapshot).toHaveBeenNthCalledWith(
         1,

--- a/web/src/pages/team/use_team_conversation_actions.ts
+++ b/web/src/pages/team/use_team_conversation_actions.ts
@@ -30,7 +30,7 @@ function readBootstrapKind(context: unknown): string {
   return typeof bootstrapKind === "string" ? bootstrapKind.trim() : "";
 }
 
-const TEAM_CONVERSATION_MESSAGE_LIMIT = 60;
+const TEAM_CONVERSATION_MESSAGE_LIMIT = 20;
 const TEAM_CONVERSATION_MAILBOX_LIMIT = 40;
 const TEAM_CONVERSATION_OPTIMISTIC_MESSAGE_BASE_ID = Number.MAX_SAFE_INTEGER - 10_000;
 const TEAM_CONVERSATION_DETAIL_REFRESH_COOLDOWN_MS = 30_000;

--- a/web/src/pages/team/use_team_conversation_actions.ts
+++ b/web/src/pages/team/use_team_conversation_actions.ts
@@ -18,6 +18,7 @@ import { buildMailboxChatPayload } from "./mailbox_helpers";
 import {
   mergeConversationMessages,
   refreshTeamConversationMailboxAfterSend,
+  TEAM_CONVERSATION_MESSAGE_RETENTION_LIMIT,
 } from "./page_helpers";
 import { parseErrorMessage } from "./create_helpers";
 import { uuidV7 } from "../../uuid";
@@ -30,7 +31,6 @@ function readBootstrapKind(context: unknown): string {
   return typeof bootstrapKind === "string" ? bootstrapKind.trim() : "";
 }
 
-const TEAM_CONVERSATION_MESSAGE_LIMIT = 20;
 const TEAM_CONVERSATION_MAILBOX_LIMIT = 40;
 const TEAM_CONVERSATION_OPTIMISTIC_MESSAGE_BASE_ID = Number.MAX_SAFE_INTEGER - 10_000;
 const TEAM_CONVERSATION_DETAIL_REFRESH_COOLDOWN_MS = 30_000;
@@ -209,7 +209,7 @@ export function useTeamConversationActions({
         }
         const [messages, taskDetail] = await Promise.all([
           api.listTeamTaskMessages(token, teamId, taskId, {
-            limit: TEAM_CONVERSATION_MESSAGE_LIMIT,
+            limit: TEAM_CONVERSATION_MESSAGE_RETENTION_LIMIT,
           }),
           shouldFetchConversationDetail
             ? api.getTeamTask(token, teamId, taskId)


### PR DESCRIPTION
## Summary

- Restore the Team shared-thread conversation fetch/client retention window to recent-20.
- Keep existing replace-refresh caps for Team run events and member ACP events unchanged.
- Add journal evidence for the P0 retention-cap follow-up without closing the TODO before PR CI/merge evidence exists.

## Purpose

`docs/todo.md` and the retention journal define shared-thread client state as a recent-20 window. After the latest main sync, the implementation had drifted to recent-60 for the conversation fetch limit and retention constant. This PR realigns the implementation with the documented P0 contract.

## Related Issue

- None.

## Testing

- `cd web && npm run test -- src/pages/team/use_team_conversation_actions.test.tsx src/pages/team/page_helpers.test.ts src/pages/team/use_team_actions.test.tsx`
- `cd web && npm exec tsc -- --noEmit`
