### PR TITLE
fix(web): complete team lens hook deps

### DIFF
--- a/web/src/pages/team/use_team_workspace_view_model.ts
+++ b/web/src/pages/team/use_team_workspace_view_model.ts
@@ -559,6 +559,7 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
     },
     [
       isCompactWorkbench,
+      navigateToTeamDetail,
       navigateToTeamLens,
       selectedChannelId,
       selectedConversationRouteTaskId,


### PR DESCRIPTION
## Summary

- Add the missing `navigateToTeamDetail` dependency to the Team workspace lens callback.

## Purpose

This closes the remaining React hooks lint warning in the Team workspace view-model path after the route-state cleanup work. The callback already calls `navigateToTeamDetail` when switching to the Teams lens, so the dependency array should reflect that runtime input.

## Related Issues

- No linked issue.

## Testing

```bash
npm --prefix web run lint
cd web && npm exec tsc -- --noEmit
npm --prefix web run test -- src/pages/team/use_team_workspace_view_model.test.tsx
npm --prefix web run build
```

Note: local dependency installation used `npm --prefix web ci --legacy-peer-deps` because current `main` has `@mantine/hooks@9.2.0` while `@mantine/core@9.1.1` remains pending in #596.
