### PR TITLE
fix(ci): use focal gcc for x86 prebuild

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
-    "apt-get update && apt-get install --assume-yes pkg-config curl unzip gcc-10 g++-10 zlib1g-dev:amd64 libsqlite3-dev:amd64 libcap-dev:amd64",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends pkg-config curl unzip gcc-10 g++-10 zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && apt-get clean && rm -rf /var/lib/apt/lists/*",
     "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100 && cc --version",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,8 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
-    "apt-get update && apt-get install --assume-yes pkg-config curl unzip gcc-12 g++-12 zlib1g-dev:amd64 libsqlite3-dev:amd64 libcap-dev:amd64",
-    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100 && cc --version",
+    "apt-get update && apt-get install --assume-yes pkg-config curl unzip gcc-10 g++-10 zlib1g-dev:amd64 libsqlite3-dev:amd64 libcap-dev:amd64",
+    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100 && cc --version",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]
 env.passthrough = ["OPENSSL_STATIC=1"]


### PR DESCRIPTION
## Summary

- switch the x86_64 release prebuild cross image setup from `gcc-12` / `g++-12` to Ubuntu focal's available `gcc-10` / `g++-10`
- keep the newer cross image, protoc 27.1 setup, and release feature matrix unchanged

## Motivation

The post-merge `Release Prebuild` run for main failed in `Prebuild x86_64-unknown-linux-gnu` while building the custom cross image. The selected `ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge` image is based on Ubuntu focal, where `gcc-12` and `g++-12` are not available from the default repositories. The apt install step aborted before `unzip` was installed, so protoc setup also failed.

`gcc-10` / `g++-10` are available on focal and still support the C17 build path required by the release-only Lance dependency.

## Testing

- `git diff --check`

The definitive validation is the post-merge `Release Prebuild` workflow because it builds inside the GitHub Actions cross image environment.
