### PR TITLE
fix(ci): install gcc 12 for x86 prebuild

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,9 @@
+# The x86 release build enables Lance fp16 kernels, which require GCC >= 12.
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
-    "apt-get update && apt-get install --assume-yes --no-install-recommends pkg-config curl unzip gcc-10 g++-10 zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && apt-get clean && rm -rf /var/lib/apt/lists/*",
-    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100 && cc --version",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates gnupg pkg-config curl unzip zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && mkdir -p /etc/apt/keyrings && curl --fail --location 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC8EC952E2A0E1FBDC5090F6A2C277A0A352154E5' | gpg --dearmor --yes --output /etc/apt/keyrings/ubuntu-toolchain-r-test.gpg && echo 'deb [signed-by=/etc/apt/keyrings/ubuntu-toolchain-r-test.gpg] https://ppa.launchpadcontent.net/ubuntu-toolchain-r/test/ubuntu focal main' > /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list && apt-get update && apt-get install --assume-yes --no-install-recommends gcc-12 g++-12 && apt-get clean && rm -rf /var/lib/apt/lists/*",
+    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100 && cc --version",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]
 env.passthrough = ["OPENSSL_STATIC=1"]


### PR DESCRIPTION
## Summary

- install GCC 12 in the x86 Linux cross prebuild image through the Ubuntu toolchain PPA
- keep the focal-compatible apt dependency setup from the previous fix
- preserve the existing release prebuild feature set instead of removing the Lance fp16 validation path

## Why

The main Release Prebuild reached `lance-linalg` after the GCC 10 fallback, but failed because the fp16 kernels require GCC >= 12 or Clang support:

```text
Unable to build AVX2 f16 kernels. Please use Clang >= 6 or GCC >= 12 or remove the fp16kernels feature.
```

The x86 cross image is still based on Ubuntu focal, so GCC 12 is not available from the default apt repositories. This patch adds the Ubuntu toolchain PPA before installing `gcc-12` and `g++-12`.

## Testing

- `git diff --check`

The definitive validation is the GitHub Release Prebuild job for `x86_64-unknown-linux-gnu`.
