### PR TITLE
fix(acp): serialize codex prompt delivery

### DIFF
--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -2736,6 +2736,13 @@ mod tests {
             &AcpCommand::Cancel
         ));
         assert!(!should_queue_while_prompts_active(
+            1,
+            AcpPromptDeliveryPolicy::StrictFifo,
+            true,
+            true,
+            &AcpCommand::Cancel
+        ));
+        assert!(!should_queue_while_prompts_active(
             0,
             AcpPromptDeliveryPolicy::StrictFifo,
             false,

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -144,6 +144,9 @@ ACP permission requests are first-class runtime records:
 
 - ACP protocol mapping must stay aligned with upstream provider schemas.
 - Codex ACP sync changes should preserve session listing, tool-call payload decode, and event handling contracts.
+- Codex ACP ordinary prompt delivery should be serialized by AgentHub. ACP cancel is the explicit
+  interrupt path and must not wait behind active prompts, but a normal Team/member message should
+  not overlap a previous active Codex turn.
 - Codex ACP live-turn diagnostics should track enough native app-server state to explain a stuck or
   panicking turn without changing the provider-neutral ACP surface:
   - active Codex thread id, turn id, and AgentHub submission id
@@ -173,7 +176,8 @@ ACP permission requests are first-class runtime records:
   - a `CustomToolCall` without matching `CustomToolCallOutput` is recorded as diagnostic state
     before turn completion/compaction can panic
   - orphan custom-tool outputs are reported without corrupting ACP event replay
-  - concurrent prompts preserve per-submission tool-call accounting
+  - ordinary Codex prompts queue behind active prompts, while ACP cancel remains dispatchable as an
+    interrupt command
 
 ## Operational Notes
 
@@ -234,3 +238,4 @@ ACP permission requests are first-class runtime records:
 - `docs/journal/2026-03-30-codex-acp-apply-patch-deadlock.md`
 - `docs/journal/2026-03-31-pretext-acp-conversation-virtualization.md`
 - `docs/journal/2026-04-24-codex-custom-tool-output-hotfix.md`
+- `docs/journal/2026-05-09-acp-permission-tool-call-settlement.md`

--- a/docs/journal/2026-05-09-acp-permission-tool-call-settlement.md
+++ b/docs/journal/2026-05-09-acp-permission-tool-call-settlement.md
@@ -19,8 +19,9 @@ tool call and accept later prompts safely.
 
 - `crates/agenthub-acp/src/lib.rs` settles denied or timed-out permission tool calls with a
   synthetic failed ACP `tool_call_update`.
-- Prompt delivery still allows provider-supported concurrent Codex prompts, but queues a new prompt
-  while the active prompt has pending tool calls.
+- Prompt delivery queues ordinary Codex ACP prompts with FIFO semantics so a follow-up channel or
+  member message cannot re-enter Codex while a previous turn is still active. Explicit ACP cancel
+  remains the interrupt path and is not queued behind active prompts.
 - `src/diagnostics.rs` filters mailbox pending summaries so terminal Team runs do not make
   `agenthub doctor agent-trace` report old delivered work as a current stall.
 - Web-only coverage tests were added for existing auth redirect and safe storage helpers so strict
@@ -30,8 +31,9 @@ tool call and accept later prompts safely.
 
 - Deny and timeout outcomes must be terminal for the associated tool call. Relying on provider
   follow-up output is not sufficient because the failure path is already controlled by AgentHub.
-- Codex ACP concurrent prompt support stays enabled in the normal case. The new queueing rule is a
-  narrow safety gate only when the active prompt still owns unresolved tool-call state.
+- Codex ACP ordinary prompt submission is serialized at the AgentHub ACP dispatch layer. This keeps
+  Team mailbox nudges and direct member messages from overlapping active Codex turns; operator
+  interrupt continues to use ACP cancel instead of being modeled as a queued prompt.
 - `agent-trace` should count pending mailbox work for active Team runs and
   `shared_thread_mailbox`, but not for terminal run rows that already reached a finished state.
 - This change does not close the broader Team ACP permission review routing backlog. Human-visible
@@ -42,6 +44,8 @@ tool call and accept later prompts safely.
 ```bash
 cargo fmt --all --check
 cargo test -p agenthub-acp
+cargo test -p agenthub-acp prompt_delivery_policy_is_provider_aware -- --nocapture
+cargo test -p agenthub acp_provider_for_agent_requires_expected_args -- --nocapture
 cargo test -p agenthub diagnostics::agent_trace
 cargo build -p agenthub
 cd web && npm exec vitest run src/auth_redirect.test.ts src/storage/safe_storage.test.ts
@@ -62,3 +66,6 @@ Codecov project and patch checks all passed.
   peer worker or coordinator fallback, no self-review, and human-visible review actions.
 - If a future `agent-trace` verdict is `event_stream_present` while the UI remains stale, switch to
   the ACP rendering workflow and inspect SSE or frontend cache handoff instead of the mailbox path.
+- If product requirements need "send message and interrupt current turn" semantics, add an explicit
+  interrupt input mode that sends ACP cancel before the replacement prompt. Do not treat ordinary
+  Team/member messages as implicit interrupts.

--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -26,7 +26,7 @@ pub(super) struct AcpProviderSpec {
 impl AcpProviderSpec {
     const CODEX: Self = Self {
         id: ACP_PROVIDER_CODEX,
-        prompt_delivery_policy: AcpPromptDeliveryPolicy::AllowConcurrentPrompts,
+        prompt_delivery_policy: AcpPromptDeliveryPolicy::StrictFifo,
         default_mode_behavior: AcpDefaultModeBehavior::ApplyWhenConfigured,
     };
 

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -227,7 +227,7 @@ fn acp_provider_for_agent_requires_expected_args() {
     assert_eq!(codex.id, ACP_PROVIDER_CODEX);
     assert_eq!(
         codex.prompt_delivery_policy,
-        AcpPromptDeliveryPolicy::AllowConcurrentPrompts
+        AcpPromptDeliveryPolicy::StrictFifo
     );
     assert_eq!(
         codex.default_mode_behavior,


### PR DESCRIPTION
## Summary

- serialize Codex ACP prompt delivery with the same FIFO policy used by other single-turn ACP providers
- keep ACP cancel commands bypassing the FIFO queue so explicit cancellation can still interrupt active prompts
- update provider and dispatch policy tests for the new Codex behavior

## Motivation

Live Team diagnostics showed worker mailbox hints were marked as sent and user messages were persisted, but the workers produced no later provider events. That points at the ACP prompt submission boundary rather than mailbox persistence or frontend rendering. Codex ACP should not receive overlapping ordinary prompts while a previous turn or tool/permission flow is still active.

## Testing

- `cargo test -p agenthub acp_provider_for_agent_requires_expected_args -- --nocapture`
- `cargo test -p agenthub-acp prompt_delivery_policy_is_provider_aware -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
