### PR TITLE
fix(acp): surface team input submission failures

### DIFF
--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -118,6 +118,10 @@ ACP permission requests are first-class runtime records:
 
 - Input/send paths must validate session alignment to avoid stale session writes.
 - Session mismatch and unavailable gateway states should surface deterministic, non-leaky errors.
+- If AgentHub has already persisted a user input event but cannot submit the prompt command to the
+  ACP provider, it should append a redacted visible ACP status event and keep detailed failure
+  metadata in diagnostics rather than serializing prompt bodies or provider internals into the
+  conversation.
 - `agent_sessions.id` is AgentHub's per-launch runtime/audit identifier and is expected to change on
   each real restart.
 - `agent_persistent_sessions.session_id` stores provider continuity identity separately so ACP/Codex

--- a/docs/journal/2026-05-09-team-acp-input-submission-diagnostics.md
+++ b/docs/journal/2026-05-09-team-acp-input-submission-diagnostics.md
@@ -1,0 +1,47 @@
+# Team ACP Input Submission Diagnostics
+
+## Summary
+
+Team member ACP input now leaves a visible, redacted ACP conversation event when AgentHub accepts
+the user's input record but cannot submit the prompt command to the ACP provider.
+
+## Background
+
+The Team member ACP panel already refreshes after successful sends. The weak path was a backend
+submission failure after the user message had been persisted: the HTTP request returned an error,
+but the ACP conversation could still look like nothing happened until a later manual refresh or
+diagnostic check.
+
+## Scope
+
+- Backend `send_input` still persists and broadcasts the user message before submitting the prompt
+  command.
+- If ACP prompt submission fails after that persistence point, AgentHub now appends a synthetic
+  `agent_message` ACP event that tells the operator to inspect redacted provider diagnostics.
+- The synthetic event does not include the prompt body, tool arguments, tool output, environment
+  values, or provider tokens.
+- Team member ACP input failure handling now refreshes the selected member events once, so the
+  persisted input and failure marker can become visible without waiting for SSE fallback timing.
+
+## Key Decisions
+
+- The failure marker is intentionally generic. The detailed failure reason stays in
+  `agenthub doctor agent-trace` provider diagnostics, where it is already redacted and grouped with
+  command-channel state.
+- This change does not treat all no-response symptoms as submission failures. Provider turns,
+  pending permissions, pending tool calls, SSE staleness, and frontend cache issues still require
+  `agent-trace` classification first.
+
+## Validation
+
+```bash
+cargo test -p agenthub acp_prompt_submission_failure_event_is_renderable_and_redacted -- --nocapture
+cd web && npm exec vitest -- run src/pages/team_page.agent_loop.test.tsx
+```
+
+## Follow-Ups
+
+- Continue the focused ACP long-session regression matrix for stale-session send recovery,
+  permission history jump/copy, runtime metrics, and long output histories.
+- When investigating a real no-response case, start with `agenthub doctor agent-trace` to classify
+  whether the stall is provider, permission/tool, persistence, SSE, or frontend downstream state.

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -187,6 +187,20 @@ fn short_random_token() -> String {
         .collect::<String>()
 }
 
+fn acp_prompt_submission_failure_event(message_id: &str) -> String {
+    serde_json::json!({
+        "type": "agent_message",
+        "text": "AgentHub could not submit this prompt to the ACP provider. Check agent-trace provider diagnostics for the redacted command error.",
+        "chunk": false,
+        "message_id": format!("{message_id}:submission-error"),
+        "meta": {
+            "source": "agenthub",
+            "category": "acp_prompt_submission_failed"
+        }
+    })
+    .to_string()
+}
+
 pub(crate) fn derive_worker_runtime_root(workdir: &str) -> String {
     let path = Path::new(workdir);
     path.parent()
@@ -1855,9 +1869,49 @@ impl AgentManager {
         };
         let _ = output_tx.send(output);
 
-        acp.prompt_with_submission(input.to_string(), message_id)
-            .await?;
-        Ok(())
+        match acp
+            .prompt_with_submission(input.to_string(), message_id.clone())
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let seq = Uuid::now_v7().to_string();
+                let ts = Utc::now().timestamp();
+                let message = acp_prompt_submission_failure_event(&message_id);
+                match persist_agent_event(
+                    &self.event_dbs,
+                    self.idle_gc.as_ref(),
+                    agent_id,
+                    &session_id,
+                    &seq,
+                    ts,
+                    &OutputStream::Acp,
+                    &message,
+                )
+                .await
+                {
+                    Ok(event_id) => {
+                        let _ = output_tx.send(AgentOutput {
+                            event_id,
+                            agent_id: agent_id.to_string(),
+                            session_id,
+                            seq,
+                            ts,
+                            stream: OutputStream::Acp,
+                            message,
+                        });
+                    }
+                    Err(persist_err) => {
+                        tracing::warn!(
+                            agent_id = %agent_id,
+                            error = %persist_err,
+                            "failed to persist ACP prompt submission failure event"
+                        );
+                    }
+                }
+                Err(err)
+            }
+        }
     }
 
     async fn update_agent_status(&self, agent_id: &str, status: AgentStatus) -> anyhow::Result<()> {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1875,43 +1875,57 @@ impl AgentManager {
         {
             Ok(()) => Ok(()),
             Err(err) => {
-                let seq = Uuid::now_v7().to_string();
-                let ts = Utc::now().timestamp();
-                let message = acp_prompt_submission_failure_event(&message_id);
-                match persist_agent_event(
-                    &self.event_dbs,
-                    self.idle_gc.as_ref(),
-                    agent_id,
-                    &session_id,
-                    &seq,
-                    ts,
-                    &OutputStream::Acp,
-                    &message,
-                )
-                .await
+                if let Err(persist_err) = self
+                    .persist_acp_prompt_submission_failure(
+                        agent_id,
+                        &session_id,
+                        &message_id,
+                        &output_tx,
+                    )
+                    .await
                 {
-                    Ok(event_id) => {
-                        let _ = output_tx.send(AgentOutput {
-                            event_id,
-                            agent_id: agent_id.to_string(),
-                            session_id,
-                            seq,
-                            ts,
-                            stream: OutputStream::Acp,
-                            message,
-                        });
-                    }
-                    Err(persist_err) => {
-                        tracing::warn!(
-                            agent_id = %agent_id,
-                            error = %persist_err,
-                            "failed to persist ACP prompt submission failure event"
-                        );
-                    }
+                    tracing::warn!(
+                        agent_id = %agent_id,
+                        error = %persist_err,
+                        "failed to persist ACP prompt submission failure event"
+                    );
                 }
                 Err(err)
             }
         }
+    }
+
+    async fn persist_acp_prompt_submission_failure(
+        &self,
+        agent_id: &str,
+        session_id: &str,
+        message_id: &str,
+        output_tx: &broadcast::Sender<AgentOutput>,
+    ) -> anyhow::Result<()> {
+        let seq = Uuid::now_v7().to_string();
+        let ts = Utc::now().timestamp();
+        let message = acp_prompt_submission_failure_event(message_id);
+        let event_id = persist_agent_event(
+            &self.event_dbs,
+            self.idle_gc.as_ref(),
+            agent_id,
+            session_id,
+            &seq,
+            ts,
+            &OutputStream::Acp,
+            &message,
+        )
+        .await?;
+        let _ = output_tx.send(AgentOutput {
+            event_id,
+            agent_id: agent_id.to_string(),
+            session_id: session_id.to_string(),
+            seq,
+            ts,
+            stream: OutputStream::Acp,
+            message,
+        });
+        Ok(())
     }
 
     async fn update_agent_status(&self, agent_id: &str, status: AgentStatus) -> anyhow::Result<()> {

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -558,6 +558,22 @@ mod tests {
     use tokio::time::Duration;
     use uuid::Uuid;
 
+    #[test]
+    fn acp_prompt_submission_failure_event_is_renderable_and_redacted() {
+        let value: serde_json::Value =
+            serde_json::from_str(&super::super::acp_prompt_submission_failure_event("msg-1"))
+                .expect("failure event should be valid JSON");
+
+        assert_eq!(value["type"], "agent_message");
+        assert_eq!(value["chunk"], false);
+        assert_eq!(value["message_id"], "msg-1:submission-error");
+        assert_eq!(value["meta"]["source"], "agenthub");
+        assert_eq!(value["meta"]["category"], "acp_prompt_submission_failed");
+        let text = value["text"].as_str().expect("text should be present");
+        assert!(text.contains("could not submit this prompt"));
+        assert!(!text.contains("msg-1"));
+    }
+
     async fn build_test_state_with_idle_gc() -> crate::state::AppState {
         let state = crate::api::team_tests::build_test_state().await;
         let idle_gc = agenthub_db::AgentEventIdleGc::new(

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -670,6 +670,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn acp_prompt_submission_failure_is_persisted_and_broadcast() {
+        let state = crate::api::team_tests::build_test_state().await;
+        let (agent_id, session_id) =
+            insert_agent_and_session(&state.db, "acp-submission-failure").await;
+        let (output_tx, mut output_rx) = tokio::sync::broadcast::channel(8);
+
+        state
+            .agents
+            .persist_acp_prompt_submission_failure(&agent_id, &session_id, "message-1", &output_tx)
+            .await
+            .expect("persist failure marker");
+
+        let output = output_rx.recv().await.expect("failure marker broadcast");
+        assert_eq!(output.agent_id, agent_id);
+        assert_eq!(output.session_id, session_id);
+        assert_eq!(output.stream, crate::agent::OutputStream::Acp);
+        assert!(output.message.contains("acp_prompt_submission_failed"));
+
+        let events = state
+            .agents
+            .list_events_for_session(&agent_id, &session_id, 8, None)
+            .await
+            .expect("list persisted events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, output.event_id);
+        assert!(events[0].message.contains("could not submit this prompt"));
+        assert!(!events[0].message.contains("secret prompt"));
+    }
+
+    #[tokio::test]
     async fn send_input_does_not_mark_running_session_exited_while_agent_is_starting() {
         let state = crate::api::team_tests::build_test_state().await;
         let (agent_id, session_id) =

--- a/web/src/pages/team_page.agent_loop.test.tsx
+++ b/web/src/pages/team_page.agent_loop.test.tsx
@@ -748,6 +748,149 @@ describe("TeamPage agent loop profile flow", () => {
     }
   });
 
+  it("refreshes Team member ACP events after input submission fails", async () => {
+    const team = {
+      id: "team-1",
+      name: "Team One",
+      description: "Mission",
+      spec: {
+        spec_version: 1,
+        coordinator_member_id: "coordinator",
+        entrypoint: "coordinator_plan",
+        steps: [],
+        members: [
+          {
+            member_id: "worker-1",
+            display_name: "Worker One",
+            role: "worker",
+            agent_id: "worker-1",
+          },
+        ],
+      },
+      created_at: 1,
+      updated_at: 1,
+    };
+    teamPageFixture.teams = [team];
+    teamPageFixture.agents = [
+      {
+        id: "worker-1",
+        name: "Worker One",
+        workdir: "/repo",
+        command: "codex",
+        args: [],
+        worktree_mode: "create_worktree",
+        worktree_repo: null,
+        worktree_ref: null,
+        code_mode: true,
+        status: "running",
+        created_at: 1,
+        updated_at: 2,
+      },
+    ];
+    getTeamSharedThread.mockResolvedValue({
+      task: {
+        id: "task-all",
+        team_id: "team-1",
+        title: "all",
+        status: "in_progress",
+        created_by_actor_id: "coordinator",
+        assigned_member_id: null,
+        context: { bootstrap_kind: "shared_thread" },
+        created_at: 1,
+        updated_at: 1,
+      },
+      conversation: {
+        id: "conv-task-all",
+        team_id: "team-1",
+        task_id: "task-all",
+        mode: "group_chat",
+        topic: "all",
+        created_at: 1,
+        updated_at: 1,
+      },
+      latest_run: null,
+    });
+    getTeamRuntime.mockResolvedValue({
+      team_id: "team-1",
+      team_name: "Team One",
+      status: "running",
+      members: [
+        {
+          member_id: "worker-1",
+          display_name: "Worker One",
+          role: "worker",
+          session_id: "runtime-session-1",
+          session_status: "running",
+          agent_status: "running",
+          card: {
+            card_id: "card-worker-1",
+            schema_version: "1",
+            description: "Investigate regressions",
+            capability_tags: [],
+          },
+        },
+      ],
+    });
+    sendInput.mockRejectedValueOnce(new Error("acp command send timed out due to backpressure"));
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routeTeamId="team-1"
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
+      await clickElement(
+        Array.from(container.querySelectorAll("button")).find((button) =>
+          button.textContent?.includes("Open worker workspace")
+        ) as HTMLButtonElement | null
+      );
+      await clickElement(
+        await waitForElement(
+          () =>
+            Array.from(container.querySelectorAll("button")).find((button) =>
+              button.textContent?.includes("Mock agent ACP panel")
+            ) as HTMLButtonElement | undefined ?? null,
+          "mock ACP panel missing"
+        )
+      );
+
+      expect(sendInput).toHaveBeenCalledWith(
+        "token",
+        "worker-1",
+        "hello from acp",
+        expect.any(String),
+        "runtime-session-1"
+      );
+      expect(loadMemberEventsSpy).toHaveBeenCalledWith("replace");
+      expect(refreshTeamRuntimeSpy).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+        await flushEffects();
+      });
+      container.remove();
+    }
+  });
+
   it("uses the member id for ACP history and input while the agent record is still backfilling", async () => {
     const team = {
       id: "team-1",

--- a/web/src/pages/team_page.agent_loop.test.tsx
+++ b/web/src/pages/team_page.agent_loop.test.tsx
@@ -748,150 +748,7 @@ describe("TeamPage agent loop profile flow", () => {
     }
   });
 
-  it("refreshes Team member ACP events after input submission fails", async () => {
-    const team = {
-      id: "team-1",
-      name: "Team One",
-      description: "Mission",
-      spec: {
-        spec_version: 1,
-        coordinator_member_id: "coordinator",
-        entrypoint: "coordinator_plan",
-        steps: [],
-        members: [
-          {
-            member_id: "worker-1",
-            display_name: "Worker One",
-            role: "worker",
-            agent_id: "worker-1",
-          },
-        ],
-      },
-      created_at: 1,
-      updated_at: 1,
-    };
-    teamPageFixture.teams = [team];
-    teamPageFixture.agents = [
-      {
-        id: "worker-1",
-        name: "Worker One",
-        workdir: "/repo",
-        command: "codex",
-        args: [],
-        worktree_mode: "create_worktree",
-        worktree_repo: null,
-        worktree_ref: null,
-        code_mode: true,
-        status: "running",
-        created_at: 1,
-        updated_at: 2,
-      },
-    ];
-    getTeamSharedThread.mockResolvedValue({
-      task: {
-        id: "task-all",
-        team_id: "team-1",
-        title: "all",
-        status: "in_progress",
-        created_by_actor_id: "coordinator",
-        assigned_member_id: null,
-        context: { bootstrap_kind: "shared_thread" },
-        created_at: 1,
-        updated_at: 1,
-      },
-      conversation: {
-        id: "conv-task-all",
-        team_id: "team-1",
-        task_id: "task-all",
-        mode: "group_chat",
-        topic: "all",
-        created_at: 1,
-        updated_at: 1,
-      },
-      latest_run: null,
-    });
-    getTeamRuntime.mockResolvedValue({
-      team_id: "team-1",
-      team_name: "Team One",
-      status: "running",
-      members: [
-        {
-          member_id: "worker-1",
-          display_name: "Worker One",
-          role: "worker",
-          session_id: "runtime-session-1",
-          session_status: "running",
-          agent_status: "running",
-          card: {
-            card_id: "card-worker-1",
-            schema_version: "1",
-            description: "Investigate regressions",
-            capability_tags: [],
-          },
-        },
-      ],
-    });
-    sendInput.mockRejectedValueOnce(new Error("acp command send timed out due to backpressure"));
-
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root: Root = createRoot(container);
-
-    try {
-      await act(async () => {
-        root.render(
-          <MantineProvider>
-            <TeamPage
-              auth={{
-                token: "token",
-                userId: "user-1",
-                username: "root",
-                role: "root",
-              }}
-              token="token"
-              onLogout={() => {}}
-              developerMode={false}
-              routeTeamId="team-1"
-            />
-          </MantineProvider>
-        );
-        await flushEffects();
-      });
-
-      await clickElement(
-        Array.from(container.querySelectorAll("button")).find((button) =>
-          button.textContent?.includes("Open worker workspace")
-        ) as HTMLButtonElement | null
-      );
-      await clickElement(
-        await waitForElement(
-          () =>
-            Array.from(container.querySelectorAll("button")).find((button) =>
-              button.textContent?.includes("Mock agent ACP panel")
-            ) as HTMLButtonElement | undefined ?? null,
-          "mock ACP panel missing"
-        )
-      );
-
-      expect(sendInput).toHaveBeenCalledWith(
-        "token",
-        "worker-1",
-        "hello from acp",
-        expect.any(String),
-        "runtime-session-1"
-      );
-      expect(loadMemberEventsSpy).toHaveBeenCalledWith("replace");
-      expect(refreshTeamRuntimeSpy).not.toHaveBeenCalled();
-    } finally {
-      await act(async () => {
-        root.unmount();
-        await flushEffects();
-      });
-      container.remove();
-    }
-  });
-
-  it("uses the member id for ACP history and input while the agent record is still backfilling", async () => {
+  it("uses the member id for ACP history and refreshes events after failed input while the agent record is still backfilling", async () => {
     const team = {
       id: "team-1",
       name: "Team One",
@@ -991,6 +848,10 @@ describe("TeamPage agent loop profile flow", () => {
         Array.from(container.querySelectorAll("button")).find((button) =>
           button.textContent?.includes("Open worker workspace")
         ) as HTMLButtonElement | null
+      );
+      loadMemberEventsSpy.mockClear();
+      sendInput.mockRejectedValueOnce(
+        new Error("acp command send timed out due to backpressure")
       );
       await clickElement(
         await waitForElement(

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -3014,6 +3014,7 @@ export function TeamPage(props: TeamPageProps) {
             return;
           }
         }
+        await loadMemberEvents("replace").catch(() => undefined);
         setError(msg);
         if (msg.includes(AGENT_NOT_RUNNING_ERROR)) {
           if (selectedTeamId) {


### PR DESCRIPTION
## Summary

- Persist a redacted ACP conversation event when Team member input is accepted locally but ACP prompt submission fails.
- Refresh Team member ACP events after failed input submission so the persisted input/failure marker is visible without waiting for SSE fallback.
- Document the narrow ACP runtime contract and rollout note for this diagnostic boundary.

## Purpose

This narrows one high-priority agent-stuck symptom: a Team ACP send can look like it produced no response when the backend persisted the user input but failed to submit the prompt command to the ACP provider. The fix makes that boundary visible and keeps detailed failure metadata in `agenthub doctor agent-trace` diagnostics.

## Related Issues

- Follow-up to the release P0/P0+ AgentHub Team ACP no-response investigation.

## Tests

```bash
cargo test -p agenthub acp_prompt_submission_failure_event_is_renderable_and_redacted -- --nocapture
cd web && npm exec vitest -- run src/pages/team_page.agent_loop.test.tsx
cargo fmt --all --check
git diff --check
```
