### PR TITLE
test(team): lock workspace layout ratios

### DIFF
--- a/web/src/pages/team/TeamWorkbenchContainer.tsx
+++ b/web/src/pages/team/TeamWorkbenchContainer.tsx
@@ -858,7 +858,7 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
   const tasksPanel = <TeamTasksContainer />;
 
   const threadPane =
-    selectedConversationMatchesChannelLane && routeThreadRootMessageId ? (
+    selectedConversationMatchesChannelLane && routeThreadRootMessageId !== null ? (
       <TeamThreadContainer />
     ) : null;
 

--- a/web/src/pages/team/TeamWorkbenchContainer.tsx
+++ b/web/src/pages/team/TeamWorkbenchContainer.tsx
@@ -279,7 +279,11 @@ export type TeamWorkbenchRuntimeContext = {
 };
 
 export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer() {
-  const { workbench: props } = useTeamWorkspace();
+  const {
+    workbench: props,
+    routeThreadRootMessageId,
+    selectedConversationMatchesChannelLane,
+  } = useTeamWorkspace();
   if (!props) {
     throw new Error("TeamWorkbenchContainer requires TeamWorkspaceContext.workbench");
   }
@@ -853,7 +857,10 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
 
   const tasksPanel = <TeamTasksContainer />;
 
-  const threadPane = <TeamThreadContainer />;
+  const threadPane =
+    selectedConversationMatchesChannelLane && routeThreadRootMessageId ? (
+      <TeamThreadContainer />
+    ) : null;
 
   const agentAcpPanel = (
     <Suspense

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -255,10 +255,20 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
                       ? "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.92fr)]"
                       : "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden"
                   }
+                  data-team-surface="channel-thread-layout"
+                  data-thread-open={threadPane ? "true" : "false"}
                 >
-                  <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{conversationPanel}</div>
+                  <div
+                    className="min-h-0 min-w-0 flex-1 overflow-hidden"
+                    data-team-surface="channel-pane"
+                  >
+                    {conversationPanel}
+                  </div>
                   {threadPane && (
-                    <div className="flex max-h-[40vh] min-h-0 shrink-0 flex-col lg:max-h-none lg:min-w-0 lg:flex-shrink">
+                    <div
+                      className="flex max-h-[40vh] min-h-0 shrink-0 flex-col lg:max-h-none lg:min-w-0 lg:flex-shrink"
+                      data-team-surface="thread-dock"
+                    >
                       {threadPane}
                     </div>
                   )}

--- a/web/tests/e2e/team_page_layout.e2e.ts
+++ b/web/tests/e2e/team_page_layout.e2e.ts
@@ -11,6 +11,8 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
 }) => {
   const fixture = await mockTeamPageApis(page);
   const teamId = "team-layout";
+  const channelId = "layout";
+  const channelTaskId = `task-${teamId}-channel-${channelId}`;
   const teamCreatedAt = fixture.now + 90;
   fixture.teams.push({
     id: teamId,
@@ -30,17 +32,58 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
     created_at: teamCreatedAt,
     updated_at: teamCreatedAt,
   });
+  fixture.seedTaskMessages(channelTaskId, [
+    {
+      message_id: 101,
+      conversation_id: `conversation-${channelTaskId}`,
+      task_id: channelTaskId,
+      from_actor_id: "planner",
+      to_actor_id: null,
+      route: "group_chat",
+      payload: {
+        type: "chat_message",
+        text: "Layout root update for ratio test.",
+      },
+      created_at: fixture.now + 95,
+    },
+    {
+      message_id: 102,
+      conversation_id: `conversation-${channelTaskId}`,
+      task_id: channelTaskId,
+      from_actor_id: "worker-1",
+      to_actor_id: null,
+      route: "team_thread_reply",
+      payload: {
+        type: "chat_message",
+        text: "Layout thread reply for ratio test.",
+        thread_root_message_id: 101,
+      },
+      created_at: fixture.now + 96,
+    },
+  ]);
 
   await page.setViewportSize({ width: 1280, height: 800 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Layout Team");
-  await selectTeamChannelFromSidebar(page, "all");
+  await page.getByLabel("Create channel").click();
+  await page.getByLabel("Channel ID").fill(channelId);
+  await page.getByLabel("Channel Description").fill("Layout ratio channel");
+  await page.locator('button[type="submit"]').filter({ hasText: "Create channel" }).click();
+  await selectTeamChannelFromSidebar(page, channelId);
   await expect(page.locator('[data-team-workspace-header-shell="true"]')).toBeVisible();
+  await expect(page.locator('[data-team-surface="channel-thread-layout"]')).toHaveAttribute(
+    "data-thread-open",
+    "false"
+  );
 
   const metrics = await page.evaluate(() => {
     const layout = document.querySelector<HTMLElement>(".teams-layout");
     const sidebar = document.querySelector<HTMLElement>('[data-team-surface="sidebar"]');
     const workbench = document.querySelector<HTMLElement>('[data-team-surface="workbench"]');
+    const channelThreadLayout = document.querySelector<HTMLElement>(
+      '[data-team-surface="channel-thread-layout"]'
+    );
+    const channelPane = document.querySelector<HTMLElement>('[data-team-surface="channel-pane"]');
     const headerShell = document.querySelector<HTMLElement>(
       '[data-team-workspace-header-shell="true"]'
     );
@@ -50,18 +93,22 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
     const sidebarSubjectTablist = document.querySelector<HTMLElement>(
       '[role="tablist"][aria-label="Team sidebar sections"]'
     );
-    if (!layout || !sidebar || !workbench || !headerShell) {
+    if (!layout || !sidebar || !workbench || !headerShell || !channelThreadLayout || !channelPane) {
       throw new Error("team workspace layout nodes missing");
     }
     const layoutRect = layout.getBoundingClientRect();
     const sidebarRect = sidebar.getBoundingClientRect();
     const workbenchRect = workbench.getBoundingClientRect();
+    const channelThreadLayoutRect = channelThreadLayout.getBoundingClientRect();
+    const channelPaneRect = channelPane.getBoundingClientRect();
     const headerRect = headerShell.getBoundingClientRect();
     return {
       layoutClassName: layout.className,
       sidebarWidth: sidebarRect.width,
       workbenchWidth: workbenchRect.width,
       layoutWidth: layoutRect.width,
+      channelThreadLayoutWidth: channelThreadLayoutRect.width,
+      channelPaneWidth: channelPaneRect.width,
       headerHeight: headerRect.height,
       workbenchHeight: workbenchRect.height,
       headerClassName: headerShell.className,
@@ -82,6 +129,7 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
   expect(metrics.sidebarWidth).toBeLessThanOrEqual(300);
   expect(metrics.workbenchWidth / metrics.sidebarWidth).toBeGreaterThanOrEqual(3.3);
   expect(metrics.workbenchWidth / metrics.sidebarWidth).toBeLessThanOrEqual(4.3);
+  expect(metrics.channelPaneWidth / metrics.channelThreadLayoutWidth).toBeGreaterThanOrEqual(0.98);
   expect(metrics.headerHeight).toBeLessThanOrEqual(74);
   expect(metrics.headerHeight / metrics.workbenchHeight).toBeLessThanOrEqual(0.12);
   expect(metrics.headerClassName).not.toContain("teams-panel-card");
@@ -99,4 +147,118 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
     "placeholder",
     "Search channels, tasks, or agents"
   );
+  await page.keyboard.press("Escape");
+  await expect(searchInput).toBeHidden();
+
+  await page.evaluate(
+    ({ nextTeamId, nextChannelId, nextTaskId }) => {
+      const nextUrl = new URL(window.location.href);
+      nextUrl.pathname = `/workspace/teams/${nextTeamId}`;
+      nextUrl.search = "";
+      nextUrl.searchParams.set("channel", nextChannelId);
+      nextUrl.searchParams.set("task", nextTaskId);
+      nextUrl.searchParams.set("thread", "101");
+      window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    },
+    { nextTeamId: teamId, nextChannelId: channelId, nextTaskId: channelTaskId }
+  );
+  await expect(page.locator('[data-team-surface="thread-pane"]')).toBeVisible();
+  await expect(page.locator('[data-team-surface="channel-thread-layout"]')).toHaveAttribute(
+    "data-thread-open",
+    "true"
+  );
+
+  const splitMetrics = await page.evaluate(() => {
+    const layout = document.querySelector<HTMLElement>(
+      '[data-team-surface="channel-thread-layout"]'
+    );
+    const channelPane = document.querySelector<HTMLElement>('[data-team-surface="channel-pane"]');
+    const threadDock = document.querySelector<HTMLElement>('[data-team-surface="thread-dock"]');
+    if (!layout || !channelPane || !threadDock) {
+      throw new Error("team workspace split nodes missing");
+    }
+    const layoutRect = layout.getBoundingClientRect();
+    const channelRect = channelPane.getBoundingClientRect();
+    const threadRect = threadDock.getBoundingClientRect();
+    return {
+      layoutWidth: layoutRect.width,
+      channelWidth: channelRect.width,
+      threadWidth: threadRect.width,
+      horizontalGap: threadRect.left - channelRect.right,
+      overlaps: channelRect.right > threadRect.left,
+      threadRightInset: layoutRect.right - threadRect.right,
+    };
+  });
+  expect(splitMetrics.overlaps).toBe(false);
+  expect(splitMetrics.horizontalGap).toBeGreaterThanOrEqual(0);
+  expect(splitMetrics.threadRightInset).toBeGreaterThanOrEqual(-1);
+  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.48);
+  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.58);
+  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.40);
+  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.50);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.locator('[data-team-surface="thread-pane"]')).toBeVisible();
+  const compactMetrics = await page.evaluate(() => {
+    const visibleSurfaceRects = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-team-surface="sidebar"], [data-team-surface="workbench"], [data-team-surface="channel-pane"], [data-team-surface="thread-dock"]'
+      )
+    )
+      .filter((node) => {
+        const style = window.getComputedStyle(node);
+        const rect = node.getBoundingClientRect();
+        return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+      })
+      .map((node) => {
+        const rect = node.getBoundingClientRect();
+        return {
+          surface: node.dataset.teamSurface ?? "",
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          bottom: rect.bottom,
+          width: rect.width,
+          height: rect.height,
+        };
+      });
+    const horizontalOverflow =
+      document.documentElement.scrollWidth - document.documentElement.clientWidth;
+    const badHorizontalBounds = visibleSurfaceRects.filter(
+      (rect) => rect.left < -1 || rect.right > document.documentElement.clientWidth + 1
+    );
+    const overlappingPairs: string[] = [];
+    for (let index = 0; index < visibleSurfaceRects.length; index += 1) {
+      for (let next = index + 1; next < visibleSurfaceRects.length; next += 1) {
+        const left = visibleSurfaceRects[index];
+        const right = visibleSurfaceRects[next];
+        const intersects =
+          left.left < right.right &&
+          left.right > right.left &&
+          left.top < right.bottom &&
+          left.bottom > right.top;
+        const nested =
+          (left.left >= right.left &&
+            left.right <= right.right &&
+            left.top >= right.top &&
+            left.bottom <= right.bottom) ||
+          (right.left >= left.left &&
+            right.right <= left.right &&
+            right.top >= left.top &&
+            right.bottom <= left.bottom);
+        if (intersects && !nested) {
+          overlappingPairs.push(`${left.surface}:${right.surface}`);
+        }
+      }
+    }
+    return {
+      horizontalOverflow,
+      badHorizontalBounds,
+      overlappingPairs,
+    };
+  });
+  expect(compactMetrics.horizontalOverflow).toBeLessThanOrEqual(1);
+  expect(compactMetrics.badHorizontalBounds).toEqual([]);
+  expect(compactMetrics.overlappingPairs).toEqual([]);
 });


### PR DESCRIPTION
## Summary

- Add Team workspace layout ratio assertions to the existing Playwright layout spec
- Cover channel full-width mode, channel/thread split mode, compact viewport overflow, and visible-surface overlap
- Gate the thread dock so the workbench only uses split layout when a thread is actually open

## Purpose

This locks the Team workspace layout contract before the next context-splitting and search-dialog work. The new regression coverage catches the previous behavior where the thread pane element was always passed into the workbench, causing the channel view to use split layout even when no thread was open.

## Testing

- `cd web && npx playwright test tests/e2e/team_page_layout.e2e.ts --project=chromium`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm exec vitest -- run src/pages/team_page.smoke.test.tsx src/pages/team_page.agent_loop.test.tsx src/pages/team_panels.test.tsx`
- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`

## Related Issues

- N/A
