### PR TITLE
fix(acp): stop canceling denied permission prompts

### DIFF
--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -30,7 +30,7 @@ use serde_json::{Map, Number, Value};
 use sqlx::{Row, SqlitePool};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::runtime::Handle;
-use tokio::sync::{Mutex, mpsc, oneshot, watch};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use uuid::Uuid;
 
@@ -695,8 +695,6 @@ impl AcpClient {
         .await;
         if !permission_outcome_allows(&outcome, &args.options) {
             self.emit_permission_denied_tool_update(&args).await;
-            self.diagnostics
-                .observe_permission_denied_for_active_prompt();
         }
         if !self
             .permissions
@@ -817,19 +815,16 @@ struct AcpRuntimeDiagnostics {
     pending_command_count: AtomicUsize,
     last_provider_event_at: AtomicI64,
     last_command_error_at: AtomicI64,
-    permission_denied_tx: watch::Sender<u64>,
     state: StdMutex<AcpRuntimeDiagnosticsState>,
 }
 
 impl Default for AcpRuntimeDiagnostics {
     fn default() -> Self {
-        let (permission_denied_tx, _permission_denied_rx) = watch::channel(0);
         Self {
             active_prompt_count: AtomicUsize::new(0),
             pending_command_count: AtomicUsize::new(0),
             last_provider_event_at: AtomicI64::new(0),
             last_command_error_at: AtomicI64::new(0),
-            permission_denied_tx,
             state: StdMutex::default(),
         }
     }
@@ -1009,10 +1004,6 @@ fn optional_timestamp(value: i64) -> Option<i64> {
 }
 
 impl AcpRuntimeDiagnostics {
-    fn permission_denied_rx(&self) -> watch::Receiver<u64> {
-        self.permission_denied_tx.subscribe()
-    }
-
     fn observe_prompt_start(&self, submission_id: &str) {
         let mut state = self.state.lock().expect("acp diagnostics state poisoned");
         if !state
@@ -1030,11 +1021,6 @@ impl AcpRuntimeDiagnostics {
         state
             .active_submission_ids
             .retain(|existing| existing != submission_id);
-    }
-
-    fn observe_permission_denied_for_active_prompt(&self) {
-        let next = self.permission_denied_tx.borrow().saturating_add(1);
-        let _ = self.permission_denied_tx.send(next);
     }
 
     fn observe_provider_event(
@@ -1128,57 +1114,17 @@ struct AcpDispatchContext<'a> {
     diagnostics: Arc<AcpRuntimeDiagnostics>,
 }
 
-async fn send_acp_prompt_with_denied_recovery(
+async fn send_acp_prompt(
     conn: Rc<AcpClientConnection>,
     request: PromptRequest,
-    session_id: String,
-    mut permission_denied_rx: watch::Receiver<u64>,
     event_sink: Arc<dyn AcpEventSink>,
     diagnostics: Arc<AcpRuntimeDiagnostics>,
 ) {
-    let conn_for_prompt = conn.clone();
-    let conn_for_cancel = conn.clone();
-    let prompt_fut = send_acp_request(&conn_for_prompt, request);
-    tokio::pin!(prompt_fut);
-
-    tokio::select! {
-        result = &mut prompt_fut => {
-            if let Err(err) = result {
-                diagnostics.observe_command_error("prompt", err.to_string());
-                event_sink
-                    .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
-                    .await;
-            }
-        }
-        changed = permission_denied_rx.changed() => {
-            if changed.is_err() {
-                match prompt_fut.await {
-                    Ok(_) => {}
-                    Err(err) => {
-                        diagnostics.observe_command_error("prompt", err.to_string());
-                        event_sink
-                            .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
-                            .await;
-                    }
-                }
-                return;
-            }
-
-            let cancel = CancelNotification::new(session_id);
-            if let Err(err) = conn_for_cancel.send_notification(cancel) {
-                diagnostics.observe_command_error("cancel", err.to_string());
-                event_sink
-                    .emit_raw(AcpStream::System, format!("acp cancel error: {err}"))
-                    .await;
-            }
-
-            if let Err(err) = prompt_fut.await {
-                diagnostics.observe_command_error("prompt", err.to_string());
-                event_sink
-                    .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
-                    .await;
-            }
-        }
+    if let Err(err) = send_acp_request(&conn, request).await {
+        diagnostics.observe_command_error("prompt", err.to_string());
+        event_sink
+            .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
+            .await;
     }
 }
 
@@ -1204,17 +1150,8 @@ async fn dispatch_acp_command(
             blocks.extend(context.prompt_prefix_blocks.iter().cloned());
             blocks.push(ContentBlock::Text(TextContent::new(input)));
             tokio::task::spawn_local(async move {
-                let request = PromptRequest::new(session_id.clone(), blocks);
-                let permission_denied_rx = diagnostics.permission_denied_rx();
-                send_acp_prompt_with_denied_recovery(
-                    conn,
-                    request,
-                    session_id,
-                    permission_denied_rx,
-                    event_sink,
-                    diagnostics.clone(),
-                )
-                .await;
+                let request = PromptRequest::new(session_id, blocks);
+                send_acp_prompt(conn, request, event_sink, diagnostics.clone()).await;
                 diagnostics.observe_prompt_done(&submission_id);
                 let _ = prompt_done_tx.send(());
             });
@@ -2744,27 +2681,6 @@ mod tests {
         let snapshot = handle.diagnostics();
         assert!(snapshot.active_submission_ids.is_empty());
         assert_eq!(snapshot.pending_tool_call_count, 0);
-    }
-
-    #[tokio::test]
-    async fn acp_runtime_diagnostics_notifies_active_prompts_after_permission_denial() {
-        let diagnostics = AcpRuntimeDiagnostics::default();
-        let mut denied_rx = diagnostics.permission_denied_rx();
-
-        assert_eq!(*denied_rx.borrow(), 0);
-        diagnostics.observe_permission_denied_for_active_prompt();
-        denied_rx
-            .changed()
-            .await
-            .expect("permission-denied signal should stay open");
-        assert_eq!(*denied_rx.borrow(), 1);
-
-        diagnostics.observe_permission_denied_for_active_prompt();
-        denied_rx
-            .changed()
-            .await
-            .expect("second permission-denied signal should be delivered");
-        assert_eq!(*denied_rx.borrow(), 2);
     }
 
     #[test]

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -49,7 +49,6 @@ const MCP_CONFIG_FILE: &str = ".agenthub/mcp.json";
 const SKILLS_CONFIG_FILE: &str = ".agenthub/skills.json";
 const ACP_COMMAND_CHANNEL_CAPACITY: usize = 64;
 const ACP_COMMAND_SEND_TIMEOUT: Duration = Duration::from_secs(5);
-const ACP_PERMISSION_DENIED_PROMPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 // Team workers may need a long resume/bootstrap window after service restarts,
 // so ACP startup should tolerate late session readiness instead of failing fast.
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(300);
@@ -1173,29 +1172,11 @@ async fn send_acp_prompt_with_denied_recovery(
                     .await;
             }
 
-            match tokio::time::timeout(ACP_PERMISSION_DENIED_PROMPT_DRAIN_TIMEOUT, &mut prompt_fut).await {
-                Ok(Ok(_)) => {}
-                Ok(Err(err)) => {
-                    diagnostics.observe_command_error("prompt", err.to_string());
-                    event_sink
-                        .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
-                        .await;
-                }
-                Err(_) => {
-                    diagnostics.observe_command_error(
-                        "prompt",
-                        format!(
-                            "permission-denied prompt did not finish within {}s after cancel",
-                            ACP_PERMISSION_DENIED_PROMPT_DRAIN_TIMEOUT.as_secs()
-                        ),
-                    );
-                    event_sink
-                        .emit_raw(
-                            AcpStream::System,
-                            "acp prompt abandoned after permission denial timeout".to_string(),
-                        )
-                        .await;
-                }
+            if let Err(err) = prompt_fut.await {
+                diagnostics.observe_command_error("prompt", err.to_string());
+                event_sink
+                    .emit_raw(AcpStream::System, format!("acp prompt error: {err}"))
+                    .await;
             }
         }
     }

--- a/docs/journal/2026-05-13-acp-permission-deny-drain.md
+++ b/docs/journal/2026-05-13-acp-permission-deny-drain.md
@@ -2,46 +2,46 @@
 
 ## Summary
 
-Permission deny and timeout recovery no longer abandons the active ACP prompt after a fixed
-post-cancel timeout. AgentHub still sends ACP cancel after a denied permission, but it now waits
-for the provider prompt request to finish so provider-side follow-up events are not dropped by
-AgentHub's prompt future.
+Permission deny and timeout recovery no longer cancels or abandons the active ACP prompt after a
+permission decision. AgentHub returns the concrete deny outcome through the ACP permission response
+and waits for the provider prompt request to finish, so provider-side follow-up events are not
+dropped by AgentHub's prompt future.
 
 ## Background
 
 The previous recovery path emitted a terminal failed `tool_call_update`, notified the ACP provider
-with cancel, then waited five seconds for the prompt request to complete. If the provider did not
-return in that window, AgentHub logged `acp prompt abandoned after permission denial timeout` and
-marked the prompt complete locally.
+with session cancel, then waited five seconds for the prompt request to complete. If the provider
+did not return in that window, AgentHub logged `acp prompt abandoned after permission denial
+timeout` and marked the prompt complete locally.
 
-That avoided a stuck active prompt, but it also meant AgentHub intentionally stopped waiting for
-the provider-side prompt response. The safer behavior is to prefer draining the provider request
-over local progress when the two conflict.
+That avoided a stuck active prompt, but it conflated a denied tool permission with cancellation of
+the whole prompt turn and could stop waiting for provider-side completion. The safer behavior is to
+return the deny outcome and keep draining the provider request.
 
 ## Scope
 
 - Remove the fixed post-deny prompt drain timeout.
-- Keep the existing cancel notification on permission deny or timeout.
+- Remove the automatic session cancel notification on permission deny or timeout.
 - Keep the active prompt occupied until the provider prompt request returns or fails.
 - Preserve the existing terminal failed `tool_call_update` for the denied permission tool call.
 
 ## Key Decisions
 
 - No-data-loss semantics take priority over local prompt throughput after permission denial.
-- The provider remains responsible for completing the cancelled prompt. AgentHub does not invent a
-  local completion when the provider is still running.
+- Permission deny is communicated by the ACP permission response, not by session cancel.
+- The provider remains responsible for completing the prompt after receiving the deny outcome.
+  AgentHub does not invent a local completion when the provider is still running.
 - Follow-up ordinary prompts may continue to queue behind the active prompt if the provider does
-  not finish cancellation promptly.
+  not finish the denied prompt promptly.
 
 ## Validation
 
 ```bash
 cargo fmt --all --check
-cargo test -p agenthub-acp permission_den -- --nocapture
 cargo test -p agenthub-acp denied_permission_tool_update_clears_diagnostics_pending_tool_call -- --nocapture
 ```
 
 ## Follow-Ups
 
 - Run a real Codex ACP permission timeout after deployment and confirm the prompt drains without
-  the old abandoned-message event.
+  the old cancel or abandoned-message event.

--- a/docs/journal/2026-05-13-acp-permission-deny-drain.md
+++ b/docs/journal/2026-05-13-acp-permission-deny-drain.md
@@ -1,0 +1,47 @@
+# ACP Permission Deny Prompt Drain
+
+## Summary
+
+Permission deny and timeout recovery no longer abandons the active ACP prompt after a fixed
+post-cancel timeout. AgentHub still sends ACP cancel after a denied permission, but it now waits
+for the provider prompt request to finish so provider-side follow-up events are not dropped by
+AgentHub's prompt future.
+
+## Background
+
+The previous recovery path emitted a terminal failed `tool_call_update`, notified the ACP provider
+with cancel, then waited five seconds for the prompt request to complete. If the provider did not
+return in that window, AgentHub logged `acp prompt abandoned after permission denial timeout` and
+marked the prompt complete locally.
+
+That avoided a stuck active prompt, but it also meant AgentHub intentionally stopped waiting for
+the provider-side prompt response. The safer behavior is to prefer draining the provider request
+over local progress when the two conflict.
+
+## Scope
+
+- Remove the fixed post-deny prompt drain timeout.
+- Keep the existing cancel notification on permission deny or timeout.
+- Keep the active prompt occupied until the provider prompt request returns or fails.
+- Preserve the existing terminal failed `tool_call_update` for the denied permission tool call.
+
+## Key Decisions
+
+- No-data-loss semantics take priority over local prompt throughput after permission denial.
+- The provider remains responsible for completing the cancelled prompt. AgentHub does not invent a
+  local completion when the provider is still running.
+- Follow-up ordinary prompts may continue to queue behind the active prompt if the provider does
+  not finish cancellation promptly.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo test -p agenthub-acp permission_den -- --nocapture
+cargo test -p agenthub-acp denied_permission_tool_update_clears_diagnostics_pending_tool_call -- --nocapture
+```
+
+## Follow-Ups
+
+- Run a real Codex ACP permission timeout after deployment and confirm the prompt drains without
+  the old abandoned-message event.


### PR DESCRIPTION
## Summary

- remove the automatic ACP session cancel after permission deny or timeout
- keep returning the concrete deny outcome through the ACP permission response
- continue waiting for the provider prompt request to finish instead of locally abandoning it
- document the no-cancel/no-abandonment behavior and validation notes

## Purpose

Avoid conflating a denied tool permission with cancellation of the whole prompt turn. Permission timeout is handled as permission deny; AgentHub should send the deny response and keep draining provider output instead of sending cancel or emitting `acp prompt abandoned after permission denial timeout`.

## Related Issue

None

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub-acp denied_permission_tool_update_clears_diagnostics_pending_tool_call -- --nocapture`
