### PR TITLE
fix(web): keep team runtime refresh live

### DIFF
--- a/web/src/pages/team/page_helpers.test.ts
+++ b/web/src/pages/team/page_helpers.test.ts
@@ -35,6 +35,7 @@ import {
   resolveSelectedTeamTask,
   shouldClearSelectedConversationTask,
   shouldClearSelectedTeamMember,
+  shouldWatchTeamRuntime,
   resolveTaskConversationMemberIds,
   resolveTaskMessageSeenByActors,
   refreshTeamConversationMailboxAfterSend,
@@ -1142,6 +1143,19 @@ describe("team page helpers", () => {
       message: "Unable to initialize shared team thread.",
     });
     expect(resolveTeamPageNotice("   ")).toBeNull();
+  });
+
+  it("keeps runtime watching enabled for configured teams even when cached status is stopped", () => {
+    expect(
+      shouldWatchTeamRuntime({
+        selectedTeamHasConfiguredMembers: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldWatchTeamRuntime({
+        selectedTeamHasConfiguredMembers: false,
+      })
+    ).toBe(false);
   });
 
   it("clears cached runtime session ids when stop-team optimistic update applies", () => {

--- a/web/src/pages/team/page_helpers.ts
+++ b/web/src/pages/team/page_helpers.ts
@@ -79,6 +79,12 @@ export function isCurrentTeamScopedRequest(
   return Boolean(teamId) && current.teamId === teamId && current.requestSeq === requestSeq;
 }
 
+export function shouldWatchTeamRuntime(args: {
+  selectedTeamHasConfiguredMembers: boolean;
+}): boolean {
+  return args.selectedTeamHasConfiguredMembers;
+}
+
 type TeamRuntimeStatusRecord = {
   status: TeamRuntimeRecord["status"];
   members: Array<Pick<TeamRuntimeRecord["members"][number], "member_id" | "session_id">>;

--- a/web/src/pages/team/use_team_member_acp_view_model.test.tsx
+++ b/web/src/pages/team/use_team_member_acp_view_model.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTeamMemberAcpViewModel } from "./use_team_member_acp_view_model";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookParams = Parameters<typeof useTeamMemberAcpViewModel>[0];
+type HookResult = ReturnType<typeof useTeamMemberAcpViewModel>;
+
+function HookHarness({
+  params,
+  onCapture,
+}: {
+  params: HookParams;
+  onCapture: (result: HookResult) => void;
+}) {
+  onCapture(useTeamMemberAcpViewModel(params));
+  return null;
+}
+
+function createParams(overrides: Partial<HookParams> = {}): HookParams {
+  return {
+    developerMode: false,
+    selectedMemberId: "worker-1",
+    memberTitle: "Worker",
+    selectedMemberSnapshot: {
+      member_id: "worker-1",
+      role: "worker",
+      model: "codex",
+      description: null,
+      prompt: null,
+      skills: [],
+      pending_inbox_count: 0,
+      status: "idle",
+      latest_step: null,
+      session_status: null,
+    },
+    selectedMemberRole: "worker",
+    selectedAgentStatus: "running",
+    selectedSessionId: null,
+    memberEvents: [],
+    memberEventsHasMore: false,
+    memberEventsLoading: false,
+    oldestMemberEventId: null,
+    acpTab: "conversation",
+    inputDockHeight: 0,
+    terminalShowJump: false,
+    acpModeId: "",
+    acpModelId: "",
+    acpConfigId: "",
+    acpConfigValue: "",
+    canControlAcp: false,
+    canInterrupt: false,
+    setAcpTab: vi.fn(),
+    setAcpModeId: vi.fn(),
+    setAcpModelId: vi.fn(),
+    setAcpConfigId: vi.fn(),
+    setAcpConfigValue: vi.fn(),
+    ansi: (input) => input,
+    terminalRef: React.createRef<HTMLDivElement>(),
+    handleTerminalScroll: vi.fn(),
+    jumpToTerminalBottom: vi.fn(),
+    handleSubmitRequestUserInput: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("useTeamMemberAcpViewModel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("uses terminal runtime status instead of stale idle snapshot while no session is selected", () => {
+    const onCapture = vi.fn();
+
+    act(() => {
+      root.render(
+        <HookHarness
+          params={createParams({ selectedAgentStatus: "exited" })}
+          onCapture={onCapture}
+        />
+      );
+    });
+
+    const result = onCapture.mock.lastCall?.[0] as HookResult;
+    expect(result.isStartingAcpSession).toBe(false);
+    expect(result.panelSubtitle).toBe("Agent is stopped");
+    expect(result.memberStatus).toBe("exited");
+  });
+});

--- a/web/src/pages/team/use_team_member_acp_view_model.ts
+++ b/web/src/pages/team/use_team_member_acp_view_model.ts
@@ -200,6 +200,11 @@ export function useTeamMemberAcpViewModel({
   const snapshotIsActive = isActiveTeamMemberStatus(snapshotStatus);
   const normalizedAgentStatus = normalizeTeamMemberStatusValue(selectedAgentStatus);
   const hasExplicitSelectedSession = Boolean(selectedSessionIdProp?.trim());
+  const hasTerminalSelectedAgentStatus = Boolean(
+    normalizedAgentStatus && !isAgentActiveStatus(normalizedAgentStatus)
+  );
+  const hasRuntimeTerminalStatus =
+    !hasExplicitSelectedSession && hasTerminalSelectedAgentStatus;
   const agentAllowsInput =
     snapshotIsActive ||
     hasExplicitSelectedSession ||
@@ -267,13 +272,11 @@ export function useTeamMemberAcpViewModel({
     selectedMemberRole?.trim() || selectedMemberSnapshot?.role?.trim() || null;
   const acpRunStatus = normalizeTeamMemberStatusValue(acpView.runStatus?.status);
   const hasAuthoritativeStoppedStatus =
-    (Boolean(snapshotStatus) && !snapshotIsActive) ||
-    (!hasExplicitSelectedSession &&
-      !snapshotIsActive &&
-      Boolean(normalizedAgentStatus) &&
-      !isAgentActiveStatus(normalizedAgentStatus));
+    (Boolean(snapshotStatus) && !snapshotIsActive) || hasRuntimeTerminalStatus;
   const authoritativeTerminalStatus = hasAuthoritativeStoppedStatus
-    ? snapshotStatus || normalizedAgentStatus || "stopped"
+    ? hasRuntimeTerminalStatus
+      ? normalizedAgentStatus
+      : snapshotStatus || normalizedAgentStatus || "stopped"
     : null;
   const effectiveRunStatus =
     authoritativeTerminalStatus ?? acpView.runStatus?.status ?? null;
@@ -291,13 +294,14 @@ export function useTeamMemberAcpViewModel({
   const canControlAcpSession =
     canSetMode || canSetModel || canSetConfig || canCancelRun || canClearSession;
   const memberStatus =
-    (snapshotIsActive
+    (authoritativeTerminalStatus ||
+      (snapshotIsActive
       ? snapshotStatus
       : !hasExplicitSelectedSession &&
         normalizedAgentStatus &&
         !isAgentActiveStatus(normalizedAgentStatus)
       ? normalizedAgentStatus
-      : snapshotStatus || acpRunStatus || normalizedAgentStatus) ||
+      : snapshotStatus || acpRunStatus || normalizedAgentStatus)) ||
     normalizeTeamMemberStatusValue(memberRoleLabel) ||
     "unknown";
   // Prefer authoritative snapshot/runtime status for startup gating so stale

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -126,6 +126,7 @@ import {
   resolveTeamMemberAgentControlState,
   shouldClearSelectedConversationTask,
   shouldClearSelectedTeamMember,
+  shouldWatchTeamRuntime,
   toPrettyJson,
   upsertRun,
 } from "./team/page_helpers";
@@ -1355,9 +1356,10 @@ export function TeamPage(props: TeamPageProps) {
   });
   const shouldWatchSelectedTeamRuntime = useMemo(
     () =>
-      selectedTeamHasConfiguredMembers &&
-      (busy === "start-team" || selectedTeamRuntimeStatus.status !== "stopped"),
-    [busy, selectedTeamHasConfiguredMembers, selectedTeamRuntimeStatus.status]
+      shouldWatchTeamRuntime({
+        selectedTeamHasConfiguredMembers,
+      }),
+    [selectedTeamHasConfiguredMembers]
   );
   const teamMemberRoleProfile = useMemo(
     () => (teamMemberDraft ? resolveTeamMemberRoleProfile(teamMemberDraft.role) : null),


### PR DESCRIPTION
## Summary

- keep Team runtime watching enabled for configured teams even when the cached runtime status is stopped
- prevent stale stopped/idle snapshot state from showing `Starting ACP session...` once runtime says the selected member has exited
- add focused regressions for stopped-to-running refresh and stale member ACP status rendering

## Purpose

The Team workspace could keep showing stale member state after a runtime restart from outside the current page. In the observed case, the backend runtime API returned a running worker session, but the page still displayed the member as stopped because the runtime watcher was disabled while the cached status was `stopped`.

## Related Issues

- None

## Testing

- `npm run test -- page_helpers.test.ts use_team_runtime_effects.test.tsx use_team_member_acp_view_model.test.tsx`
- `npm run lint`
- `npm run build`

## Manual Validation

- Reproduced the stale page state in Chrome DevTools MCP where the backend returned `running` for `tidb-fuzz-bugfix-team-worker-1` but the member panel still showed stopped.
- Confirmed the rebuilt page opens `/sse/teams/:team_id/runtime`, refreshes the runtime, and renders the member as `IDLE / Active thread`.
