### PR TITLE
fix(ci): move x86 prebuild to newer cross image

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
     "apt-get update && apt-get install --assume-yes pkg-config curl unzip gcc-12 g++-12 zlib1g-dev:amd64 libsqlite3-dev:amd64 libcap-dev:amd64",
     "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100 && cc --version",


### PR DESCRIPTION
## Summary

- Move the x86_64 Linux release prebuild cross target to the newer cross-rs image.
- Keep the pinned GCC/G++ 12 setup so Lance fp16 release kernels can compile with C17 and AVX512FP16 support.

## Purpose

The post-merge `Release Prebuild` run for PR #565 failed before compilation because the default cross image is Ubuntu xenial and cannot install `gcc-12` / `g++-12`. The x86 release build needs a newer compiler for `lance-linalg/fp16kernels`.

## Related Issue

- Follow-up for PR #565 release prebuild failure.

## Testing

- `cargo metadata --locked --format-version 1 --features release-lance-fp16`
- `cargo fmt --all --check`
- `git diff --check`

## Notes

`Release Prebuild` now runs only after merge on `push` to `main`, so this PR validates through the normal PR CI first. The x86 release prebuild fix must be confirmed on the next main push after merge.
