### PR TITLE
fix(acp): defer large SSE tool payloads

### DIFF
--- a/docs/journal/2026-05-13-acp-sse-lazy-payload.md
+++ b/docs/journal/2026-05-13-acp-sse-lazy-payload.md
@@ -1,0 +1,46 @@
+# ACP SSE Lazy Payload
+
+## Summary
+
+Large ACP tool-call payloads are now compacted before they are sent over SSE.
+The persisted agent event remains complete in SQLite, and active ACP consumers can hydrate the
+full event through a targeted event API when the UI actually needs the large fields.
+
+## Background
+
+ACP tool events can include large `content`, `raw_input`, and `raw_output` fields. Pushing those
+fields through SSE is wasteful when the browser is closed, when a panel is inactive, or when the
+client only needs metadata to keep the live stream ordered.
+
+## Scope
+
+- Compact large ACP `tool_call` and `tool_call_update` SSE messages by removing large payload
+  fields and adding deferred metadata.
+- Keep SQLite `agent_events` as the complete source for live event replay and lazy hydration.
+- Add a single-event API for retrieving the exact persisted event by `(agent_id, event_id)`.
+- Hydrate deferred Team member ACP events only while the member ACP consumer is active.
+
+## Key Decisions
+
+- The compaction boundary is the SSE transport, not persistence. Agent event storage still writes
+  the complete compressed payload to the per-agent SQLite event database.
+- Deferred SSE events keep identifying metadata inline and add `deferred_event_id`,
+  `deferred_fields`, and `deferred_reason` so clients can decide whether to fetch the full event.
+- The event API returns the persisted event rather than reconstructing ACP payloads from archive
+  data.
+- LanceDB remains an archive/search plane for message-shaped history. This change does not add a
+  second live write of ACP SSE payloads into LanceDB.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo test -p agenthub compact_output_for_sse -- --nocapture
+cd web && npm run test -- use_team_member_acp_effects.test.tsx
+cd web && npm run lint
+cd web && npm run build
+```
+
+## Follow-Ups
+
+None for this slice.

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1466,6 +1466,44 @@ impl AgentManager {
         Ok(events)
     }
 
+    pub async fn get_event(&self, agent_id: &str, event_id: i64) -> anyhow::Result<AgentEvent> {
+        let agent = self.get_agent(agent_id).await?;
+        if let Some(target_node_id) = agent.target_node_id.as_deref() {
+            let client = self
+                .remote_control_client_for_target_node(target_node_id)
+                .await?;
+            return client
+                .list_agent_events(agent_id, 1, None, Some(event_id.saturating_add(1)))
+                .await?
+                .into_iter()
+                .find(|event| event.event_id == event_id)
+                .ok_or_else(|| anyhow::anyhow!("agent event not found"));
+        }
+        let event_db = self.event_dbs.pool_for_agent(agent_id).await?;
+        let row = sqlx::query(
+            r#"
+            SELECT id, session_id, seq, ts, stream, message
+            FROM agent_events
+            WHERE id = ?1
+            LIMIT 1
+            "#,
+        )
+        .bind(event_id)
+        .fetch_optional(&event_db)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("agent event not found"))?;
+        let stream_str: String = row.get("stream");
+        Ok(AgentEvent {
+            event_id: row.get("id"),
+            agent_id: agent_id.to_string(),
+            session_id: row.get("session_id"),
+            seq: row.get("seq"),
+            ts: row.get("ts"),
+            stream: stream_from_str(&stream_str),
+            message: decode_message_from_storage(row.get::<Vec<u8>, _>("message").as_slice()),
+        })
+    }
+
     #[cfg(test)]
     pub(crate) async fn test_event_pool_for_agent(
         &self,

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -184,6 +184,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/{id}", delete(delete_agent))
         .route("/{id}/events", get(list_events))
+        .route("/{id}/events/{event_id}", get(get_event))
         .route("/{id}/code_mode", post(set_code_mode))
         .route("/{id}/agent_loop", post(set_agent_loop))
         .route("/{id}/acp/session/clear", post(clear_acp_session))
@@ -497,6 +498,26 @@ async fn list_events(
             .await?
     };
     Ok(Json(events))
+}
+
+async fn get_event(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((agent_id, event_id)): Path<(String, i64)>,
+) -> Result<Json<crate::agent::AgentEvent>, ApiError> {
+    let _user = require_user(&headers, &state).await?;
+    let event = state
+        .agents
+        .get_event(&agent_id, event_id)
+        .await
+        .map_err(|err| {
+            if err.to_string().contains("agent event not found") {
+                ApiError::not_found("agent event not found")
+            } else {
+                ApiError::from(err)
+            }
+        })?;
+    Ok(Json(event))
 }
 
 async fn set_code_mode(

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -30,6 +30,9 @@ use crate::team::{
     TeamRuntimeRecord, TeamRuntimeStatus,
 };
 
+const ACP_SSE_INLINE_MESSAGE_LIMIT: usize = 16 * 1024;
+const ACP_DEFERRED_FIELD_NAMES: &[&str] = &["content", "raw_input", "raw_output"];
+
 #[derive(Debug, serde::Deserialize)]
 struct SseTokenQuery {
     token: String,
@@ -605,8 +608,65 @@ fn output_to_message(output: &AgentOutput) -> SseServerMessage {
     };
     SseServerMessage {
         r#type: msg_type.to_string(),
-        payload: serde_json::json!(output),
+        payload: serde_json::json!(compact_output_for_sse(output)),
     }
+}
+
+fn compact_output_for_sse(output: &AgentOutput) -> AgentOutput {
+    if !matches!(output.stream, crate::agent::OutputStream::Acp)
+        || output.message.len() <= ACP_SSE_INLINE_MESSAGE_LIMIT
+    {
+        return output.clone();
+    }
+
+    let Some(message) = compact_acp_message_for_sse(&output.message, output.event_id) else {
+        return output.clone();
+    };
+
+    AgentOutput {
+        message,
+        ..output.clone()
+    }
+}
+
+fn compact_acp_message_for_sse(message: &str, event_id: i64) -> Option<String> {
+    let mut value = serde_json::from_str::<serde_json::Value>(message).ok()?;
+    let obj = value.as_object_mut()?;
+    let event_type = obj.get("type").and_then(serde_json::Value::as_str)?;
+    if !matches!(event_type, "tool_call" | "tool_call_update") {
+        return None;
+    }
+
+    let mut deferred_fields = Vec::new();
+    for field in ACP_DEFERRED_FIELD_NAMES {
+        if obj.remove(*field).is_some() {
+            deferred_fields.push(serde_json::Value::String((*field).to_string()));
+        }
+    }
+    if deferred_fields.is_empty() {
+        return None;
+    }
+
+    obj.insert(
+        "deferred_event_id".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(event_id)),
+    );
+    obj.insert(
+        "deferred_fields".to_string(),
+        serde_json::Value::Array(deferred_fields),
+    );
+    obj.insert(
+        "deferred_reason".to_string(),
+        serde_json::Value::String("large_acp_payload".to_string()),
+    );
+    obj.insert(
+        "preview".to_string(),
+        serde_json::Value::String(format!(
+            "Large ACP payload deferred from SSE event {event_id}"
+        )),
+    );
+
+    serde_json::to_string(&value).ok()
 }
 
 fn team_conversation_event_to_message(
@@ -964,6 +1024,10 @@ fn take_batched_event(state: &mut OutputStreamState) -> Option<Event> {
     let text = if outputs.len() == 1 {
         serde_json::to_string(&output_to_message(&outputs[0])).ok()?
     } else {
+        let outputs = outputs
+            .iter()
+            .map(compact_output_for_sse)
+            .collect::<Vec<_>>();
         serde_json::to_string(&SseServerBatchMessage {
             r#type: "batch".to_string(),
             payload: outputs,
@@ -994,6 +1058,8 @@ fn estimate_output_size(output: &AgentOutput) -> usize {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
+    use super::{ACP_SSE_INLINE_MESSAGE_LIMIT, compact_output_for_sse};
 
     use axum::{
         body::Body,
@@ -1301,6 +1367,54 @@ mod tests {
             stream,
             message: message.to_string(),
         }
+    }
+
+    #[test]
+    fn compact_output_for_sse_defers_large_acp_tool_payload() {
+        let message = serde_json::json!({
+            "type": "tool_call_update",
+            "id": "call-1",
+            "title": "Run command",
+            "status": "completed",
+            "content": "x".repeat(ACP_SSE_INLINE_MESSAGE_LIMIT),
+            "raw_input": {"cmd": "cargo test"},
+            "raw_output": {"stdout": "y".repeat(ACP_SSE_INLINE_MESSAGE_LIMIT)}
+        })
+        .to_string();
+        let output = sample_output_with(77, OutputStream::Acp, &message);
+
+        let compact = compact_output_for_sse(&output);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&compact.message).expect("compact message JSON");
+
+        assert_eq!(parsed["type"], "tool_call_update");
+        assert_eq!(parsed["id"], "call-1");
+        assert_eq!(parsed["status"], "completed");
+        assert_eq!(parsed["deferred_event_id"], 77);
+        assert_eq!(parsed["deferred_reason"], "large_acp_payload");
+        assert!(parsed.get("content").is_none());
+        assert!(parsed.get("raw_input").is_none());
+        assert!(parsed.get("raw_output").is_none());
+        assert_eq!(
+            parsed["deferred_fields"],
+            serde_json::json!(["content", "raw_input", "raw_output"])
+        );
+    }
+
+    #[test]
+    fn compact_output_for_sse_keeps_small_acp_payload_inline() {
+        let message = serde_json::json!({
+            "type": "tool_call_update",
+            "id": "call-1",
+            "status": "completed",
+            "raw_output": {"stdout": "ok"}
+        })
+        .to_string();
+        let output = sample_output_with(78, OutputStream::Acp, &message);
+
+        let compact = compact_output_for_sse(&output);
+
+        assert_eq!(compact.message, output.message);
     }
 
     #[test]

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1245,6 +1245,11 @@ export const api = {
       token
     );
   },
+  getAgentEvent: (token: string, id: string, eventId: number) =>
+    apiFetch<AgentEvent>(
+      `/api/agents/${encodePathSegment(id)}/events/${encodePathSegment(String(eventId))}`,
+      token
+    ),
   setAgentCodeMode: (token: string, id: string, code_mode: boolean) =>
     apiFetch<{ status: string }>(`/api/agents/${encodePathSegment(id)}/code_mode`, token, {
       method: "POST",

--- a/web/src/pages/team/use_team_member_acp_effects.test.tsx
+++ b/web/src/pages/team/use_team_member_acp_effects.test.tsx
@@ -2,7 +2,7 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentEvent } from "../../api";
+import { api, type AgentEvent } from "../../api";
 import { useTeamMemberAcpEffects } from "./use_team_member_acp_effects";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -418,6 +418,57 @@ describe("useTeamMemberAcpEffects", () => {
     });
 
     expect(memberEvents.state.current.map((event) => event.event_id)).toEqual([1, 11]);
+  });
+
+  it("hydrates deferred ACP SSE payloads from the event API while the member panel is active", async () => {
+    const memberEvents = createStateSetter<AgentEvent[]>([buildAgentEvent(1)]);
+    const deferredEvent = buildAgentEvent(11, {
+      message: JSON.stringify({
+        type: "tool_call_update",
+        id: "call-1",
+        status: "completed",
+        deferred_event_id: 11,
+        deferred_fields: ["raw_output"],
+      }),
+    });
+    const fullEvent = buildAgentEvent(11, {
+      message: JSON.stringify({
+        type: "tool_call_update",
+        id: "call-1",
+        status: "completed",
+        raw_output: { stdout: "full output" },
+      }),
+    });
+    const getAgentEvent = vi.spyOn(api, "getAgentEvent").mockResolvedValueOnce(fullEvent);
+    const params = createParams({
+      eventsAutoRefresh: true,
+      setMemberEvents: memberEvents.setter,
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const source = MockEventSource.instances[0];
+    await act(async () => {
+      source.emitOpen();
+      source.emitMessage(
+        JSON.stringify({
+          type: "acp",
+          payload: deferredEvent,
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getAgentEvent).toHaveBeenCalledWith("token-1", "agent-1", 11);
+    expect(memberEvents.state.current.find((event) => event.event_id === 11)?.message).toBe(
+      fullEvent.message
+    );
   });
 
   it("syncs related ACP consumers after matching SSE activity", async () => {

--- a/web/src/pages/team/use_team_member_acp_effects.test.tsx
+++ b/web/src/pages/team/use_team_member_acp_effects.test.tsx
@@ -471,6 +471,48 @@ describe("useTeamMemberAcpEffects", () => {
     );
   });
 
+  it("ignores deferred ACP hints that do not match the persisted event id", async () => {
+    const memberEvents = createStateSetter<AgentEvent[]>([buildAgentEvent(1)]);
+    const deferredEvent = buildAgentEvent(11, {
+      message: JSON.stringify({
+        type: "tool_call_update",
+        id: "call-1",
+        status: "completed",
+        deferred_event_id: 99,
+        deferred_fields: ["raw_output"],
+      }),
+    });
+    const getAgentEvent = vi.spyOn(api, "getAgentEvent");
+    const params = createParams({
+      eventsAutoRefresh: true,
+      setMemberEvents: memberEvents.setter,
+    });
+
+    act(() => {
+      root.render(<HookHarness params={params} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const source = MockEventSource.instances[0];
+    await act(async () => {
+      source.emitOpen();
+      source.emitMessage(
+        JSON.stringify({
+          type: "acp",
+          payload: deferredEvent,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(getAgentEvent).not.toHaveBeenCalled();
+    expect(memberEvents.state.current.find((event) => event.event_id === 11)?.message).toBe(
+      deferredEvent.message
+    );
+  });
+
   it("syncs related ACP consumers after matching SSE activity", async () => {
     vi.useFakeTimers();
     const params = createParams({

--- a/web/src/pages/team/use_team_member_acp_effects.ts
+++ b/web/src/pages/team/use_team_member_acp_effects.ts
@@ -6,7 +6,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import type { AgentEvent } from "../../api";
+import { api, type AgentEvent } from "../../api";
 import { normalizeSseOutputLines } from "../../app_live_output";
 import { isSseConnectionStale } from "../../event_polling";
 import { upsertAgentEventList } from "./page_helpers";
@@ -35,6 +35,23 @@ const TEAM_MEMBER_ACP_SSE_STALE_RECONNECT_THRESHOLD_MS = 30_000;
 
 function isMemberAcpTab(tab: TeamTab): boolean {
   return tab === "agent_acp" || tab === "member_console";
+}
+
+function isDeferredAcpEvent(event: AgentEvent): boolean {
+  if (event.stream !== "acp") return false;
+  try {
+    const parsed = JSON.parse(event.message) as {
+      deferred_event_id?: unknown;
+      deferred_fields?: unknown;
+    };
+    return (
+      typeof parsed.deferred_event_id === "number" &&
+      Array.isArray(parsed.deferred_fields) &&
+      parsed.deferred_fields.length > 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function useTeamMemberAcpEffects({
@@ -66,6 +83,7 @@ export function useTeamMemberAcpEffects({
   const pollFallbackEnabledRef = useRef(pollFallbackEnabled);
   const lastSelectionRefreshKeyRef = useRef<string | null>(null);
   const lastSelectionRefreshAtRef = useRef<number>(0);
+  const deferredHydrationInFlightRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     pollFallbackEnabledRef.current = pollFallbackEnabled;
@@ -197,6 +215,40 @@ export function useTeamMemberAcpEffects({
       void runSync().catch(() => undefined);
     }, TEAM_MEMBER_ACP_ACTIVITY_SYNC_DEBOUNCE_MS);
   }, []);
+
+  const hydrateDeferredEvents = useCallback(
+    (events: AgentEvent[]) => {
+      const deferred = events.filter(isDeferredAcpEvent);
+      if (deferred.length === 0) {
+        return;
+      }
+      for (const event of deferred) {
+        if (deferredHydrationInFlightRef.current.has(event.event_id)) {
+          continue;
+        }
+        deferredHydrationInFlightRef.current.add(event.event_id);
+        void api
+          .getAgentEvent(token, event.agent_id, event.event_id)
+          .then((fullEvent) => {
+            const current = latestSelectionRef.current;
+            if (
+              fullEvent.agent_id !== current.agentId ||
+              fullEvent.session_id !== current.sessionId
+            ) {
+              return;
+            }
+            setMemberEvents((prev) =>
+              upsertAgentEventList(prev, [fullEvent], "replace", current.sessionId)
+            );
+          })
+          .catch(() => undefined)
+          .finally(() => {
+            deferredHydrationInFlightRef.current.delete(event.event_id);
+          });
+      }
+    },
+    [setMemberEvents, token]
+  );
 
   useEffect(() => {
     if (!isMemberAcpTab(tab) || !selectedAgentId.trim()) {
@@ -353,6 +405,7 @@ export function useTeamMemberAcpEffects({
         setMemberEvents((prev) =>
           upsertAgentEventList(prev, liveLines, "replace", sessionId)
         );
+        hydrateDeferredEvents(liveLines);
         scheduleLiveActivitySync();
       };
       nextSource.onerror = () => {
@@ -376,6 +429,7 @@ export function useTeamMemberAcpEffects({
     };
   }, [
     scheduleLiveActivitySync,
+    hydrateDeferredEvents,
     memberAcpSyncEnabled,
     selectedAgentId,
     selectedSessionId,

--- a/web/src/pages/team/use_team_member_acp_effects.ts
+++ b/web/src/pages/team/use_team_member_acp_effects.ts
@@ -44,8 +44,10 @@ function isDeferredAcpEvent(event: AgentEvent): boolean {
       deferred_event_id?: unknown;
       deferred_fields?: unknown;
     };
+    // Treat the ACP payload as a hydration hint only; the event API returns the
+    // persisted SQLite row that replaces this SSE summary.
     return (
-      typeof parsed.deferred_event_id === "number" &&
+      parsed.deferred_event_id === event.event_id &&
       Array.isArray(parsed.deferred_fields) &&
       parsed.deferred_fields.length > 0
     );


### PR DESCRIPTION
## Summary

- compact large ACP tool-call SSE payloads by deferring `content`, `raw_input`, and `raw_output` while keeping identifying metadata inline
- add an authenticated single-event API so active ACP views can hydrate deferred events from persisted SQLite history
- hydrate deferred Team member ACP events only when the active member ACP consumer receives them
- document the storage boundary between SQLite live events and LanceDB archive/search

## Purpose

Reduce unnecessary SSE traffic for large ACP tool-call logs, especially when clients keep an SSE connection open without displaying the ACP UI. The complete payload remains available through persisted agent events and is fetched lazily when the UI needs it.

## Related Issue

None

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub compact_output_for_sse -- --nocapture`
- `cd web && npm run test -- use_team_member_acp_effects.test.tsx`
- `cd web && npm run lint`
- `cd web && npm run build`
