### PR TITLE
fix(team): sync sidebar lens defaults

### DIFF
--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -2191,7 +2191,7 @@ describe("TeamPage smoke render", () => {
     }
   });
 
-  it("collapses the compact sidebar after selecting # all", async () => {
+  it("collapses the compact sidebar after selecting the Channels subject default", async () => {
     const buildTeam = (id: string, name: string) => ({
       id,
       name,
@@ -2271,22 +2271,7 @@ describe("TeamPage smoke render", () => {
       });
 
       await act(async () => {
-        (container.querySelector('[aria-label="Show tasks"]') as HTMLButtonElement | null)?.click();
-        await Promise.resolve();
-      });
-
-      const showWorkbenchButton = container.querySelector(
-        '[aria-label="Show workbench"]'
-      ) as HTMLButtonElement | null;
-      expect(showWorkbenchButton).not.toBeNull();
-
-      const allButtons = Array.from(container.querySelectorAll("button")).filter(
-        (button) => button.textContent?.includes("# all")
-      ) as HTMLButtonElement[];
-      expect(allButtons.length).toBeGreaterThan(0);
-
-      await act(async () => {
-        allButtons[0]?.click();
+        (container.querySelector('[aria-label="Show channels"]') as HTMLButtonElement | null)?.click();
         await Promise.resolve();
       });
 
@@ -2300,7 +2285,7 @@ describe("TeamPage smoke render", () => {
     }
   });
 
-  it("collapses the compact sidebar after selecting Kanban", async () => {
+  it("collapses the compact sidebar after selecting the Tasks subject default", async () => {
     const buildTeam = (id: string, name: string) => ({
       id,
       name,
@@ -2381,16 +2366,6 @@ describe("TeamPage smoke render", () => {
 
       await act(async () => {
         (container.querySelector('[aria-label="Show tasks"]') as HTMLButtonElement | null)?.click();
-        await Promise.resolve();
-      });
-
-      const kanbanButtons = Array.from(container.querySelectorAll("button")).filter(
-        (button) => button.textContent?.includes("Kanban")
-      ) as HTMLButtonElement[];
-      expect(kanbanButtons.length).toBeGreaterThan(0);
-
-      await act(async () => {
-        kanbanButtons[0]?.click();
         await Promise.resolve();
       });
 

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -568,6 +568,42 @@ describe("team panels interactions", () => {
     expect(onSelectAgentTab).toHaveBeenCalledWith("coordinator-agent", "agent_acp");
   });
 
+  it("TeamSidebar subject tabs fall back to the first available channel and focused agent", () => {
+    const onSelectChannel = vi.fn();
+    const onSelectAgentTab = vi.fn();
+
+    renderTeamSidebar(root, {
+      channelItems: [
+        {
+          id: "review",
+          label: "# review",
+          description: "Review lane",
+        },
+      ],
+      selectedChannelId: "missing",
+      memberLiveStates: [
+        buildMemberLiveState({
+          member_id: "coordinator-agent",
+          agent_name: "Coordinator Agent",
+        }),
+        buildMemberLiveState({
+          member_id: "worker-agent",
+          role: "worker",
+          agent_name: "Worker Agent",
+        }),
+      ],
+      focusedAgentMemberId: "worker-agent",
+      onSelectChannel,
+      onSelectAgentTab,
+    });
+
+    clickElement(findButtonByAriaLabel(container, "Show channels"));
+    expect(onSelectChannel).toHaveBeenCalledWith("review");
+
+    clickElement(findButtonByAriaLabel(container, "Show agents"));
+    expect(onSelectAgentTab).toHaveBeenCalledWith("worker-agent", "agent_acp");
+  });
+
   it("TeamSidebar renders subject rail and triggers navigation callbacks", async () => {
     const onRefreshTeams = vi.fn();
     const onOpenCreateTeam = vi.fn();

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -522,6 +522,52 @@ describe("team panels interactions", () => {
     expect(tasksTab.textContent?.trim()).toBe("");
   });
 
+  it("TeamSidebar subject tabs select the default item for the right workspace pane", () => {
+    const onSelectChannel = vi.fn();
+    const onSelectKanban = vi.fn();
+    const onSelectAgentTab = vi.fn();
+
+    renderTeamSidebar(root, {
+      channelItems: [
+        {
+          id: "all",
+          label: "# all",
+          description: "Shared lane",
+        },
+        {
+          id: "review",
+          label: "# review",
+          description: "Review lane",
+        },
+      ],
+      selectedChannelId: "review",
+      memberLiveStates: [
+        buildMemberLiveState({
+          member_id: "coordinator-agent",
+          agent_name: "Coordinator Agent",
+        }),
+        buildMemberLiveState({
+          member_id: "worker-agent",
+          role: "worker",
+          agent_name: "Worker Agent",
+        }),
+      ],
+      focusedAgentMemberId: "",
+      onSelectChannel,
+      onSelectKanban,
+      onSelectAgentTab,
+    });
+
+    clickElement(findButtonByAriaLabel(container, "Show tasks"));
+    expect(onSelectKanban).toHaveBeenCalledTimes(1);
+
+    clickElement(findButtonByAriaLabel(container, "Show channels"));
+    expect(onSelectChannel).toHaveBeenCalledWith("review");
+
+    clickElement(findButtonByAriaLabel(container, "Show agents"));
+    expect(onSelectAgentTab).toHaveBeenCalledWith("coordinator-agent", "agent_acp");
+  });
+
   it("TeamSidebar renders subject rail and triggers navigation callbacks", async () => {
     const onRefreshTeams = vi.fn();
     const onOpenCreateTeam = vi.fn();
@@ -650,7 +696,7 @@ describe("team panels interactions", () => {
     expect(onOpenCreateTeam).toHaveBeenCalledTimes(1);
     expect(onSelectTeam).toHaveBeenCalledWith("team-2");
     expect(onSelectChannel).toHaveBeenCalledWith("all");
-    expect(onSelectKanban).toHaveBeenCalledTimes(1);
+    expect(onSelectKanban).toHaveBeenCalledTimes(2);
     expect(onSelectSearch).toHaveBeenCalledTimes(1);
     expect(onSelectAgentTab).toHaveBeenCalledWith("worker-agent", "agent_acp");
     expect(container.textContent).toContain("Teams");
@@ -803,7 +849,7 @@ describe("team panels interactions", () => {
     });
 
     clickElement(findButtonByText(container, "# all"));
-    expect(onSelectChannel).toHaveBeenCalledTimes(2);
+    expect(onSelectChannel).toHaveBeenLastCalledWith("all");
 
     act(() => {
       root.render(

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -322,6 +322,20 @@ function TeamSidebarImpl(props: TeamSidebarProps) {
       "# all",
     [channelItems, selectedChannelId]
   );
+  const selectedSidebarChannelId = React.useMemo(
+    () =>
+      channelItems.find((channel) => channel.id === selectedChannelId)?.id ??
+      channelItems[0]?.id ??
+      DEFAULT_TEAM_CHANNEL_ID,
+    [channelItems, selectedChannelId]
+  );
+  const defaultSidebarAgentMemberId = React.useMemo(
+    () =>
+      memberLiveStates.find((member) => member.member_id === focusedAgentMemberId)?.member_id ??
+      memberLiveStates[0]?.member_id ??
+      "",
+    [focusedAgentMemberId, memberLiveStates]
+  );
   const normalizedSidebarSearchQuery = sidebarSearchQuery.trim().toLowerCase();
   const sidebarSearchResults = React.useMemo(() => {
     const matches = (value: string) => {
@@ -430,6 +444,35 @@ function TeamSidebarImpl(props: TeamSidebarProps) {
     setNewChannelId("");
     setNewChannelDescription("");
   }, []);
+  const handleSelectSubjectPane = React.useCallback(
+    (value: TeamSidebarSubjectPane) => {
+      setActiveSubjectPane(value);
+      if (value === "channels") {
+        onSelectChannel(selectedSidebarChannelId);
+        return;
+      }
+      if (value === "tasks") {
+        onSelectKanban();
+        return;
+      }
+      if (value === "agents") {
+        if (defaultSidebarAgentMemberId) {
+          onSelectAgentTab(defaultSidebarAgentMemberId, "agent_acp");
+        }
+        return;
+      }
+      setSearchPopoverOpen(true);
+      onSelectSearch();
+    },
+    [
+      defaultSidebarAgentMemberId,
+      onSelectAgentTab,
+      onSelectChannel,
+      onSelectKanban,
+      onSelectSearch,
+      selectedSidebarChannelId,
+    ]
+  );
   const handleCreateChannelSubmit = React.useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -815,13 +858,7 @@ function TeamSidebarImpl(props: TeamSidebarProps) {
                         ? TEAM_SUBJECT_SWITCHER_ACTIVE_CLASS
                         : TEAM_SUBJECT_SWITCHER_IDLE_CLASS
                     }
-                    onClick={() => {
-                      setActiveSubjectPane(item.value);
-                      if (item.value === "search") {
-                        setSearchPopoverOpen(true);
-                        onSelectSearch();
-                      }
-                    }}
+                    onClick={() => handleSelectSubjectPane(item.value)}
                   >
                     <i className={`bi ${item.icon}`} aria-hidden="true" />
                   </button>


### PR DESCRIPTION
## Summary

- Make the Team sidebar Channels, Tasks, and Agents subject buttons select a default row immediately.
- Keep Channels on the selected channel when available, otherwise fall back to the first/default channel.
- Make Agents select the focused agent when available, otherwise fall back to the first visible agent.
- Add focused TeamSidebar coverage for default subject selection.

## Purpose

The sidebar subject buttons previously changed only the left sidebar list. The right workspace pane did not always follow until the user clicked an item inside that list. This keeps the sidebar subject switch and the main workspace content synchronized.

## Related Issue

None.

## Testing

- `npm exec vitest -- run src/pages/team_panels.test.tsx`
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `make build-web`
