### PR TITLE
fix(ci): disable lance fp16 release feature

### DIFF
--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -23,7 +23,7 @@ jobs:
             os: ubuntu-22.04
             arch: amd64
             cross: true
-            agenthub_features: release-vendored-openssl,release-lance-fp16
+            agenthub_features: release-vendored-openssl
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             arch: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             os: ubuntu-22.04
             arch: amd64
             cross: true
-            agenthub_features: release-vendored-openssl,release-lance-fp16
+            agenthub_features: release-vendored-openssl
           
           # Linux ARM64
           - target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

- remove `release-lance-fp16` from the x86 Linux release and release-prebuild feature set
- keep `release-vendored-openssl` as the release Linux feature

## Why

The main Release Prebuild now gets past the GCC 12 setup and Lance C kernel compilation, but fails while linking the `agenthub` binary:

```text
rust-lld: error: undefined symbol: norm_l2_f16_avx512
rust-lld: error: undefined symbol: dot_f16_avx512
rust-lld: error: undefined symbol: cosine_f16_avx512
rust-lld: error: undefined symbol: l2_f16_avx512
```

The `lance-linalg` `fp16kernels` path builds native AVX512 f16 archives, but the final cross link does not receive the corresponding native static libraries. This makes the release-only `release-lance-fp16` feature unsafe for the current release pipeline.

This keeps LanceDB enabled while avoiding the experimental native fp16 kernel path for release artifacts.

## Testing

- `git diff --check`

The definitive validation is the GitHub Release Prebuild workflow after merge to `main`.
