### PR TITLE
chore(team): introduce workspace context

### DIFF
--- a/web/src/pages/team/TeamConversationContainer.tsx
+++ b/web/src/pages/team/TeamConversationContainer.tsx
@@ -6,46 +6,9 @@ import {
   toPrettyJson,
 } from "./page_helpers";
 import { buildTeamWorkspacePath } from "../team_page";
-import type {
-  TeamActorMessageRecord,
-  TeamConversationMessageRecord,
-  TeamRunSnapshotRecord,
-} from "../../api";
-import type { TeamMemberLiveState } from "./member_helpers";
-import type { WorkspaceLens } from "../../app_route_selection";
+import { useTeamWorkspace } from "./team_workspace_context";
 
-type TeamConversationContainerProps = {
-  selectedConversation: { id?: string | null } | null;
-  developerMode: boolean;
-  token: string;
-  tasksLoading: boolean;
-  onRefreshTasks: () => void;
-  taskMessageDraft: string;
-  setTaskMessageDraft: (val: string) => void;
-  onSendTaskMessage: (payload: { text: string; mentionActorIds: string[] }) => void | Promise<void>;
-  taskMessages: TeamConversationMessageRecord[];
-  conversationMailboxMessages: TeamActorMessageRecord[];
-  snapshot: TeamRunSnapshotRecord | null;
-  mailboxDisplayNameByActorId: Record<string, string>;
-  selectedTeamMemberLiveStates: TeamMemberLiveState[];
-  taskConversationMemberIds: string[];
-  activeConversationTitle: string;
-  selectedConversationMatchesChannelLane: boolean;
-  taskMessagesLoading: boolean;
-  busy: string | null;
-  routeThreadRootMessageId: number | null;
-  channelFocusMessageId: number | null;
-  setChannelFocusMessageId: (id: number | null) => void;
-  effectiveSelectedTeamId: string | null;
-  routeWorkspaceLens: WorkspaceLens | null;
-  routeChannelId: string;
-  activeChannelConversationTaskId: string | null;
-  navigateTeamRoute: (path: string) => void;
-};
-
-export const TeamConversationContainer = React.memo(function TeamConversationContainer(
-  props: TeamConversationContainerProps
-) {
+export const TeamConversationContainer = React.memo(function TeamConversationContainer() {
   const {
     selectedConversation,
     developerMode,
@@ -73,7 +36,7 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
     routeChannelId,
     activeChannelConversationTaskId,
     navigateTeamRoute,
-  } = props;
+  } = useTeamWorkspace();
 
   const onOpenThread = useCallback(
     (messageId: number) => {

--- a/web/src/pages/team/TeamTasksContainer.tsx
+++ b/web/src/pages/team/TeamTasksContainer.tsx
@@ -3,8 +3,6 @@ import { TeamTasksPanel } from "../team_tasks_panel";
 import { formatTs, toPrettyJson } from "./page_helpers";
 import { useTeamWorkspace } from "./team_workspace_context";
 
-type TeamTasksPanelProps = React.ComponentProps<typeof TeamTasksPanel>;
-
 export const TeamTasksContainer = React.memo(function TeamTasksContainer() {
   const {
     isCompactWorkbench,
@@ -32,7 +30,7 @@ export const TeamTasksContainer = React.memo(function TeamTasksContainer() {
   return (
     <TeamTasksPanel
       compactMode={isCompactWorkbench}
-      channelLabel={selectedChannelItem.label}
+      channelLabel={selectedChannelItem?.label ?? "# all"}
       developerMode={developerMode}
       tasks={workspaceTasks}
       tasksLoading={tasksLoading}
@@ -47,7 +45,7 @@ export const TeamTasksContainer = React.memo(function TeamTasksContainer() {
       onCompilePreviewContextIdChange={setCompilePreviewContextId}
       onCompileTaskRunPreview={onCompileTaskRunPreview}
       canCompileTask={canCompileTask}
-      compiledRunPreview={compiledRunPreview as TeamTasksPanelProps["compiledRunPreview"]}
+      compiledRunPreview={compiledRunPreview}
       onUseCompiledRunPayload={onUseCompiledRunPayload}
       onCreateRunFromCompiledPreview={onCreateRunFromCompiledPreview}
       formatTs={formatTs}

--- a/web/src/pages/team/TeamTasksContainer.tsx
+++ b/web/src/pages/team/TeamTasksContainer.tsx
@@ -1,36 +1,11 @@
 import React from "react";
 import { TeamTasksPanel } from "../team_tasks_panel";
 import { formatTs, toPrettyJson } from "./page_helpers";
-import type { TeamChannelItem } from "./channel_metadata";
+import { useTeamWorkspace } from "./team_workspace_context";
 
 type TeamTasksPanelProps = React.ComponentProps<typeof TeamTasksPanel>;
 
-type TeamTasksContainerProps = {
-  isCompactWorkbench: boolean;
-  selectedChannelItem: Pick<TeamChannelItem, "label">;
-  developerMode: boolean;
-  workspaceTasks: TeamTasksPanelProps["tasks"];
-  tasksLoading: boolean;
-  selectedTaskId: string;
-  setSelectedTaskId: (id: string) => void;
-  onRefreshTasks: () => void;
-  onSelectConversationSubject: (taskId?: string | null, taskChannelId?: string | null) => void;
-  busy: string | null;
-  runs: TeamTasksPanelProps["runs"];
-  onOpenTaskRun: (runId: string) => void;
-  compilePreviewContextId: string;
-  setCompilePreviewContextId: (id: string) => void;
-  onCompileTaskRunPreview: () => void;
-  canCompileTask: boolean;
-  compiledRunPreview: TeamTasksPanelProps["compiledRunPreview"];
-  onUseCompiledRunPayload: () => void;
-  onCreateRunFromCompiledPreview: () => void;
-  selectedTeamMemberLiveStates: TeamTasksPanelProps["memberLiveStates"];
-};
-
-export const TeamTasksContainer = React.memo(function TeamTasksContainer(
-  props: TeamTasksContainerProps
-) {
+export const TeamTasksContainer = React.memo(function TeamTasksContainer() {
   const {
     isCompactWorkbench,
     selectedChannelItem,
@@ -52,7 +27,7 @@ export const TeamTasksContainer = React.memo(function TeamTasksContainer(
     onUseCompiledRunPayload,
     onCreateRunFromCompiledPreview,
     selectedTeamMemberLiveStates,
-  } = props;
+  } = useTeamWorkspace();
 
   return (
     <TeamTasksPanel
@@ -72,7 +47,7 @@ export const TeamTasksContainer = React.memo(function TeamTasksContainer(
       onCompilePreviewContextIdChange={setCompilePreviewContextId}
       onCompileTaskRunPreview={onCompileTaskRunPreview}
       canCompileTask={canCompileTask}
-      compiledRunPreview={compiledRunPreview}
+      compiledRunPreview={compiledRunPreview as TeamTasksPanelProps["compiledRunPreview"]}
       onUseCompiledRunPayload={onUseCompiledRunPayload}
       onCreateRunFromCompiledPreview={onCreateRunFromCompiledPreview}
       formatTs={formatTs}

--- a/web/src/pages/team/TeamThreadContainer.tsx
+++ b/web/src/pages/team/TeamThreadContainer.tsx
@@ -6,46 +6,46 @@ import {
   resolveThreadRootMessageIdFromPayload,
 } from "./page_helpers";
 import { buildTeamWorkspacePath } from "../team_page";
-import type { TeamConversationMessageRecord } from "../../api";
 import type { MentionCandidate } from "./mailbox_helpers";
-import type { WorkspaceLens } from "../../app_route_selection";
+import { useTeamWorkspace } from "./team_workspace_context";
 
-type TeamThreadContainerProps = {
-  channelLabel: string;
-  routeThreadRootMessageId: number | null;
-  taskMessages: TeamConversationMessageRecord[];
-  threadReplyDraft: string;
-  setThreadReplyDraft: (val: string) => void;
-  onSendThreadReply: (payload: { text: string; mentionActorIds: string[] }) => void;
-  replyBusy: boolean;
-  threadMentionCandidates: MentionCandidate[];
-  effectiveSelectedTeamId: string | null;
-  routeWorkspaceLens: WorkspaceLens | null;
-  routeChannelId: string;
-  activeChannelConversationTaskId: string | null;
-  navigateTeamRoute: (path: string) => void;
-  setChannelFocusMessageId: (id: number | null) => void;
-};
-
-export const TeamThreadContainer = React.memo(function TeamThreadContainer(
-  props: TeamThreadContainerProps
-) {
+export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
   const {
-    channelLabel,
+    selectedChannelItem,
     routeThreadRootMessageId,
     taskMessages,
     threadReplyDraft,
     setThreadReplyDraft,
     onSendThreadReply,
-    replyBusy,
-    threadMentionCandidates,
+    busy,
+    mailboxDisplayNameByActorId,
+    selectedTeamMemberLiveStates,
+    selectedConversationMatchesChannelLane,
     effectiveSelectedTeamId,
     routeWorkspaceLens,
     routeChannelId,
     activeChannelConversationTaskId,
     navigateTeamRoute,
     setChannelFocusMessageId,
-  } = props;
+  } = useTeamWorkspace();
+  const channelLabel = selectedChannelItem.label;
+  const replyBusy = busy === "send-thread-reply";
+  const threadMentionCandidates = useMemo<MentionCandidate[]>(
+    () =>
+      selectedTeamMemberLiveStates.map((member) => {
+        const actorId = member.member_id.trim();
+        const label =
+          member.agent_name?.trim() ||
+          mailboxDisplayNameByActorId[actorId]?.trim() ||
+          actorId;
+        return {
+          actorId,
+          label,
+          aliases: [actorId],
+        };
+      }),
+    [mailboxDisplayNameByActorId, selectedTeamMemberLiveStates]
+  );
 
   const activeThreadRootMessage = useMemo(
     () =>
@@ -105,7 +105,7 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer(
     }
   }, [buildCurrentThreadlessPath, navigateTeamRoute]);
 
-  if (!routeThreadRootMessageId) {
+  if (!selectedConversationMatchesChannelLane || !routeThreadRootMessageId) {
     return null;
   }
 

--- a/web/src/pages/team/TeamThreadContainer.tsx
+++ b/web/src/pages/team/TeamThreadContainer.tsx
@@ -28,7 +28,7 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
     navigateTeamRoute,
     setChannelFocusMessageId,
   } = useTeamWorkspace();
-  const channelLabel = selectedChannelItem.label;
+  const channelLabel = selectedChannelItem?.label ?? "";
   const replyBusy = busy === "send-thread-reply";
   const threadMentionCandidates = useMemo<MentionCandidate[]>(
     () =>

--- a/web/src/pages/team/TeamWorkbenchContainer.tsx
+++ b/web/src/pages/team/TeamWorkbenchContainer.tsx
@@ -3,7 +3,6 @@ import { TeamWorkbenchContent, TeamPanelLoadingFallback } from "./team_workbench
 import type {
   TeamDefinitionRecord,
   TeamActorMessageRecord,
-  TeamConversationMessageRecord,
   AgentEvent,
   TeamRunRecord,
   TeamRunSnapshotRecord,
@@ -12,15 +11,11 @@ import type {
   TeamMemberSnapshot,
   AgentRecord,
   AgentDiscoveryCardRecord,
-  TeamTaskRecord,
-  TeamTaskRunCompilePreviewRecord,
 } from "../../api";
 import type { WorkspaceLens } from "../../app_route_selection";
 import type { StepAction, TeamTab } from "./state";
 import type { TeamMemberProfileDraft } from "./create_helpers";
-import type { MailboxTemplateKey, MentionCandidate, TeamMailboxChatActors } from "./mailbox_helpers";
-import type { TeamChannelItem } from "./channel_metadata";
-import type { TeamMemberLiveState } from "./member_helpers";
+import type { MailboxTemplateKey, TeamMailboxChatActors } from "./mailbox_helpers";
 import type { TeamRunStatusFilter } from "./run_helpers";
 import { TeamConversationContainer } from "./TeamConversationContainer";
 import { TeamTasksContainer } from "./TeamTasksContainer";
@@ -80,7 +75,6 @@ type TeamWorkbenchContainerProps = {
   tab: TeamTab;
   activeWorkspaceLens: WorkspaceLens;
   developerMode: boolean;
-  token: string;
   busy: string | null;
 
   // Header Inputs
@@ -144,47 +138,10 @@ type TeamWorkbenchContainerProps = {
   onLoadMoreRuns: () => void;
 
   // Workbench Body Logic Props
-  tasksLoading: boolean;
-  onRefreshTasks: () => void;
-  taskMessageDraft: string;
-  setTaskMessageDraft: (val: string) => void;
-  onSendTaskMessage: (payload: { text: string; mentionActorIds: string[] }) => void | Promise<void>;
-  taskMessages: TeamConversationMessageRecord[];
-  conversationMailboxMessages: TeamActorMessageRecord[];
   snapshot: TeamRunSnapshotRecord | null;
   snapshotLoading: boolean;
   onRefreshOverviewSnapshot: () => void;
   mailboxDisplayNameByActorId: Record<string, string>;
-  selectedTeamMemberLiveStates: TeamMemberLiveState[];
-  taskConversationMemberIds: string[];
-  activeConversationTitle: string;
-  selectedConversationMatchesChannelLane: boolean;
-  taskMessagesLoading: boolean;
-  routeThreadRootMessageId: number | null;
-  channelFocusMessageId: number | null;
-  setChannelFocusMessageId: (id: number | null) => void;
-  routeWorkspaceLens: WorkspaceLens | null;
-  routeChannelId: string;
-  activeChannelConversationTaskId: string | null;
-  navigateTeamRoute: (path: string) => void;
-  isCompactWorkbench: boolean;
-  selectedChannelItem: TeamChannelItem;
-  workspaceTasks: TeamTaskRecord[];
-  selectedTaskId: string;
-  setSelectedTaskId: (id: string) => void;
-  onSelectConversationSubject: (taskId?: string | null, taskChannelId?: string | null) => void;
-  runs: TeamRunRecord[];
-  onOpenTaskRun: (runId: string) => void;
-  compilePreviewContextId: string;
-  setCompilePreviewContextId: (id: string) => void;
-  onCompileTaskRunPreview: () => void;
-  canCompileTask: boolean;
-  compiledRunPreview: TeamTaskRunCompilePreviewRecord | null;
-  onUseCompiledRunPayload: () => void;
-  onCreateRunFromCompiledPreview: () => void;
-  onSendThreadReply: (payload: { text: string; mentionActorIds: string[] }) => void;
-  threadReplyDraft: string;
-  setThreadReplyDraft: (val: string) => void;
   selectedAgentWorkspaceSessionId: string | null;
   memberEvents: AgentEvent[];
   memberEventsLoading: boolean;
@@ -318,7 +275,6 @@ type TeamWorkbenchContainerProps = {
   selectedMemberDiscoveryCard: AgentDiscoveryCardRecord | null;
   selectedMemberDiscoveryCardLoading: boolean;
   onOpenMailboxForMember: (id: string) => void;
-  selectedConversation: TeamTaskRecord | null;
 };
 
 export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer(
@@ -338,7 +294,6 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
     tab,
     activeWorkspaceLens,
     developerMode,
-    token,
     busy,
     workspaceEyebrow,
     showDedicatedWorkspaceHeading,
@@ -394,47 +349,10 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
     runsHasMore,
     effectiveSelectedTeamId,
     onLoadMoreRuns,
-    tasksLoading,
-    onRefreshTasks,
-    taskMessageDraft,
-    setTaskMessageDraft,
-    onSendTaskMessage,
-    taskMessages,
-    conversationMailboxMessages,
     snapshot,
     snapshotLoading,
     onRefreshOverviewSnapshot,
     mailboxDisplayNameByActorId,
-    selectedTeamMemberLiveStates,
-    taskConversationMemberIds,
-    activeConversationTitle,
-    selectedConversationMatchesChannelLane,
-    taskMessagesLoading,
-    routeThreadRootMessageId,
-    channelFocusMessageId,
-    setChannelFocusMessageId,
-    routeWorkspaceLens,
-    routeChannelId,
-    activeChannelConversationTaskId,
-    navigateTeamRoute,
-    isCompactWorkbench,
-    selectedChannelItem,
-    workspaceTasks,
-    selectedTaskId,
-    setSelectedTaskId,
-    onSelectConversationSubject,
-    runs,
-    onOpenTaskRun,
-    compilePreviewContextId,
-    setCompilePreviewContextId,
-    onCompileTaskRunPreview,
-    canCompileTask,
-    compiledRunPreview,
-    onUseCompiledRunPayload,
-    onCreateRunFromCompiledPreview,
-    onSendThreadReply,
-    threadReplyDraft,
-    setThreadReplyDraft,
     selectedAgentWorkspaceSessionId,
     memberEvents,
     memberEventsLoading,
@@ -562,7 +480,6 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
     selectedMemberDiscoveryCard,
     selectedMemberDiscoveryCardLoading,
     onOpenMailboxForMember,
-    selectedConversation,
   } = props;
 
   const workspaceHeaderProps = useMemo(
@@ -861,25 +778,6 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
       }
     : null;
 
-  const threadMentionCandidates = useMemo<MentionCandidate[]>(
-    () =>
-      selectedTeamMemberLiveStates.map((member) => {
-        const actorId = member.member_id.trim();
-        const label =
-          member.agent_name?.trim() ||
-          mailboxDisplayNameByActorId[actorId]?.trim() ||
-          actorId;
-        return {
-          actorId,
-          label,
-          aliases: [actorId],
-        };
-      }),
-    [mailboxDisplayNameByActorId, selectedTeamMemberLiveStates]
-  );
-
-  const canOpenThreadForSelectedConversation = selectedConversationMatchesChannelLane;
-
   const teamDebugChrome = useMemo(
     () => ({
       panelCardClassName: teamSectionCardClassName,
@@ -948,81 +846,11 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
     />
   );
 
-  const conversationPanel = (
-    <TeamConversationContainer
-      selectedConversation={selectedConversation}
-      developerMode={developerMode}
-      token={token}
-      tasksLoading={tasksLoading}
-      onRefreshTasks={onRefreshTasks}
-      taskMessageDraft={taskMessageDraft}
-      setTaskMessageDraft={setTaskMessageDraft}
-      onSendTaskMessage={onSendTaskMessage}
-      taskMessages={taskMessages}
-      conversationMailboxMessages={conversationMailboxMessages}
-      snapshot={snapshot}
-      mailboxDisplayNameByActorId={mailboxDisplayNameByActorId}
-      selectedTeamMemberLiveStates={selectedTeamMemberLiveStates}
-      taskConversationMemberIds={taskConversationMemberIds}
-      activeConversationTitle={activeConversationTitle}
-      selectedConversationMatchesChannelLane={selectedConversationMatchesChannelLane}
-      taskMessagesLoading={taskMessagesLoading}
-      busy={busy}
-      routeThreadRootMessageId={routeThreadRootMessageId}
-      channelFocusMessageId={channelFocusMessageId}
-      setChannelFocusMessageId={setChannelFocusMessageId}
-      effectiveSelectedTeamId={effectiveSelectedTeamId}
-      routeWorkspaceLens={routeWorkspaceLens}
-      routeChannelId={routeChannelId}
-      activeChannelConversationTaskId={activeChannelConversationTaskId}
-      navigateTeamRoute={navigateTeamRoute}
-    />
-  );
+  const conversationPanel = <TeamConversationContainer />;
 
-  const tasksPanel = (
-    <TeamTasksContainer
-      isCompactWorkbench={isCompactWorkbench}
-      selectedChannelItem={selectedChannelItem}
-      developerMode={developerMode}
-      workspaceTasks={workspaceTasks}
-      tasksLoading={tasksLoading}
-      selectedTaskId={selectedTaskId}
-      setSelectedTaskId={setSelectedTaskId}
-      onRefreshTasks={onRefreshTasks}
-      onSelectConversationSubject={onSelectConversationSubject}
-      busy={busy}
-      runs={runs}
-      onOpenTaskRun={onOpenTaskRun}
-      compilePreviewContextId={compilePreviewContextId}
-      setCompilePreviewContextId={setCompilePreviewContextId}
-      onCompileTaskRunPreview={onCompileTaskRunPreview}
-      canCompileTask={canCompileTask}
-      compiledRunPreview={compiledRunPreview}
-      onUseCompiledRunPayload={onUseCompiledRunPayload}
-      onCreateRunFromCompiledPreview={onCreateRunFromCompiledPreview}
-      selectedTeamMemberLiveStates={selectedTeamMemberLiveStates}
-    />
-  );
+  const tasksPanel = <TeamTasksContainer />;
 
-  const threadPane =
-    canOpenThreadForSelectedConversation && routeThreadRootMessageId ? (
-      <TeamThreadContainer
-        channelLabel={selectedChannelItem?.label ?? ""}
-        routeThreadRootMessageId={routeThreadRootMessageId}
-        taskMessages={taskMessages}
-        threadReplyDraft={threadReplyDraft}
-        setThreadReplyDraft={setThreadReplyDraft}
-        onSendThreadReply={onSendThreadReply}
-        replyBusy={busy === "send-thread-reply"}
-        threadMentionCandidates={threadMentionCandidates}
-        effectiveSelectedTeamId={effectiveSelectedTeamId}
-        routeWorkspaceLens={routeWorkspaceLens}
-        routeChannelId={routeChannelId}
-        activeChannelConversationTaskId={activeChannelConversationTaskId}
-        navigateTeamRoute={navigateTeamRoute}
-        setChannelFocusMessageId={setChannelFocusMessageId}
-      />
-    ) : null;
+  const threadPane = <TeamThreadContainer />;
 
   const agentAcpPanel = (
     <Suspense

--- a/web/src/pages/team/team_workspace_context.tsx
+++ b/web/src/pages/team/team_workspace_context.tsx
@@ -1,15 +1,18 @@
 import React from "react";
+import type { ComponentProps } from "react";
 import type {
   TeamActorMessageRecord,
   TeamConversationMessageRecord,
   TeamRunRecord,
   TeamRunSnapshotRecord,
   TeamTaskRecord,
-  TeamTaskRunCompilePreviewRecord,
 } from "../../api";
 import type { WorkspaceLens } from "../../app_route_selection";
+import { TeamTasksPanel } from "../team_tasks_panel";
 import type { TeamChannelItem } from "./channel_metadata";
 import type { TeamMemberLiveState } from "./member_helpers";
+
+type TeamTasksPanelProps = ComponentProps<typeof TeamTasksPanel>;
 
 export type TeamWorkspaceContextValue = {
   selectedConversation: TeamTaskRecord | null;
@@ -39,7 +42,7 @@ export type TeamWorkspaceContextValue = {
   activeChannelConversationTaskId: string | null;
   navigateTeamRoute: (path: string) => void;
   isCompactWorkbench: boolean;
-  selectedChannelItem: TeamChannelItem;
+  selectedChannelItem: TeamChannelItem | null | undefined;
   workspaceTasks: TeamTaskRecord[];
   selectedTaskId: string;
   setSelectedTaskId: (id: string) => void;
@@ -50,7 +53,7 @@ export type TeamWorkspaceContextValue = {
   setCompilePreviewContextId: (id: string) => void;
   onCompileTaskRunPreview: () => void;
   canCompileTask: boolean;
-  compiledRunPreview: TeamTaskRunCompilePreviewRecord | null;
+  compiledRunPreview: TeamTasksPanelProps["compiledRunPreview"];
   onUseCompiledRunPayload: () => void;
   onCreateRunFromCompiledPreview: () => void;
   onSendThreadReply: (payload: { text: string; mentionActorIds: string[] }) => void;

--- a/web/src/pages/team/team_workspace_context.tsx
+++ b/web/src/pages/team/team_workspace_context.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import type {
+  TeamActorMessageRecord,
+  TeamConversationMessageRecord,
+  TeamRunRecord,
+  TeamRunSnapshotRecord,
+  TeamTaskRecord,
+  TeamTaskRunCompilePreviewRecord,
+} from "../../api";
+import type { WorkspaceLens } from "../../app_route_selection";
+import type { TeamChannelItem } from "./channel_metadata";
+import type { TeamMemberLiveState } from "./member_helpers";
+
+export type TeamWorkspaceContextValue = {
+  selectedConversation: TeamTaskRecord | null;
+  developerMode: boolean;
+  token: string;
+  tasksLoading: boolean;
+  onRefreshTasks: () => void;
+  taskMessageDraft: string;
+  setTaskMessageDraft: (val: string) => void;
+  onSendTaskMessage: (payload: { text: string; mentionActorIds: string[] }) => void | Promise<void>;
+  taskMessages: TeamConversationMessageRecord[];
+  conversationMailboxMessages: TeamActorMessageRecord[];
+  snapshot: TeamRunSnapshotRecord | null;
+  mailboxDisplayNameByActorId: Record<string, string>;
+  selectedTeamMemberLiveStates: TeamMemberLiveState[];
+  taskConversationMemberIds: string[];
+  activeConversationTitle: string;
+  selectedConversationMatchesChannelLane: boolean;
+  taskMessagesLoading: boolean;
+  busy: string | null;
+  routeThreadRootMessageId: number | null;
+  channelFocusMessageId: number | null;
+  setChannelFocusMessageId: (id: number | null) => void;
+  effectiveSelectedTeamId: string | null;
+  routeWorkspaceLens: WorkspaceLens | null;
+  routeChannelId: string;
+  activeChannelConversationTaskId: string | null;
+  navigateTeamRoute: (path: string) => void;
+  isCompactWorkbench: boolean;
+  selectedChannelItem: TeamChannelItem;
+  workspaceTasks: TeamTaskRecord[];
+  selectedTaskId: string;
+  setSelectedTaskId: (id: string) => void;
+  onSelectConversationSubject: (taskId?: string | null, taskChannelId?: string | null) => void;
+  runs: TeamRunRecord[];
+  onOpenTaskRun: (runId: string) => void;
+  compilePreviewContextId: string;
+  setCompilePreviewContextId: (id: string) => void;
+  onCompileTaskRunPreview: () => void;
+  canCompileTask: boolean;
+  compiledRunPreview: TeamTaskRunCompilePreviewRecord | null;
+  onUseCompiledRunPayload: () => void;
+  onCreateRunFromCompiledPreview: () => void;
+  onSendThreadReply: (payload: { text: string; mentionActorIds: string[] }) => void;
+  threadReplyDraft: string;
+  setThreadReplyDraft: (val: string) => void;
+};
+
+const TeamWorkspaceContext = React.createContext<TeamWorkspaceContextValue | null>(null);
+
+export function TeamWorkspaceProvider({
+  value,
+  children,
+}: {
+  value: TeamWorkspaceContextValue;
+  children: React.ReactNode;
+}) {
+  return (
+    <TeamWorkspaceContext.Provider value={value}>
+      {children}
+    </TeamWorkspaceContext.Provider>
+  );
+}
+
+export function useTeamWorkspace(): TeamWorkspaceContextValue {
+  const value = React.useContext(TeamWorkspaceContext);
+  if (!value) {
+    throw new Error("useTeamWorkspace must be used within TeamWorkspaceProvider");
+  }
+  return value;
+}

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -125,6 +125,10 @@ import { useTeamMailboxState } from "./team/use_team_mailbox_state";
 import { TeamSidebarContainer } from "./team/TeamSidebarContainer";
 import { TeamWorkbenchContainer } from "./team/TeamWorkbenchContainer";
 import {
+  TeamWorkspaceProvider,
+  type TeamWorkspaceContextValue,
+} from "./team/team_workspace_context";
+import {
   DEFAULT_TEAM_RUN_BROWSER_STATE,
   DEFAULT_WORKTREE_ROOT,
   MAILBOX_TEMPLATE_OPTIONS,
@@ -3002,6 +3006,52 @@ export function TeamPage(props: TeamPageProps) {
     : teamsSidebarCollapsed
       ? "Show teams panel"
       : "Hide teams panel";
+  const teamWorkspaceContext: TeamWorkspaceContextValue = {
+    selectedConversation,
+    developerMode: props.developerMode,
+    token: props.token,
+    tasksLoading,
+    onRefreshTasks,
+    taskMessageDraft,
+    setTaskMessageDraft,
+    onSendTaskMessage,
+    taskMessages,
+    conversationMailboxMessages,
+    snapshot,
+    mailboxDisplayNameByActorId,
+    selectedTeamMemberLiveStates,
+    taskConversationMemberIds,
+    activeConversationTitle,
+    selectedConversationMatchesChannelLane,
+    taskMessagesLoading,
+    busy,
+    routeThreadRootMessageId,
+    channelFocusMessageId,
+    setChannelFocusMessageId,
+    effectiveSelectedTeamId,
+    routeWorkspaceLens,
+    routeChannelId,
+    activeChannelConversationTaskId,
+    navigateTeamRoute,
+    isCompactWorkbench,
+    selectedChannelItem,
+    workspaceTasks,
+    selectedTaskId,
+    setSelectedTaskId,
+    onSelectConversationSubject,
+    runs,
+    onOpenTaskRun,
+    compilePreviewContextId,
+    setCompilePreviewContextId,
+    onCompileTaskRunPreview,
+    canCompileTask,
+    compiledRunPreview,
+    onUseCompiledRunPayload,
+    onCreateRunFromCompiledPreview,
+    onSendThreadReply,
+    threadReplyDraft,
+    setThreadReplyDraft,
+  };
 
   return (
     <WorkspaceShell
@@ -3121,6 +3171,7 @@ export function TeamPage(props: TeamPageProps) {
             />
           ) : null}
           {showWorkbenchPane ? (
+            <TeamWorkspaceProvider value={teamWorkspaceContext}>
             <TeamWorkbenchContainer
               showTeamBootstrapLoading={showTeamBootstrapLoading}
               showTeamUnavailable={showTeamUnavailable}
@@ -3144,6 +3195,7 @@ export function TeamPage(props: TeamPageProps) {
               showRunContextLoading={showRunContextLoading}
               showNoActiveRunNotice={showNoActiveRunNotice}
               activeWorkspaceLens={activeWorkspaceLens}
+              developerMode={props.developerMode}
               onGoToRuns={onGoToRuns}
               workspaceEyebrow={workspaceEyebrow}
               showDedicatedWorkspaceHeading={showDedicatedWorkspaceHeading}
@@ -3213,49 +3265,9 @@ export function TeamPage(props: TeamPageProps) {
               mailboxEmptyBody={isAgentWorkspace
                 ? "This agent is selected, but there is no active execution run context for its direct thread yet. Use Execution Runs to inspect execution history or wait for the next task."
                 : "Execution mailbox is run-scoped. Start or select a run to inspect delivery and direct member conversations."}
-              selectedConversation={selectedConversation}
-              developerMode={props.developerMode}
-              token={props.token}
-              tasksLoading={tasksLoading}
-              onRefreshTasks={onRefreshTasks}
-              taskMessageDraft={taskMessageDraft}
-              setTaskMessageDraft={setTaskMessageDraft}
-              onSendTaskMessage={onSendTaskMessage}
-              taskMessages={taskMessages}
-              conversationMailboxMessages={conversationMailboxMessages}
               snapshot={snapshot}
               mailboxDisplayNameByActorId={mailboxDisplayNameByActorId}
-              selectedTeamMemberLiveStates={selectedTeamMemberLiveStates}
-              taskConversationMemberIds={taskConversationMemberIds}
-              activeConversationTitle={activeConversationTitle}
-              selectedConversationMatchesChannelLane={selectedConversationMatchesChannelLane}
-              taskMessagesLoading={taskMessagesLoading}
               busy={busy}
-              routeThreadRootMessageId={routeThreadRootMessageId}
-              channelFocusMessageId={channelFocusMessageId}
-              setChannelFocusMessageId={setChannelFocusMessageId}
-              routeWorkspaceLens={routeWorkspaceLens}
-              routeChannelId={routeChannelId}
-              activeChannelConversationTaskId={activeChannelConversationTaskId}
-              navigateTeamRoute={navigateTeamRoute}
-              isCompactWorkbench={isCompactWorkbench}
-              selectedChannelItem={selectedChannelItem}
-              workspaceTasks={workspaceTasks}
-              selectedTaskId={selectedTaskId}
-              setSelectedTaskId={setSelectedTaskId}
-              onSelectConversationSubject={onSelectConversationSubject}
-              runs={runs}
-              onOpenTaskRun={onOpenTaskRun}
-              compilePreviewContextId={compilePreviewContextId}
-              setCompilePreviewContextId={setCompilePreviewContextId}
-              onCompileTaskRunPreview={onCompileTaskRunPreview}
-              canCompileTask={canCompileTask}
-              compiledRunPreview={compiledRunPreview}
-              onUseCompiledRunPayload={onUseCompiledRunPayload}
-              onCreateRunFromCompiledPreview={onCreateRunFromCompiledPreview}
-              onSendThreadReply={onSendThreadReply}
-              threadReplyDraft={threadReplyDraft}
-              setThreadReplyDraft={setThreadReplyDraft}
               selectedAgentWorkspaceSessionId={selectedAgentWorkspaceSessionId}
               memberEvents={memberEvents}
               memberEventsLoading={memberEventsLoading}
@@ -3363,6 +3375,7 @@ export function TeamPage(props: TeamPageProps) {
               chatDraft={chatDraft}
               onChatDraftChange={setChatDraft}
             />
+            </TeamWorkspaceProvider>
           ) : null}
         </div>
       )}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2602,11 +2602,7 @@ describe("team panels interactions", () => {
       activeChannelConversationTaskId: "task-1",
       navigateTeamRoute: vi.fn(),
       isCompactWorkbench: false,
-      selectedChannelItem: {
-        id: "all",
-        label: "# all",
-        description: "Shared lane",
-      },
+      selectedChannelItem: undefined,
       workspaceTasks: [],
       selectedTaskId: "",
       setSelectedTaskId: vi.fn(),

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -30,6 +30,10 @@ import { TeamTabsBar } from "./team_tabs_bar";
 import * as mailboxHelpers from "./team/mailbox_helpers";
 import { TeamThreadContainer } from "./team/TeamThreadContainer";
 import {
+  TeamWorkspaceProvider,
+  type TeamWorkspaceContextValue,
+} from "./team/team_workspace_context";
+import {
   MAILBOX_ADVANCED_PANEL_TITLE_CLASS,
   MAILBOX_CHAT_HEADER_CLASS,
   MAILBOX_COMPOSER_TEXTAREA_CLASS,
@@ -2536,57 +2540,96 @@ describe("team panels interactions", () => {
   });
 
   it("TeamThreadContainer only renders routed thread replies for the active thread", () => {
+    const taskMessages = [
+      buildTaskMessage(1, {
+        from_actor_id: "coordinator-agent",
+        route: "group_chat",
+        payload: { type: "chat_message", text: "Root message." },
+      }),
+      buildTaskMessage(2, {
+        from_actor_id: "worker-agent",
+        route: "team_thread_reply",
+        payload: {
+          type: "chat_message",
+          text: "Visible thread reply.",
+          thread_root_message_id: 1,
+        },
+      }),
+      buildTaskMessage(3, {
+        from_actor_id: "coordinator-agent",
+        route: "group_chat",
+        payload: {
+          type: "chat_message",
+          text: "Channel message with a thread id should stay out.",
+          thread_root_message_id: 1,
+        },
+      }),
+      buildTaskMessage(4, {
+        from_actor_id: "worker-agent",
+        route: "team_thread_reply",
+        payload: {
+          type: "chat_message",
+          text: "Different thread reply should stay out.",
+          thread_root_message_id: 99,
+        },
+      }),
+    ];
+    const workspaceContext: TeamWorkspaceContextValue = {
+      selectedConversation: null,
+      developerMode: false,
+      token: "token",
+      tasksLoading: false,
+      onRefreshTasks: vi.fn(),
+      taskMessageDraft: "",
+      setTaskMessageDraft: vi.fn(),
+      onSendTaskMessage: vi.fn(),
+      taskMessages,
+      conversationMailboxMessages: [],
+      snapshot: null,
+      mailboxDisplayNameByActorId: {},
+      selectedTeamMemberLiveStates: [],
+      taskConversationMemberIds: [],
+      activeConversationTitle: "# all",
+      selectedConversationMatchesChannelLane: true,
+      taskMessagesLoading: false,
+      busy: null,
+      routeThreadRootMessageId: 1,
+      channelFocusMessageId: null,
+      setChannelFocusMessageId: vi.fn(),
+      effectiveSelectedTeamId: "team-1",
+      routeWorkspaceLens: "channels",
+      routeChannelId: "all",
+      activeChannelConversationTaskId: "task-1",
+      navigateTeamRoute: vi.fn(),
+      isCompactWorkbench: false,
+      selectedChannelItem: {
+        id: "all",
+        label: "# all",
+        description: "Shared lane",
+      },
+      workspaceTasks: [],
+      selectedTaskId: "",
+      setSelectedTaskId: vi.fn(),
+      onSelectConversationSubject: vi.fn(),
+      runs: [],
+      onOpenTaskRun: vi.fn(),
+      compilePreviewContextId: "",
+      setCompilePreviewContextId: vi.fn(),
+      onCompileTaskRunPreview: vi.fn(),
+      canCompileTask: false,
+      compiledRunPreview: null,
+      onUseCompiledRunPayload: vi.fn(),
+      onCreateRunFromCompiledPreview: vi.fn(),
+      onSendThreadReply: vi.fn(),
+      threadReplyDraft: "",
+      setThreadReplyDraft: vi.fn(),
+    };
+
     renderWithMantine(
       root,
-      <TeamThreadContainer
-        channelLabel="# all"
-        routeThreadRootMessageId={1}
-        taskMessages={[
-          buildTaskMessage(1, {
-            from_actor_id: "coordinator-agent",
-            route: "group_chat",
-            payload: { type: "chat_message", text: "Root message." },
-          }),
-          buildTaskMessage(2, {
-            from_actor_id: "worker-agent",
-            route: "team_thread_reply",
-            payload: {
-              type: "chat_message",
-              text: "Visible thread reply.",
-              thread_root_message_id: 1,
-            },
-          }),
-          buildTaskMessage(3, {
-            from_actor_id: "coordinator-agent",
-            route: "group_chat",
-            payload: {
-              type: "chat_message",
-              text: "Channel message with a thread id should stay out.",
-              thread_root_message_id: 1,
-            },
-          }),
-          buildTaskMessage(4, {
-            from_actor_id: "worker-agent",
-            route: "team_thread_reply",
-            payload: {
-              type: "chat_message",
-              text: "Different thread reply should stay out.",
-              thread_root_message_id: 99,
-            },
-          }),
-        ]}
-        threadReplyDraft=""
-        setThreadReplyDraft={vi.fn()}
-        onSendThreadReply={vi.fn()}
-        replyBusy={false}
-        threadMentionCandidates={[]}
-        effectiveSelectedTeamId="team-1"
-        routeWorkspaceLens="channels"
-        routeChannelId="all"
-        activeChannelConversationTaskId="task-1"
-        navigateTeamRoute={vi.fn()}
-        setChannelFocusMessageId={vi.fn()}
-      />
+      <TeamWorkspaceProvider value={workspaceContext}>
+        <TeamThreadContainer />
+      </TeamWorkspaceProvider>
     );
 
     expect(container.textContent).toContain("Root message.");


### PR DESCRIPTION
## Summary

- Add `TeamWorkspaceProvider` / `useTeamWorkspace` for primary Team workspace state.
- Move Conversation, Tasks, and Thread container inputs from prop drilling to the workspace context.
- Remove the corresponding pass-through props from `TeamWorkbenchContainer` and the `TeamPage` JSX callsite.
- Keep runtime controls, mailbox, events, and debug panels on the existing prop path for this first slice.

## Purpose

This is the first bounded step toward reducing the `TeamPage -> TeamWorkbenchContainer -> panel` prop bottleneck. The primary workspace panels now consume shared state/actions from context instead of having `TeamWorkbenchContainer` forward each value.

## Related Issue

None.

## Testing

- `npm exec tsc -- --noEmit`
- `npm exec vitest -- run src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx src/pages/team/team_workbench_content.test.tsx`
- `npm run lint`
- `make build-web`
