### PR TITLE
feat(team): share channel and thread composer chrome

### DIFF
--- a/docs/journal/2026-04-24-team-conversation-slock-polish.md
+++ b/docs/journal/2026-04-24-team-conversation-slock-polish.md
@@ -46,6 +46,29 @@ This pass tightened the Team chat, thread, and ACP presentation so they read lik
   - rounded send action
   - low-emphasis helper text / secondary actions
 
+## 2026-05-16 Team Composer Component Checkpoint
+
+This follow-up moves the Team channel and Team thread composers from parallel
+page-local markup to a shared `TeamMessageComposer` component. The goal is not a
+visual redesign; it narrows drift by making both surfaces reuse the same shell,
+editor row, mention menu, helper row, and send-button structure while leaving
+channel/thread-specific submit semantics in their owning panels.
+
+What changed:
+
+- `TeamTaskPanel` now uses the shared composer for the channel lane.
+- `TeamThreadPane` now uses the same composer for thread replies.
+- shared composer class names now own the mention-menu and context-row styling;
+  existing thread constants alias those shared names for compatibility.
+- focused component coverage locks the shared shell and mention-selection
+  behavior.
+
+Browser note:
+
+- local Vite loaded successfully at `http://127.0.0.1:4176/workspace/teams`,
+  but the unauthenticated local session redirected to the login page, so this
+  checkpoint does not close the deployed Chrome MCP validation item.
+
 ## Chrome DevTools MCP Baseline Notes
 
 Chrome DevTools MCP was used against logged-in `app.slock.ai` surfaces during this pass to keep the target interaction language honest.
@@ -70,6 +93,16 @@ Executed during this pass:
 ```bash
 cd web && pnpm exec vitest run src/markdown.test.ts src/pages/team/team_markdown.test.ts src/pages/team_panels.test.tsx
 cd web && pnpm exec vitest run src/acp_panel.test.tsx src/pages/team/team_thread_pane.test.tsx src/input_dock_render.test.tsx
+cd web && npm run build
+```
+
+Additional validation for the 2026-05-16 composer checkpoint:
+
+```bash
+cd web && npm exec vitest run src/pages/team/team_message_composer.test.tsx src/pages/team/team_thread_pane.test.tsx
+cd web && npm exec vitest run src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx
+cd web && npm exec tsc -- --noEmit
+cd web && npm run lint
 cd web && npm run build
 ```
 

--- a/web/src/pages/team/team_message_composer.test.tsx
+++ b/web/src/pages/team/team_message_composer.test.tsx
@@ -110,8 +110,23 @@ describe("TeamMessageComposer", () => {
     expect(container.innerHTML).toContain(TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS);
     expect(container.innerHTML).toContain(TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS);
 
+    const textarea = container.querySelector("textarea");
+    expect(textarea?.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(textarea?.getAttribute("aria-expanded")).toBe("true");
+    const listboxId = textarea?.getAttribute("aria-controls");
+    expect(listboxId).toBeTruthy();
+    expect(textarea?.getAttribute("aria-activedescendant")).toBe(
+      `${listboxId}-option-worker-agent`
+    );
+    const listbox = Array.from(container.querySelectorAll("[role='listbox']")).find(
+      (node) => node.getAttribute("id") === listboxId
+    );
+    expect(listbox?.getAttribute("role")).toBe("listbox");
     const option = container.querySelector('[data-team-mention-option="worker-agent"]');
     expect(option).not.toBeNull();
+    expect(option?.getAttribute("role")).toBe("option");
+    expect(option?.getAttribute("aria-selected")).toBe("true");
+    expect(option?.getAttribute("id")).toBe(`${listboxId}-option-worker-agent`);
     act(() => {
       option?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
     });

--- a/web/src/pages/team/team_message_composer.test.tsx
+++ b/web/src/pages/team/team_message_composer.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { MantineProvider } from "@mantine/core";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamMessageComposer } from "./team_message_composer";
+import {
+  TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS,
+  TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
+} from "../../ui/tailwind_classes";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+}
+
+function expectStaticClassTokens(html: string, className: string): void {
+  for (const token of className.split(/\s+/).filter(Boolean)) {
+    expect(html).toContain(token.split("&").join("&amp;"));
+  }
+}
+
+describe("TeamMessageComposer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders a shared shell for channel and thread composers", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <TeamMessageComposer
+          id="team-message"
+          name="team_message"
+          draft="hello"
+          placeholder="Message #all"
+          contextText="Full context in thread"
+          helperText="@name to reply · Enter to send"
+          sendLabel="Send"
+          onDraftChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain('id="team-message"');
+    expect(html).toContain('name="team_message"');
+    expect(html).toContain("Message #all");
+    expect(html).toContain("Full context in thread");
+    expect(html).toContain("@name to reply · Enter to send");
+    expect(html).toContain("Send");
+    expectStaticClassTokens(html, TEAM_MESSAGE_COMPOSER_SHELL_CLASS);
+    expectStaticClassTokens(html, TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS);
+  });
+
+  it("renders mention options and delegates selection without blurring the textarea first", () => {
+    const onSelectMention = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamMessageComposer
+            draft="@wo"
+            placeholder="Message #all"
+            helperText="@name to reply · Enter to send"
+            sendLabel="Send"
+            mentionOptions={[
+              {
+                actorId: "worker-agent",
+                label: "Worker Agent",
+                aliases: ["worker-agent"],
+              },
+            ]}
+            activeMentionIndex={0}
+            onSelectMention={onSelectMention}
+            onDraftChange={vi.fn()}
+            onSend={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    expect(container.textContent).toContain("Select teammate mention");
+    expect(container.textContent).toContain("@Worker Agent");
+    expect(container.innerHTML).toContain(TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS);
+    expect(container.innerHTML).toContain(TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS);
+
+    const option = container.querySelector('[data-team-mention-option="worker-agent"]');
+    expect(option).not.toBeNull();
+    act(() => {
+      option?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onSelectMention).toHaveBeenCalledWith({
+      actorId: "worker-agent",
+      label: "Worker Agent",
+      aliases: ["worker-agent"],
+    });
+  });
+});

--- a/web/src/pages/team/team_message_composer.tsx
+++ b/web/src/pages/team/team_message_composer.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { ActionButton, MenuOptionButton, ToolbarRow, cx } from "../../ui/primitives";
+import type { MentionCandidate } from "./mailbox_helpers";
+import {
+  TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
+  TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS,
+  TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS,
+  TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_HINT_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS,
+  TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS,
+  TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS,
+  TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
+  TEAM_PANEL_TEXTAREA_CLASS,
+} from "../../ui/tailwind_classes";
+
+export type TeamMessageComposerMentionOption = MentionCandidate;
+
+type TeamMessageComposerProps = {
+  textareaRef?: React.Ref<HTMLTextAreaElement>;
+  id?: string;
+  name?: string;
+  draft: string;
+  rows?: number;
+  placeholder: string;
+  contextText?: string;
+  helperText: string;
+  sendLabel: string;
+  busyLabel?: string;
+  busy?: boolean;
+  disabled?: boolean;
+  className?: string;
+  textareaClassName?: string;
+  sendButtonClassName?: string;
+  mentionOptions?: TeamMessageComposerMentionOption[];
+  activeMentionIndex?: number;
+  onSelectMention?: (option: TeamMessageComposerMentionOption) => void;
+  onDraftChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+  onSend: () => void;
+  onTextareaClick?: React.MouseEventHandler<HTMLTextAreaElement>;
+  onTextareaKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onTextareaKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onTextareaBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
+  onCompositionStart?: React.CompositionEventHandler<HTMLTextAreaElement>;
+  onCompositionEnd?: React.CompositionEventHandler<HTMLTextAreaElement>;
+};
+
+export function TeamMessageComposer({
+  textareaRef,
+  id,
+  name,
+  draft,
+  rows = 1,
+  placeholder,
+  contextText,
+  helperText,
+  sendLabel,
+  busyLabel,
+  busy = false,
+  disabled = false,
+  className,
+  textareaClassName,
+  sendButtonClassName,
+  mentionOptions = [],
+  activeMentionIndex = 0,
+  onSelectMention,
+  onDraftChange,
+  onSend,
+  onTextareaClick,
+  onTextareaKeyUp,
+  onTextareaKeyDown,
+  onTextareaBlur,
+  onCompositionStart,
+  onCompositionEnd,
+}: TeamMessageComposerProps) {
+  const hasMentionOptions = mentionOptions.length > 0 && onSelectMention != null;
+  return (
+    <div className={cx(TEAM_MESSAGE_COMPOSER_SHELL_CLASS, className)}>
+      {contextText ? (
+        <div className={TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS}>{contextText}</div>
+      ) : null}
+      <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
+        <textarea
+          id={id}
+          name={name}
+          ref={textareaRef}
+          className={cx(TEAM_PANEL_TEXTAREA_CLASS, textareaClassName)}
+          rows={rows}
+          placeholder={placeholder}
+          value={draft}
+          onChange={onDraftChange}
+          onClick={onTextareaClick}
+          onKeyUp={onTextareaKeyUp}
+          onBlur={onTextareaBlur}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
+          onKeyDown={onTextareaKeyDown}
+        />
+        <ActionButton
+          tone="primary"
+          size="sm"
+          className={cx(TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS, sendButtonClassName)}
+          onClick={onSend}
+          disabled={disabled}
+        >
+          {busy && busyLabel ? busyLabel : sendLabel}
+        </ActionButton>
+      </div>
+      {hasMentionOptions ? (
+        <div className={TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS}>
+          <div className={TEAM_MESSAGE_COMPOSER_MENTION_HINT_CLASS}>
+            Select teammate mention (`@` without selection stays plain text)
+          </div>
+          <div className={TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS}>
+            {mentionOptions.map((option, index) => (
+              <MenuOptionButton
+                key={option.actorId}
+                active={index === activeMentionIndex}
+                data-team-mention-option={option.actorId}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  onSelectMention(option);
+                }}
+              >
+                <span>{option.label}</span>
+                <span className={TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS}>
+                  {`@${option.label}`}
+                </span>
+              </MenuOptionButton>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
+        <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>{helperText}</span>
+      </ToolbarRow>
+    </div>
+  );
+}

--- a/web/src/pages/team/team_message_composer.tsx
+++ b/web/src/pages/team/team_message_composer.tsx
@@ -74,7 +74,14 @@ export function TeamMessageComposer({
   onCompositionStart,
   onCompositionEnd,
 }: TeamMessageComposerProps) {
+  const reactId = React.useId();
   const hasMentionOptions = mentionOptions.length > 0 && onSelectMention != null;
+  const listboxId = `${id ?? reactId}-mention-listbox`;
+  const activeMentionOption = mentionOptions[activeMentionIndex] ?? mentionOptions[0];
+  const activeMentionOptionId =
+    hasMentionOptions && activeMentionOption
+      ? `${listboxId}-option-${activeMentionOption.actorId}`
+      : undefined;
   return (
     <div className={cx(TEAM_MESSAGE_COMPOSER_SHELL_CLASS, className)}>
       {contextText ? (
@@ -89,6 +96,10 @@ export function TeamMessageComposer({
           rows={rows}
           placeholder={placeholder}
           value={draft}
+          aria-haspopup="listbox"
+          aria-expanded={hasMentionOptions}
+          aria-controls={hasMentionOptions ? listboxId : undefined}
+          aria-activedescendant={activeMentionOptionId}
           onChange={onDraftChange}
           onClick={onTextareaClick}
           onKeyUp={onTextareaKeyUp}
@@ -112,10 +123,17 @@ export function TeamMessageComposer({
           <div className={TEAM_MESSAGE_COMPOSER_MENTION_HINT_CLASS}>
             Select teammate mention (`@` without selection stays plain text)
           </div>
-          <div className={TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS}>
+          <div
+            id={listboxId}
+            role="listbox"
+            className={TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS}
+          >
             {mentionOptions.map((option, index) => (
               <MenuOptionButton
                 key={option.actorId}
+                id={`${listboxId}-option-${option.actorId}`}
+                role="option"
+                aria-selected={index === activeMentionIndex}
                 active={index === activeMentionIndex}
                 data-team-mention-option={option.actorId}
                 onMouseDown={(event) => {

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import {
-  ActionButton,
   Badge,
   CompactButton,
   ConversationBubble,
   EmptyState,
-  MenuOptionButton,
   SurfaceCard,
   ToolbarRow,
 } from "../../ui/primitives";
 import { DeterministicAvatar } from "../../components/deterministic_avatar";
 import { TeamThreadRichText } from "./team_thread_rich_text";
+import { TeamMessageComposer } from "./team_message_composer";
 import {
   applyMentionAtTag,
   canonicalizeMentionDraft,
@@ -18,15 +17,8 @@ import {
   resolveMentionDraftQuery,
 } from "./mailbox_helpers";
 import {
-  TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
-  TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS,
-  TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS,
-  TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS,
-  TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
-  TEAM_PANEL_TEXTAREA_CLASS,
   TEAM_THREAD_BODY_CLASS,
   TEAM_THREAD_CHANNEL_BADGE_CLASS,
-  TEAM_THREAD_COMPOSER_CONTEXT_CLASS,
   TEAM_THREAD_COMPOSER_REGION_CLASS,
   TEAM_THREAD_EMPTY_REPLIES_CLASS,
   TEAM_THREAD_EMPTY_STATE_CLASS,
@@ -38,10 +30,6 @@ import {
   TEAM_THREAD_HEADER_TITLE_CLASS,
   TEAM_THREAD_HEADER_TITLE_ROW_CLASS,
   TEAM_THREAD_HELP_TEXT_CLASS,
-  TEAM_THREAD_MENTION_ALIAS_CLASS,
-  TEAM_THREAD_MENTION_HINT_CLASS,
-  TEAM_THREAD_MENTION_LIST_CLASS,
-  TEAM_THREAD_MENTION_MENU_CLASS,
   TEAM_THREAD_MESSAGE_AUTHOR_CLASS,
   TEAM_THREAD_MESSAGE_AVATAR_CLASS,
   TEAM_THREAD_MESSAGE_BUBBLE_CLASS,
@@ -411,121 +399,88 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
       </div>
       {hasSelectedRoot ? (
         <div className={TEAM_THREAD_COMPOSER_REGION_CLASS}>
-          <div className={TEAM_MESSAGE_COMPOSER_SHELL_CLASS}>
-            <div className={TEAM_THREAD_COMPOSER_CONTEXT_CLASS}>
-              Full context in thread · root message stays summary-first · {channelLabel}
-            </div>
-            <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
-              <textarea
-                ref={replyTextareaRef}
-                className={`${TEAM_PANEL_TEXTAREA_CLASS} ${TEAM_THREAD_TEXTAREA_CLASS}`}
-                rows={2}
-                placeholder={`Reply in thread · ${channelLabel}`}
-                value={replyDraft}
-                onChange={(event) => {
-                  const nextDraft = event.currentTarget.value;
-                  onReplyDraftChange(nextDraft);
-                  updateMentionQuery(nextDraft, event.currentTarget.selectionStart);
-                }}
-                onClick={(event) =>
-                  updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+          <TeamMessageComposer
+            textareaRef={replyTextareaRef}
+            draft={replyDraft}
+            rows={2}
+            placeholder={`Reply in thread · ${channelLabel}`}
+            contextText={`Full context in thread · root message stays summary-first · ${channelLabel}`}
+            helperText={
+              sendOnEnter
+                ? "@name to reply · Enter to reply"
+                : "@name to reply · Enter adds a new line"
+            }
+            sendLabel="Reply"
+            busyLabel="Replying..."
+            busy={replyBusy}
+            disabled={replyBusy || replyDraft.trim().length === 0}
+            textareaClassName={TEAM_THREAD_TEXTAREA_CLASS}
+            mentionOptions={activeMention ? filteredMentionCandidates : []}
+            activeMentionIndex={activeMentionIndex}
+            onSelectMention={applyMentionSelection}
+            onDraftChange={(event) => {
+              const nextDraft = event.currentTarget.value;
+              onReplyDraftChange(nextDraft);
+              updateMentionQuery(nextDraft, event.currentTarget.selectionStart);
+            }}
+            onTextareaClick={(event) =>
+              updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+            }
+            onTextareaKeyUp={(event) =>
+              updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+            }
+            onTextareaBlur={() => {
+              setTimeout(() => {
+                setActiveMention(null);
+                setActiveMentionIndex(0);
+              }, 0);
+            }}
+            onTextareaKeyDown={(event) => {
+              if (activeMention && filteredMentionCandidates.length > 0) {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  setActiveMentionIndex((prev) => (prev + 1) % filteredMentionCandidates.length);
+                  return;
                 }
-                onKeyUp={(event) =>
-                  updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+                if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  setActiveMentionIndex((prev) =>
+                    prev === 0 ? filteredMentionCandidates.length - 1 : prev - 1
+                  );
+                  return;
                 }
-                onBlur={() => {
-                  setTimeout(() => {
-                    setActiveMention(null);
-                    setActiveMentionIndex(0);
-                  }, 0);
-                }}
-                onKeyDown={(event) => {
-                  if (activeMention && filteredMentionCandidates.length > 0) {
-                    if (event.key === "ArrowDown") {
-                      event.preventDefault();
-                      setActiveMentionIndex((prev) => (prev + 1) % filteredMentionCandidates.length);
-                      return;
-                    }
-                    if (event.key === "ArrowUp") {
-                      event.preventDefault();
-                      setActiveMentionIndex((prev) =>
-                        prev === 0 ? filteredMentionCandidates.length - 1 : prev - 1
-                      );
-                      return;
-                    }
-                    if ((event.key === "Enter" || event.key === "Tab") && !event.metaKey && !event.ctrlKey) {
-                      event.preventDefault();
-                      const selected =
-                        filteredMentionCandidates[activeMentionIndex] ?? filteredMentionCandidates[0];
-                      if (selected) {
-                        applyMentionSelection(selected);
-                      }
-                      return;
-                    }
-                    if (event.key === "Escape") {
-                      event.preventDefault();
-                      setActiveMention(null);
-                      setActiveMentionIndex(0);
-                      return;
-                    }
+                if ((event.key === "Enter" || event.key === "Tab") && !event.metaKey && !event.ctrlKey) {
+                  event.preventDefault();
+                  const selected =
+                    filteredMentionCandidates[activeMentionIndex] ?? filteredMentionCandidates[0];
+                  if (selected) {
+                    applyMentionSelection(selected);
                   }
-                  if (
-                    event.key === "Enter" &&
-                    !event.shiftKey &&
-                    !event.altKey &&
-                    !event.metaKey &&
-                    !event.ctrlKey &&
-                    sendOnEnter &&
-                    !replyBusy &&
-                    replyDraft.trim().length > 0
-                  ) {
-                    event.preventDefault();
-                    sendCurrentReply();
-                  }
-                }}
-              />
-              <ActionButton
-                type="button"
-                className={TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS}
-                onClick={() => {
-                  sendCurrentReply();
-                }}
-                disabled={replyBusy || replyDraft.trim().length === 0}
-              >
-                {replyBusy ? "Replying..." : "Reply"}
-              </ActionButton>
-            </div>
-            {activeMention && filteredMentionCandidates.length > 0 && (
-              <div className={TEAM_THREAD_MENTION_MENU_CLASS}>
-                <div className={TEAM_THREAD_MENTION_HINT_CLASS}>
-                  Select teammate mention (`@` without selection stays plain text)
-                </div>
-                <div className={TEAM_THREAD_MENTION_LIST_CLASS}>
-                  {filteredMentionCandidates.map((candidate, index) => (
-                    <MenuOptionButton
-                      key={candidate.actorId}
-                      active={index === activeMentionIndex}
-                      data-team-mention-option={candidate.actorId}
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                        applyMentionSelection(candidate);
-                      }}
-                    >
-                      <span>{candidate.label}</span>
-                      <span className={TEAM_THREAD_MENTION_ALIAS_CLASS}>{`@${candidate.label}`}</span>
-                    </MenuOptionButton>
-                  ))}
-                </div>
-              </div>
-            )}
-            <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
-              <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>
-                {sendOnEnter
-                  ? "@name to reply · Enter to reply"
-                  : "@name to reply · Enter adds a new line"}
-              </span>
-            </ToolbarRow>
-          </div>
+                  return;
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setActiveMention(null);
+                  setActiveMentionIndex(0);
+                  return;
+                }
+              }
+              if (
+                event.key === "Enter" &&
+                !event.shiftKey &&
+                !event.altKey &&
+                !event.metaKey &&
+                !event.ctrlKey &&
+                sendOnEnter &&
+                !replyBusy &&
+                replyDraft.trim().length > 0
+              ) {
+                event.preventDefault();
+                sendCurrentReply();
+              }
+            }}
+            onSend={sendCurrentReply}
+          />
         </div>
       ) : null}
     </SurfaceCard>

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -30,10 +30,9 @@ import {
   IconButton,
   KeyValueItem,
   KeyValueList,
-  MenuOptionButton,
   SurfaceCard,
-  ToolbarRow,
 } from "../ui/primitives";
+import { TeamMessageComposer } from "./team/team_message_composer";
 import { TeamMemberLiveState } from "./team/member_helpers";
 import {
   applyMentionAtTag,
@@ -53,12 +52,6 @@ import { isMobileInputViewport } from "../components/input_dock";
 import { DeterministicAvatar } from "../components/deterministic_avatar";
 import {
   TEAM_PANEL_CARD_CLASS,
-  TEAM_PANEL_TEXTAREA_CLASS,
-  TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS,
-  TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
-  TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS,
-  TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS,
-  TEAM_MESSAGE_COMPOSER_SHELL_CLASS,
   TEAM_TASK_ACTIVITY_AUTHOR_CLASS,
   TEAM_TASK_ACTIVITY_BODY_CLASS,
   TEAM_TASK_ACTIVITY_COMMAND_BODY_CLASS,
@@ -183,7 +176,6 @@ type TeamTaskPanelAudioWindow = Window &
     webkitAudioContext?: PermissionToneAudioContextConstructor;
   };
 
-const TEAM_TASK_SHORTCUT_CLASS = TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS;
 const TEAM_TASK_MESSAGE_EMPTY_CLASS =
   "px-8 py-4 text-sm text-notion-text-muted italic";
 const TEAM_TASK_ACTIVITY_LIST_EMPTY_CLASS = TEAM_TASK_ACTIVITY_LIST_CLASS;
@@ -1785,131 +1777,97 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         className={TEAM_TASK_COMPOSER_PANEL_CLASS}
         data-team-channel-composer="true"
       >
-        <div className={TEAM_MESSAGE_COMPOSER_SHELL_CLASS}>
-          <div className={TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}>
-            <textarea
-              id="team-task-panel-message"
-              name="team_task_message"
-              ref={messageTextareaRef}
-              className={`${TEAM_PANEL_TEXTAREA_CLASS} min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0`}
-              rows={1}
-              placeholder={messagePlaceholder}
-              value={messageDraft}
-              onChange={(event) => {
-                const nextDraft = event.target.value;
-                onMessageDraftChange(nextDraft);
-                updateMentionQuery(nextDraft, event.target.selectionStart);
-              }}
-              onClick={(event) =>
-                updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+        <TeamMessageComposer
+          id="team-task-panel-message"
+          name="team_task_message"
+          textareaRef={messageTextareaRef}
+          draft={messageDraft}
+          rows={1}
+          placeholder={messagePlaceholder}
+          helperText={composerHelperText}
+          sendLabel="Send"
+          disabled={!canSendMessage}
+          textareaClassName="min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0"
+          mentionOptions={activeMention ? filteredMentionCandidates : []}
+          activeMentionIndex={activeMentionIndex}
+          onSelectMention={applyMentionSelection}
+          onDraftChange={(event) => {
+            const nextDraft = event.target.value;
+            onMessageDraftChange(nextDraft);
+            updateMentionQuery(nextDraft, event.target.selectionStart);
+          }}
+          onTextareaClick={(event) =>
+            updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+          }
+          onTextareaKeyUp={(event) =>
+            updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
+          }
+          onTextareaBlur={() => {
+            setTimeout(() => {
+              setActiveMention(null);
+              setActiveMentionIndex(0);
+            }, 0);
+          }}
+          onCompositionStart={() => {
+            messageDraftComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            messageDraftComposingRef.current = false;
+          }}
+          onTextareaKeyDown={(event) => {
+            const composing = isTeamImeComposing(
+              messageDraftComposingRef.current,
+              event.nativeEvent.isComposing,
+              "keyCode" in event.nativeEvent
+                ? Number((event.nativeEvent as KeyboardEvent).keyCode)
+                : undefined
+            );
+            if (activeMention && filteredMentionCandidates.length > 0) {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setActiveMentionIndex((prev) => (prev + 1) % filteredMentionCandidates.length);
+                return;
               }
-              onKeyUp={(event) =>
-                updateMentionQuery(event.currentTarget.value, event.currentTarget.selectionStart)
-              }
-              onBlur={() => {
-                setTimeout(() => {
-                  setActiveMention(null);
-                  setActiveMentionIndex(0);
-                }, 0);
-              }}
-              onCompositionStart={() => {
-                messageDraftComposingRef.current = true;
-              }}
-              onCompositionEnd={() => {
-                messageDraftComposingRef.current = false;
-              }}
-              onKeyDown={(event) => {
-                const composing = isTeamImeComposing(
-                  messageDraftComposingRef.current,
-                  event.nativeEvent.isComposing,
-                  "keyCode" in event.nativeEvent
-                    ? Number((event.nativeEvent as KeyboardEvent).keyCode)
-                    : undefined
+              if (event.key === "ArrowUp") {
+                event.preventDefault();
+                setActiveMentionIndex((prev) =>
+                  prev === 0 ? filteredMentionCandidates.length - 1 : prev - 1
                 );
-                if (activeMention && filteredMentionCandidates.length > 0) {
-                  if (event.key === "ArrowDown") {
-                    event.preventDefault();
-                    setActiveMentionIndex((prev) => (prev + 1) % filteredMentionCandidates.length);
-                    return;
-                  }
-                  if (event.key === "ArrowUp") {
-                    event.preventDefault();
-                    setActiveMentionIndex((prev) =>
-                      prev === 0 ? filteredMentionCandidates.length - 1 : prev - 1
-                    );
-                    return;
-                  }
-                  if ((event.key === "Enter" || event.key === "Tab") && !event.metaKey && !event.ctrlKey) {
-                    event.preventDefault();
-                    const selected =
-                      filteredMentionCandidates[activeMentionIndex] ?? filteredMentionCandidates[0];
-                    if (selected) {
-                      applyMentionSelection(selected);
-                    }
-                    return;
-                  }
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    setActiveMention(null);
-                    setActiveMentionIndex(0);
-                    return;
-                  }
+                return;
+              }
+              if ((event.key === "Enter" || event.key === "Tab") && !event.metaKey && !event.ctrlKey) {
+                event.preventDefault();
+                const selected =
+                  filteredMentionCandidates[activeMentionIndex] ?? filteredMentionCandidates[0];
+                if (selected) {
+                  applyMentionSelection(selected);
                 }
-                if (
-                  event.key === "Enter" &&
-                  !event.shiftKey &&
-                  !event.altKey &&
-                  !event.metaKey &&
-                  !event.ctrlKey &&
-                  !composing &&
-                  sendOnEnter &&
-                  canSendMessage
-                ) {
-                  event.preventDefault();
-                  sendCurrentMessage();
-                  return;
-                }
-              }}
-            />
-            <ActionButton
-              tone="primary"
-              size="sm"
-              className={TEAM_MESSAGE_COMPOSER_SEND_BUTTON_CLASS}
-              onClick={() => {
-                sendCurrentMessage();
-              }}
-              disabled={!canSendMessage}
-            >
-              Send
-            </ActionButton>
-          </div>
-          {activeMention && filteredMentionCandidates.length > 0 && (
-            <div className="mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm">
-              <div className="px-3 py-1 text-xs text-ui-text-muted">
-                Select teammate mention (`@` without selection stays plain text)
-              </div>
-              <div className="max-h-44 overflow-auto py-1">
-                {filteredMentionCandidates.map((candidate, index) => (
-                  <MenuOptionButton
-                    key={candidate.actorId}
-                    active={index === activeMentionIndex}
-                    data-team-mention-option={candidate.actorId}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      applyMentionSelection(candidate);
-                    }}
-                  >
-                    <span>{candidate.label}</span>
-                    <span className="text-[11px] text-ui-text-muted">{`@${candidate.label}`}</span>
-                  </MenuOptionButton>
-                ))}
-              </div>
-            </div>
-          )}
-          <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
-            <span className={TEAM_TASK_SHORTCUT_CLASS}>{composerHelperText}</span>
-          </ToolbarRow>
-        </div>
+                return;
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setActiveMention(null);
+                setActiveMentionIndex(0);
+                return;
+              }
+            }
+            if (
+              event.key === "Enter" &&
+              !event.shiftKey &&
+              !event.altKey &&
+              !event.metaKey &&
+              !event.ctrlKey &&
+              !composing &&
+              sendOnEnter &&
+              canSendMessage
+            ) {
+              event.preventDefault();
+              sendCurrentMessage();
+              return;
+            }
+          }}
+          onSend={sendCurrentMessage}
+        />
       </div>
     </SurfaceCard>
   );

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -307,6 +307,19 @@ export const TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS =
 export const TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS =
   "text-[11px] font-normal tracking-[0.01em] text-notion-text-muted/65";
 
+export const TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS =
+  "px-1 pb-1 text-[10px] leading-5 text-notion-text-muted";
+
+export const TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS =
+  "mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm";
+
+export const TEAM_MESSAGE_COMPOSER_MENTION_HINT_CLASS =
+  "px-3 py-1 text-xs text-ui-text-muted";
+
+export const TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS = "max-h-44 overflow-auto py-1";
+
+export const TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS = "text-[11px] text-ui-text-muted";
+
 export const TEAM_TASK_ACTIVITY_SHELL_CLASS = "min-h-full bg-white py-1.5";
 
 export const TEAM_TASK_ACTIVITY_STACK_CLASS = "flex w-full flex-col";
@@ -568,20 +581,18 @@ export const TEAM_THREAD_EMPTY_REPLIES_CLASS = "px-2 text-[11px] leading-5 text-
 export const TEAM_THREAD_COMPOSER_REGION_CLASS =
   "border-t border-notion-border/55 bg-white/92 px-2.5 py-1.5";
 
-export const TEAM_THREAD_COMPOSER_CONTEXT_CLASS =
-  "px-1 pb-1 text-[10px] leading-5 text-notion-text-muted";
+export const TEAM_THREAD_COMPOSER_CONTEXT_CLASS = TEAM_MESSAGE_COMPOSER_CONTEXT_CLASS;
 
 export const TEAM_THREAD_TEXTAREA_CLASS =
   "min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0";
 
-export const TEAM_THREAD_MENTION_MENU_CLASS =
-  "mt-2 overflow-hidden rounded-xl border border-ui-border bg-ui-surface shadow-sm";
+export const TEAM_THREAD_MENTION_MENU_CLASS = TEAM_MESSAGE_COMPOSER_MENTION_MENU_CLASS;
 
-export const TEAM_THREAD_MENTION_HINT_CLASS = "px-3 py-1 text-xs text-ui-text-muted";
+export const TEAM_THREAD_MENTION_HINT_CLASS = TEAM_MESSAGE_COMPOSER_MENTION_HINT_CLASS;
 
-export const TEAM_THREAD_MENTION_LIST_CLASS = "max-h-44 overflow-auto py-1";
+export const TEAM_THREAD_MENTION_LIST_CLASS = TEAM_MESSAGE_COMPOSER_MENTION_LIST_CLASS;
 
-export const TEAM_THREAD_MENTION_ALIAS_CLASS = "text-[11px] text-ui-text-muted";
+export const TEAM_THREAD_MENTION_ALIAS_CLASS = TEAM_MESSAGE_COMPOSER_MENTION_ALIAS_CLASS;
 
 export const TASKS_BOARD_LANES_CLASS =
   "grid min-w-full auto-cols-[minmax(280px,1fr)] grid-flow-col gap-4";


### PR DESCRIPTION
## Summary

- Add a shared `TeamMessageComposer` for Team channel and thread inputs.
- Move shared composer context and mention-menu styling into common Tailwind constants.
- Record the implementation checkpoint in the Team conversation Slock polish journal.

## Purpose

This keeps the Team channel and thread composer surfaces visually and structurally aligned, reducing drift between two previously parallel form shells while preserving their separate send semantics.

## Related Issues

- Follows the open Team conversation/thread/composer refinement item in `docs/todo.md`.

## Testing

```bash
cd web && npm exec vitest run src/pages/team/team_message_composer.test.tsx src/pages/team/team_thread_pane.test.tsx
cd web && npm exec vitest run src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx
cd web && npm exec tsc -- --noEmit
cd web && npm run lint
cd web && npm run build
```

Browser check:

- `agent-browser open http://127.0.0.1:4176/workspace/teams` reached the local Vite app, but the unauthenticated local session redirected to the login page. Deployed Chrome MCP validation remains open in `docs/todo.md`.
