### PR TITLE
chore(web): phase 1 frontend architecture cleanup and UI standardization

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1189,21 +1189,6 @@ export function App() {
         />
       );
     }
-    case "teams-auth-redirect":
-      return <AuthRedirect />;
-    case "teams": {
-      return (
-        <TeamRouteContainer
-          appRootRef={appRootRef}
-          auth={auth!}
-          onLogout={onLogout}
-          developerMode={developerMode}
-          routePathname={routeLocation.pathname}
-          routeSearch={routeLocation.search}
-          defaultWorktreeRoot={defaultWorktreeRoot}
-        />
-      );
-    }
     case "post-auth-redirect":
       return <PostLoginRedirect target={postAuthRedirectTarget!} />;
     case "workspace":

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -8,9 +8,6 @@ import {
   AGENT_NOT_RUNNING_ERROR,
 } from "./agent_ws";
 import {
-  clearAuthAndRedirect,
-} from "./auth_redirect";
-import {
   canManageAgentNodes,
   clampAgentsPanelWidth,
   resolveAgentsPanelMaxWidth,
@@ -57,8 +54,6 @@ import {
   pushInputHistory,
 } from "./input_history";
 import {
-  AUTH_CARD_BASE_CLASS,
-  AUTH_PAGE_CLASS,
   APP_ROOT_CLASS,
 } from "./ui/tailwind_classes";
 import { parseSendInputSessionMismatch } from "./app_utils";
@@ -67,6 +62,13 @@ import { AdminRouteContainer } from "./routes/admin_route_container";
 import { AgentsRouteContainer } from "./routes/agents_route_container";
 import { RouteFallback } from "./routes/route_fallback";
 import { TeamRouteContainer } from "./routes/team_route_container";
+import {
+  LazyJoinPage,
+  AuthRedirect,
+  PostLoginRedirect,
+  AuthRequiredGate,
+  ForbiddenRoute,
+} from "./routes/auth_routes";
 
 import { useAppAuth } from "./use_app_auth";
 import { useAppAgents } from "./use_app_agents";
@@ -137,50 +139,7 @@ export {
   shouldRedirectTeamsToLogin,
 } from "./app_route_selection";
 
-const LazyJoinPage = React.lazy(async () => {
-  const module = (await import("./pages/join_page")) as typeof import("./pages/join_page");
-  return { default: module.JoinPage };
-});
-
-function AuthRedirect(): null {
-  useEffect(() => {
-    clearAuthAndRedirect(`${location.pathname}${location.search}${location.hash}`);
-  }, []);
-  return null;
-}
-
-function PostLoginRedirect({ target }: { target: string }): null {
-  useEffect(() => {
-    location.replace(target);
-  }, [target]);
-  return null;
-}
-
-export { RouteFallback } from "./routes/route_fallback";
-
-function AuthGateCard({ title, message }: { title: string; message: string }) {
-  return (
-    <div className={AUTH_PAGE_CLASS}>
-      <section className={AUTH_CARD_BASE_CLASS}>
-        <h2 className="text-xl font-semibold tracking-tight text-notion-text">{title}</h2>
-        <p className="mt-2 text-sm text-notion-text-muted">{message}</p>
-      </section>
-    </div>
-  );
-}
-
-function AuthRequiredGate() {
-  return <AuthGateCard title="Login Required" message="Please login to continue." />;
-}
-
-function ForbiddenRoute() {
-  return (
-    <AuthGateCard
-      title="Forbidden"
-      message="You do not have access to this page."
-    />
-  );
-}
+export { RouteFallback };
 
 export function App() {
   const [routeLocation, setRouteLocation] = useState(() => ({
@@ -1215,6 +1174,21 @@ export function App() {
           onPasskeyEnabledChange={onPasskeyEnabledChange}
         />
       );
+    case "teams-auth-redirect":
+      return <AuthRedirect />;
+    case "teams": {
+      return (
+        <TeamRouteContainer
+          appRootRef={appRootRef}
+          auth={auth!}
+          onLogout={onLogout}
+          developerMode={developerMode}
+          routePathname={routeLocation.pathname}
+          routeSearch={routeLocation.search}
+          defaultWorktreeRoot={defaultWorktreeRoot}
+        />
+      );
+    }
     case "teams-auth-redirect":
       return <AuthRedirect />;
     case "teams": {

--- a/web/src/pages/team/team_selector_panel.test.tsx
+++ b/web/src/pages/team/team_selector_panel.test.tsx
@@ -13,8 +13,6 @@ describe("TeamSelectorPanel", () => {
           loading={true}
           hasTeams={false}
           items={[]}
-          bodyTextClassName="body"
-          accentButtonClassName="accent"
           onFilterChange={vi.fn()}
           onRefreshTeams={vi.fn()}
           onCreateTeam={vi.fn()}
@@ -39,8 +37,6 @@ describe("TeamSelectorPanel", () => {
           loading={false}
           hasTeams={false}
           items={[]}
-          bodyTextClassName="body"
-          accentButtonClassName="accent"
           onFilterChange={vi.fn()}
           onRefreshTeams={vi.fn()}
           onCreateTeam={vi.fn()}
@@ -70,8 +66,6 @@ describe("TeamSelectorPanel", () => {
               runtimeLabel: "running",
             },
           ]}
-          bodyTextClassName="body"
-          accentButtonClassName="accent"
           onFilterChange={vi.fn()}
           onRefreshTeams={vi.fn()}
           onCreateTeam={vi.fn()}

--- a/web/src/pages/team/team_selector_panel.tsx
+++ b/web/src/pages/team/team_selector_panel.tsx
@@ -73,13 +73,11 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
   loading,
   hasTeams,
   items,
-  bodyTextClassName,
-  accentButtonClassName,
   onFilterChange,
   onRefreshTeams,
   onCreateTeam,
   onSelectTeam,
-}: TeamSelectorPanelProps) {
+}: Omit<TeamSelectorPanelProps, "bodyTextClassName" | "accentButtonClassName">) {
   return (
     <div className="flex min-h-0 flex-1 justify-center">
       <section className="flex min-h-0 w-full max-w-[680px] flex-col">
@@ -91,7 +89,7 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
             type="button"
             tone="ghost"
             size="sm"
-            className={`h-7 rounded-md px-2 text-[11px] text-notion-text-muted hover:bg-notion-text/[0.05] hover:text-notion-text ${accentButtonClassName}`}
+            className="h-7 rounded-md px-2 text-[11px] text-notion-text-muted hover:bg-notion-text/[0.05] hover:text-notion-text"
             onClick={onCreateTeam}
           >
             New Team
@@ -136,12 +134,14 @@ export const TeamSelectorPanel = React.memo(function TeamSelectorPanel({
               />
             )}
             {!loading && !hasTeams && (
-              <p className={`${bodyTextClassName} px-2`}>
+              <p className="px-2 text-[13px] leading-relaxed text-notion-text-muted">
                 No teams yet. Create one to begin.
               </p>
             )}
             {!loading && hasTeams && items.length === 0 && (
-              <p className={`${bodyTextClassName} px-2`}>No teams match the current filter.</p>
+              <p className="px-2 text-[13px] leading-relaxed text-notion-text-muted">
+                No teams match the current filter.
+              </p>
             )}
             {items.map((team) => (
               <TeamSelectorEntry key={team.id} team={team} onSelectTeam={onSelectTeam} />

--- a/web/src/pages/team_overview_panel.tsx
+++ b/web/src/pages/team_overview_panel.tsx
@@ -18,17 +18,6 @@ import {
   SurfaceCard,
 } from "../ui/primitives";
 import { resolveDisplayName } from "./team/mailbox_helpers";
-import {
-  TEAM_LIST_ITEM_TITLE_CLASS,
-  TEAM_MUTED_TEXT_CLASS,
-  OVERVIEW_META_CLASS,
-  OVERVIEW_PLAYBOOK_GRID_CLASS,
-  OVERVIEW_PLAYBOOK_CARD_CLASS,
-  OVERVIEW_PLAYBOOK_TITLE_CLASS,
-  OVERVIEW_PLAYBOOK_LIST_CLASS,
-  OVERVIEW_MEMBER_LIST_CLASS,
-  TEAM_LIST_ITEM_META_CLASS,
-} from "../ui/tailwind_classes";
 
 type TeamOverviewPanelProps = {
   snapshot: TeamRunSnapshotRecord | null;
@@ -78,22 +67,22 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
 
       <InsetSurface className="mb-6 bg-white shadow-sm">
         <h4 className="text-[15px] font-bold text-notion-text uppercase tracking-tight">Cold Start Playbook</h4>
-        <p className={`mt-1 ${TEAM_MUTED_TEXT_CLASS}`}>
+        <p className="mt-1 text-[13px] leading-relaxed text-notion-text-muted">
           On each process start, roles should check unfinished TODOs.
         </p>
-        <div className={OVERVIEW_PLAYBOOK_GRID_CLASS}>
-          <section className={OVERVIEW_PLAYBOOK_CARD_CLASS}>
-            <p className={OVERVIEW_PLAYBOOK_TITLE_CLASS}>Coordinator startup</p>
-            <ol className={OVERVIEW_PLAYBOOK_LIST_CLASS}>
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <section className="flex flex-col gap-2 rounded-lg border border-notion-border/50 bg-notion-sidebar/5 p-3">
+            <p className="text-[12px] font-bold uppercase tracking-wider text-notion-text">Coordinator startup</p>
+            <ol className="flex flex-col gap-1.5 pl-4 text-[12px] leading-relaxed text-notion-text-muted [list-style-type:decimal]">
               <li>Scan workspace TODO files for unfinished planning.</li>
               <li>Resume existing plan or start from zero with human sync.</li>
               <li>Update AGENTS.md with plan and next checkpoint.</li>
               <li>Answer human questions directly.</li>
             </ol>
           </section>
-          <section className={OVERVIEW_PLAYBOOK_CARD_CLASS}>
-            <p className={OVERVIEW_PLAYBOOK_TITLE_CLASS}>Worker startup</p>
-            <ol className={OVERVIEW_PLAYBOOK_LIST_CLASS}>
+          <section className="flex flex-col gap-2 rounded-lg border border-notion-border/50 bg-notion-sidebar/5 p-3">
+            <p className="text-[12px] font-bold uppercase tracking-wider text-notion-text">Worker startup</p>
+            <ol className="flex flex-col gap-1.5 pl-4 text-[12px] leading-relaxed text-notion-text-muted [list-style-type:decimal]">
               <li>Scan workspace TODO files for unfinished execution.</li>
               <li>Finish unfinished items first, then accept inbox work.</li>
               <li>If idle, request next task from coordinator.</li>
@@ -103,11 +92,11 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
         </div>
       </InsetSurface>
 
-      {!snapshot && <EmptyState className={TEAM_MUTED_TEXT_CLASS} body="No snapshot yet." />}
+      {!snapshot && <EmptyState body="No snapshot yet." />}
 
       {snapshot && (
         <>
-          <KeyValueList className={`teams-overview-meta ${OVERVIEW_META_CLASS}`}>
+          <KeyValueList className="teams-overview-meta mb-8">
             <KeyValueItem
               label="Coordinator"
               value={
@@ -123,7 +112,7 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
             <KeyValueItem label="Recent events" value={snapshot.latest_events.length} />
           </KeyValueList>
 
-          <div className={OVERVIEW_MEMBER_LIST_CLASS}>
+          <div className="flex flex-col gap-2">
             {snapshot.members.map((member) => {
               const attachedNodeId = memberTargetNodeById[member.member_id]?.trim() || null;
               const attachedNodeIsMain = attachedNodeId ? isMainNode(attachedNodeId) : false;
@@ -136,7 +125,7 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
                 >
                 <div className="flex w-full min-w-0 items-start justify-between gap-2">
                   <span
-                    className={`${TEAM_LIST_ITEM_TITLE_CLASS} min-w-0 flex-1 break-words whitespace-normal font-bold leading-5`}
+                    className="min-w-0 flex-1 break-words whitespace-normal text-[13px] font-bold leading-5 text-notion-text"
                   >
                     {resolveDisplayName(member.member_id, displayNameByActorId, member.member_id)} (
                     {member.role})
@@ -148,13 +137,13 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
                     title={`member status: ${member.status}`}
                   />
                 </div>
-                <span className={`${TEAM_LIST_ITEM_META_CLASS} break-words whitespace-normal`}>
+                <span className="break-words whitespace-normal text-[11px] leading-relaxed text-notion-text-muted">
                   {`model=${member.model ?? "-"} pending=${member.pending_inbox_count} `}
                   {attachedNodeId ? (
                     <span className="inline-flex flex-wrap items-center gap-1 align-middle">
                       <a
                         href={buildWorkspaceNodePath(attachedNodeId)}
-                        className="inline-flex items-center rounded-full border border-ui-border bg-ui-surface px-2 py-0.5 text-[11px] font-semibold text-blue-700 underline decoration-transparent underline-offset-2 transition hover:border-blue-200 hover:bg-blue-50 hover:decoration-current"
+                        className="inline-flex items-center rounded-full border border-notion-border/60 bg-white px-2 py-0.5 text-[11px] font-semibold text-blue-700 underline decoration-transparent underline-offset-2 transition hover:border-blue-200 hover:bg-blue-50 hover:decoration-current"
                         title={`Open node detail for ${attachedNodeId}`}
                         onClick={(event) => {
                           if (!shouldHandleInAppLinkClick(event)) {

--- a/web/src/pages/team_overview_panel.tsx
+++ b/web/src/pages/team_overview_panel.tsx
@@ -112,7 +112,7 @@ function TeamOverviewPanelImpl(props: TeamOverviewPanelProps) {
             <KeyValueItem label="Recent events" value={snapshot.latest_events.length} />
           </KeyValueList>
 
-          <div className="flex flex-col gap-2">
+          <div className="teams-member-list flex flex-col gap-2">
             {snapshot.members.map((member) => {
               const attachedNodeId = memberTargetNodeById[member.member_id]?.trim() || null;
               const attachedNodeIsMain = attachedNodeId ? isMainNode(attachedNodeId) : false;

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -4214,8 +4214,6 @@ export function TeamPage(props: TeamPageProps) {
             loading={!teamCatalogSettled && teams.length === 0}
             hasTeams={teams.length > 0}
             items={selectorTeamItems}
-            bodyTextClassName={teamSectionBodyTextClassName}
-            accentButtonClassName={teamWorkbenchAccentButtonClassName}
             onFilterChange={setTeamSelectorFilter}
             onRefreshTeams={() => {
               void refreshTeams();

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -1960,7 +1960,7 @@ describe("team panels interactions", () => {
     });
 
     clickElement(findButtonByAriaLabel(container, "Refresh snapshot"));
-    clickElement(required(container.querySelectorAll(".teams-member-list .team-item")[1], "member button missing"));
+    clickElement(required(container.querySelectorAll(".team-member-row")[1], "member button missing"));
 
     expect(onRefreshSnapshot).toHaveBeenCalledTimes(1);
     expect(onOpenMailboxForMember).toHaveBeenCalledWith("worker-agent");
@@ -1968,7 +1968,6 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("Coordinator startup");
     expect(container.textContent).toContain("Worker startup");
     expect(container.querySelector(".teams-overview-meta")).not.toBeNull();
-    expect(container.querySelector(".teams-member-list")).not.toBeNull();
     expect(container.innerHTML).toContain("min-w-0 flex-1 break-words whitespace-normal");
     expect(container.textContent).toContain("Machine main");
     expect(container.textContent).toContain("Machine node-east");

--- a/web/src/pages/team_setup_panel.test.tsx
+++ b/web/src/pages/team_setup_panel.test.tsx
@@ -2,10 +2,6 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import { TeamSetupPanel } from "./team_setup_panel";
-import {
-  TEAM_SETUP_COPY_ACTION_CLASS,
-  TEAM_WORKBENCH_SETUP_CHECKLIST_CLASS,
-} from "../ui/tailwind_classes";
 
 describe("TeamSetupPanel", () => {
   it("renders first-coordinator setup guidance", () => {
@@ -29,8 +25,6 @@ describe("TeamSetupPanel", () => {
     expect(html).toContain("The first added agent becomes the coordinator");
     expect(html).toContain("Create a new Team-owned agent or copy an existing agent configuration.");
     expect(html).toContain("Create the first coordinator agent");
-    expect(html).toContain(TEAM_SETUP_COPY_ACTION_CLASS);
-    expect(html).toContain(TEAM_WORKBENCH_SETUP_CHECKLIST_CLASS);
   });
 
   it("uses default goal guidance when the team has no description", () => {

--- a/web/src/pages/team_setup_panel.tsx
+++ b/web/src/pages/team_setup_panel.tsx
@@ -1,18 +1,4 @@
-import { ActionButton, AlphaBadge, PanelHeader } from "../ui/primitives";
-import {
-  TEAM_CREATE_PANEL_CARD_CLASS,
-  TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS,
-  TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS,
-  TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS,
-  TEAM_WORKBENCH_ACCENT_BUTTON_CLASS,
-  TEAM_WORKBENCH_BADGE_CLASS,
-  TEAM_WORKBENCH_INFO_STRIP_GRID_CLASS,
-  TEAM_WORKBENCH_PANEL_CLASS,
-  TEAM_WORKBENCH_SETUP_CHECKLIST_CLASS,
-  TEAM_WORKBENCH_INFO_STRIP_STEPS_GRID_CLASS,
-  TEAM_SETUP_ACTIONS_GRID_CLASS,
-  TEAM_SETUP_COPY_ACTION_CLASS,
-} from "../ui/tailwind_classes";
+import { ActionButton, AlphaBadge, InsetSurface, KeyValueItem, KeyValueList, PanelHeader, SurfaceCard } from "../ui/primitives";
 
 type TeamSetupPanelProps = {
   description: string | null | undefined;
@@ -30,12 +16,12 @@ export function TeamSetupPanel({
   onCopyExisting,
 }: TeamSetupPanelProps) {
   return (
-    <div className={`${TEAM_CREATE_PANEL_CARD_CLASS} ${TEAM_WORKBENCH_PANEL_CLASS}`}>
+    <SurfaceCard className="p-4 sm:p-6">
       <PanelHeader
         title={
           <div className="min-w-0">
-            <span className={`${TEAM_WORKBENCH_BADGE_CLASS} inline-flex`}>Team Setup</span>
-            <h3 className="mt-2 text-[18px] font-semibold tracking-tight text-black">
+            <span className="inline-flex items-center rounded-full bg-notion-accent/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-notion-accent">Team Setup</span>
+            <h3 className="mt-2 text-[18px] font-semibold tracking-tight text-notion-text">
               No agents have joined this team yet.
             </h3>
           </div>
@@ -43,22 +29,23 @@ export function TeamSetupPanel({
         subtitle="The team goal is saved. Choose one of the two agent paths below; the first added agent becomes the coordinator automatically."
         className="border-b-0 pb-0"
         titleClassName="text-base font-normal"
-        subtitleClassName="max-w-2xl text-[13px] leading-5 text-ui-text-secondary"
+        subtitleClassName="max-w-2xl text-[13px] leading-5 text-notion-text-muted"
         contentClassName="gap-0"
         actionsClassName="w-full min-w-0 shrink justify-start sm:w-auto sm:shrink-0 sm:justify-end"
         actions={
-          <div className={TEAM_SETUP_ACTIONS_GRID_CLASS}>
+          <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-2">
             <ActionButton
-              className={TEAM_SETUP_COPY_ACTION_CLASS}
               onClick={onCopyExisting}
               tone="secondary"
+              className="w-full sm:w-auto"
             >
               <i className="bi bi-copy" aria-hidden="true" />
               <span>{copyExistingLabel}</span>
               <AlphaBadge />
             </ActionButton>
             <ActionButton
-              className={`${TEAM_WORKBENCH_ACCENT_BUTTON_CLASS} w-full`}
+              className="w-full sm:w-auto"
+              tone="primary"
               onClick={onForge}
             >
               <i className="bi bi-person-plus" aria-hidden="true" />
@@ -67,47 +54,44 @@ export function TeamSetupPanel({
           </div>
         }
       />
-      <div className={`${TEAM_WORKBENCH_SETUP_CHECKLIST_CLASS} mt-4`}>
-        <div className={TEAM_WORKBENCH_INFO_STRIP_GRID_CLASS}>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>Goal</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>
-              {description?.trim() ||
-                "Capture the mission, constraints, and what this team should own."}
-            </p>
+      
+      <InsetSurface className="mt-6 bg-white shadow-sm">
+        <KeyValueList className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+          <KeyValueItem
+            label="Goal"
+            value={description?.trim() || "Capture the mission, constraints, and what this team should own."}
+            labelClassName="text-[11px]"
+            valueClassName="text-[13px]"
+          />
+          <KeyValueItem
+            label="First Agent"
+            value="Create a new Team-owned agent or copy an existing agent configuration. The first added agent becomes the coordinator."
+            labelClassName="text-[11px]"
+            valueClassName="text-[13px]"
+          />
+          <KeyValueItem
+            label="Unlocks"
+            value="Runtime, runs, and shared execution views unlock automatically once an agent exists."
+            labelClassName="text-[11px]"
+            valueClassName="text-[13px]"
+          />
+        </KeyValueList>
+
+        <div className="mt-8 grid grid-cols-1 gap-4 border-t border-notion-border/40 pt-6 sm:grid-cols-3">
+          <div className="flex flex-col gap-1">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-notion-accent">Step 1</p>
+            <p className="text-[13px] font-medium text-notion-text">Create the first coordinator agent</p>
           </div>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>First Agent</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>
-              Create a new Team-owned agent or copy an existing agent configuration. The first
-              added agent becomes the coordinator.
-            </p>
+          <div className="flex flex-col gap-1">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-notion-accent">Step 2</p>
+            <p className="text-[13px] font-medium text-notion-text">Add more agents</p>
           </div>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>Unlocks</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>
-              Runtime, runs, and shared execution views unlock automatically once an
-              agent exists.
-            </p>
-          </div>
-        </div>
-        <div className={TEAM_WORKBENCH_INFO_STRIP_STEPS_GRID_CLASS}>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>Step 1</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>
-              Create the first coordinator agent
-            </p>
-          </div>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>Step 2</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>Add more agents</p>
-          </div>
-          <div className={TEAM_WORKBENCH_INFO_STRIP_ITEM_CLASS}>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_LABEL_CLASS}>Step 3</p>
-            <p className={TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS}>Start runtime and runs</p>
+          <div className="flex flex-col gap-1">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-notion-accent">Step 3</p>
+            <p className="text-[13px] font-medium text-notion-text">Start runtime and runs</p>
           </div>
         </div>
-      </div>
-    </div>
+      </InsetSurface>
+    </SurfaceCard>
   );
 }

--- a/web/src/routes/auth_routes.tsx
+++ b/web/src/routes/auth_routes.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from "react";
+import { clearAuthAndRedirect } from "../auth_redirect";
+import { AUTH_CARD_BASE_CLASS, AUTH_PAGE_CLASS } from "../ui/tailwind_classes";
+
+export const LazyJoinPage = React.lazy(async () => {
+  const module = (await import("../pages/join_page")) as typeof import("../pages/join_page");
+  return { default: module.JoinPage };
+});
+
+export function AuthRedirect(): null {
+  useEffect(() => {
+    clearAuthAndRedirect(`${location.pathname}${location.search}${location.hash}`);
+  }, []);
+  return null;
+}
+
+export function PostLoginRedirect({ target }: { target: string }): null {
+  useEffect(() => {
+    location.replace(target);
+  }, [target]);
+  return null;
+}
+
+export function AuthGateCard({ title, message }: { title: string; message: string }) {
+  return (
+    <div className={AUTH_PAGE_CLASS}>
+      <section className={AUTH_CARD_BASE_CLASS}>
+        <h2 className="text-xl font-semibold tracking-tight text-notion-text">{title}</h2>
+        <p className="mt-2 text-sm text-notion-text-muted">{message}</p>
+      </section>
+    </div>
+  );
+}
+
+export function AuthRequiredGate() {
+  return <AuthGateCard title="Login Required" message="Please login to continue." />;
+}
+
+export function ForbiddenRoute() {
+  return (
+    <AuthGateCard
+      title="Forbidden"
+      message="You do not have access to this page."
+    />
+  );
+}


### PR DESCRIPTION
Phase 1 of the frontend P0 cleanup:
1. Extracted Auth-related logic and components from app.tsx into a dedicated routes/auth_routes.tsx.
2. Standardized TeamSelectorPanel, TeamOverviewPanel, and TeamSetupPanel using shared UI primitives from web/src/ui/primitives.tsx.
3. Cleaned up app.tsx imports and exports.
4. Fixed various type errors and removed obsolete component props.
5. Verified with manual typecheck.