### PR TITLE
fix(acp): settle denied permission tool calls

### DIFF
--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -693,6 +693,9 @@ impl AcpClient {
             "responded_at": Utc::now().timestamp(),
         }))
         .await;
+        if !permission_outcome_allows(&outcome, &args.options) {
+            self.emit_permission_denied_tool_update(&args).await;
+        }
         if !self
             .permissions
             .has_pending_permissions_for_session(&self.session_id)
@@ -708,6 +711,26 @@ impl AcpClient {
         }
 
         Ok(RequestPermissionResponse::new(outcome))
+    }
+
+    async fn emit_permission_denied_tool_update(&self, args: &RequestPermissionRequest) {
+        let tool_call_id = args.tool_call.tool_call_id.to_string();
+        self.diagnostics.observe_provider_event(
+            "tool_call_update",
+            Some((tool_call_id.clone(), Some("failed".to_string()))),
+        );
+        self.emit_json(serde_json::json!({
+            "type": "tool_call_update",
+            "id": tool_call_id,
+            "status": "failed",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Permission request was denied or timed out."
+                }
+            ],
+        }))
+        .await;
     }
 
     async fn session_notification(
@@ -734,6 +757,22 @@ fn permission_review_failure_outcome(options: &[PermissionOption]) -> RequestPer
             ))
         })
         .unwrap_or(RequestPermissionOutcome::Cancelled)
+}
+
+fn permission_outcome_allows(
+    outcome: &RequestPermissionOutcome,
+    options: &[PermissionOption],
+) -> bool {
+    let RequestPermissionOutcome::Selected(selected) = outcome else {
+        return false;
+    };
+    options.iter().any(|option| {
+        option.option_id == selected.option_id
+            && matches!(
+                option.kind,
+                PermissionOptionKind::AllowOnce | PermissionOptionKind::AllowAlways
+            )
+    })
 }
 
 #[derive(Debug)]
@@ -1005,6 +1044,11 @@ impl AcpRuntimeDiagnostics {
             message,
         });
     }
+
+    fn has_pending_tool_calls(&self) -> bool {
+        let state = self.state.lock().expect("acp diagnostics state poisoned");
+        !state.pending_tool_calls.is_empty()
+    }
 }
 
 async fn send_acp_request<Req>(
@@ -1028,6 +1072,7 @@ fn should_queue_while_prompts_active(
     active_prompt_count: usize,
     prompt_delivery_policy: AcpPromptDeliveryPolicy,
     has_pending_session_mutation: bool,
+    has_pending_tool_call: bool,
     cmd: &AcpCommand,
 ) -> bool {
     if active_prompt_count == 0 {
@@ -1038,6 +1083,7 @@ fn should_queue_while_prompts_active(
         AcpCommand::Cancel => false,
         AcpCommand::Prompt { .. } => {
             has_pending_session_mutation
+                || has_pending_tool_call
                 || !matches!(
                     prompt_delivery_policy,
                     AcpPromptDeliveryPolicy::AllowConcurrentPrompts
@@ -1435,10 +1481,13 @@ pub async fn spawn_acp_session(request: SpawnAcpSessionRequest) -> anyhow::Resul
                             Some(cmd) => {
                                 let has_pending_session_mutation =
                                     pending_commands.iter().any(is_session_mutation_command);
+                                let has_pending_tool_call =
+                                    diagnostics_for_runtime.has_pending_tool_calls();
                                 if should_queue_while_prompts_active(
                                     active_prompt_count,
                                     prompt_delivery_policy,
                                     has_pending_session_mutation,
+                                    has_pending_tool_call,
                                     &cmd,
                                 ) {
                                     pending_commands.push_back(cmd);
@@ -2369,7 +2418,7 @@ mod tests {
         acp_permission_review_timeout, acp_session_start_timeout, build_prompt_prefix_blocks,
         dedupe_skills, format_auth_required_message, handle_auth_required_failure,
         is_auth_required_error, load_mcp_servers_from_path, load_skills_from_config,
-        load_workdir_skills, permission_review_failure_outcome,
+        load_workdir_skills, permission_outcome_allows, permission_review_failure_outcome,
         remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
     };
     use agent_client_protocol::schema::{
@@ -2619,6 +2668,7 @@ mod tests {
             1,
             AcpPromptDeliveryPolicy::StrictFifo,
             false,
+            false,
             &AcpCommand::Prompt {
                 input: "hello".to_string(),
                 submission_id: "submission-1".to_string(),
@@ -2627,6 +2677,7 @@ mod tests {
         assert!(!should_queue_while_prompts_active(
             1,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
+            false,
             false,
             &AcpCommand::Prompt {
                 input: "hello".to_string(),
@@ -2637,6 +2688,7 @@ mod tests {
             1,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
             true,
+            false,
             &AcpCommand::Prompt {
                 input: "hello".to_string(),
                 submission_id: "submission-1".to_string(),
@@ -2646,17 +2698,30 @@ mod tests {
             1,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
             false,
+            true,
+            &AcpCommand::Prompt {
+                input: "hello".to_string(),
+                submission_id: "submission-1".to_string(),
+            }
+        ));
+        assert!(should_queue_while_prompts_active(
+            1,
+            AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
+            false,
+            false,
             &AcpCommand::SetMode("auto".to_string())
         ));
         assert!(should_queue_while_prompts_active(
             2,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
             false,
+            false,
             &AcpCommand::SetModel("gpt-5".to_string())
         ));
         assert!(should_queue_while_prompts_active(
             1,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
+            false,
             false,
             &AcpCommand::SetConfig {
                 config_id: "mode".to_string(),
@@ -2667,12 +2732,14 @@ mod tests {
             1,
             AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
             true,
+            true,
             &AcpCommand::Cancel
         ));
         assert!(!should_queue_while_prompts_active(
             0,
             AcpPromptDeliveryPolicy::StrictFifo,
             false,
+            true,
             &AcpCommand::Prompt {
                 input: "hello".to_string(),
                 submission_id: "submission-1".to_string(),
@@ -3582,6 +3649,57 @@ Fallback to the user-level review contract.
             )]),
             RequestPermissionOutcome::Cancelled
         ));
+    }
+
+    #[test]
+    fn permission_outcome_allows_only_selected_allow_options() {
+        let options = [
+            PermissionOption::new("allow", "Allow once", PermissionOptionKind::AllowOnce),
+            PermissionOption::new("deny", "Deny", PermissionOptionKind::RejectOnce),
+        ];
+
+        assert!(permission_outcome_allows(
+            &RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new("allow")),
+            &options,
+        ));
+        assert!(!permission_outcome_allows(
+            &RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new("deny")),
+            &options,
+        ));
+        assert!(!permission_outcome_allows(
+            &RequestPermissionOutcome::Cancelled,
+            &options,
+        ));
+        assert!(!permission_outcome_allows(
+            &RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new("missing")),
+            &options,
+        ));
+    }
+
+    #[test]
+    fn denied_permission_tool_update_clears_diagnostics_pending_tool_call() {
+        let diagnostics = Arc::new(AcpRuntimeDiagnostics::default());
+        diagnostics.observe_provider_event(
+            "tool_call",
+            Some(("tool-1".to_string(), Some("in_progress".to_string()))),
+        );
+        diagnostics.observe_provider_event(
+            "tool_call_update",
+            Some(("tool-1".to_string(), Some("failed".to_string()))),
+        );
+
+        let (tx, _rx) = mpsc::channel::<AcpCommand>(1);
+        let handle = AcpHandle {
+            session_id: "session-diagnostics".to_string(),
+            tx,
+            diagnostics,
+        };
+        let snapshot = handle.diagnostics();
+        assert_eq!(
+            snapshot.last_provider_event_type.as_deref(),
+            Some("tool_call_update")
+        );
+        assert_eq!(snapshot.pending_tool_call_count, 0);
     }
 
     #[test]

--- a/docs/journal/2026-05-09-acp-permission-tool-call-settlement.md
+++ b/docs/journal/2026-05-09-acp-permission-tool-call-settlement.md
@@ -1,0 +1,64 @@
+# ACP Permission Tool Call Settlement
+
+## Summary
+
+PR #560 closes the ACP permission deny and timeout stall path by emitting a terminal failed
+`tool_call_update` when a permission request does not select an allow option. It also narrows
+prompt concurrency for Codex ACP sessions when the active prompt still has pending tool calls, and
+removes stale mailbox false positives from `agenthub doctor agent-trace`.
+
+## Background
+
+A Team channel message was persisted and delivered to every member mailbox, but the member ACP pane
+still appeared to stop returning output. Backend diagnostics showed the message delivery path was
+healthy and the affected turns were waiting on permission requests that timed out to deny. The
+runtime then needed a terminal tool-call event so the UI and diagnostics could clear the in-progress
+tool call and accept later prompts safely.
+
+## Scope
+
+- `crates/agenthub-acp/src/lib.rs` settles denied or timed-out permission tool calls with a
+  synthetic failed ACP `tool_call_update`.
+- Prompt delivery still allows provider-supported concurrent Codex prompts, but queues a new prompt
+  while the active prompt has pending tool calls.
+- `src/diagnostics.rs` filters mailbox pending summaries so terminal Team runs do not make
+  `agenthub doctor agent-trace` report old delivered work as a current stall.
+- Web-only coverage tests were added for existing auth redirect and safe storage helpers so strict
+  Codecov gates stay green after the backend fix.
+
+## Key Decisions
+
+- Deny and timeout outcomes must be terminal for the associated tool call. Relying on provider
+  follow-up output is not sufficient because the failure path is already controlled by AgentHub.
+- Codex ACP concurrent prompt support stays enabled in the normal case. The new queueing rule is a
+  narrow safety gate only when the active prompt still owns unresolved tool-call state.
+- `agent-trace` should count pending mailbox work for active Team runs and
+  `shared_thread_mailbox`, but not for terminal run rows that already reached a finished state.
+- This change does not close the broader Team ACP permission review routing backlog. Human-visible
+  review cards, peer review routing, and no-self-review behavior remain separate validation work.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo test -p agenthub-acp
+cargo test -p agenthub diagnostics::agent_trace
+cargo build -p agenthub
+cd web && npm exec vitest run src/auth_redirect.test.ts src/storage/safe_storage.test.ts
+cd web && npm exec tsc -- --noEmit
+gh pr checks 560 | cat
+```
+
+PR #560 CI was green after the final coverage push: Bazel Build, Bazel Test, Bazel Coverage, Rust
+Fmt, Cargo Test, Proto Check, Web, Web E2E, Web E2E Mobile, Clippy, Distributed P2P Pipeline, and
+Codecov project and patch checks all passed.
+
+## Follow-Ups
+
+- After merge and deployment restart, run a real Team ACP regression: send a message that triggers
+  a permission request, let the request deny or timeout, and confirm the member tool call does not
+  remain running.
+- Continue the broader Team ACP permission review routing validation separately, including idle
+  peer worker or coordinator fallback, no self-review, and human-visible review actions.
+- If a future `agent-trace` verdict is `event_stream_present` while the UI remains stale, switch to
+  the ACP rendering workflow and inspect SSE or frontend cache handoff instead of the mailbox path.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -696,7 +696,15 @@ pub(crate) mod agent_trace {
                 FROM team_actor_messages
                 WHERE to_actor_id = ?1
                   AND status = 'pending'
-                  AND run_id IN (SELECT id FROM team_runs WHERE team_id = ?2)
+                  AND run_id IN (
+                      SELECT id
+                      FROM team_runs
+                      WHERE team_id = ?2
+                        AND (
+                            status IN ('submitted', 'working', 'input_required')
+                            OR trim(COALESCE(json_extract(input_json, '$.bootstrap_kind'), '')) = 'shared_thread_mailbox'
+                        )
+                  )
                 "#,
             )
             .bind(agent_id)
@@ -910,6 +918,7 @@ pub(crate) mod agent_trace {
                     id TEXT PRIMARY KEY,
                     team_id TEXT NOT NULL,
                     status TEXT NOT NULL,
+                    input_json TEXT,
                     created_at INTEGER NOT NULL
                 );
                 CREATE TABLE team_actor_messages (
@@ -1114,7 +1123,7 @@ pub(crate) mod agent_trace {
             )
             .bind("run-1")
             .bind("team-1")
-            .bind("running")
+            .bind("working")
             .bind(20_i64)
             .execute(&pool)
             .await
@@ -1147,6 +1156,103 @@ pub(crate) mod agent_trace {
                 report.team.as_ref().expect("team").latest_run_id.as_deref(),
                 Some("run-1")
             );
+            assert_eq!(report.verdict.layer, AgentTraceStallLayer::MailboxPending);
+            let _ = std::fs::remove_dir_all(event_dir);
+        }
+
+        #[tokio::test]
+        async fn agent_trace_ignores_pending_mailbox_for_terminal_team_runs() {
+            let pool = test_pool().await;
+            insert_agent_fixture(&pool).await;
+            sqlx::query("INSERT INTO team_definitions (id, spec_json) VALUES (?1, ?2)")
+                .bind("team-1")
+                .bind(r#"{"members":[{"member_id":"worker","role":"worker"}]}"#)
+                .execute(&pool)
+                .await
+                .expect("insert team");
+            sqlx::query(
+                "INSERT INTO team_runs (id, team_id, status, created_at) VALUES (?1, ?2, ?3, ?4)",
+            )
+            .bind("run-canceled")
+            .bind("team-1")
+            .bind("canceled")
+            .bind(20_i64)
+            .execute(&pool)
+            .await
+            .expect("insert run");
+            sqlx::query(
+                "INSERT INTO team_actor_messages (run_id, to_actor_id, status) VALUES (?1, ?2, ?3)",
+            )
+            .bind("run-canceled")
+            .bind("worker")
+            .bind("pending")
+            .execute(&pool)
+            .await
+            .expect("insert mailbox");
+
+            let event_dir = test_event_dir();
+            let report = collect_from_pool(
+                &pool,
+                event_dir.clone(),
+                AgentTraceRequest {
+                    team_id: Some("team-1".to_string()),
+                    member_id: Some("worker".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("collect trace");
+
+            assert_eq!(report.mailbox.pending_to_actor_count, 0);
+            assert_ne!(report.verdict.layer, AgentTraceStallLayer::MailboxPending);
+            let _ = std::fs::remove_dir_all(event_dir);
+        }
+
+        #[tokio::test]
+        async fn agent_trace_includes_shared_thread_mailbox_run_pending_messages() {
+            let pool = test_pool().await;
+            insert_agent_fixture(&pool).await;
+            sqlx::query("INSERT INTO team_definitions (id, spec_json) VALUES (?1, ?2)")
+                .bind("team-1")
+                .bind(r#"{"members":[{"member_id":"worker","role":"worker"}]}"#)
+                .execute(&pool)
+                .await
+                .expect("insert team");
+            sqlx::query(
+                "INSERT INTO team_runs (id, team_id, status, input_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            )
+            .bind("shared-run")
+            .bind("team-1")
+            .bind("completed")
+            .bind(r#"{"bootstrap_kind":"shared_thread_mailbox"}"#)
+            .bind(20_i64)
+            .execute(&pool)
+            .await
+            .expect("insert run");
+            sqlx::query(
+                "INSERT INTO team_actor_messages (run_id, to_actor_id, status) VALUES (?1, ?2, ?3)",
+            )
+            .bind("shared-run")
+            .bind("worker")
+            .bind("pending")
+            .execute(&pool)
+            .await
+            .expect("insert mailbox");
+
+            let event_dir = test_event_dir();
+            let report = collect_from_pool(
+                &pool,
+                event_dir.clone(),
+                AgentTraceRequest {
+                    team_id: Some("team-1".to_string()),
+                    member_id: Some("worker".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("collect trace");
+
+            assert_eq!(report.mailbox.pending_to_actor_count, 1);
             assert_eq!(report.verdict.layer, AgentTraceStallLayer::MailboxPending);
             let _ = std::fs::remove_dir_all(event_dir);
         }

--- a/src/team/permission_review.rs
+++ b/src/team/permission_review.rs
@@ -737,6 +737,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn worker_request_uses_coordinator_when_no_peer_worker_exists() {
+        let spec = json!({
+            "entrypoint":"coordinator",
+            "coordinator_member_id":"coordinator",
+            "members":[
+                {"member_id":"coordinator","role":"coordinator"},
+                {"member_id":"worker","role":"worker"}
+            ]
+        });
+
+        let (reviewer, dispatch_status) =
+            resolve_team_permission_review_target(&spec, "worker", "worker")
+                .expect("resolve coordinator fallback reviewer");
+
+        assert_eq!(reviewer, "coordinator");
+        assert_eq!(dispatch_status, "coordinator_dispatched");
+    }
+
+    #[test]
+    fn coordinator_request_errors_without_subordinate_reviewer() {
+        let spec = json!({
+            "entrypoint":"coordinator",
+            "coordinator_member_id":"coordinator",
+            "members":[
+                {"member_id":"coordinator","role":"coordinator"}
+            ]
+        });
+
+        let err = resolve_team_permission_review_target(&spec, "coordinator", "coordinator")
+            .expect_err("coordinator should need a subordinate reviewer");
+
+        assert!(
+            err.to_string()
+                .contains("team has no subordinate reviewer configured"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn dispatches_worker_permission_to_peer_worker_before_human_review() {
         let state = build_test_state().await;
@@ -1348,5 +1387,171 @@ mod tests {
             inbox.messages[0].payload["review_target_actor_id"],
             Value::from("reviewer")
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_failure_falls_back_to_human_permission_card() {
+        let state = build_test_state().await;
+        let team = state
+            .teams
+            .create_team(TeamDefinitionConfig {
+                name: format!("permission-review-dispatch-failure-{}", Uuid::new_v4()),
+                description: Some("permission review dispatch failure".to_string()),
+                spec: json!({
+                    "entrypoint":"coordinator",
+                    "coordinator_member_id":"coordinator",
+                    "members":[
+                        {"member_id":"coordinator","role":"coordinator"}
+                    ]
+                }),
+            })
+            .await
+            .expect("create team");
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO agents (
+                id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref, code_mode, status, created_at, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, 1, 'running', ?7, ?8)
+            "#,
+        )
+        .bind("coordinator-agent-fallback")
+        .bind("coordinator-agent-fallback")
+        .bind("/tmp")
+        .bind("agenthub-codex-acp")
+        .bind("[]")
+        .bind("use_existing")
+        .bind(now)
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert coordinator agent");
+        sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO agent_sessions (id, agent_id, status, started_at, ended_at)
+            VALUES (?1, ?2, 'running', ?3, NULL)
+            "#,
+        )
+        .bind("coordinator-session-fallback")
+        .bind("coordinator-agent-fallback")
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert coordinator session");
+        sqlx::query(
+            r#"
+            INSERT INTO acp_permission_requests (
+                id,
+                agent_id,
+                session_id,
+                acp_session_id,
+                team_id,
+                requester_actor_id,
+                requester_role,
+                tool_call_id,
+                options_json,
+                tool_call_json,
+                status,
+                created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', ?11)
+            "#,
+        )
+        .bind("perm-review-dispatch-failure")
+        .bind("coordinator-agent-fallback")
+        .bind("coordinator-session-fallback")
+        .bind("acp-session-dispatch-failure")
+        .bind(&team.id)
+        .bind("coordinator")
+        .bind("coordinator")
+        .bind("tool-call-dispatch-failure")
+        .bind(
+            json!([
+                {
+                    "option_id": "allow",
+                    "name": "Allow once",
+                    "kind": "allow_once"
+                }
+            ])
+            .to_string(),
+        )
+        .bind(json!({"tool":{"name":"mcp__fs__write"}}).to_string())
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert coordinator permission request");
+
+        let dispatcher = TeamPermissionReviewDispatcher::new(
+            state.teams.clone(),
+            state.agents.clone(),
+            Arc::new(AcpPermissionService::new(state.db.clone())),
+            TeamPermissionReviewDispatcherSettings {
+                human_fallback_delay: Duration::from_secs(60),
+            },
+        );
+        let request = AcpPermissionReviewRequest {
+            request_id: "perm-review-dispatch-failure".to_string(),
+            agent_id: "coordinator-agent-fallback".to_string(),
+            agent_session_id: "coordinator-session-fallback".to_string(),
+            acp_session_id: "acp-session-dispatch-failure".to_string(),
+            tool_call_id: Some("tool-call-dispatch-failure".to_string()),
+            options: vec![agenthub_acp::AcpPermissionOption {
+                option_id: "allow".to_string(),
+                name: "Allow once".to_string(),
+                kind: agent_client_protocol::schema::PermissionOptionKind::AllowOnce,
+            }],
+            tool_call: Some(json!({"tool":{"name":"mcp__fs__write"}})),
+            current_run_id: None,
+            routing: AcpPermissionRoutingMetadata {
+                team_id: Some(team.id.clone()),
+                requester_actor_id: Some("coordinator".to_string()),
+                requester_role: Some("coordinator".to_string()),
+            },
+        };
+
+        dispatcher
+            .dispatch_review(request)
+            .await
+            .expect("dispatch failure should be handled as human fallback");
+
+        let record = state
+            .acp_permissions
+            .get("perm-review-dispatch-failure")
+            .await
+            .expect("load permission record")
+            .expect("permission record");
+        assert_eq!(
+            record.review_dispatch_status.as_deref(),
+            Some("review_dispatch_failed")
+        );
+        assert!(record.review_target_actor_id.is_none());
+        assert!(record.human_review_notified_at.is_some());
+
+        let (task_id, _) = state
+            .teams
+            .ensure_shared_thread_target_for_team(&team.id, "coordinator")
+            .await
+            .expect("ensure shared thread");
+        let conversation_messages = state
+            .teams
+            .list_task_conversation_messages(&task_id, 50, None)
+            .await
+            .expect("list shared-thread messages");
+        let fallback = conversation_messages
+            .iter()
+            .find(|message| {
+                message.payload.get("type").and_then(Value::as_str)
+                    == Some(TEAM_HUMAN_PERMISSION_CARD_PAYLOAD_TYPE)
+                    && message.payload.get("permission_id").and_then(Value::as_str)
+                        == Some("perm-review-dispatch-failure")
+            })
+            .expect("human permission card");
+        assert_eq!(fallback.from_actor_id, "coordinator");
+        assert_eq!(
+            fallback.payload["reason_text"],
+            json!("Agent review dispatch failed")
+        );
+        assert_eq!(fallback.payload["status"], json!("pending"));
     }
 }

--- a/web/src/auth_redirect.test.ts
+++ b/web/src/auth_redirect.test.ts
@@ -1,15 +1,48 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildLoginRedirectPath,
+  clearAuthAndRedirect,
   isInvalidTokenMessage,
   normalizePostLoginRedirectTarget,
   resolvePostLoginRedirectTarget,
   shouldRedirectOnAuthError,
 } from "./auth_redirect";
 
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(globalThis, "location");
+
+function installLocation(pathname: string, search = "", hash = "") {
+  const location = {
+    pathname,
+    search,
+    hash,
+    href: `${pathname}${search}${hash}`,
+    reload: vi.fn(),
+  };
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: location,
+  });
+  return location;
+}
+
+function restoreLocation() {
+  if (originalLocationDescriptor) {
+    Object.defineProperty(globalThis, "location", originalLocationDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "location");
+  }
+}
+
 describe("auth redirect helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreLocation();
+  });
+
   it("detects invalid token messages", () => {
+    expect(isInvalidTokenMessage(null)).toBe(false);
     expect(isInvalidTokenMessage("invalid token")).toBe(true);
+    expect(isInvalidTokenMessage(" Invalid Token ")).toBe(true);
     expect(isInvalidTokenMessage("missing authorization token")).toBe(true);
     expect(isInvalidTokenMessage("unauthorized")).toBe(true);
     expect(isInvalidTokenMessage("root required")).toBe(false);
@@ -27,7 +60,10 @@ describe("auth redirect helpers", () => {
     expect(normalizePostLoginRedirectTarget("/teams?tab=runs#active")).toBe(
       "/teams?tab=runs#active"
     );
+    expect(normalizePostLoginRedirectTarget(undefined)).toBeNull();
+    expect(normalizePostLoginRedirectTarget("   ")).toBeNull();
     expect(normalizePostLoginRedirectTarget("/")).toBeNull();
+    expect(normalizePostLoginRedirectTarget("teams")).toBeNull();
     expect(normalizePostLoginRedirectTarget("https://example.com")).toBeNull();
     expect(normalizePostLoginRedirectTarget("//example.com")).toBeNull();
     expect(buildLoginRedirectPath("/teams?tab=runs#active")).toBe(
@@ -38,5 +74,23 @@ describe("auth redirect helpers", () => {
       "/teams/run-1"
     );
     expect(resolvePostLoginRedirectTarget("?next=https%3A%2F%2Fevil.example")).toBeNull();
+  });
+
+  it("reloads instead of rewriting the same login redirect", () => {
+    const location = installLocation("/", "?next=%2Fteams", "");
+
+    clearAuthAndRedirect("/teams");
+
+    expect(location.reload).toHaveBeenCalledOnce();
+    expect(location.href).toBe("/?next=%2Fteams");
+  });
+
+  it("updates href when redirect target differs from the current page", () => {
+    const location = installLocation("/workspace", "", "");
+
+    clearAuthAndRedirect("/teams");
+
+    expect(location.reload).not.toHaveBeenCalled();
+    expect(location.href).toBe("/?next=%2Fteams");
   });
 });

--- a/web/src/storage/safe_storage.test.ts
+++ b/web/src/storage/safe_storage.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getLocalStorageItemSafe,
+  removeLocalStorageItemSafe,
+  setLocalStorageItemSafe,
+} from "./safe_storage";
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage"
+);
+
+function installMemoryLocalStorage() {
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+    },
+  });
+}
+
+function restoreLocalStorage() {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  }
+}
+
+describe("safe storage helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreLocalStorage();
+  });
+
+  it("reads, writes, and removes localStorage values", () => {
+    installMemoryLocalStorage();
+
+    expect(setLocalStorageItemSafe("agenthub:test", "value")).toBe(true);
+    expect(getLocalStorageItemSafe("agenthub:test")).toBe("value");
+
+    removeLocalStorageItemSafe("agenthub:test");
+
+    expect(getLocalStorageItemSafe("agenthub:test")).toBeNull();
+  });
+
+  it("returns fallback values when localStorage is unavailable", () => {
+    Reflect.deleteProperty(globalThis, "localStorage");
+
+    expect(getLocalStorageItemSafe("agenthub:test")).toBeNull();
+    expect(setLocalStorageItemSafe("agenthub:test", "value")).toBe(false);
+    expect(() => removeLocalStorageItemSafe("agenthub:test")).not.toThrow();
+  });
+
+  it("swallows localStorage access errors", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("read failed");
+      }),
+      setItem: vi.fn(() => {
+        throw new Error("write failed");
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error("remove failed");
+      }),
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+
+    expect(getLocalStorageItemSafe("agenthub:test")).toBeNull();
+    expect(setLocalStorageItemSafe("agenthub:test", "value")).toBe(false);
+    expect(() => removeLocalStorageItemSafe("agenthub:test")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Emit a failed ACP `tool_call_update` when a permission request is denied or times out.
- Queue new ACP prompts while an active prompt still has pending tool calls, even for providers that otherwise allow concurrent prompts.
- Narrow `agent-trace` mailbox diagnostics so terminal team runs do not create stale mailbox-pending verdicts, while preserving shared-thread mailbox visibility.

## Purpose

This fixes the P0 ACP stuck state where a denied or timed-out permission request could leave tool calls visually running and allow follow-up prompts to stack on top of an unresolved provider turn.

## Related Issue

- None

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub-acp`
- `cargo test -p agenthub diagnostics::agent_trace`
