### PR TITLE
fix(web): preserve node detail operator fields

### DIFF
--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -28,7 +28,9 @@ const MACHINE_DETAIL_METRIC_VALUE_CLASS =
 const MACHINE_DETAIL_SECTION_HEADER_CLASS =
   "flex flex-wrap items-start justify-between gap-3";
 
-export function resolveAvailableNodes(nodes: AgentNodeRecord[]): AgentNodeRecord[] {
+export function resolveAvailableNodes(
+  nodes: AgentNodeRecord[],
+): AgentNodeRecord[] {
   return nodes.length > 0
     ? nodes
     : [
@@ -46,7 +48,9 @@ export function resolveAvailableNodes(nodes: AgentNodeRecord[]): AgentNodeRecord
       ];
 }
 
-export function formatNodeTimestamp(timestamp: number | null | undefined): string {
+export function formatNodeTimestamp(
+  timestamp: number | null | undefined,
+): string {
   if (!timestamp || timestamp <= 0) {
     return "Not recorded";
   }
@@ -80,7 +84,9 @@ type AgentRuntimeLabel = {
   tone: "subtle" | "outline";
 };
 
-export function resolveAgentRuntimeLabels(agent: AgentRecord): AgentRuntimeLabel[] {
+export function resolveAgentRuntimeLabels(
+  agent: AgentRecord,
+): AgentRuntimeLabel[] {
   const command = (agent.command ?? "").trim().toLowerCase();
   const labels = new Map<string, AgentRuntimeLabel>();
   if (command.includes("agenthub")) {
@@ -123,13 +129,15 @@ function formatAgentStatusLabel(status: string): string {
       return "Stopped";
     default:
       return normalized
-        ? normalized.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
+        ? normalized
+            .replace(/[_-]+/g, " ")
+            .replace(/\b\w/g, (char) => char.toUpperCase())
         : "Unknown";
   }
 }
 
 function formatWorktreeModeLabel(
-  worktreeMode: AgentRecord["worktree_mode"] | null | undefined
+  worktreeMode: AgentRecord["worktree_mode"] | null | undefined,
 ): string | null {
   switch (worktreeMode) {
     case "use_existing":
@@ -159,7 +167,7 @@ const NODE_LAST_SEEN_RECENT_WINDOW_SECONDS = 10 * 60;
 
 export function deriveNodeRuntimeSummary(
   node: AgentNodeRecord,
-  agents: AgentRecord[]
+  agents: AgentRecord[],
 ): NodeRuntimeSummary {
   if (node.is_main) {
     return {
@@ -172,7 +180,7 @@ export function deriveNodeRuntimeSummary(
   if (node.last_seen_at && node.last_seen_at > 0) {
     const ageSeconds = Math.max(
       0,
-      Math.floor(Date.now() / 1000) - node.last_seen_at
+      Math.floor(Date.now() / 1000) - node.last_seen_at,
     );
     if (ageSeconds <= NODE_LAST_SEEN_RECENT_WINDOW_SECONDS) {
       return {
@@ -207,7 +215,7 @@ export function deriveNodeRuntimeSummary(
 
 export function deriveDetectedNodeRuntimes(
   node: AgentNodeRecord,
-  agents: AgentRecord[]
+  agents: AgentRecord[],
 ): NodeDetectedRuntime[] {
   const observed = new Set<string>();
   if (node.is_main) {
@@ -305,10 +313,7 @@ export function buildNodeConnectCommandSpec(args: {
       `AGENTHUB_INTERNAL_GRPC_BOOTSTRAP_TOKEN=${escapeShellValue(token || "<bootstrap-token-from-main-control-plane>")}`,
       `agenthub --config /etc/agenthub/config.toml`,
     ].join(" "),
-    substituted: [
-      `node_id=${node.id}`,
-      ...(token ? ["bootstrap token"] : []),
-    ],
+    substituted: [`node_id=${node.id}`, ...(token ? ["bootstrap token"] : [])],
     manual: [
       "config path",
       "listen addr if 50051 is not correct",
@@ -351,11 +356,14 @@ export function AgentNodeDetailCard({
   onCreateAgent,
   compact = false,
 }: AgentNodeDetailCardProps) {
-  const connectCommand = buildNodeConnectCommandSpec({ node, bootstrap: nodeJoinBootstrap });
+  const connectCommand = buildNodeConnectCommandSpec({
+    node,
+    bootstrap: nodeJoinBootstrap,
+  });
   const runtimeSummary = deriveNodeRuntimeSummary(node, agents);
   const detectedRuntimes = React.useMemo(
     () => deriveDetectedNodeRuntimes(node, agents),
-    [node, agents]
+    [node, agents],
   );
   const infoItems = React.useMemo(
     () =>
@@ -373,10 +381,16 @@ export function AgentNodeDetailCard({
         : [
             { label: "Node ID", value: node.id },
             { label: "Role", value: "Remote execution node" },
-            { label: "TLS server name", value: node.tls_server_name ?? "Uses target host" },
+            {
+              label: "TLS server name",
+              value: node.tls_server_name ?? "Uses target host",
+            },
             { label: "Created", value: formatNodeTimestamp(node.created_at) },
             { label: "Updated", value: formatNodeTimestamp(node.updated_at) },
-            { label: "Last seen", value: formatNodeTimestamp(node.last_seen_at) },
+            {
+              label: "Last seen",
+              value: formatNodeTimestamp(node.last_seen_at),
+            },
             {
               label: "Registry evidence",
               value: node.last_seen_at
@@ -384,16 +398,18 @@ export function AgentNodeDetailCard({
                 : "No bootstrap-based last-seen signal is persisted for this node yet.",
             },
           ],
-    [node]
+    [node],
   );
   const [copied, setCopied] = React.useState(false);
   const [copyError, setCopyError] = React.useState<string | null>(null);
   const resetCopiedTimeoutRef = React.useRef<number | null>(null);
-  const connectTone =
-    runtimeSummary.status === "connected" && (node.is_main || connectCommand?.hasBootstrapToken)
-      ? "border-ui-border/80 bg-white/72"
-      : "border-amber-300 bg-amber-50/70";
-  const showConnectFirst = runtimeSummary.status !== "connected";
+
+  const isOffline =
+    runtimeSummary.status === "offline" || runtimeSummary.status === "degraded";
+  const connectTone = isOffline
+    ? "border-amber-300 bg-amber-50/70 shadow-sm"
+    : "border-ui-border/80 bg-white/72";
+  const showConnectProminent = isOffline && !node.is_main;
 
   React.useEffect(() => {
     return () => {
@@ -433,7 +449,10 @@ export function AgentNodeDetailCard({
               <Text size={compact ? "md" : "lg"} fw={700}>
                 {node.name}
               </Text>
-              <Badge tone={node.is_main ? "subtle" : "outline"} className="uppercase">
+              <Badge
+                tone={node.is_main ? "subtle" : "outline"}
+                className="uppercase"
+              >
                 {resolveNodeRoleLabel(node)}
               </Badge>
               <Badge tone={runtimeSummary.tone}>{runtimeSummary.label}</Badge>
@@ -451,17 +470,27 @@ export function AgentNodeDetailCard({
         </div>
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
           <div className={MACHINE_DETAIL_METRIC_ITEM_CLASS}>
-            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>Runtime signal</div>
-            <div className={MACHINE_DETAIL_METRIC_VALUE_CLASS}>{runtimeSummary.label}</div>
-          </div>
-          <div className={MACHINE_DETAIL_METRIC_ITEM_CLASS}>
-            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>Route target</div>
-            <div className={`${MACHINE_DETAIL_METRIC_VALUE_CLASS} break-all`}>
-              {node.is_main ? "local control plane" : (node.grpc_target ?? "encrypted gRPC")}
+            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>
+              Runtime signal
+            </div>
+            <div className={MACHINE_DETAIL_METRIC_VALUE_CLASS}>
+              {runtimeSummary.label}
             </div>
           </div>
           <div className={MACHINE_DETAIL_METRIC_ITEM_CLASS}>
-            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>Worktree root</div>
+            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>
+              Route target
+            </div>
+            <div className={`${MACHINE_DETAIL_METRIC_VALUE_CLASS} break-all`}>
+              {node.is_main
+                ? "local control plane"
+                : (node.grpc_target ?? "encrypted gRPC")}
+            </div>
+          </div>
+          <div className={MACHINE_DETAIL_METRIC_ITEM_CLASS}>
+            <div className={MACHINE_DETAIL_METRIC_LABEL_CLASS}>
+              Worktree root
+            </div>
             <div className={`${MACHINE_DETAIL_METRIC_VALUE_CLASS} break-all`}>
               {node.default_worktree_root ?? "Explicit workdir required"}
             </div>
@@ -470,66 +499,31 @@ export function AgentNodeDetailCard({
       </div>
 
       <div className="grid gap-3 xl:grid-cols-2">
-        <div className={`${MACHINE_DETAIL_SECTION_CLASS} ${showConnectFirst ? "xl:order-2" : ""}`}>
-          <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
-            <div>
-              <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                Info
-              </Text>
-              <Text size="xs" c="dimmed" mt={4}>
-                Stable registry identity and lightweight runtime evidence for this node.
-              </Text>
-            </div>
-          </div>
-          <KeyValueList className="mt-3 grid gap-2">
-            {infoItems.map((item) => (
-              <KeyValueItem
-                key={item.label}
-                label={item.label}
-                value={item.value}
-                labelClassName="text-[10px] uppercase tracking-[0.08em] text-ui-text-muted"
-                valueClassName="text-xs text-ui-text break-all"
-              />
-            ))}
-          </KeyValueList>
-          <div className="mt-3 rounded-lg border border-ui-border/80 bg-white/80 px-3 py-3">
-            <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-              Observed Agent Runtimes
-            </Text>
-            <Text size="xs" c="dimmed" mt={4}>
-              Derived from attached agent commands and known operator-facing runtime surfaces; this is not a host binary probe.
-            </Text>
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {detectedRuntimes.map((runtime) => (
-                <Badge
-                  key={runtime.label}
-                  tone={runtime.available ? "subtle" : "outline"}
-                >
-                  {runtime.label}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        </div>
-
         <div
-          className={`${MACHINE_DETAIL_SECTION_CLASS} ${connectTone} ${showConnectFirst ? "xl:order-1" : ""}`}
+          className={`${MACHINE_DETAIL_SECTION_CLASS} ${connectTone} ${showConnectProminent ? "xl:order-1" : "xl:order-2"}`}
         >
           <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
             <div>
-              <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+              <Text
+                size="xs"
+                fw={700}
+                c="dimmed"
+                className={SECTION_HEADER_CLASS}
+              >
                 Connect Command
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
-                Bootstrap this node from the control plane, or inspect the canonical reconnect
-                contract if you need to wire it into longer-lived infra.
+                Bootstrap this node from the control plane, or inspect the
+                canonical reconnect contract if you need to wire it into
+                longer-lived infra.
               </Text>
             </div>
           </div>
           <div className="mt-3">
             {node.is_main ? (
               <Text size="sm" c="dimmed">
-                The local control plane node does not need a remote bootstrap command.
+                The local control plane node does not need a remote bootstrap
+                command.
               </Text>
             ) : nodeJoinBootstrapLoading ? (
               <Text size="sm" c="dimmed">
@@ -541,13 +535,9 @@ export function AgentNodeDetailCard({
               </Alert>
             ) : connectCommand ? (
               <Stack gap="xs">
-                <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                  Connect Command
-                </Text>
                 <Text size="sm" c="dimmed">
-                  Start the node process with the registered node id, then keep the process
-                  running. The command below only substitutes values this page can derive
-                  canonically.
+                  Start the node process with the registered node id, then keep
+                  the process running.
                 </Text>
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="flex flex-wrap gap-1.5">
@@ -562,11 +552,15 @@ export function AgentNodeDetailCard({
                       </Badge>
                     ))}
                   </div>
-                  <ActionButton tone="secondary" size="sm" onClick={() => void handleCopyConnectCommand()}>
+                  <ActionButton
+                    tone="secondary"
+                    size="sm"
+                    onClick={() => void handleCopyConnectCommand()}
+                  >
                     {copied ? "Copied" : "Copy"}
                   </ActionButton>
                 </div>
-                <pre className="overflow-x-auto rounded-lg border border-ui-border/80 bg-slate-950 px-3 py-3 text-[12px] leading-5 text-slate-50">
+                <pre className="overflow-x-auto rounded-lg border border-ui-border/80 bg-slate-950 px-3 py-3 text-[12px] font-mono leading-5 text-slate-50">
                   {connectCommand.command}
                 </pre>
                 {copyError ? (
@@ -576,12 +570,17 @@ export function AgentNodeDetailCard({
                 ) : null}
                 {!connectCommand.hasBootstrapToken ? (
                   <Text size="xs" c="dimmed">
-                    Bootstrap data is missing from the current API response, so the command keeps an
-                    explicit token placeholder instead of pretending it is fully resolved.
+                    Bootstrap data is missing from the current API response, so
+                    the command keeps an explicit token placeholder.
                   </Text>
                 ) : null}
                 <div className="mt-2 rounded-lg border border-ui-border/80 bg-white/80 px-3 py-3">
-                  <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                  <Text
+                    size="xs"
+                    fw={700}
+                    c="dimmed"
+                    className={SECTION_HEADER_CLASS}
+                  >
                     Connect Config
                   </Text>
                   <KeyValueList className="mt-3 grid gap-2">
@@ -599,10 +598,65 @@ export function AgentNodeDetailCard({
               </Stack>
             ) : (
               <Text size="sm" c="dimmed">
-                Bootstrap token details are not available yet. Load them from the root control
-                plane before starting this node.
+                Bootstrap token details are not available yet.
               </Text>
             )}
+          </div>
+        </div>
+
+        <div
+          className={`${MACHINE_DETAIL_SECTION_CLASS} ${showConnectProminent ? "xl:order-2" : "xl:order-1"}`}
+        >
+          <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
+            <div>
+              <Text
+                size="xs"
+                fw={700}
+                c="dimmed"
+                className={SECTION_HEADER_CLASS}
+              >
+                Info
+              </Text>
+              <Text size="xs" c="dimmed" mt={4}>
+                Stable registry identity and lightweight runtime evidence for
+                this node.
+              </Text>
+            </div>
+          </div>
+          <KeyValueList className="mt-3 grid gap-2">
+            {infoItems.map((item) => (
+              <KeyValueItem
+                key={item.label}
+                label={item.label}
+                value={item.value}
+                labelClassName="text-[10px] uppercase tracking-[0.08em] text-ui-text-muted"
+                valueClassName="text-xs text-ui-text break-all"
+              />
+            ))}
+          </KeyValueList>
+          <div className="mt-3 rounded-lg border border-ui-border/80 bg-white/80 px-3 py-3">
+            <Text
+              size="xs"
+              fw={700}
+              c="dimmed"
+              className={SECTION_HEADER_CLASS}
+            >
+              Observed Agent Runtimes
+            </Text>
+            <Text size="xs" c="dimmed" mt={4}>
+              Derived from attached agent signals; this is not a host binary
+              probe.
+            </Text>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {detectedRuntimes.map((runtime) => (
+                <Badge
+                  key={runtime.label}
+                  tone={runtime.available ? "subtle" : "outline"}
+                >
+                  {runtime.label}
+                </Badge>
+              ))}
+            </div>
           </div>
         </div>
       </div>
@@ -610,11 +664,17 @@ export function AgentNodeDetailCard({
       <div className={MACHINE_DETAIL_SECTION_CLASS}>
         <div className={MACHINE_DETAIL_SECTION_HEADER_CLASS}>
           <div className="min-w-0 flex-1">
-            <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+            <Text
+              size="xs"
+              fw={700}
+              c="dimmed"
+              className={SECTION_HEADER_CLASS}
+            >
               Agents on this node ({agents.length})
             </Text>
             <Text size="xs" c="dimmed" mt={4}>
-              Route new agents here or open an attached agent for deeper runtime inspection.
+              Route new agents here or open an attached agent for deeper runtime
+              inspection.
             </Text>
           </div>
           {onCreateAgent ? (

--- a/web/src/components/agent_nodes_workbench.tsx
+++ b/web/src/components/agent_nodes_workbench.tsx
@@ -43,7 +43,8 @@ const NODE_TEAM_METRIC_ITEM_CLASS =
   "rounded-xl border border-ui-border/70 bg-white/80 px-2.5 py-2 text-left shadow-[0_1px_2px_rgba(15,23,42,0.03)]";
 const NODE_TEAM_METRIC_LABEL_CLASS =
   "text-[10px] font-bold uppercase tracking-[0.08em] text-notion-text-muted/80";
-const NODE_TEAM_METRIC_VALUE_CLASS = "mt-1 text-[13px] font-semibold text-notion-text";
+const NODE_TEAM_METRIC_VALUE_CLASS =
+  "mt-1 text-[13px] font-semibold text-notion-text";
 
 type NodeTeamUsageSummary = {
   teamId: string;
@@ -78,7 +79,7 @@ export function buildNodeEditDraft(node: AgentNodeRecord): NodeEditDraft {
 
 export function buildNodeNameUpdatePayload(
   node: AgentNodeRecord,
-  draft: NodeEditDraft
+  draft: NodeEditDraft,
 ): AgentNodeUpdate | null {
   const grpcTarget = node.grpc_target?.trim() || "";
   if (!grpcTarget) {
@@ -94,7 +95,10 @@ export function buildNodeNameUpdatePayload(
 
 export function buildNodeSettingsUpdatePayload(
   node: AgentNodeRecord,
-  draft: Pick<NodeEditDraft, "grpcTarget" | "tlsServerName" | "defaultWorktreeRoot">
+  draft: Pick<
+    NodeEditDraft,
+    "grpcTarget" | "tlsServerName" | "defaultWorktreeRoot"
+  >,
 ): AgentNodeUpdate {
   return {
     name: node.name.trim(),
@@ -104,7 +108,10 @@ export function buildNodeSettingsUpdatePayload(
   };
 }
 
-function resolveNameUpdateError(node: AgentNodeRecord, draft: NodeEditDraft): string | null {
+function resolveNameUpdateError(
+  node: AgentNodeRecord,
+  draft: NodeEditDraft,
+): string | null {
   if (!draft.name.trim()) {
     return "Node name is required.";
   }
@@ -115,7 +122,7 @@ function resolveNameUpdateError(node: AgentNodeRecord, draft: NodeEditDraft): st
 }
 
 function parseTeamSpecMembers(
-  spec: unknown
+  spec: unknown,
 ): Array<{ memberId: string; role: string | null }> {
   if (!spec || typeof spec !== "object") {
     return [];
@@ -131,7 +138,8 @@ function parseTeamSpecMembers(
       }
       const memberId = (member as { member_id?: unknown }).member_id;
       const role = (member as { role?: unknown }).role;
-      const normalizedMemberId = typeof memberId === "string" ? memberId.trim() : "";
+      const normalizedMemberId =
+        typeof memberId === "string" ? memberId.trim() : "";
       if (!normalizedMemberId) {
         return null;
       }
@@ -140,8 +148,8 @@ function parseTeamSpecMembers(
         role: typeof role === "string" ? role.trim() || null : null,
       };
     })
-    .filter(
-      (member): member is { memberId: string; role: string | null } => Boolean(member)
+    .filter((member): member is { memberId: string; role: string | null } =>
+      Boolean(member),
     );
 }
 
@@ -153,7 +161,7 @@ function deriveNodeTeamUsageSummaries(
   teams: TeamDefinitionRecord[],
   agents: AgentRecord[],
   fallbackAgentsById: Record<string, AgentRecord | null>,
-  nodeId: string
+  nodeId: string,
 ): NodeTeamUsageSummary[] {
   const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
   for (const [memberId, agent] of Object.entries(fallbackAgentsById)) {
@@ -177,12 +185,12 @@ function deriveNodeTeamUsageSummaries(
         })
         .filter(
           (
-            member
+            member,
           ): member is {
             memberId: string;
             label: string;
             role: string | null;
-          } => Boolean(member)
+          } => Boolean(member),
         );
       if (matchedMembers.length === 0) {
         return null;
@@ -209,7 +217,7 @@ function deriveNodeTeamUsageSummaries(
 
 function handleInAppLinkClick(
   event: React.MouseEvent<HTMLAnchorElement>,
-  pathname: string
+  pathname: string,
 ): void {
   if (!shouldHandleInAppLinkClick(event)) {
     return;
@@ -218,12 +226,211 @@ function handleInAppLinkClick(
   navigateToPath(pathname);
 }
 
+type RemoteNodeEditorProps = {
+  node: AgentNodeRecord;
+  draft: NodeEditDraft;
+  updating: boolean;
+  onDraftChange: (draft: NodeEditDraft) => void;
+  onSaveName: (draft: NodeEditDraft) => void;
+  onSaveSettings: (
+    draft: Pick<
+      NodeEditDraft,
+      "grpcTarget" | "tlsServerName" | "defaultWorktreeRoot"
+    >,
+  ) => void;
+};
+
+function RemoteNodeNameEditor({
+  node,
+  draft,
+  updating,
+  onDraftChange,
+  onSaveName,
+}: Pick<
+  RemoteNodeEditorProps,
+  "node" | "draft" | "updating" | "onDraftChange" | "onSaveName"
+>) {
+  const nameError = resolveNameUpdateError(node, draft);
+  return (
+    <div className={SECTION_CARD_CLASS}>
+      <Stack gap="sm">
+        <div>
+          <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+            Rename Node
+          </Text>
+          <Text size="sm" c="dimmed" mt={4}>
+            Update the operator-facing display name for this remote node.
+          </Text>
+        </div>
+        <TextInput
+          label="Display name"
+          value={draft.name}
+          onChange={(event) =>
+            onDraftChange({ ...draft, name: event.currentTarget.value })
+          }
+        />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Text size="xs" c={nameError ? "red" : "dimmed"}>
+            {nameError ??
+              "This name is used in rosters and team attachment maps."}
+          </Text>
+          <Button
+            variant="light"
+            size="xs"
+            loading={updating}
+            disabled={updating || nameError !== null}
+            onClick={() => onSaveName(draft)}
+          >
+            Save Name
+          </Button>
+        </div>
+      </Stack>
+    </div>
+  );
+}
+
+function RemoteNodeSettingsEditor({
+  node,
+  draft,
+  updating,
+  onDraftChange,
+  onSaveSettings,
+}: Pick<
+  RemoteNodeEditorProps,
+  "node" | "draft" | "updating" | "onDraftChange" | "onSaveSettings"
+>) {
+  const updateError = validateAgentNodeUpdateDraft({
+    nodeName: node.name,
+    grpcTarget: draft.grpcTarget,
+  });
+  return (
+    <div className={SECTION_CARD_CLASS}>
+      <Stack gap="sm">
+        <div>
+          <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+            Routing & Infrastructure
+          </Text>
+          <Text size="sm" c="dimmed" mt={4}>
+            Update the technical connectivity parameters for this remote host.
+          </Text>
+        </div>
+        <TextInput
+          label="gRPC target"
+          description="Host and port for remote execution, such as 10.0.1.5:50051."
+          value={draft.grpcTarget}
+          onChange={(event) =>
+            onDraftChange({ ...draft, grpcTarget: event.currentTarget.value })
+          }
+        />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <TextInput
+            label="TLS server name"
+            description="Used for certificate verification."
+            value={draft.tlsServerName}
+            onChange={(event) =>
+              onDraftChange({
+                ...draft,
+                tlsServerName: event.currentTarget.value,
+              })
+            }
+          />
+          <TextInput
+            label="Default worktree root"
+            description="Remote filesystem base path."
+            placeholder="Optional"
+            value={draft.defaultWorktreeRoot}
+            onChange={(event) =>
+              onDraftChange({
+                ...draft,
+                defaultWorktreeRoot: event.currentTarget.value,
+              })
+            }
+          />
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Text size="xs" c={updateError ? "red" : "dimmed"}>
+            {updateError ??
+              "Leave Default worktree root blank to require explicit workdir."}
+          </Text>
+          <Button
+            variant="light"
+            size="xs"
+            loading={updating}
+            disabled={updating || updateError !== null}
+            onClick={() =>
+              onSaveSettings({
+                grpcTarget: draft.grpcTarget,
+                tlsServerName: draft.tlsServerName,
+                defaultWorktreeRoot: draft.defaultWorktreeRoot,
+              })
+            }
+          >
+            Save Settings
+          </Button>
+        </div>
+      </Stack>
+    </div>
+  );
+}
+
+function RemoteNodeDangerZone({
+  attachedAgentCount,
+  deleting,
+  onDelete,
+}: {
+  attachedAgentCount: number;
+  deleting: boolean;
+  onDelete: () => void;
+}) {
+  const hasAttachedAgents = attachedAgentCount > 0;
+  return (
+    <div className="rounded-xl border border-red-100 bg-red-50/40 p-4">
+      <Stack gap="sm">
+        <Text size="xs" fw={700} c="red" className={SECTION_HEADER_CLASS}>
+          Danger Zone
+        </Text>
+        <Text size="xs" c={hasAttachedAgents ? "red" : "dimmed"}>
+          {hasAttachedAgents
+            ? `This node still has ${attachedAgentCount} attached agent${
+                attachedAgentCount === 1 ? "" : "s"
+              }.`
+            : "No attached agents remain on this node."}
+        </Text>
+        <Button
+          color="red"
+          variant="light"
+          size="xs"
+          loading={deleting}
+          disabled={deleting || hasAttachedAgents}
+          onClick={onDelete}
+        >
+          Delete Node
+        </Button>
+      </Stack>
+    </div>
+  );
+}
+
 function buildTeamMemberAcpPath(teamId: string, memberId: string): string {
-  return buildTeamWorkspacePath(teamId, "members", null, null, memberId, "agent_acp");
+  return buildTeamWorkspacePath(
+    teamId,
+    "members",
+    null,
+    null,
+    memberId,
+    "agent_acp",
+  );
 }
 
 function buildTeamMemberConsolePath(teamId: string, memberId: string): string {
-  return buildTeamWorkspacePath(teamId, "members", null, null, memberId, "member_console");
+  return buildTeamWorkspacePath(
+    teamId,
+    "members",
+    null,
+    null,
+    memberId,
+    "member_console",
+  );
 }
 
 type AgentNodesWorkbenchProps = {
@@ -261,7 +468,10 @@ export function AgentNodesWorkbench({
   onUpdateNode,
   onDeleteNode,
 }: AgentNodesWorkbenchProps) {
-  const availableNodes = React.useMemo(() => resolveAvailableNodes(nodes), [nodes]);
+  const availableNodes = React.useMemo(
+    () => resolveAvailableNodes(nodes),
+    [nodes],
+  );
   const agentsByNodeId = React.useMemo(() => {
     const buckets = new Map<string, AgentRecord[]>();
     for (const agent of agents) {
@@ -277,7 +487,12 @@ export function AgentNodesWorkbench({
     for (const node of availableNodes) {
       summaries.set(
         node.id,
-        deriveNodeTeamUsageSummaries(teams, agents, teamMemberAgentsById, node.id)
+        deriveNodeTeamUsageSummaries(
+          teams,
+          agents,
+          teamMemberAgentsById,
+          node.id,
+        ),
       );
     }
     return summaries;
@@ -289,28 +504,33 @@ export function AgentNodesWorkbench({
     "";
   const selectedNode =
     availableNodes.find((node) => node.id === effectiveSelectedNodeId) ?? null;
-  const selectedNodeAgents = selectedNode ? (agentsByNodeId.get(selectedNode.id) ?? []) : [];
+  const selectedNodeAgents = selectedNode
+    ? (agentsByNodeId.get(selectedNode.id) ?? [])
+    : [];
   const selectedNodeTeams = React.useMemo(
     () => (selectedNode ? (teamUsageByNodeId.get(selectedNode.id) ?? []) : []),
-    [selectedNode, teamUsageByNodeId]
+    [selectedNode, teamUsageByNodeId],
   );
   const selectedNodeTeamMemberCount = selectedNodeTeams.reduce(
     (sum, team) => sum + team.matchedMembers.length,
-    0
+    0,
   );
   const selectedNodeActiveTeamAgentCount = selectedNodeTeams.reduce(
     (sum, team) => sum + team.activeAgentCount,
-    0
+    0,
   );
   const selectedNodeCoordinatorCount = selectedNodeTeams.reduce(
     (sum, team) =>
-      sum + team.matchedMembers.filter((member) => member.role === "coordinator").length,
-    0
+      sum +
+      team.matchedMembers.filter((member) => member.role === "coordinator")
+        .length,
+    0,
   );
   const selectedNodeWorkerCount = selectedNodeTeams.reduce(
     (sum, team) =>
-      sum + team.matchedMembers.filter((member) => member.role === "worker").length,
-    0
+      sum +
+      team.matchedMembers.filter((member) => member.role === "worker").length,
+    0,
   );
   const [editDrafts, setEditDrafts] = React.useState<
     Record<string, NodeEditDraft>
@@ -341,7 +561,7 @@ export function AgentNodesWorkbench({
       }
       onUpdateNode?.(nodeId, payload);
     },
-    [availableNodes, onUpdateNode]
+    [availableNodes, onUpdateNode],
   );
 
   const handleSaveNodeSettings = React.useCallback(
@@ -351,7 +571,7 @@ export function AgentNodesWorkbench({
         grpcTarget: string;
         tlsServerName: string;
         defaultWorktreeRoot: string;
-      }
+      },
     ) => {
       const node = availableNodes.find((candidate) => candidate.id === nodeId);
       if (!node) {
@@ -359,7 +579,7 @@ export function AgentNodesWorkbench({
       }
       onUpdateNode?.(nodeId, buildNodeSettingsUpdatePayload(node, draft));
     },
-    [availableNodes, onUpdateNode]
+    [availableNodes, onUpdateNode],
   );
 
   if (!selectedNode) {
@@ -382,8 +602,8 @@ export function AgentNodesWorkbench({
             Node Detail
           </Text>
           <Text size="sm" c="dimmed" mt={4}>
-            Inspect node routing metadata, copy the connect command, and trace which teams currently
-            depend on this global node.
+            Inspect node routing metadata, copy the connect command, and trace
+            which teams currently depend on this global node.
           </Text>
         </div>
 
@@ -397,7 +617,12 @@ export function AgentNodesWorkbench({
               data-node-roster="true"
             >
               <Stack gap="xs">
-                <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                <Text
+                  size="xs"
+                  fw={700}
+                  c="dimmed"
+                  className={SECTION_HEADER_CLASS}
+                >
                   Nodes
                 </Text>
                 <Text size="xs" c="dimmed">
@@ -424,13 +649,18 @@ export function AgentNodesWorkbench({
                             <Text size="sm" fw={600}>
                               {node.name}
                             </Text>
-                            <Badge tone={node.is_main ? "subtle" : "outline"} className="uppercase">
+                            <Badge
+                              tone={node.is_main ? "subtle" : "outline"}
+                              className="uppercase"
+                            >
                               {resolveNodeRoleLabel(node)}
                             </Badge>
                           </div>
                           <Text size="xs" c="dimmed" mt={4}>
-                            {nodeAgents.length} agent{nodeAgents.length === 1 ? "" : "s"} ·{" "}
-                            {nodeTeams.length} team{nodeTeams.length === 1 ? "" : "s"}
+                            {nodeAgents.length} agent
+                            {nodeAgents.length === 1 ? "" : "s"} ·{" "}
+                            {nodeTeams.length} team
+                            {nodeTeams.length === 1 ? "" : "s"}
                           </Text>
                         </div>
                       </div>
@@ -456,7 +686,12 @@ export function AgentNodesWorkbench({
                 <div className={SECTION_CARD_CLASS}>
                   <Stack gap="sm">
                     <div>
-                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                      <Text
+                        size="xs"
+                        fw={700}
+                        c="dimmed"
+                        className={SECTION_HEADER_CLASS}
+                      >
                         Name
                       </Text>
                       <Text size="sm" c="dimmed" mt={6}>
@@ -468,196 +703,72 @@ export function AgentNodesWorkbench({
                         {selectedNode.name}
                       </Text>
                       <Text size="xs" c="dimmed" mt={6}>
-                        The local control-plane node name is currently read only from this surface.
+                        The local control-plane node name is currently read only
+                        from this surface.
                       </Text>
                     </div>
                   </Stack>
                 </div>
                 <div className={SECTION_CARD_CLASS}>
-                  <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                  <Text
+                    size="xs"
+                    fw={700}
+                    c="dimmed"
+                    className={SECTION_HEADER_CLASS}
+                  >
                     Danger Zone
                   </Text>
                   <Text size="sm" c="dimmed" mt={8}>
-                    The local control-plane node cannot be deleted or re-pointed from this surface.
+                    The local control-plane node cannot be deleted or re-pointed
+                    from this surface.
                   </Text>
                 </div>
               </>
             ) : (
               <div className="space-y-4">
-                <div className={SECTION_CARD_CLASS}>
-                  <Stack gap="sm">
-                    <div>
-                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                        Name
-                      </Text>
-                      <Text size="sm" c="dimmed" mt={6}>
-                        Keep the node display name visible and editable as a first-class object field.
-                      </Text>
-                    </div>
-                    {(() => {
-                      const draft = editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
-                      const nameError = resolveNameUpdateError(selectedNode, draft);
-                      return (
-                        <>
-                          <TextInput
-                            label="Node name"
-                            value={draft.name}
-                            onChange={(event) =>
-                              setEditDrafts((prev) => ({
-                                ...prev,
-                                [selectedNode.id]: {
-                                  ...draft,
-                                  name: event.currentTarget.value,
-                                },
-                              }))
-                            }
-                          />
-                          <div className="flex flex-wrap items-center justify-between gap-3">
-                            <Text size="xs" c={nameError ? "red" : "dimmed"}>
-                              {nameError ??
-                                "This is the canonical operator-facing name shown in global node rosters and detail pages."}
-                            </Text>
-                            <Button
-                              variant="light"
-                              size="xs"
-                              loading={Boolean(updatingNodeIds[selectedNode.id])}
-                              disabled={
-                                Boolean(updatingNodeIds[selectedNode.id]) || nameError !== null
-                              }
-                              onClick={() => handleSaveNodeName(selectedNode.id, draft)}
-                            >
-                              Save Name
-                            </Button>
-                          </div>
-                        </>
-                      );
-                    })()}
-                  </Stack>
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+                  <RemoteNodeNameEditor
+                    node={selectedNode}
+                    draft={
+                      editDrafts[selectedNode.id] ??
+                      buildNodeEditDraft(selectedNode)
+                    }
+                    updating={Boolean(updatingNodeIds[selectedNode.id])}
+                    onDraftChange={(draft) =>
+                      setEditDrafts((prev) => ({
+                        ...prev,
+                        [selectedNode.id]: draft,
+                      }))
+                    }
+                    onSaveName={(draft) =>
+                      handleSaveNodeName(selectedNode.id, draft)
+                    }
+                  />
+
+                  <RemoteNodeDangerZone
+                    attachedAgentCount={selectedNodeAgents.length}
+                    deleting={Boolean(deletingNodeIds[selectedNode.id])}
+                    onDelete={() => onDeleteNode?.(selectedNode.id)}
+                  />
                 </div>
 
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-                  <div className={SECTION_CARD_CLASS}>
-                    <Stack gap="sm">
-                      <div>
-                        <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
-                          Settings
-                        </Text>
-                        <Text size="sm" c="dimmed" mt={6}>
-                          Update routing and default worktree behavior for this node without mixing
-                          in the object name field.
-                        </Text>
-                      </div>
-                      {(() => {
-                        const draft =
-                          editDrafts[selectedNode.id] ?? buildNodeEditDraft(selectedNode);
-                        const updateError = validateAgentNodeUpdateDraft({
-                          nodeName: selectedNode.name,
-                          grpcTarget: draft.grpcTarget,
-                        });
-                        return (
-                          <>
-                            <TextInput
-                              label="gRPC target"
-                              value={draft.grpcTarget}
-                              onChange={(event) =>
-                                setEditDrafts((prev) => ({
-                                  ...prev,
-                                  [selectedNode.id]: {
-                                    ...draft,
-                                    grpcTarget: event.currentTarget.value,
-                                  },
-                                }))
-                              }
-                            />
-                            <div className="grid gap-3 lg:grid-cols-2">
-                              <TextInput
-                                label="TLS server name"
-                                value={draft.tlsServerName}
-                                onChange={(event) =>
-                                  setEditDrafts((prev) => ({
-                                    ...prev,
-                                    [selectedNode.id]: {
-                                      ...draft,
-                                      tlsServerName: event.currentTarget.value,
-                                    },
-                                  }))
-                                }
-                              />
-                              <TextInput
-                                label="Default worktree root"
-                                placeholder="Optional"
-                                value={draft.defaultWorktreeRoot}
-                                onChange={(event) =>
-                                  setEditDrafts((prev) => ({
-                                    ...prev,
-                                    [selectedNode.id]: {
-                                      ...draft,
-                                      defaultWorktreeRoot: event.currentTarget.value,
-                                    },
-                                  }))
-                                }
-                              />
-                            </div>
-                            <div className="flex flex-wrap items-center justify-between gap-3">
-                              <Text size="xs" c={updateError ? "red" : "dimmed"}>
-                                {updateError ??
-                                  "Leave Default worktree root blank to require explicit remote workdir."}
-                              </Text>
-                              <Button
-                                variant="light"
-                                size="xs"
-                                loading={Boolean(updatingNodeIds[selectedNode.id])}
-                                disabled={
-                                  Boolean(updatingNodeIds[selectedNode.id]) ||
-                                  updateError !== null
-                                }
-                                onClick={() =>
-                                  handleSaveNodeSettings(selectedNode.id, {
-                                    grpcTarget: draft.grpcTarget,
-                                    tlsServerName: draft.tlsServerName,
-                                    defaultWorktreeRoot: draft.defaultWorktreeRoot,
-                                  })
-                                }
-                              >
-                                Save Settings
-                              </Button>
-                            </div>
-                          </>
-                        );
-                      })()}
-                    </Stack>
-                  </div>
-
-                  <div className="rounded-xl border border-red-200 bg-red-50/70 px-4 py-4">
-                    <Stack gap="sm">
-                      <div>
-                        <Text size="xs" fw={700} c="red" className={SECTION_HEADER_CLASS}>
-                          Danger Zone
-                        </Text>
-                        <Text size="sm" c="dimmed" mt={6}>
-                          Delete this node only after its attached agents have been removed or rerouted.
-                        </Text>
-                      </div>
-                      <Text size="xs" c={selectedNodeAgents.length > 0 ? "red" : "dimmed"}>
-                        {selectedNodeAgents.length > 0
-                          ? `This node still has ${selectedNodeAgents.length} attached agent${selectedNodeAgents.length === 1 ? "" : "s"}.`
-                          : "No attached agents remain on this node."}
-                      </Text>
-                      <Button
-                        color="red"
-                        variant="light"
-                        size="xs"
-                        loading={Boolean(deletingNodeIds[selectedNode.id])}
-                        disabled={
-                          Boolean(deletingNodeIds[selectedNode.id]) || selectedNodeAgents.length > 0
-                        }
-                        onClick={() => onDeleteNode?.(selectedNode.id)}
-                      >
-                        Delete Node
-                      </Button>
-                    </Stack>
-                  </div>
-                </div>
+                <RemoteNodeSettingsEditor
+                  node={selectedNode}
+                  draft={
+                    editDrafts[selectedNode.id] ??
+                    buildNodeEditDraft(selectedNode)
+                  }
+                  updating={Boolean(updatingNodeIds[selectedNode.id])}
+                  onDraftChange={(draft) =>
+                    setEditDrafts((prev) => ({
+                      ...prev,
+                      [selectedNode.id]: draft,
+                    }))
+                  }
+                  onSaveSettings={(draft) =>
+                    handleSaveNodeSettings(selectedNode.id, draft)
+                  }
+                />
               </div>
             )}
           </div>
@@ -669,10 +780,18 @@ export function AgentNodesWorkbench({
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <div className="inline-flex h-8 w-8 items-center justify-center rounded-2xl border border-ui-border/70 bg-white/85 text-notion-text-muted shadow-notion-row">
-                    <i className="bi bi-diagram-3 text-[13px]" aria-hidden="true" />
+                    <i
+                      className="bi bi-diagram-3 text-[13px]"
+                      aria-hidden="true"
+                    />
                   </div>
                   <div>
-                    <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                    <Text
+                      size="xs"
+                      fw={700}
+                      c="dimmed"
+                      className={SECTION_HEADER_CLASS}
+                    >
                       Teams Using This Node
                     </Text>
                     <Text size="sm" fw={600} mt={2}>
@@ -683,7 +802,8 @@ export function AgentNodesWorkbench({
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <Badge tone="outline">
-                  {selectedNodeTeams.length} team{selectedNodeTeams.length === 1 ? "" : "s"}
+                  {selectedNodeTeams.length} team
+                  {selectedNodeTeams.length === 1 ? "" : "s"}
                 </Badge>
                 <Badge tone="outline">
                   {pluralize(selectedNodeTeamMemberCount, "member")}
@@ -694,8 +814,9 @@ export function AgentNodesWorkbench({
               </div>
             </div>
             <Text size="sm" c="dimmed" mt={10}>
-              Because nodes are global resources, this section shows which teams currently land
-              members on the selected node rather than treating node usage as team-local state.
+              Because nodes are global resources, this section shows which teams
+              currently land members on the selected node rather than treating
+              node usage as team-local state.
             </Text>
             <div
               className="mt-3 grid gap-2 min-[420px]:grid-cols-2 sm:grid-cols-4"
@@ -703,11 +824,15 @@ export function AgentNodesWorkbench({
             >
               <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
                 <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Teams</div>
-                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>{selectedNodeTeams.length}</div>
+                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
+                  {selectedNodeTeams.length}
+                </div>
               </div>
               <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
                 <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Members</div>
-                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>{selectedNodeTeamMemberCount}</div>
+                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
+                  {selectedNodeTeamMemberCount}
+                </div>
               </div>
               <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
                 <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Coordinators</div>
@@ -717,7 +842,9 @@ export function AgentNodesWorkbench({
               </div>
               <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
                 <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Workers</div>
-                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>{selectedNodeWorkerCount}</div>
+                <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
+                  {selectedNodeWorkerCount}
+                </div>
               </div>
             </div>
           </div>
@@ -733,7 +860,10 @@ export function AgentNodesWorkbench({
                           className={NODE_TEAM_LINK_CLASS}
                           title={`Open team detail for ${team.teamName}`}
                           onClick={(event) =>
-                            handleInAppLinkClick(event, buildTeamDetailPath(team.teamId))
+                            handleInAppLinkClick(
+                              event,
+                              buildTeamDetailPath(team.teamId),
+                            )
                           }
                         >
                           <Text size="sm" fw={700} span inherit>
@@ -743,7 +873,9 @@ export function AgentNodesWorkbench({
                         <Badge tone="outline">
                           {pluralize(team.matchedMembers.length, "member")}
                         </Badge>
-                        <Badge tone="subtle">{team.activeAgentCount} active</Badge>
+                        <Badge tone="subtle">
+                          {team.activeAgentCount} active
+                        </Badge>
                       </div>
                       <Text size="xs" c="dimmed" mt={4}>
                         <a
@@ -751,7 +883,10 @@ export function AgentNodesWorkbench({
                           className={NODE_TEAM_LINK_CLASS}
                           title={`Open team detail for ${team.teamId}`}
                           onClick={(event) =>
-                            handleInAppLinkClick(event, buildTeamDetailPath(team.teamId))
+                            handleInAppLinkClick(
+                              event,
+                              buildTeamDetailPath(team.teamId),
+                            )
                           }
                         >
                           {`team_id=${team.teamId}`}
@@ -760,49 +895,76 @@ export function AgentNodesWorkbench({
                     </div>
                     <div className="grid min-w-0 w-full gap-2 min-[420px]:grid-cols-2 sm:max-w-[280px] sm:grid-cols-3">
                       <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
-                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Members</div>
+                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>
+                          Members
+                        </div>
                         <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
                           {team.matchedMembers.length}
                         </div>
                       </div>
                       <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
-                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Coordinators</div>
+                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>
+                          Coordinators
+                        </div>
                         <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
-                          {team.matchedMembers.filter((member) => member.role === "coordinator").length}
+                          {
+                            team.matchedMembers.filter(
+                              (member) => member.role === "coordinator",
+                            ).length
+                          }
                         </div>
                       </div>
                       <div className={NODE_TEAM_METRIC_ITEM_CLASS}>
-                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>Workers</div>
+                        <div className={NODE_TEAM_METRIC_LABEL_CLASS}>
+                          Workers
+                        </div>
                         <div className={NODE_TEAM_METRIC_VALUE_CLASS}>
-                          {team.matchedMembers.filter((member) => member.role === "worker").length}
+                          {
+                            team.matchedMembers.filter(
+                              (member) => member.role === "worker",
+                            ).length
+                          }
                         </div>
                       </div>
                     </div>
                   </div>
                   <div className="mt-3 border-t border-ui-border/60 pt-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <Text size="xs" fw={700} c="dimmed" className={SECTION_HEADER_CLASS}>
+                      <Text
+                        size="xs"
+                        fw={700}
+                        c="dimmed"
+                        className={SECTION_HEADER_CLASS}
+                      >
                         Member Runtime Drill-down
                       </Text>
                       <Text size="xs" c="dimmed">
-                        Jump straight into the thread or console without re-finding the member inside the
-                        team shell.
+                        Jump straight into the thread or console without
+                        re-finding the member inside the team shell.
                       </Text>
                     </div>
                     <div className="mt-2 grid gap-2 lg:grid-cols-2">
                       {team.matchedMembers.map((member) => {
-                        const acpPath = buildTeamMemberAcpPath(team.teamId, member.memberId);
+                        const acpPath = buildTeamMemberAcpPath(
+                          team.teamId,
+                          member.memberId,
+                        );
                         const consolePath = buildTeamMemberConsolePath(
                           team.teamId,
-                          member.memberId
+                          member.memberId,
                         );
                         return (
-                          <div key={member.memberId} className={NODE_MEMBER_DRILLDOWN_CLASS}>
+                          <div
+                            key={member.memberId}
+                            className={NODE_MEMBER_DRILLDOWN_CLASS}
+                          >
                             <a
                               href={acpPath}
                               className="min-w-0 flex-1 truncate text-notion-text no-underline"
                               title={`Open thread for ${member.label}`}
-                              onClick={(event) => handleInAppLinkClick(event, acpPath)}
+                              onClick={(event) =>
+                                handleInAppLinkClick(event, acpPath)
+                              }
                             >
                               {member.label}
                               {member.role ? ` · ${member.role}` : ""}
@@ -812,7 +974,9 @@ export function AgentNodesWorkbench({
                                 href={acpPath}
                                 className={NODE_MEMBER_ACTION_CLASS}
                                 title={`Open member thread for ${member.label}`}
-                                onClick={(event) => handleInAppLinkClick(event, acpPath)}
+                                onClick={(event) =>
+                                  handleInAppLinkClick(event, acpPath)
+                                }
                               >
                                 Thread
                               </a>
@@ -820,7 +984,9 @@ export function AgentNodesWorkbench({
                                 href={consolePath}
                                 className={NODE_MEMBER_ACTION_CLASS}
                                 title={`Open member console for ${member.label}`}
-                                onClick={(event) => handleInAppLinkClick(event, consolePath)}
+                                onClick={(event) =>
+                                  handleInAppLinkClick(event, consolePath)
+                                }
                               >
                                 Console
                               </a>


### PR DESCRIPTION
## Summary

- keep the node detail connect-command config block visible after the layout cleanup
- only promote the connect-command card for offline or degraded remote nodes
- extract remote node rename, routing settings, and danger-zone controls into focused local components
- preserve the main-node read-only name and delete-boundary messaging

## Purpose

This keeps the Agent Nodes detail surface reviewable while avoiding regressions in operator-facing node bootstrap and deletion context.

## Related Issues

N/A

## Testing

- `npm --prefix web run test -- src/components/agent_nodes_workbench.test.tsx`
- `npm exec tsc -- --noEmit` from `web/`
- `npm --prefix web run build`
- `npm --prefix web run lint`
- `git diff --check`
