### PR TITLE
fix(web): refresh pending member acp sessions

### DIFF
--- a/web/src/pages/team/use_team_member_acp_session_discovery.test.tsx
+++ b/web/src/pages/team/use_team_member_acp_session_discovery.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS,
+  useTeamMemberAcpSessionDiscovery,
+} from "./use_team_member_acp_session_discovery";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookParams = Parameters<typeof useTeamMemberAcpSessionDiscovery>[0];
+
+function HookHarness({ params }: { params: HookParams }) {
+  useTeamMemberAcpSessionDiscovery(params);
+  return null;
+}
+
+function createParams(overrides: Partial<HookParams> = {}): HookParams {
+  return {
+    activeRunId: "run-1",
+    tab: "agent_acp",
+    selectedMemberId: "worker-1",
+    selectedSessionId: null,
+    snapshotStatus: "working",
+    agentStatus: "running",
+    runtimeSessionStatus: null,
+    runtimeAgentStatus: null,
+    refreshSnapshot: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("useTeamMemberAcpSessionDiscovery", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes immediately and then polls while an active ACP member has no session id", async () => {
+    const refreshSnapshot = vi.fn().mockResolvedValue(undefined);
+    const params = createParams({ refreshSnapshot });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(refreshSnapshot).toHaveBeenCalledTimes(1);
+    expect(refreshSnapshot).toHaveBeenLastCalledWith("run-1");
+
+    await act(async () => {
+      vi.advanceTimersByTime(TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS);
+      await Promise.resolve();
+    });
+
+    expect(refreshSnapshot).toHaveBeenCalledTimes(2);
+    expect(refreshSnapshot).toHaveBeenLastCalledWith("run-1");
+  });
+
+  it("stops polling once a selected session id appears", async () => {
+    const refreshSnapshot = vi.fn().mockResolvedValue(undefined);
+    const params = createParams({ refreshSnapshot });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(refreshSnapshot).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.render(
+        <HookHarness
+          params={{
+            ...params,
+            selectedSessionId: "session-1",
+          }}
+        />
+      );
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS * 2);
+      await Promise.resolve();
+    });
+
+    expect(refreshSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh outside ACP session tabs or for stopped runtime state", async () => {
+    const refreshSnapshot = vi.fn().mockResolvedValue(undefined);
+
+    act(() => {
+      root.render(
+        <HookHarness
+          params={createParams({
+            refreshSnapshot,
+            tab: "mailbox",
+          })}
+        />
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(refreshSnapshot).not.toHaveBeenCalled();
+
+    act(() => {
+      root.render(
+        <HookHarness
+          params={createParams({
+            refreshSnapshot,
+            snapshotStatus: "stopped",
+            agentStatus: "stopped",
+          })}
+        />
+      );
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS);
+      await Promise.resolve();
+    });
+
+    expect(refreshSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/team/use_team_member_acp_session_discovery.ts
+++ b/web/src/pages/team/use_team_member_acp_session_discovery.ts
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { isAgentActiveStatus } from "../../agent_ws";
+import type { TeamTab } from "./state";
+
+const TEAM_AGENT_ACP_SESSION_TABS = new Set<TeamTab>(["agent_acp", "member_console"]);
+const ACTIVE_MEMBER_RUNTIME_STATUSES = new Set([
+  "idle",
+  "running",
+  "working",
+  "submitted",
+  "input_required",
+  "pending",
+]);
+
+export const TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS = 2000;
+
+function isActiveMemberRuntimeStatus(status?: string | null): boolean {
+  return ACTIVE_MEMBER_RUNTIME_STATUSES.has(status?.trim().toLowerCase() ?? "");
+}
+
+export function shouldRefreshSelectedAgentWorkspaceSession(args: {
+  activeRunId: string | null | undefined;
+  tab: TeamTab;
+  selectedMemberId: string | null | undefined;
+  selectedSessionId: string | null | undefined;
+  snapshotStatus?: string | null;
+  agentStatus?: string | null;
+  runtimeSessionStatus?: string | null;
+  runtimeAgentStatus?: string | null;
+}): boolean {
+  if (!args.activeRunId?.trim()) {
+    return false;
+  }
+  if (!TEAM_AGENT_ACP_SESSION_TABS.has(args.tab)) {
+    return false;
+  }
+  if (!args.selectedMemberId?.trim()) {
+    return false;
+  }
+  if (args.selectedSessionId?.trim()) {
+    return false;
+  }
+  const runtimeSessionStatus = args.runtimeSessionStatus?.trim().toLowerCase() ?? "";
+  if (runtimeSessionStatus && !isActiveMemberRuntimeStatus(runtimeSessionStatus)) {
+    return false;
+  }
+  const runtimeAgentStatus = args.runtimeAgentStatus?.trim().toLowerCase() ?? "";
+  if (runtimeAgentStatus && !isActiveMemberRuntimeStatus(runtimeAgentStatus)) {
+    return false;
+  }
+  return (
+    isActiveMemberRuntimeStatus(args.snapshotStatus) ||
+    isActiveMemberRuntimeStatus(runtimeAgentStatus) ||
+    (!args.snapshotStatus?.trim() &&
+      (isActiveMemberRuntimeStatus(args.agentStatus) ||
+        isAgentActiveStatus(args.agentStatus ?? null)))
+  );
+}
+
+type UseTeamMemberAcpSessionDiscoveryOptions = Parameters<
+  typeof shouldRefreshSelectedAgentWorkspaceSession
+>[0] & {
+  refreshSnapshot: (runId: string) => Promise<unknown>;
+};
+
+export function useTeamMemberAcpSessionDiscovery({
+  activeRunId,
+  refreshSnapshot,
+  ...args
+}: UseTeamMemberAcpSessionDiscoveryOptions) {
+  const shouldDiscoverSelectedAgentWorkspaceSession =
+    shouldRefreshSelectedAgentWorkspaceSession({
+      ...args,
+      activeRunId,
+    });
+
+  useEffect(() => {
+    const runId = activeRunId?.trim() ?? "";
+    if (!shouldDiscoverSelectedAgentWorkspaceSession || !runId) {
+      return;
+    }
+    let cancelled = false;
+    const refreshSelectedMemberSession = () => {
+      if (cancelled) {
+        return;
+      }
+      void refreshSnapshot(runId).catch(() => undefined);
+    };
+    refreshSelectedMemberSession();
+    const timer = window.setInterval(
+      refreshSelectedMemberSession,
+      TEAM_MEMBER_ACP_SESSION_DISCOVERY_INTERVAL_MS
+    );
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [
+    activeRunId,
+    refreshSnapshot,
+    shouldDiscoverSelectedAgentWorkspaceSession,
+  ]);
+}

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -20,6 +20,7 @@ import {
   validateRunInputJson,
 } from "./team_page";
 import { isCurrentTeamScopedRequest } from "./team/page_helpers";
+import { shouldRefreshSelectedAgentWorkspaceSession } from "./team/use_team_member_acp_session_discovery";
 
 describe("team_page helpers", () => {
   it("parses agent session mismatch payloads and rejects malformed messages", () => {
@@ -351,6 +352,94 @@ describe("team_page helpers", () => {
         "runtime-session-3"
       )
     ).toBe(override);
+  });
+
+  it("refreshes selected member ACP session metadata while an active member has no session id", () => {
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        snapshotStatus: "working",
+        agentStatus: "running",
+      })
+    ).toBe(true);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "member_console",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        runtimeAgentStatus: "running",
+      })
+    ).toBe(true);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        agentStatus: "WORKING",
+      })
+    ).toBe(true);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: "session-1",
+        snapshotStatus: "working",
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "mailbox",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        snapshotStatus: "working",
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: null,
+        selectedSessionId: null,
+        snapshotStatus: "working",
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        snapshotStatus: "working",
+        runtimeSessionStatus: "stopped",
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        snapshotStatus: "working",
+        runtimeAgentStatus: "stopped",
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshSelectedAgentWorkspaceSession({
+        activeRunId: "run-1",
+        tab: "agent_acp",
+        selectedMemberId: "worker-1",
+        selectedSessionId: null,
+        snapshotStatus: "stopped",
+        agentStatus: "stopped",
+      })
+    ).toBe(false);
   });
 
   it("extracts positive thread root message ids from conversation payloads", () => {

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -148,6 +148,7 @@ import { useTeamTaskEffects } from "./team/use_team_task_effects";
 import { useTeamRuntimeEffects } from "./team/use_team_runtime_effects";
 import { useTeamRunLifecycleEffects } from "./team/use_team_run_lifecycle_effects";
 import { useTeamStepActions } from "./team/use_team_step_actions";
+import { useTeamMemberAcpSessionDiscovery } from "./team/use_team_member_acp_session_discovery";
 import {
   DEFAULT_TEAM_CONTROL_STATE,
   DEFAULT_TEAM_MAILBOX_STATE,
@@ -2303,6 +2304,18 @@ export function TeamPage(props: TeamPageProps) {
     }
     await loadMemberEvents("prepend");
   }, [loadMemberEvents, selectedAgentWorkspaceMemberId, selectedAgentWorkspaceSessionId]);
+
+  useTeamMemberAcpSessionDiscovery({
+    activeRunId: activeRunIdForSelectedTeam,
+    tab,
+    selectedMemberId: selectedAgentWorkspaceMemberId,
+    selectedSessionId: selectedAgentWorkspaceSessionId,
+    snapshotStatus: selectedAgentWorkspaceSnapshot?.status ?? null,
+    agentStatus: selectedAgentWorkspaceAgent?.status ?? null,
+    runtimeSessionStatus: selectedAgentWorkspaceRuntimeMember?.session_status ?? null,
+    runtimeAgentStatus: selectedAgentWorkspaceRuntimeMember?.agent_status ?? null,
+    refreshSnapshot,
+  });
 
   useTeamMemberAcpEffects({
     token: props.token,


### PR DESCRIPTION
## Summary

- Refresh the selected Team member runtime snapshot while the ACP panel is waiting for a session id.
- Add helper coverage for the active-member/no-session discovery gate.

## Purpose

When a Team member is active but runtime metadata has not yet reported an ACP session id, the ACP panel can sit on `Starting ACP session...` until another runtime refresh catches up. This change performs an immediate and short-interval snapshot refresh only for the selected ACP/member-console view while the member is active and still has no session id.

## Related Issues

- No linked issue.

## Testing

```bash
npm --prefix web run test -- src/pages/team_page.helpers.test.ts src/pages/team/use_team_member_acp_effects.test.tsx src/pages/team_member_acp_panel.test.tsx
cd web && npm exec tsc -- --noEmit
npm --prefix web run lint
npm --prefix web run build
```
