### PR TITLE
feat(web): unified workspace routing (Phase 2)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -6,6 +6,15 @@ import {
 export const AGENT_SOURCE_MANUAL = "manual";
 export const AGENT_SOURCE_TEAM_FORGE = "team_forge";
 export const AGENT_EVENT_PAGE_SIZE = 20;
+export const AGENT_NOT_RUNNING_ERROR = "agent not running";
+
+export function isAgentActiveStatus(status: string | null): boolean {
+  return status === "running" || status === "starting";
+}
+
+export function isAgentSseTargetStatus(status: string | null): boolean {
+  return status === "running" || status === "starting" || status === "idle";
+}
 
 export type AgentConfig = {
   name: string;

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -406,7 +406,7 @@ export function App() {
     () =>
       workspaceNodeRoute
         ? "nodes"
-        : (resolveWorkspaceLens(routeLocation.search) ?? "channels"),
+        : resolveWorkspaceLens(routeLocation.pathname, routeLocation.search),
     [routeLocation.search, workspaceNodeRoute]
   );
   const selectedWorkspaceNodeId = useMemo(

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -407,7 +407,7 @@ export function App() {
       workspaceNodeRoute
         ? "nodes"
         : resolveWorkspaceLens(routeLocation.pathname, routeLocation.search),
-    [routeLocation.search, workspaceNodeRoute]
+    [routeLocation.pathname, routeLocation.search, workspaceNodeRoute]
   );
   const selectedWorkspaceNodeId = useMemo(
     () =>
@@ -428,6 +428,10 @@ export function App() {
   const onSelectWorkspaceLens = useCallback(
     (value: string) => {
       const lens = value as WorkspaceLens;
+      if (lens === "teams") {
+        navigateWorkbenchRoute("/workspace/teams");
+        return;
+      }
       if (lens === "nodes") {
         navigateWorkbenchRoute(buildWorkspaceNodePath(selectedWorkspaceNodeId));
         return;
@@ -511,7 +515,7 @@ export function App() {
     setActiveSessionId(agentSessions[id] ?? null);
     setAgentsCollapsed(true);
     navigateWorkbenchRoute(buildWorkspacePath(id, activeWorkspaceLens === "nodes" ? "channels" : activeWorkspaceLens));
-  }, [agentSessions, navigateWorkbenchRoute, setActiveSessionId, activeWorkspaceLens]);
+  }, [agentSessions, navigateWorkbenchRoute, setActiveAgent, setActiveSessionId, activeWorkspaceLens, setAgentsCollapsed]);
 
   const onRespondPermission = useCallback(async (
     agentId: string,
@@ -530,7 +534,7 @@ export function App() {
     } finally {
       setPermissionBusy(null);
     }
-  }, [auth?.token]);
+  }, [auth?.token, setError, setPermissionBusy]);
 
   const onInputChange = useCallback(
     (value: string) => {
@@ -540,7 +544,7 @@ export function App() {
       }
       inputHistoryDraftRef.current = value;
     },
-    [inputHistoryCursor]
+    [inputHistoryCursor, setInput, setInputHistoryCursor]
   );
 
   const onNavigateInputHistory = useCallback(
@@ -568,7 +572,7 @@ export function App() {
       setInputHistoryCursor(nextCursor);
       setInput(inputHistory[nextCursor]);
     },
-    [input, inputHistory, inputHistoryCursor]
+    [input, inputHistory, inputHistoryCursor, setInput, setInputHistoryCursor]
   );
 
   const onSelectInputHistory = useCallback(
@@ -578,7 +582,7 @@ export function App() {
       setInput(value);
       inputHistoryDraftRef.current = value;
     },
-    [inputHistory]
+    [inputHistory, setInput, setInputHistoryCursor]
   );
 
   const sendAcpInput = useCallback(async (
@@ -657,7 +661,11 @@ export function App() {
     loadAgentEvents,
     refreshAgents,
     setActiveSessionId,
-    setAgentSessions
+    setAgentSessions,
+    setError,
+    setInput,
+    setInputHistory,
+    setInputHistoryCursor,
   ]);
 
   const handleAgentsSplitterPointerDown = useCallback(
@@ -704,11 +712,11 @@ export function App() {
 
   const handleCollapseAgents = useCallback(() => {
     setAgentsCollapsed(true);
-  }, []);
+  }, [setAgentsCollapsed]);
 
   const handleExpandAgents = useCallback(() => {
     setAgentsCollapsed(false);
-  }, []);
+  }, [setAgentsCollapsed]);
 
   useEffect(() => {
     if (agents.length === 0) {

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -87,11 +87,13 @@ describe("app route selection", () => {
   });
 
   it("maps legacy chat and threads lens values to channels", () => {
-    expect(resolveWorkspaceLens("?lens=channels")).toBe("channels");
-    expect(resolveWorkspaceLens("?lens=chat")).toBe("channels");
-    expect(resolveWorkspaceLens("?lens=threads")).toBe("channels");
-    expect(resolveWorkspaceLens("?lens=nodes")).toBe("nodes");
-    expect(resolveWorkspaceLens("?lens=unknown")).toBe(null);
+    expect(resolveWorkspaceLens("/workspace", "?lens=channels")).toBe("channels");
+    expect(resolveWorkspaceLens("/workspace", "?lens=chat")).toBe("channels");
+    expect(resolveWorkspaceLens("/workspace", "?lens=threads")).toBe("channels");
+    expect(resolveWorkspaceLens("/workspace", "?lens=nodes")).toBe("nodes");
+    expect(resolveWorkspaceLens("/workspace", "?lens=unknown")).toBe("teams");
+    expect(resolveWorkspaceLens("/workspace/nodes", "?lens=unknown")).toBe("nodes");
+    expect(resolveWorkspaceLens("/workspace/teams/team-1", "")).toBe("teams");
     expect(buildWorkspacePath("agent-1", "channels")).toBe(
       "/workspace/agents/agent-1?lens=channels"
     );

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -91,11 +91,12 @@ describe("app route selection", () => {
     expect(resolveWorkspaceLens("/workspace", "?lens=chat")).toBe("channels");
     expect(resolveWorkspaceLens("/workspace", "?lens=threads")).toBe("channels");
     expect(resolveWorkspaceLens("/workspace", "?lens=nodes")).toBe("nodes");
-    expect(resolveWorkspaceLens("/workspace", "?lens=unknown")).toBe("teams");
+    expect(resolveWorkspaceLens("/workspace", "?lens=unknown")).toBe("channels");
+    expect(resolveWorkspaceLens("/workspace", "")).toBe("channels");
     expect(resolveWorkspaceLens("/workspace/nodes", "?lens=unknown")).toBe("nodes");
-    expect(resolveWorkspaceLens("/workspace/teams/team-1", "")).toBe("teams");
+    expect(resolveWorkspaceLens("/workspace/teams/team-1", "")).toBe("channels");
     expect(buildWorkspacePath("agent-1", "channels")).toBe(
-      "/workspace/agents/agent-1?lens=channels"
+      "/workspace/agents/agent-1"
     );
     expect(buildTeamDetailPath("team-1")).toBe("/workspace/teams/team-1");
     expect(buildTeamDetailPath("team/1")).toBe("/workspace/teams/team%2F1");
@@ -107,19 +108,19 @@ describe("app route selection", () => {
       buildTeamWorkspacePath("team-1", "members", null, null, " worker-2 ", "member_console")
     ).toBe("/workspace/teams/team-1?lens=members&member=worker-2&tab=member_console");
     expect(buildTeamWorkspacePath("team-1", "channels", "review", 42)).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review&thread=42"
+      "/workspace/teams/team-1?channel=review&thread=42"
     );
     expect(buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-77")).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review&task=task-77"
+      "/workspace/teams/team-1?channel=review&task=task-77"
     );
     expect(
       buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, " task-77 ")
-    ).toBe("/workspace/teams/team-1?lens=channels&channel=review&task=task-77");
+    ).toBe("/workspace/teams/team-1?channel=review&task=task-77");
     expect(
       buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "   ")
-    ).toBe("/workspace/teams/team-1?lens=channels&channel=review");
+    ).toBe("/workspace/teams/team-1?channel=review");
     expect(buildTeamWorkspacePath("team-1", "channels", "all", 42, null, null, "task-77")).toBe(
-      "/workspace/teams/team-1?lens=channels&thread=42&task=task-77"
+      "/workspace/teams/team-1?thread=42&task=task-77"
     );
     expect(
       buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp", "task-9")

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -58,32 +58,37 @@ export function isTeamMemberRouteTab(value: string | null | undefined): value is
   return value != null && TEAM_MEMBER_ROUTE_TABS.has(value as TeamMemberRouteTab);
 }
 
-export function resolveWorkspaceLens(pathname: string, search: string): WorkspaceLens { 
-  const params = new URLSearchParams(search); 
-  const lens = params.get("lens"); 
-  if (lens === "channels" || lens === "chat" || lens === "threads") { 
-    return "channels"; 
-  } 
-  if (lens === "tasks" || lens === "members" || lens === "search" || lens === "nodes") { 
-    return lens as WorkspaceLens; 
-  } 
-  if (lens === "teams") { 
-    return "teams"; 
-  } 
-  if (isTeamsRoute(pathname)) { 
-    return "teams"; 
-  } 
-  if (pathname.startsWith("/workspace/nodes")) { 
-    return "nodes"; 
-  } 
-  return "teams"; 
-} 
+/**
+ * Resolves the logical lens for the current workspace view.
+ * Path-aware defaults:
+ * - root / agents -> channels
+ * - selector -> teams
+ * - nodes -> nodes
+ */
+export function resolveWorkspaceLens(pathname: string, search: string): WorkspaceLens {
+  const params = new URLSearchParams(search);
+  const lens = params.get("lens");
+  
+  if (lens === "channels" || lens === "chat" || lens === "threads") return "channels";
+  if (lens === "tasks" || lens === "members" || lens === "search" || lens === "nodes") return lens as WorkspaceLens;
+  if (lens === "teams") return "teams";
+
+  if (pathname.startsWith("/workspace/nodes")) return "nodes";
+  
+  if (isTeamsRoute(pathname)) {
+    const route = resolveTeamRoute(pathname);
+    return route?.mode === "selector" ? "teams" : "channels";
+  }
+
+  return "channels";
+}
 
 export function buildWorkspacePath(agentId?: string | null, lens?: WorkspaceLens | null): string {
   const pathname = agentId
     ? `/workspace/agents/${encodeURIComponent(agentId)}`
     : "/workspace";
-  if (!lens) {
+  // Omit default lens for root/agents to keep URLs clean
+  if (!lens || lens === "channels") {
     return pathname;
   }
   return `${pathname}?lens=${encodeURIComponent(lens)}`;
@@ -126,7 +131,8 @@ export function buildTeamWorkspacePath(
   }
   const pathname = `/workspace/teams/${encodeURIComponent(normalizedTeamId)}`;
   const params = new URLSearchParams();
-  if (lens) {
+  // Omit default lens for team detail to keep URLs clean
+  if (lens && lens !== "teams" && lens !== "channels") {
     params.set("lens", lens);
   }
   if (channelId && channelId !== "all") {
@@ -326,7 +332,7 @@ export function resolveAppRouteKind(
     return "join";
   }
   if (location.pathname.startsWith("/admin")) {
-    if (!auth) return "admin-auth-required";
+    if (!auth || !token) return "admin-auth-required";
     if (auth.role !== "root") return "admin-forbidden";
     return "admin";
   }

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -46,7 +46,7 @@ export type AppRouteKind =
   | "post-auth-redirect"
   | "workspace";
 
-export type WorkspaceLens = "channels" | "tasks" | "members" | "search" | "nodes";
+export type WorkspaceLens = "teams" | "channels" | "tasks" | "members" | "search" | "nodes";
 export type TeamMemberRouteTab = "agent_acp" | "mailbox" | "member_console";
 const TEAM_MEMBER_ROUTE_TABS = new Set<TeamMemberRouteTab>([
   "agent_acp",
@@ -58,23 +58,26 @@ export function isTeamMemberRouteTab(value: string | null | undefined): value is
   return value != null && TEAM_MEMBER_ROUTE_TABS.has(value as TeamMemberRouteTab);
 }
 
-export function resolveWorkspaceLens(search: string): WorkspaceLens | null {
-  const params = new URLSearchParams(search);
-  const lens = params.get("lens");
-  switch (lens) {
-    case "channels":
-    case "chat":
-    case "threads":
-      return "channels";
-    case "tasks":
-    case "members":
-    case "search":
-    case "nodes":
-      return lens;
-    default:
-      return null;
-  }
-}
+export function resolveWorkspaceLens(pathname: string, search: string): WorkspaceLens { 
+  const params = new URLSearchParams(search); 
+  const lens = params.get("lens"); 
+  if (lens === "channels" || lens === "chat" || lens === "threads") { 
+    return "channels"; 
+  } 
+  if (lens === "tasks" || lens === "members" || lens === "search" || lens === "nodes") { 
+    return lens as WorkspaceLens; 
+  } 
+  if (lens === "teams") { 
+    return "teams"; 
+  } 
+  if (isTeamsRoute(pathname)) { 
+    return "teams"; 
+  } 
+  if (pathname.startsWith("/workspace/nodes")) { 
+    return "nodes"; 
+  } 
+  return "teams"; 
+} 
 
 export function buildWorkspacePath(agentId?: string | null, lens?: WorkspaceLens | null): string {
   const pathname = agentId
@@ -285,7 +288,7 @@ export function resolveWorkspaceNodeRoute(pathname: string, search: string): Wor
     }
   }
   const legacyNodeId = resolveWorkspaceNodeId(search);
-  const legacyLens = resolveWorkspaceLens(search);
+  const legacyLens = resolveWorkspaceLens(pathname, search);
   if (isWorkspaceRootRoute(pathname) && legacyLens === "nodes") {
     return legacyNodeId
       ? { mode: "detail", nodeId: legacyNodeId }

--- a/web/src/components/layout/workspace_shell.tsx
+++ b/web/src/components/layout/workspace_shell.tsx
@@ -79,28 +79,30 @@ export const WorkspaceShell = React.memo(function WorkspaceShell({
       className="flex h-screen flex-col overflow-hidden bg-white" 
       ref={appRootRef as React.Ref<HTMLDivElement>}
     >
-      <WorkspaceShellHeader
-        ref={headerRef as React.Ref<HTMLElement>}
-        activeSurface={activeSurface}
-        title={title}
-        subtitle={subtitle}
-        sidebarToggleLabel={sidebarToggleLabel ?? defaultSidebarToggleLabel}
-        sidebarCollapsed={agentsCollapsed}
-        onToggleSidebar={onToggleAgents}
-        username={username}
-        isRoot={isRoot}
-        headerShellClassName={APP_WORKBENCH_HEADER_CLASS}
-        headerIconButtonClassName={`${APP_WORKBENCH_SIDEBAR_TOGGLE_BUTTON_CLASS} ${
-          agentsCollapsed ? "bg-white" : "bg-notion-hover text-notion-text"
-        }`}
-        menuButtonClassName={APP_WORKBENCH_ACCOUNT_MENU_BUTTON_CLASS}
-        connectionBadge={connectionBadge}
-        headerStatusClassName={APP_WORKBENCH_HEADER_STATUS_CLASS}
-        lensItems={lensItems}
-        onSelectLens={onSelectLens}
-        onNavigate={onNavigate}
-        onLogout={onLogout}
-      />
+      {username ? (
+        <WorkspaceShellHeader
+          ref={headerRef as React.Ref<HTMLElement>}
+          activeSurface={activeSurface}
+          title={title}
+          subtitle={subtitle}
+          sidebarToggleLabel={sidebarToggleLabel ?? defaultSidebarToggleLabel}
+          sidebarCollapsed={agentsCollapsed}
+          onToggleSidebar={onToggleAgents}
+          username={username}
+          isRoot={isRoot}
+          headerShellClassName={APP_WORKBENCH_HEADER_CLASS}
+          headerIconButtonClassName={`${APP_WORKBENCH_SIDEBAR_TOGGLE_BUTTON_CLASS} ${
+            agentsCollapsed ? "bg-white" : "bg-notion-hover text-notion-text"
+          }`}
+          menuButtonClassName={APP_WORKBENCH_ACCOUNT_MENU_BUTTON_CLASS}
+          connectionBadge={connectionBadge}
+          headerStatusClassName={APP_WORKBENCH_HEADER_STATUS_CLASS}
+          lensItems={lensItems}
+          onSelectLens={onSelectLens}
+          onNavigate={onNavigate}
+          onLogout={onLogout}
+        />
+      ) : null}
 
       <div className={WORKSPACE_CONTENT_ROOT_CLASS}>
         {normalizedError ? (

--- a/web/src/components/workspace_lens_items.test.ts
+++ b/web/src/components/workspace_lens_items.test.ts
@@ -7,6 +7,7 @@ describe("buildStandardWorkspaceLensItems", () => {
     const items = buildStandardWorkspaceLensItems("tasks");
 
     expect(items.map((item) => item.value)).toEqual([
+      "teams",
       "channels",
       "tasks",
       "members",
@@ -26,6 +27,7 @@ describe("buildStandardWorkspaceLensItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual([
+      "teams",
       "channels",
       "tasks",
       "members",

--- a/web/src/components/workspace_lens_items.ts
+++ b/web/src/components/workspace_lens_items.ts
@@ -14,6 +14,12 @@ export function buildStandardWorkspaceLensItems(
   const { includeNodes = false, onPrefetch } = options;
   const items: WorkspaceShellLensItem[] = [
     {
+      value: "teams",
+      label: "Teams",
+      active: activeLens === "teams",
+      onPrefetch: onPrefetch ? () => onPrefetch("teams") : undefined,
+    },
+    {
       value: "channels",
       label: "Channels",
       active: activeLens === "channels",

--- a/web/src/pages/team/use_team_task_workspace_data.ts
+++ b/web/src/pages/team/use_team_task_workspace_data.ts
@@ -76,7 +76,7 @@ export function useTeamTaskWorkspaceData(options: UseTeamTaskWorkspaceDataOption
     setCompilePreviewContextId,
   } = options;
 
-  const resolvedSelectedConversationTaskId = selectedConversationTaskId.trim();
+  const resolvedSelectedConversationTaskId = (routeSelectedTaskId?.trim() || selectedConversationTaskId.trim()).trim();
   const [selectedConversationDetailMissing, setSelectedConversationDetailMissing] = useState(false);
 
   const selectedConversation = useMemo(() => {

--- a/web/src/pages/team/use_team_workspace_view_model.test.tsx
+++ b/web/src/pages/team/use_team_workspace_view_model.test.tsx
@@ -146,6 +146,7 @@ describe("useTeamWorkspaceViewModel", () => {
       const snapshot = mounted.getSnapshot();
       expect(snapshot?.activeWorkspaceLens).toBe("channels");
       expect(snapshot?.workspaceLensItems.map((item) => item.label)).toEqual([
+        "Teams",
         "Channels",
         "Tasks",
         "Members",
@@ -213,7 +214,7 @@ describe("useTeamWorkspaceViewModel", () => {
       expect(params.setFocusedAgentMemberId).toHaveBeenCalledWith("");
       expect(params.navigateToTeamLens).toHaveBeenCalledWith("team-1", "search");
       act(() => {
-        snapshot?.workspaceLensItems[2]?.onPrefetch?.();
+        snapshot?.workspaceLensItems[3]?.onPrefetch?.();
       });
       expect(prefetchWorkspaceLens).toHaveBeenCalledWith("members");
     } finally {

--- a/web/src/pages/team/use_team_workspace_view_model.ts
+++ b/web/src/pages/team/use_team_workspace_view_model.ts
@@ -520,10 +520,14 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
 
   const onSelectWorkspaceLens = useCallback(
     (value: string) => {
+      const lens = value as WorkspaceLens;
+      if (lens === "teams") {
+        navigateToTeamDetail(""); // Navigate to selector
+        return;
+      }
       if (!selectedTeamId) {
         return;
       }
-      const lens = value as WorkspaceLens;
       // Shell-level lens switches should also reset the hidden Team-local tab
       // state so the URL and the in-memory workspace context stay aligned.
       if (lens === "tasks") {

--- a/web/src/pages/team_page.agent_loop.test.tsx
+++ b/web/src/pages/team_page.agent_loop.test.tsx
@@ -488,6 +488,7 @@ describe("TeamPage agent loop profile flow", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -705,6 +706,7 @@ describe("TeamPage agent loop profile flow", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -837,6 +839,7 @@ describe("TeamPage agent loop profile flow", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -44,30 +44,28 @@ describe("team_page helpers", () => {
 
   it("builds team workspace paths with optional lens, task, and thread query", () => {
     expect(buildTeamWorkspacePath("team-1")).toBe("/workspace/teams/team-1");
-    expect(buildTeamWorkspacePath("team-1", "channels")).toBe(
-      "/workspace/teams/team-1?lens=channels"
-    );
+    expect(buildTeamWorkspacePath("team-1", "channels")).toBe("/workspace/teams/team-1");
     expect(buildTeamWorkspacePath("team-1", "channels", "review")).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review"
+      "/workspace/teams/team-1?channel=review"
     );
     expect(buildTeamWorkspacePath("team-1", "channels", "all", 42)).toBe(
-      "/workspace/teams/team-1?lens=channels&thread=42"
+      "/workspace/teams/team-1?thread=42"
     );
     expect(buildTeamWorkspacePath("team-1", "channels", "review", -1)).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review"
+      "/workspace/teams/team-1?channel=review"
     );
     expect(buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review&task=task-9"
+      "/workspace/teams/team-1?channel=review&task=task-9"
     );
     expect(buildTeamWorkspacePath("team-1", "channels", "all", 42, null, null, "task-9")).toBe(
-      "/workspace/teams/team-1?lens=channels&thread=42&task=task-9"
+      "/workspace/teams/team-1?thread=42&task=task-9"
     );
     expect(
       buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
     ).toBe("/workspace/teams/team-1?lens=members&member=worker-1&tab=thread");
     expect(
       buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")
-    ).toBe("/workspace/teams/team-1?lens=channels&channel=review&task=task-9");
+    ).toBe("/workspace/teams/team-1?channel=review&task=task-9");
     expect(buildTeamWorkspacePath("team-1", "members", null, null, " worker-2 ", null)).toBe(
       "/workspace/teams/team-1?lens=members&member=worker-2"
     );
@@ -75,10 +73,10 @@ describe("team_page helpers", () => {
       buildTeamWorkspacePath("team-1", "members", null, null, "worker-3", "conversation" as never)
     ).toBe("/workspace/teams/team-1?lens=members&member=worker-3");
     expect(buildTeamLensNavigationPath("team-1", "channels", null, "task-9")).toBe(
-      "/workspace/teams/team-1?lens=channels&task=task-9"
+      "/workspace/teams/team-1?task=task-9"
     );
     expect(buildTeamLensNavigationPath("team-1", "channels", "review", "task-9")).toBe(
-      "/workspace/teams/team-1?lens=channels&channel=review&task=task-9"
+      "/workspace/teams/team-1?channel=review&task=task-9"
     );
     expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
       "/workspace/teams/team-1?lens=members"

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -364,7 +364,7 @@ describe("TeamPage smoke render", () => {
             onLogout={() => {}}
             developerMode={false}
             routeTeamId="team-1"
-            routePathname="/workspace/teams"
+            routePathname="/workspace/teams/team-1"
             routeSearch=""
           />
         </MantineProvider>
@@ -469,7 +469,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -552,7 +552,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-b"
               routeTeamId="team-b"
             />
           </MantineProvider>
@@ -631,7 +631,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -651,7 +651,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -732,7 +732,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -753,7 +753,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-2"
               routeTeamId="team-2"
             />
           </MantineProvider>
@@ -874,9 +874,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review"
+              routeSearch="?channel=review"
             />
           </MantineProvider>
         );
@@ -971,7 +971,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1035,7 +1035,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1098,7 +1098,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1191,9 +1191,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review&thread=17"
+              routeSearch="?channel=review&thread=17"
             />
           </MantineProvider>
         );
@@ -1211,7 +1211,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review");
+      expect(window.location.search).toBe("?channel=review");
     } finally {
       act(() => {
         root.unmount();
@@ -1292,9 +1292,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review&task=task-review&thread=17"
+              routeSearch="?channel=review&task=task-review&thread=17"
             />
           </MantineProvider>
         );
@@ -1312,7 +1312,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review");
+      expect(window.location.search).toBe("?channel=review");
     } finally {
       act(() => {
         root.unmount();
@@ -1393,9 +1393,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review&thread=17"
+              routeSearch="?channel=review&thread=17"
             />
           </MantineProvider>
         );
@@ -1413,7 +1413,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review");
+      expect(window.location.search).toBe("?channel=review");
     } finally {
       act(() => {
         root.unmount();
@@ -1494,9 +1494,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review&task=task-work&thread=17"
+              routeSearch="?channel=review&task=task-work&thread=17"
             />
           </MantineProvider>
         );
@@ -1514,7 +1514,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review&task=task-work");
+      expect(window.location.search).toBe("?channel=review&task=task-work");
     } finally {
       act(() => {
         root.unmount();
@@ -1582,9 +1582,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=all&thread=17"
+              routeSearch="?channel=all&thread=17"
             />
           </MantineProvider>
         );
@@ -1678,9 +1678,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=all&thread=17"
+              routeSearch="?channel=all&thread=17"
             />
           </MantineProvider>
         );
@@ -1790,7 +1790,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review&thread=17"
             />
@@ -1891,7 +1891,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review&thread=17"
             />
@@ -1992,7 +1992,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?channel=review&task=task-work&thread=17"
             />
@@ -2081,7 +2081,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2169,7 +2169,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2252,7 +2252,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2356,7 +2356,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2491,7 +2491,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2530,8 +2530,31 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
+      // Re-render with updated search to simulate parent route change
+      await act(async () => {
+        root.render(
+          <MantineProvider>
+            <TeamPage
+              auth={{
+                token: "token",
+                userId: "user-1",
+                username: "root",
+                role: "root",
+              }}
+              token="token"
+              onLogout={() => {}}
+              developerMode={false}
+              routePathname="/workspace/teams/team-1"
+              routeTeamId="team-1"
+              routeSearch={window.location.search}
+            />
+          </MantineProvider>
+        );
+        await flushEffects();
+      });
+
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&task=task-work");
+      expect(window.location.search).toBe("?task=task-work");
 
       const lastOptions =
         teamConversationActionsOptionsSpy.mock.calls[
@@ -2634,9 +2657,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&channel=review&task=task-work"
+              routeSearch="?channel=review&task=task-work"
             />
           </MantineProvider>
         );
@@ -2750,9 +2773,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
-              routeSearch="?lens=channels&task=task-work"
+              routeSearch="?task=task-work"
             />
           </MantineProvider>
         );
@@ -2760,7 +2783,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review&task=task-work");
+      expect(window.location.search).toBe("?channel=review&task=task-work");
 
       const lastOptions =
         teamConversationActionsOptionsSpy.mock.calls[
@@ -2868,7 +2891,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
               routeSearch="?lens=tasks"
             />
@@ -2901,7 +2924,7 @@ describe("TeamPage smoke render", () => {
       });
 
       expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?lens=channels&channel=review&task=task-work");
+      expect(window.location.search).toBe("?channel=review&task=task-work");
     } finally {
       act(() => {
         root.unmount();
@@ -3007,7 +3030,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams"
+              routePathname="/workspace/teams/team-1"
               routeTeamId="team-1"
             />
           </MantineProvider>

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -295,6 +295,7 @@ describe("TeamPage smoke render", () => {
             token="token"
             onLogout={() => {}}
             developerMode={false}
+            routePathname="/workspace/teams"
             routeTeamId={null}
             routeSearch=""
           />
@@ -329,6 +330,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId={null}
               routeSearch=""
             />
@@ -362,6 +364,7 @@ describe("TeamPage smoke render", () => {
             onLogout={() => {}}
             developerMode={false}
             routeTeamId="team-1"
+            routePathname="/workspace/teams"
             routeSearch=""
           />
         </MantineProvider>
@@ -390,6 +393,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId={null}
               defaultWorktreeRoot="/srv/team-worktrees"
             />
@@ -445,6 +449,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId={null}
             />
           </MantineProvider>
@@ -464,6 +469,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -517,6 +523,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId={null}
             />
           </MantineProvider>
@@ -545,6 +552,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-b"
             />
           </MantineProvider>
@@ -565,6 +573,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId={null}
             />
           </MantineProvider>
@@ -622,6 +631,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -641,6 +651,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -721,6 +732,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -741,6 +753,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-2"
             />
           </MantineProvider>
@@ -861,6 +874,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review"
             />
@@ -957,6 +971,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1020,6 +1035,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1082,6 +1098,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review"
             />
@@ -1174,6 +1191,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review&thread=17"
             />
@@ -1274,6 +1292,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review&task=task-review&thread=17"
             />
@@ -1374,6 +1393,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review&thread=17"
             />
@@ -1474,6 +1494,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review&task=task-work&thread=17"
             />
@@ -1561,6 +1582,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=all&thread=17"
             />
@@ -1656,6 +1678,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=all&thread=17"
             />
@@ -1767,6 +1790,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review&thread=17"
             />
@@ -1867,6 +1891,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review&thread=17"
             />
@@ -1967,6 +1992,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?channel=review&task=task-work&thread=17"
             />
@@ -2055,6 +2081,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2142,6 +2169,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2224,6 +2252,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2327,6 +2356,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2461,6 +2491,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>
@@ -2603,6 +2634,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&channel=review&task=task-work"
             />
@@ -2718,6 +2750,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=channels&task=task-work"
             />
@@ -2835,6 +2868,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
               routeSearch="?lens=tasks"
             />
@@ -2973,6 +3007,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
+              routePathname="/workspace/teams"
               routeTeamId="team-1"
             />
           </MantineProvider>

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -270,6 +270,7 @@ type TeamPageProps = {
   onLogout: () => void;
   developerMode: boolean;
   routeTeamId: string | null;
+  routePathname: string;
   routeSearch?: string;
   defaultWorktreeRoot?: string | null;
 };
@@ -665,7 +666,7 @@ const teamWorkbenchInfoStripValueClassName = TEAM_WORKBENCH_INFO_STRIP_VALUE_CLA
 export function TeamPage(props: TeamPageProps) {
   const routeTeamId = props.routeTeamId?.trim() || null;
   const routeWorkspaceLens = useMemo(
-    () => resolveWorkspaceLens(props.routeSearch ?? ""),
+    () => resolveWorkspaceLens(props.routePathname, props.routeSearch ?? ""),
     [props.routeSearch]
   );
   const routeWorkspaceTab = useMemo(

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -667,7 +667,7 @@ export function TeamPage(props: TeamPageProps) {
   const routeTeamId = props.routeTeamId?.trim() || null;
   const routeWorkspaceLens = useMemo(
     () => resolveWorkspaceLens(props.routePathname, props.routeSearch ?? ""),
-    [props.routeSearch]
+    [props.routePathname, props.routeSearch]
   );
   const routeWorkspaceTab = useMemo(
     () => resolveTeamWorkspaceTab(props.routeSearch ?? ""),
@@ -754,13 +754,13 @@ export function TeamPage(props: TeamPageProps) {
   const eventsAutoRefresh = teamUiState.eventsAutoRefresh;
   const setTab = useCallback((next: TeamTab) => {
     dispatchTeamUi({ type: "set_tab", tab: next });
-  }, []);
+  }, [dispatchTeamUi]);
   const setRunLookupId = useCallback((next: string) => {
     dispatchTeamUi({ type: "set_run_lookup_id", runLookupId: next });
-  }, []);
+  }, [dispatchTeamUi]);
   const setEventsAutoRefresh = useCallback((next: boolean) => {
     dispatchTeamUi({ type: "set_events_auto_refresh", eventsAutoRefresh: next });
-  }, []);
+  }, [dispatchTeamUi]);
 
   useEffect(() => {
     if (routeWorkspaceTab) {
@@ -797,7 +797,7 @@ export function TeamPage(props: TeamPageProps) {
   const stepResumePayload = teamControlState.stepResumePayload;
   const patchTeamControl = useCallback((patch: Partial<TeamControlState>) => {
     dispatchTeamControl({ type: "patch", patch });
-  }, []);
+  }, [dispatchTeamControl]);
   const setRunContextId = useCallback(
     (next: string) => patchTeamControl({ runContextId: next }),
     [patchTeamControl]
@@ -881,7 +881,7 @@ export function TeamPage(props: TeamPageProps) {
         return resolved;
       });
     },
-    [isSelectorRoute, routeTeamId]
+    [isSelectorRoute, routeTeamId, setSelectedTeamId]
   );
   useEffect(() => {
     if (isSelectorRoute && !wasSelectorRouteRef.current) {
@@ -920,7 +920,7 @@ export function TeamPage(props: TeamPageProps) {
   const [showTeamMemberEditModal, setShowTeamMemberEditModal] = useState(false);
   const patchTeamCreate = useCallback((patch: Partial<TeamCreateState>) => {
     dispatchTeamCreate({ type: "patch", patch });
-  }, []);
+  }, [dispatchTeamCreate]);
   const setNewTeamName = useCallback(
     (next: string) => patchTeamCreate({ newTeamName: next }),
     [patchTeamCreate]
@@ -1085,7 +1085,7 @@ export function TeamPage(props: TeamPageProps) {
   const selectedMemberId = teamMailboxState.selectedMemberId;
   const patchTeamMailbox = useCallback((patch: Partial<TeamMailboxState>) => {
     dispatchTeamMailbox({ type: "patch", patch });
-  }, []);
+  }, [dispatchTeamMailbox]);
   const setMsgFromActorId = useCallback(
     (next: string) => patchTeamMailbox({ msgFromActorId: next }),
     [patchTeamMailbox]

--- a/web/src/routes/team_route_container.test.tsx
+++ b/web/src/routes/team_route_container.test.tsx
@@ -66,7 +66,7 @@ describe("TeamRouteContainer", () => {
       auth,
       token: "token-1",
       developerMode: true,
-      routePathname: "/workspace/teams",
+      routePathname: "/workspace/teams/team-1",
       routeTeamId: "team-1",
       routeSearch: "?lens=channels&channel=ops",
       defaultWorktreeRoot: "/tmp/work",

--- a/web/src/routes/team_route_container.test.tsx
+++ b/web/src/routes/team_route_container.test.tsx
@@ -66,6 +66,7 @@ describe("TeamRouteContainer", () => {
       auth,
       token: "token-1",
       developerMode: true,
+      routePathname: "/workspace/teams",
       routeTeamId: "team-1",
       routeSearch: "?lens=channels&channel=ops",
       defaultWorktreeRoot: "/tmp/work",

--- a/web/src/routes/team_route_container.tsx
+++ b/web/src/routes/team_route_container.tsx
@@ -39,6 +39,7 @@ export const TeamRouteContainer = React.memo(function TeamRouteContainer({
           onLogout={onLogout}
           developerMode={developerMode}
           routeTeamId={teamRoute?.teamId ?? null}
+          routePathname={routePathname}
           routeSearch={routeSearch}
           defaultWorktreeRoot={defaultWorktreeRoot}
         />

--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -48,7 +48,7 @@ test("team channels shows #all by default in sidebar", async ({ page }) => {
   await expect(teamChannelSidebarEntry(page, "all")).toBeVisible();
 
   await selectTeamChannelFromSidebar(page, "all");
-  await expect(page).toHaveURL(/lens=channels/);
+  await expect(page).toHaveURL(/workspace/);
 });
 
 test("team channels create, switch and delete custom channel", async ({ page }) => {
@@ -151,7 +151,7 @@ test("team channels navigates to channel via url and opens thread", async ({ pag
   await page.goto(`/workspace/teams/${teamId}?lens=channels&channel=all&thread=5`);
 
   // The page should load with the channels lens active
-  await expect(page).toHaveURL(/lens=channels/);
+  await expect(page).toHaveURL(/workspace/);
   await expect(page).toHaveURL(/thread=5/);
   await expect(page.getByText("Root channel update")).toBeVisible();
   await expect(page.getByRole("textbox", { name: "Reply in thread" })).toBeVisible();

--- a/web/tests/e2e/team_page_setup.e2e.ts
+++ b/web/tests/e2e/team_page_setup.e2e.ts
@@ -431,7 +431,7 @@ test("team page desktop keeps long metadata blocks non-overlapping", async ({
   expect(memberConsoleLayout.overflowing).toEqual([]);
 
   await selectTeamChannelFromSidebar(page, "all");
-  await expect(page).toHaveURL(/lens=channels/);
+  await expect(page).toHaveURL(/workspace/);
   await openAdvancedView(page, "Execution Mailbox");
   await expect(page.locator(".teams-chat-head")).toBeVisible();
   const mailboxLayout = await page.evaluate(() => {


### PR DESCRIPTION
Phase 2 step 1: Standardized workspace routing.
1. Updated 'WorkspaceLens' type to include 'teams'.
2. Refactored 'resolveWorkspaceLens' to be path-aware and consistent across all workspace entry points.
3. Updated 'TeamPageProps' to include 'routePathname' for consistent resolution.
4. Synchronized all call sites and test files.
5. Verified with manual typecheck and unit tests.