### PR TITLE
chore(team): share detail panel class contracts

### DIFF
--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -5,8 +5,21 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamThreadPane } from "./team_thread_pane";
+import {
+  TEAM_THREAD_CHANNEL_BADGE_CLASS,
+  TEAM_THREAD_MESSAGE_AVATAR_CLASS,
+  TEAM_THREAD_MESSAGE_BUBBLE_CLASS,
+  TEAM_THREAD_PANE_CLASS,
+  TEAM_THREAD_SOURCE_CARD_CLASS,
+} from "../../ui/tailwind_classes";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function expectStaticClassTokens(html: string, className: string): void {
+  for (const token of className.split(/\s+/).filter(Boolean)) {
+    expect(html).toContain(token.split("&").join("&amp;"));
+  }
+}
 
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   window.matchMedia = ((query: string) =>
@@ -99,9 +112,11 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("Reply in thread · # all");
     expect(html).toContain("@name to reply · Enter to reply");
     expect(html).toContain("Reply");
-    expect(html).toContain("max-w-[360px]");
-    expect(html).toContain("rounded-full");
-    expect(html).toContain("hover:border-black");
+    expectStaticClassTokens(html, TEAM_THREAD_PANE_CLASS);
+    expectStaticClassTokens(html, TEAM_THREAD_CHANNEL_BADGE_CLASS);
+    expectStaticClassTokens(html, TEAM_THREAD_SOURCE_CARD_CLASS);
+    expectStaticClassTokens(html, TEAM_THREAD_MESSAGE_AVATAR_CLASS);
+    expectStaticClassTokens(html, TEAM_THREAD_MESSAGE_BUBBLE_CLASS);
   });
 
   it("keeps the reply composer available when the root has no chat text body", () => {

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -18,13 +18,51 @@ import {
   resolveMentionDraftQuery,
 } from "./mailbox_helpers";
 import {
-  CONVERSATION_MESSAGE_INLINE_ROW_CLASS,
   TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
   TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS,
   TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS,
   TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS,
   TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
   TEAM_PANEL_TEXTAREA_CLASS,
+  TEAM_THREAD_BODY_CLASS,
+  TEAM_THREAD_CHANNEL_BADGE_CLASS,
+  TEAM_THREAD_COMPOSER_CONTEXT_CLASS,
+  TEAM_THREAD_COMPOSER_REGION_CLASS,
+  TEAM_THREAD_EMPTY_REPLIES_CLASS,
+  TEAM_THREAD_EMPTY_STATE_CLASS,
+  TEAM_THREAD_HEADER_ACTIONS_CLASS,
+  TEAM_THREAD_HEADER_BUTTON_CLASS,
+  TEAM_THREAD_HEADER_CLASS,
+  TEAM_THREAD_HEADER_CONTENT_CLASS,
+  TEAM_THREAD_HEADER_ICON_CLASS,
+  TEAM_THREAD_HEADER_TITLE_CLASS,
+  TEAM_THREAD_HEADER_TITLE_ROW_CLASS,
+  TEAM_THREAD_HELP_TEXT_CLASS,
+  TEAM_THREAD_MENTION_ALIAS_CLASS,
+  TEAM_THREAD_MENTION_HINT_CLASS,
+  TEAM_THREAD_MENTION_LIST_CLASS,
+  TEAM_THREAD_MENTION_MENU_CLASS,
+  TEAM_THREAD_MESSAGE_AUTHOR_CLASS,
+  TEAM_THREAD_MESSAGE_AVATAR_CLASS,
+  TEAM_THREAD_MESSAGE_BUBBLE_CLASS,
+  TEAM_THREAD_MESSAGE_CONTENT_CLASS,
+  TEAM_THREAD_MESSAGE_META_ROW_CLASS,
+  TEAM_THREAD_MESSAGE_ROW_CLASS,
+  TEAM_THREAD_MISSING_TEXT_CLASS,
+  TEAM_THREAD_ORIGINAL_BADGE_CLASS,
+  TEAM_THREAD_PANE_CLASS,
+  TEAM_THREAD_REPLY_COUNT_CLASS,
+  TEAM_THREAD_REPLIES_LIST_CLASS,
+  TEAM_THREAD_RICH_TEXT_CLASS,
+  TEAM_THREAD_SECTION_ROW_CLASS,
+  TEAM_THREAD_SECTION_TITLE_CLASS,
+  TEAM_THREAD_SOURCE_CARD_CLASS,
+  TEAM_THREAD_SOURCE_LABEL_CLASS,
+  TEAM_THREAD_SOURCE_PREVIEW_CLASS,
+  TEAM_THREAD_SOURCE_ROW_CLASS,
+  TEAM_THREAD_SOURCE_VALUE_CLASS,
+  TEAM_THREAD_TEXTAREA_CLASS,
+  TEAM_THREAD_TRANSCRIPT_CLASS,
 } from "../../ui/tailwind_classes";
 import { isMobileInputViewport } from "../../components/input_dock";
 
@@ -59,17 +97,6 @@ type TeamThreadPaneProps = {
   mentionCandidates?: MentionCandidate[];
 };
 
-const TEAM_THREAD_MESSAGE_ROW_CLASS =
-  `${CONVERSATION_MESSAGE_INLINE_ROW_CLASS} rounded-xl`;
-const TEAM_THREAD_MESSAGE_AVATAR_CLASS =
-  "mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-black/8 bg-white text-[10px] font-semibold uppercase tracking-tight text-notion-text-muted shadow-sm";
-const TEAM_THREAD_MESSAGE_META_ROW_CLASS =
-  "flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-notion-text-muted";
-const TEAM_THREAD_MESSAGE_CONTENT_CLASS = "min-w-0 flex flex-1 flex-col gap-1";
-const TEAM_THREAD_MESSAGE_BUBBLE_CLASS =
-  "w-full rounded-[12px] border border-black/6 bg-white/96 px-2 py-[5px] shadow-none [&_.md-blockquote]:bg-slate-50/92 [&_.md-table-wrap]:bg-white/88 [&_.md-table-wrap]:border-black/6 [&_.md-code-block]:border-slate-900/80";
-const TEAM_THREAD_SECTION_ROW_CLASS =
-  "flex flex-wrap items-center justify-between gap-2 px-2";
 function formatThreadReplyCount(count: number): string {
   return count === 1 ? "1 reply" : `${count} replies`;
 }
@@ -241,73 +268,73 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
   }, [mentionCandidates, onSendReply, replyDraft]);
   return (
     <SurfaceCard
-      className="flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80"
+      className={TEAM_THREAD_PANE_CLASS}
       data-team-surface="thread-pane"
     >
-      <ToolbarRow className="items-start gap-2 border-b border-notion-border/70 px-2.5 py-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
+      <ToolbarRow className={TEAM_THREAD_HEADER_CLASS}>
+        <div className={TEAM_THREAD_HEADER_CONTENT_CLASS}>
+          <div className={TEAM_THREAD_HEADER_TITLE_ROW_CLASS}>
+            <div className={TEAM_THREAD_HEADER_TITLE_CLASS}>
               Reply in thread
             </div>
             <Badge
               tone="outline"
               shape="pill"
-              className="border-black/8 bg-white/92 px-2 py-0 text-[9px] font-semibold text-notion-text-muted"
+              className={TEAM_THREAD_CHANNEL_BADGE_CLASS}
             >
               {channelLabel}
             </Badge>
-            <span className="text-[10px] text-notion-text-muted">{replyCountLabel}</span>
+            <span className={TEAM_THREAD_REPLY_COUNT_CLASS}>{replyCountLabel}</span>
           </div>
-          <div className="mt-0.5 text-[11px] text-notion-text-muted">
+          <div className={TEAM_THREAD_HELP_TEXT_CLASS}>
             Keep the root summary-first. Use the thread for detailed context, logs, and follow-up.
           </div>
           {sourceSummary ? (
-            <div className="mt-1 flex max-w-full flex-col gap-0.5 rounded-md border border-black/6 bg-white/92 px-2 py-1 text-[10px] font-medium text-notion-text-muted">
-              <div className="inline-flex min-w-0 items-center gap-1.5">
-                <span className="uppercase tracking-[0.08em] text-notion-text-muted/70">
+            <div className={TEAM_THREAD_SOURCE_CARD_CLASS}>
+              <div className={TEAM_THREAD_SOURCE_ROW_CLASS}>
+                <span className={TEAM_THREAD_SOURCE_LABEL_CLASS}>
                   Source
                 </span>
-                <span className="truncate text-notion-text">{sourceSummary}</span>
+                <span className={TEAM_THREAD_SOURCE_VALUE_CLASS}>{sourceSummary}</span>
               </div>
               {sourcePreview ? (
-                <div className="truncate text-[11px] font-normal leading-4 text-notion-text-muted/90">
+                <div className={TEAM_THREAD_SOURCE_PREVIEW_CLASS}>
                   {sourcePreview}
                 </div>
               ) : null}
             </div>
           ) : null}
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className={TEAM_THREAD_HEADER_ACTIONS_CLASS}>
           <CompactButton
             type="button"
-            className="px-1.5 text-[10px] text-notion-text-muted/80"
+            className={TEAM_THREAD_HEADER_BUTTON_CLASS}
             onClick={onViewInChannel}
           >
-            <i className="bi bi-arrow-left text-[10px]" aria-hidden="true" />
+            <i className={`bi bi-arrow-left ${TEAM_THREAD_HEADER_ICON_CLASS}`} aria-hidden="true" />
             View in channel
           </CompactButton>
           <CompactButton
             type="button"
-            className="px-1.5 text-[10px] text-notion-text-muted/80"
+            className={TEAM_THREAD_HEADER_BUTTON_CLASS}
             onClick={onClose}
           >
-            <i className="bi bi-x-lg text-[10px]" aria-hidden="true" />
+            <i className={`bi bi-x-lg ${TEAM_THREAD_HEADER_ICON_CLASS}`} aria-hidden="true" />
             Close thread
           </CompactButton>
         </div>
       </ToolbarRow>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2.5 py-2">
+      <div className={TEAM_THREAD_BODY_CLASS}>
         {!hasSelectedRoot ? (
           <EmptyState
             title="Select a channel message"
-            className="border-0 bg-transparent px-0 py-0"
+            className={TEAM_THREAD_EMPTY_STATE_CLASS}
           >
             Thread roots open from existing channel messages.
           </EmptyState>
         ) : (
-          <div className="flex flex-col gap-3">
+          <div className={TEAM_THREAD_TRANSCRIPT_CLASS}>
             <div className={TEAM_THREAD_MESSAGE_ROW_CLASS}>
               <DeterministicAvatar
                 name={rootRenderMessage?.authorLabel ?? "Unknown"}
@@ -316,7 +343,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
               />
               <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                 <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
-                  <span className="font-semibold text-notion-text">
+                  <span className={TEAM_THREAD_MESSAGE_AUTHOR_CLASS}>
                     {rootRenderMessage?.authorLabel ?? "Unknown"}
                   </span>
                   <span>{rootRenderMessage?.createdAtLabel ?? ""}</span>
@@ -324,7 +351,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                   <Badge
                     tone="outline"
                     shape="pill"
-                    className="ml-0.5 border-black/8 bg-white/92 px-2 py-0 text-[9px] font-semibold uppercase tracking-[0.06em] text-notion-text-muted"
+                    className={TEAM_THREAD_ORIGINAL_BADGE_CLASS}
                   >
                     Original
                   </Badge>
@@ -332,11 +359,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                   {rootRenderMessage?.text ? (
                     <TeamThreadRichText
-                      className="text-[13px] leading-6 text-notion-text"
+                      className={TEAM_THREAD_RICH_TEXT_CLASS}
                       text={rootRenderMessage.text}
                     />
                   ) : (
-                    <div className="text-[12px] italic leading-5 text-notion-text-muted">
+                    <div className={TEAM_THREAD_MISSING_TEXT_CLASS}>
                       Original content is not available in chat text form.
                     </div>
                   )}
@@ -344,14 +371,14 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
               </div>
             </div>
             <div className={TEAM_THREAD_SECTION_ROW_CLASS}>
-              <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted">
+              <div className={TEAM_THREAD_SECTION_TITLE_CLASS}>
                 Replies
               </div>
-              <span className="text-[10px] text-notion-text-muted">{replyCountLabel}</span>
+              <span className={TEAM_THREAD_REPLY_COUNT_CLASS}>{replyCountLabel}</span>
             </div>
-            <div className="flex flex-col gap-2 border-t border-notion-border/70 pt-3">
+            <div className={TEAM_THREAD_REPLIES_LIST_CLASS}>
               {replies.length === 0 ? (
-                <div className="px-2 text-[11px] leading-5 text-notion-text-muted">
+                <div className={TEAM_THREAD_EMPTY_REPLIES_CLASS}>
                   No replies yet.
                 </div>
               ) : (
@@ -364,13 +391,13 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                     />
                     <div className={TEAM_THREAD_MESSAGE_CONTENT_CLASS}>
                       <div className={TEAM_THREAD_MESSAGE_META_ROW_CLASS}>
-                        <span className="font-semibold text-notion-text">{reply.authorLabel}</span>
+                        <span className={TEAM_THREAD_MESSAGE_AUTHOR_CLASS}>{reply.authorLabel}</span>
                         <span>{reply.createdAtLabel}</span>
                         <span>{`#${reply.messageId}`}</span>
                       </div>
                       <ConversationBubble className={TEAM_THREAD_MESSAGE_BUBBLE_CLASS}>
                         <TeamThreadRichText
-                          className="text-[13px] leading-6 text-notion-text"
+                          className={TEAM_THREAD_RICH_TEXT_CLASS}
                           text={reply.text}
                         />
                       </ConversationBubble>
@@ -383,15 +410,15 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         )}
       </div>
       {hasSelectedRoot ? (
-        <div className="border-t border-notion-border/55 bg-white/92 px-2.5 py-1.5">
+        <div className={TEAM_THREAD_COMPOSER_REGION_CLASS}>
           <div className={TEAM_MESSAGE_COMPOSER_SHELL_CLASS}>
-            <div className="px-1 pb-1 text-[10px] leading-5 text-notion-text-muted">
+            <div className={TEAM_THREAD_COMPOSER_CONTEXT_CLASS}>
               Full context in thread · root message stays summary-first · {channelLabel}
             </div>
             <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
               <textarea
                 ref={replyTextareaRef}
-                className={`${TEAM_PANEL_TEXTAREA_CLASS} min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0`}
+                className={`${TEAM_PANEL_TEXTAREA_CLASS} ${TEAM_THREAD_TEXTAREA_CLASS}`}
                 rows={2}
                 placeholder={`Reply in thread · ${channelLabel}`}
                 value={replyDraft}
@@ -469,11 +496,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
               </ActionButton>
             </div>
             {activeMention && filteredMentionCandidates.length > 0 && (
-              <div className="mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm">
-                <div className="px-3 py-1 text-xs text-ui-text-muted">
+              <div className={TEAM_THREAD_MENTION_MENU_CLASS}>
+                <div className={TEAM_THREAD_MENTION_HINT_CLASS}>
                   Select teammate mention (`@` without selection stays plain text)
                 </div>
-                <div className="max-h-44 overflow-auto py-1">
+                <div className={TEAM_THREAD_MENTION_LIST_CLASS}>
                   {filteredMentionCandidates.map((candidate, index) => (
                     <MenuOptionButton
                       key={candidate.actorId}
@@ -485,7 +512,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                       }}
                     >
                       <span>{candidate.label}</span>
-                      <span className="text-[11px] text-ui-text-muted">{`@${candidate.label}`}</span>
+                      <span className={TEAM_THREAD_MENTION_ALIAS_CLASS}>{`@${candidate.label}`}</span>
                     </MenuOptionButton>
                   ))}
                 </div>

--- a/web/src/pages/team_active_run_panel.tsx
+++ b/web/src/pages/team_active_run_panel.tsx
@@ -9,6 +9,11 @@ import {
   SurfaceCard,
   ToolbarRow,
 } from "../ui/primitives";
+import {
+  TEAM_ACTIVE_RUN_ACTIONS_CLASS,
+  TEAM_ACTIVE_RUN_HEADER_CLASS,
+  TEAM_ACTIVE_RUN_METADATA_CLASS,
+} from "../ui/tailwind_classes";
 
 type TeamActiveRunPanelProps = {
   run: TeamRunRecord;
@@ -42,11 +47,11 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
   return (
     <SurfaceCard className={cardClassName}>
       <PanelHeader
-        className="mb-3"
+        className={TEAM_ACTIVE_RUN_HEADER_CLASS}
         title="Active Execution Run"
         titleClassName={titleClassName}
         actions={
-          <ToolbarRow className="justify-end gap-2">
+          <ToolbarRow className={TEAM_ACTIVE_RUN_ACTIONS_CLASS}>
             <ActionButton
               tone="secondary"
               size="sm"
@@ -94,7 +99,7 @@ function TeamActiveRunPanelImpl(props: TeamActiveRunPanelProps) {
           </ToolbarRow>
         }
       />
-      <KeyValueList className="mt-3 gap-y-2 text-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3">
+      <KeyValueList className={TEAM_ACTIVE_RUN_METADATA_CLASS}>
         <KeyValueItem label="Execution run:" value={<code>{run.id}</code>} />
         <KeyValueItem
           label="Execution status:"

--- a/web/src/pages/team_member_acp_panel.tsx
+++ b/web/src/pages/team_member_acp_panel.tsx
@@ -27,6 +27,24 @@ import {
   OUTPUT_HEADER_TITLE_HEADING_CLASS,
   OUTPUT_HEADER_TITLE_MAIN_CLASS,
   OUTPUT_HEADER_TITLE_TEXT_CLASS,
+  TEAM_MEMBER_ACP_ACTIVITY_BADGE_CLASS,
+  TEAM_MEMBER_ACP_ACTIVITY_STRIP_CLASS,
+  TEAM_MEMBER_ACP_BODY_SHELL_CLASS,
+  TEAM_MEMBER_ACP_DESCRIPTION_CLASS,
+  TEAM_MEMBER_ACP_HEADER_CONTEXT_CLASS,
+  TEAM_MEMBER_ACP_INFO_BADGE_CLASS,
+  TEAM_MEMBER_ACP_INFO_STRIP_CLASS,
+  TEAM_MEMBER_ACP_INPUT_DOCK_SHELL_CLASS,
+  TEAM_MEMBER_ACP_NODE_LINK_CLASS,
+  TEAM_MEMBER_ACP_PANEL_BODY_CLASS,
+  TEAM_MEMBER_ACP_PANEL_SHELL_CLASS,
+  TEAM_MEMBER_ACP_SENDING_TEXT_CLASS,
+  TEAM_MEMBER_ACP_STARTING_LABEL_CLASS,
+  TEAM_MEMBER_ACP_STARTING_PROGRESS_BAR_CLASS,
+  TEAM_MEMBER_ACP_STARTING_PROGRESS_TRACK_CLASS,
+  TEAM_MEMBER_ACP_STARTING_SESSION_CLASS,
+  TEAM_MEMBER_ACP_TECHNICAL_SUMMARY_CLASS,
+  TEAM_MEMBER_ACP_TITLE_SHELL_CLASS,
   TEAM_MUTED_TEXT_CLASS,
   TEAM_PANEL_CARD_CLASS,
 } from "../ui/tailwind_classes";
@@ -231,7 +249,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
       ...acpPanelProps,
       subtitle: null,
       headerContext: (
-        <div className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1 rounded-2xl border border-notion-border/80 bg-notion-sidebar/68 px-1.5 py-1 shadow-notion-row">
+        <div className={TEAM_MEMBER_ACP_HEADER_CONTEXT_CLASS}>
           <StatusBadge
             label={memberStatusLabel}
             tone={resolveTeamRunStatusTone(memberStatus)}
@@ -241,7 +259,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
           {attachedNodeId ? (
             <a
               href={buildWorkspaceNodePath(attachedNodeId)}
-              className="inline-flex min-w-0 max-w-full items-center rounded-xl border border-transparent px-1.5 py-0.5 text-[11px] font-medium text-notion-text-muted transition hover:bg-white/70 hover:text-notion-text"
+              className={TEAM_MEMBER_ACP_NODE_LINK_CLASS}
               title={`Open node detail for ${attachedNodeId}`}
               onClick={(event) => {
                 if (!shouldHandleInAppLinkClick(event)) {
@@ -255,11 +273,11 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
             </a>
           ) : null}
           {infoStripSummary ? (
-            <div className="min-w-0 max-w-full">
+            <div className={TEAM_MEMBER_ACP_INFO_STRIP_CLASS}>
               <Badge
                 tone="outline"
                 shape="pill"
-                className="max-w-full truncate border-transparent bg-transparent px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-notion-text-muted shadow-none"
+                className={TEAM_MEMBER_ACP_INFO_BADGE_CLASS}
                 title={infoStripSummary}
               >
                 {infoStripSummary}
@@ -268,7 +286,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
           ) : null}
           {activitySummaryItems.length > 0 ? (
             <div
-              className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-1"
+              className={TEAM_MEMBER_ACP_ACTIVITY_STRIP_CLASS}
               data-team-member-acp-activity-strip="true"
             >
               {activitySummaryItems.map((item) => (
@@ -276,7 +294,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
                   key={item.id}
                   tone="outline"
                   shape="pill"
-                  className="max-w-full truncate border-notion-border/70 bg-white/80 px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-notion-text-muted shadow-none"
+                  className={TEAM_MEMBER_ACP_ACTIVITY_BADGE_CLASS}
                   title={item.title ?? item.label}
                 >
                   {item.label}
@@ -285,21 +303,21 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
             </div>
           ) : null}
           {isStartingAcpSession ? (
-            <div className="inline-flex min-w-[12rem] items-center gap-2 rounded-xl border border-notion-border/70 bg-white/80 px-2 py-1 text-[11px] font-medium text-notion-text-muted">
-              <span className="shrink-0">Starting session</span>
+            <div className={TEAM_MEMBER_ACP_STARTING_SESSION_CLASS}>
+              <span className={TEAM_MEMBER_ACP_STARTING_LABEL_CLASS}>Starting session</span>
               <span
                 role="progressbar"
                 aria-label="Starting ACP session"
                 aria-valuetext="Starting ACP session"
-                className="relative h-1.5 min-w-[6rem] flex-1 overflow-hidden rounded-full bg-notion-hover/80"
+                className={TEAM_MEMBER_ACP_STARTING_PROGRESS_TRACK_CLASS}
               >
-                <span className="absolute inset-y-0 left-0 w-2/5 animate-pulse rounded-full bg-notion-accent/75" />
+                <span className={TEAM_MEMBER_ACP_STARTING_PROGRESS_BAR_CLASS} />
               </span>
             </div>
           ) : null}
           <OutputHeaderDetails
             items={developerTechnicalMetadata}
-            summaryClassName="inline-flex cursor-pointer list-none items-center rounded-xl border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-notion-text-muted/70 transition hover:bg-white/70 hover:text-notion-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent/10"
+            summaryClassName={TEAM_MEMBER_ACP_TECHNICAL_SUMMARY_CLASS}
           />
         </div>
       ),
@@ -318,7 +336,7 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
   );
 
   return (
-    <div className={`${TEAM_PANEL_CARD_CLASS} px-2 pb-2 pt-1.5`}>
+    <div className={`${TEAM_PANEL_CARD_CLASS} ${TEAM_MEMBER_ACP_PANEL_SHELL_CLASS}`}>
       {!selectedMemberId.trim() && (
         <p className={`mt-1 ${TEAM_MUTED_TEXT_CLASS}`}>
           Select an agent from the left rail to inspect its thread.
@@ -326,16 +344,16 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
       )}
 
       {shouldRenderPanel && (
-        <div className="relative mt-1 flex min-h-0 flex-1 flex-col gap-0 sm:gap-1">
+        <div className={TEAM_MEMBER_ACP_BODY_SHELL_CLASS}>
           {!hideMemberTitle && (
-            <div className="shrink-0 px-4 pt-0.5 sm:px-6">
+            <div className={TEAM_MEMBER_ACP_TITLE_SHELL_CLASS}>
               <div className={OUTPUT_HEADER_TITLE_CLASS}>
                 <div className={OUTPUT_HEADER_TITLE_TEXT_CLASS}>
                   <div className={OUTPUT_HEADER_TITLE_MAIN_CLASS}>
                     <h2 className={OUTPUT_HEADER_TITLE_HEADING_CLASS}>{memberTitle}</h2>
                   </div>
                   {memberDescription ? (
-                    <p className="mt-0.5 text-[12px] leading-5 text-notion-text-muted">
+                    <p className={TEAM_MEMBER_ACP_DESCRIPTION_CLASS}>
                       {memberDescription}
                     </p>
                   ) : null}
@@ -343,14 +361,14 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
               </div>
             </div>
           )}
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className={TEAM_MEMBER_ACP_PANEL_BODY_CLASS}>
             <AcpPanel {...acpPanelPropsWithoutSubtitle} />
           </div>
         </div>
       )}
 
       {hasVisibleInputDock && (
-        <div className="mt-1.5 shrink-0">
+        <div className={TEAM_MEMBER_ACP_INPUT_DOCK_SHELL_CLASS}>
           <InputDock
             input={input}
             historyCommands={inputHistory}
@@ -372,7 +390,9 @@ function TeamMemberAcpPanelImpl(props: TeamMemberAcpPanelProps) {
             isComposingRef={isComposingRef}
           />
           {sendingInput && (
-            <p className={`mt-1.5 ${TEAM_MUTED_TEXT_CLASS}`}>Sending prompt to selected agent...</p>
+            <p className={`${TEAM_MEMBER_ACP_SENDING_TEXT_CLASS} ${TEAM_MUTED_TEXT_CLASS}`}>
+              Sending prompt to selected agent...
+            </p>
           )}
         </div>
       )}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -34,6 +34,11 @@ import {
   MAILBOX_COMPOSER_TEXTAREA_CLASS,
   MAILBOX_MEMBER_UNREAD_BADGE_CLASS,
   MAILBOX_MESSAGE_PRE_CLASS,
+  TEAM_ACTIVE_RUN_ACTIONS_CLASS,
+  TEAM_ACTIVE_RUN_METADATA_CLASS,
+  TEAM_MEMBER_ACP_HEADER_CONTEXT_CLASS,
+  TEAM_MEMBER_ACP_INFO_BADGE_CLASS,
+  TEAM_MEMBER_ACP_NODE_LINK_CLASS,
   TEAM_RUN_FOOT_META_CLASS,
   TEAM_RUN_LIST_ITEMS_CLASS,
   TEAM_SIDEBAR_NAV_ITEM_ACTIVE_CLASS,
@@ -1410,6 +1415,14 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Execution status:");
     expect(container.textContent).toContain("run-1");
     expect(container.textContent).toContain("ctx-1");
+    expect(container.innerHTML).toContain(TEAM_ACTIVE_RUN_METADATA_CLASS);
+    expectClassTokens(
+      required(
+        findButtonByText(container, "Cancel Execution Run").parentElement,
+        "active run action row missing"
+      ),
+      TEAM_ACTIVE_RUN_ACTIONS_CLASS
+    );
     expect(
       findButtonByAriaLabel(container, "Refresh active execution run").getAttribute("title")
     ).toBe("Refresh active execution run");
@@ -5396,6 +5409,23 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Active thread has no events yet");
     expect(container.textContent).toContain("Details");
     expect(container.innerHTML).toContain("/workspace/nodes/node-east");
+    expectClassTokens(
+      required(container.querySelector(".agent-status")?.parentElement ?? null, "member header context missing"),
+      TEAM_MEMBER_ACP_HEADER_CONTEXT_CLASS
+    );
+    expectClassTokens(
+      required(container.querySelector('a[href="/workspace/nodes/node-east"]'), "member node link missing"),
+      TEAM_MEMBER_ACP_NODE_LINK_CLASS
+    );
+    expectClassTokens(
+      required(
+        Array.from(container.querySelectorAll('[title="worker · gpt-5 · Active thread has no events yet"]')).find(
+          (element) => element.textContent?.includes("worker")
+        ) ?? null,
+        "member info badge missing"
+      ),
+      TEAM_MEMBER_ACP_INFO_BADGE_CLASS
+    );
     expect(container.textContent).not.toContain("member");
     expect(container.textContent).not.toContain("session");
     expect(container.textContent).not.toContain("role=worker");

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -431,6 +431,158 @@ export const TEAM_RUN_HINT_TEXT_CLASS = "text-[13px] text-notion-text-muted ital
 export const TEAM_RUN_FOOT_META_CLASS =
   "mono text-[10px] font-bold uppercase tracking-widest text-notion-text-muted opacity-70";
 
+export const TEAM_ACTIVE_RUN_HEADER_CLASS = "mb-3";
+
+export const TEAM_ACTIVE_RUN_ACTIONS_CLASS = "justify-end gap-2";
+
+export const TEAM_ACTIVE_RUN_METADATA_CLASS =
+  "mt-3 gap-y-2 text-sm text-ui-text-secondary sm:grid-cols-2 xl:grid-cols-3";
+
+export const TEAM_MEMBER_ACP_HEADER_CONTEXT_CLASS =
+  "inline-flex min-w-0 max-w-full flex-wrap items-center gap-1 rounded-2xl border border-notion-border/80 bg-notion-sidebar/68 px-1.5 py-1 shadow-notion-row";
+
+export const TEAM_MEMBER_ACP_NODE_LINK_CLASS =
+  "inline-flex min-w-0 max-w-full items-center rounded-xl border border-transparent px-1.5 py-0.5 text-[11px] font-medium text-notion-text-muted transition hover:bg-white/70 hover:text-notion-text";
+
+export const TEAM_MEMBER_ACP_INFO_STRIP_CLASS = "min-w-0 max-w-full";
+
+export const TEAM_MEMBER_ACP_INFO_BADGE_CLASS =
+  "max-w-full truncate border-transparent bg-transparent px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-notion-text-muted shadow-none";
+
+export const TEAM_MEMBER_ACP_ACTIVITY_STRIP_CLASS =
+  "inline-flex min-w-0 max-w-full flex-wrap items-center gap-1";
+
+export const TEAM_MEMBER_ACP_ACTIVITY_BADGE_CLASS =
+  "max-w-full truncate border-notion-border/70 bg-white/80 px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-notion-text-muted shadow-none";
+
+export const TEAM_MEMBER_ACP_STARTING_SESSION_CLASS =
+  "inline-flex min-w-[12rem] items-center gap-2 rounded-xl border border-notion-border/70 bg-white/80 px-2 py-1 text-[11px] font-medium text-notion-text-muted";
+
+export const TEAM_MEMBER_ACP_STARTING_LABEL_CLASS = "shrink-0";
+
+export const TEAM_MEMBER_ACP_STARTING_PROGRESS_TRACK_CLASS =
+  "relative h-1.5 min-w-[6rem] flex-1 overflow-hidden rounded-full bg-notion-hover/80";
+
+export const TEAM_MEMBER_ACP_STARTING_PROGRESS_BAR_CLASS =
+  "absolute inset-y-0 left-0 w-2/5 animate-pulse rounded-full bg-notion-accent/75";
+
+export const TEAM_MEMBER_ACP_TECHNICAL_SUMMARY_CLASS =
+  "inline-flex cursor-pointer list-none items-center rounded-xl border border-transparent bg-transparent px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-notion-text-muted/70 transition hover:bg-white/70 hover:text-notion-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-notion-accent/10";
+
+export const TEAM_MEMBER_ACP_PANEL_SHELL_CLASS = "px-2 pb-2 pt-1.5";
+
+export const TEAM_MEMBER_ACP_BODY_SHELL_CLASS =
+  "relative mt-1 flex min-h-0 flex-1 flex-col gap-0 sm:gap-1";
+
+export const TEAM_MEMBER_ACP_TITLE_SHELL_CLASS = "shrink-0 px-4 pt-0.5 sm:px-6";
+
+export const TEAM_MEMBER_ACP_DESCRIPTION_CLASS =
+  "mt-0.5 text-[12px] leading-5 text-notion-text-muted";
+
+export const TEAM_MEMBER_ACP_PANEL_BODY_CLASS = "flex min-h-0 flex-1 flex-col overflow-hidden";
+
+export const TEAM_MEMBER_ACP_INPUT_DOCK_SHELL_CLASS = "mt-1.5 shrink-0";
+
+export const TEAM_MEMBER_ACP_SENDING_TEXT_CLASS = "mt-1.5";
+
+export const TEAM_THREAD_PANE_CLASS =
+  "flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80";
+
+export const TEAM_THREAD_HEADER_CLASS =
+  "items-start gap-2 border-b border-notion-border/70 px-2.5 py-2";
+
+export const TEAM_THREAD_HEADER_CONTENT_CLASS = "min-w-0 flex-1";
+
+export const TEAM_THREAD_HEADER_TITLE_ROW_CLASS = "flex flex-wrap items-center gap-1.5";
+
+export const TEAM_THREAD_HEADER_TITLE_CLASS =
+  "text-[11px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted";
+
+export const TEAM_THREAD_CHANNEL_BADGE_CLASS =
+  "border-black/8 bg-white/92 px-2 py-0 text-[9px] font-semibold text-notion-text-muted";
+
+export const TEAM_THREAD_REPLY_COUNT_CLASS = "text-[10px] text-notion-text-muted";
+
+export const TEAM_THREAD_HELP_TEXT_CLASS = "mt-0.5 text-[11px] text-notion-text-muted";
+
+export const TEAM_THREAD_SOURCE_CARD_CLASS =
+  "mt-1 flex max-w-full flex-col gap-0.5 rounded-md border border-black/6 bg-white/92 px-2 py-1 text-[10px] font-medium text-notion-text-muted";
+
+export const TEAM_THREAD_SOURCE_ROW_CLASS = "inline-flex min-w-0 items-center gap-1.5";
+
+export const TEAM_THREAD_SOURCE_LABEL_CLASS =
+  "uppercase tracking-[0.08em] text-notion-text-muted/70";
+
+export const TEAM_THREAD_SOURCE_VALUE_CLASS = "truncate text-notion-text";
+
+export const TEAM_THREAD_SOURCE_PREVIEW_CLASS =
+  "truncate text-[11px] font-normal leading-4 text-notion-text-muted/90";
+
+export const TEAM_THREAD_HEADER_ACTIONS_CLASS = "flex shrink-0 items-center gap-1.5";
+
+export const TEAM_THREAD_HEADER_BUTTON_CLASS = "px-1.5 text-[10px] text-notion-text-muted/80";
+
+export const TEAM_THREAD_HEADER_ICON_CLASS = "text-[10px]";
+
+export const TEAM_THREAD_BODY_CLASS = "flex min-h-0 flex-1 flex-col overflow-y-auto px-2.5 py-2";
+
+export const TEAM_THREAD_EMPTY_STATE_CLASS = "border-0 bg-transparent px-0 py-0";
+
+export const TEAM_THREAD_TRANSCRIPT_CLASS = "flex flex-col gap-3";
+
+export const TEAM_THREAD_MESSAGE_ROW_CLASS =
+  `${CONVERSATION_MESSAGE_INLINE_ROW_CLASS} rounded-xl`;
+
+export const TEAM_THREAD_MESSAGE_AVATAR_CLASS =
+  "mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-black/8 bg-white text-[10px] font-semibold uppercase tracking-tight text-notion-text-muted shadow-sm";
+
+export const TEAM_THREAD_MESSAGE_META_ROW_CLASS =
+  "flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-notion-text-muted";
+
+export const TEAM_THREAD_MESSAGE_CONTENT_CLASS = "min-w-0 flex flex-1 flex-col gap-1";
+
+export const TEAM_THREAD_MESSAGE_AUTHOR_CLASS = "font-semibold text-notion-text";
+
+export const TEAM_THREAD_ORIGINAL_BADGE_CLASS =
+  "ml-0.5 border-black/8 bg-white/92 px-2 py-0 text-[9px] font-semibold uppercase tracking-[0.06em] text-notion-text-muted";
+
+export const TEAM_THREAD_MESSAGE_BUBBLE_CLASS =
+  "w-full rounded-[12px] border border-black/6 bg-white/96 px-2 py-[5px] shadow-none [&_.md-blockquote]:bg-slate-50/92 [&_.md-table-wrap]:bg-white/88 [&_.md-table-wrap]:border-black/6 [&_.md-code-block]:border-slate-900/80";
+
+export const TEAM_THREAD_RICH_TEXT_CLASS = "text-[13px] leading-6 text-notion-text";
+
+export const TEAM_THREAD_MISSING_TEXT_CLASS =
+  "text-[12px] italic leading-5 text-notion-text-muted";
+
+export const TEAM_THREAD_SECTION_ROW_CLASS =
+  "flex flex-wrap items-center justify-between gap-2 px-2";
+
+export const TEAM_THREAD_SECTION_TITLE_CLASS =
+  "text-[10px] font-semibold uppercase tracking-[0.08em] text-notion-text-muted";
+
+export const TEAM_THREAD_REPLIES_LIST_CLASS =
+  "flex flex-col gap-2 border-t border-notion-border/70 pt-3";
+
+export const TEAM_THREAD_EMPTY_REPLIES_CLASS = "px-2 text-[11px] leading-5 text-notion-text-muted";
+
+export const TEAM_THREAD_COMPOSER_REGION_CLASS =
+  "border-t border-notion-border/55 bg-white/92 px-2.5 py-1.5";
+
+export const TEAM_THREAD_COMPOSER_CONTEXT_CLASS =
+  "px-1 pb-1 text-[10px] leading-5 text-notion-text-muted";
+
+export const TEAM_THREAD_TEXTAREA_CLASS =
+  "min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0";
+
+export const TEAM_THREAD_MENTION_MENU_CLASS =
+  "mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm";
+
+export const TEAM_THREAD_MENTION_HINT_CLASS = "px-3 py-1 text-xs text-ui-text-muted";
+
+export const TEAM_THREAD_MENTION_LIST_CLASS = "max-h-44 overflow-auto py-1";
+
+export const TEAM_THREAD_MENTION_ALIAS_CLASS = "text-[11px] text-ui-text-muted";
+
 export const TASKS_BOARD_LANES_CLASS =
   "grid min-w-full auto-cols-[minmax(280px,1fr)] grid-flow-col gap-4";
 


### PR DESCRIPTION
## Summary

- Move Team active-run, member ACP, and thread-pane detail styling into shared Tailwind class contracts.
- Reuse those contracts in the corresponding Team panels instead of keeping local inline class strings.
- Extend focused Team panel tests to lock the shared class contracts for active-run metadata/actions, member ACP header metadata, and thread-pane shell/message styling.

## Purpose

This continues the P0 shared UI primitive cleanup by reducing Tailwind drift in Team detail surfaces without changing user-visible behavior.

## Related Issue

- None.

## Testing

- `npm run test -- team_panels.test.tsx team/team_thread_pane.test.tsx`
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Browser Validation

- Chrome DevTools MCP validation was attempted, but the MCP browser target is currently stale: `Error: The selected page has been closed. Call list_pages to see open pages.`
