### PR TITLE
fix(acp): upgrade Codex to 0.130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -1292,15 +1293,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256",
+ "rand 0.8.6",
  "sha1",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -1362,6 +1368,30 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c8ee580b0c24a1e16e63efc2d96d0d0e6f9ecfd397818467d247b628a7cad5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -2430,8 +2460,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2449,8 +2479,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2468,8 +2498,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2497,8 +2527,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2516,7 +2546,6 @@ dependencies = [
  "codex-config",
  "codex-core",
  "codex-core-plugins",
- "codex-device-key",
  "codex-exec-server",
  "codex-external-agent-migration",
  "codex-external-agent-sessions",
@@ -2547,7 +2576,6 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -2557,14 +2585,13 @@ dependencies = [
  "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
- "url",
  "uuid",
 ]
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2587,8 +2614,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2611,8 +2638,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2647,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2662,8 +2689,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2680,8 +2707,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2690,8 +2717,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2704,8 +2731,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2721,8 +2748,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2731,19 +2758,19 @@ dependencies = [
 
 [[package]]
 name = "codex-builtin-mcps"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
- "codex-config",
  "codex-memories-mcp",
  "codex-utils-absolute-path",
+ "tokio",
 ]
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2762,8 +2789,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2788,8 +2815,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2812,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2829,13 +2856,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 
 [[package]]
 name = "codex-config"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2877,8 +2904,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2888,8 +2915,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2988,8 +3015,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2999,6 +3026,7 @@ dependencies = [
  "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
+ "codex-hooks",
  "codex-login",
  "codex-model-provider",
  "codex-otel",
@@ -3023,8 +3051,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3052,25 +3080,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-device-key"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "p256",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "codex-exec-server"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3092,14 +3104,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3114,8 +3127,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3124,8 +3137,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3135,8 +3148,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3148,8 +3161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3161,8 +3174,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3174,8 +3187,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3189,8 +3202,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3200,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3224,8 +3237,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3246,8 +3259,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "keyring",
  "tracing",
@@ -3255,8 +3268,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "clap",
  "codex-process-hardening",
@@ -3275,8 +3288,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3309,8 +3322,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3341,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3365,8 +3378,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-mcp"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-utils-absolute-path",
@@ -3381,8 +3394,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3394,8 +3407,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3425,8 +3438,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -3447,8 +3460,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3460,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3480,8 +3493,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3510,8 +3523,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3542,8 +3555,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -3553,16 +3566,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3599,8 +3612,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3610,8 +3623,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3644,8 +3657,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3668,8 +3681,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3682,8 +3695,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3699,8 +3712,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "age",
  "anyhow",
@@ -3718,8 +3731,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3737,8 +3750,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3757,8 +3770,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3767,8 +3780,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3789,16 +3802,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3806,20 +3819,17 @@ dependencies = [
  "codex-protocol",
  "codex-rollout",
  "codex-state",
- "prost",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
- "tonic-prost",
  "tracing",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
@@ -3835,8 +3845,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-io",
  "tokio",
@@ -3846,8 +3856,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "dirs",
  "dunce",
@@ -3858,16 +3868,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "lru",
  "sha1",
@@ -3876,8 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3887,8 +3897,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3896,8 +3906,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3909,8 +3919,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3918,8 +3928,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3927,8 +3937,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3937,8 +3947,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -3949,8 +3959,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3965,8 +3975,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -3976,21 +3986,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "regex-lite",
  "serde",
@@ -3999,13 +4009,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.130.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,23 +26,23 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -911,6 +911,7 @@ impl AppServerCodexThread {
                         call_id: params.item_id,
                         approval_id: params.approval_id,
                         turn_id: params.turn_id,
+                        started_at_ms: params.started_at_ms,
                         command: command_vec.clone(),
                         cwd: params.cwd.unwrap_or_else(|| state.config.cwd.clone()),
                         reason: params.reason,
@@ -954,6 +955,7 @@ impl AppServerCodexThread {
                     msg: EventMsg::ApplyPatchApprovalRequest(ApplyPatchApprovalRequestEvent {
                         call_id: params.item_id,
                         turn_id: params.turn_id,
+                        started_at_ms: params.started_at_ms,
                         changes,
                         reason: params.reason,
                         grant_root: params.grant_root,
@@ -2767,6 +2769,7 @@ fn permissions_request_event_from_params(
     RequestPermissionsEvent {
         call_id: params.item_id,
         turn_id: params.turn_id,
+        started_at_ms: params.started_at_ms,
         reason: params.reason,
         permissions: RequestPermissionProfile {
             network: params.permissions.network.map(Into::into),
@@ -3222,6 +3225,7 @@ mod tests {
                 thread_id: "thread-1".to_string(),
                 turn_id: "turn-1".to_string(),
                 item_id: "call-1".to_string(),
+                started_at_ms: 0,
                 cwd: cwd.clone(),
                 reason: Some("need write access".to_string()),
                 permissions: codex_app_server_protocol::RequestPermissionProfile {

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1384,6 +1384,7 @@ impl PromptState {
             // grant_root doesn't seem to be set anywhere on the codex side
             grant_root: _,
             turn_id: _,
+            started_at_ms: _,
         } = event;
         let (title, locations, content) = extract_tool_call_content_from_changes(changes);
         let request_key = patch_request_key(&call_id);
@@ -1639,6 +1640,7 @@ impl PromptState {
             call_id,
             command,
             turn_id,
+            started_at_ms: _,
             cwd,
             reason,
             parsed_cmd,
@@ -5967,6 +5969,7 @@ mod tests {
                                     call_id: "call-id".to_string(),
                                     approval_id: Some("approval-id".to_string()),
                                     turn_id: id.to_string(),
+                                    started_at_ms: 0,
                                     command: vec!["echo".to_string(), "hi".to_string()],
                                     cwd: current_dir_abs().unwrap(),
                                     reason: None,
@@ -6390,6 +6393,7 @@ mod tests {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
                             cwd: current_dir_abs()?,
                             reason: None,
@@ -6476,6 +6480,7 @@ mod tests {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
                             cwd: current_dir_abs()?,
                             reason: None,
@@ -6568,6 +6573,7 @@ mod tests {
                         &session_client,
                         ApplyPatchApprovalRequestEvent {
                             call_id: "patch-call".to_string(),
+                            started_at_ms: 0,
                             changes,
                             reason: Some("Need write approval".to_string()),
                             grant_root: None,
@@ -6645,6 +6651,7 @@ mod tests {
                         &session_client,
                         ApplyPatchApprovalRequestEvent {
                             call_id: "patch-call".to_string(),
+                            started_at_ms: 0,
                             changes,
                             reason: Some("Need write approval".to_string()),
                             grant_root: None,
@@ -6720,6 +6727,7 @@ mod tests {
                         RequestPermissionsEvent {
                             call_id: "permissions-call".to_string(),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             reason: Some("Need additional permissions".to_string()),
                             permissions:
                                 codex_protocol::request_permissions::RequestPermissionProfile::default(),
@@ -6798,6 +6806,7 @@ mod tests {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             command: vec![
                                 actor_cli.clone(),
                                 "actor".to_string(),
@@ -6878,6 +6887,7 @@ mod tests {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             command: vec![
                                 "/bin/zsh".to_string(),
                                 "-lc".to_string(),
@@ -7138,6 +7148,7 @@ mod tests {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
                             turn_id: "turn-id".to_string(),
+                            started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
                             cwd: current_dir_abs()?,
                             reason: None,

--- a/docs/journal/2026-05-18-codex-130-upgrade.md
+++ b/docs/journal/2026-05-18-codex-130-upgrade.md
@@ -1,0 +1,74 @@
+# Summary
+
+Upgraded `agenthub-codex-acp` from the official `openai/codex` `rust-v0.129.0` baseline to
+`rust-v0.130.0` (release commit `58573da43ab697e8b79f152c53df4b42230395a8`).
+
+The AgentHub ACP adapter only needed a narrow compatibility update for the new
+`started_at_ms` field on approval-related protocol events.
+
+# Background
+
+AgentHub keeps the ACP adapter close to the upstream Codex release train so the
+app-server bridge does not accumulate avoidable protocol drift.
+
+Current `main` already uses Cargo tag pins for the direct Codex Rust crates while
+keeping `MODULE.bazel`'s `codex_src` fetch separate. This upgrade follows that
+current repository shape instead of reintroducing an older "pin everything to one
+rev" layout.
+
+# Scope
+
+- bumped all direct `agenthub-codex-acp` Codex git dependencies from
+  `rust-v0.129.0` to `rust-v0.130.0`
+- refreshed `Cargo.lock` onto the `0.130.0` Codex graph
+- updated ACP approval event translation and test fixtures for the newly required
+  `started_at_ms` field
+
+# Key Decisions
+
+- Keep the upgrade narrow.
+  The first `0.130.0` compile break was limited to approval event schema changes,
+  so the adapter now forwards `started_at_ms` from app-server approval params into
+  ACP-facing protocol events and otherwise keeps behavior unchanged.
+
+- Do not change `MODULE.bazel` in this slice.
+  The current repository no longer ties Bazel's `codex_src` fetch directly to the
+  Cargo tag pin, and the focused Rust ACP validation passed without any Bazel-side
+  source adjustment.
+
+- Treat test fixtures as part of the compatibility surface.
+  `cargo check --tests` surfaced the same schema change in ACP test-only event
+  constructors, so those fixtures now set `started_at_ms: 0` explicitly.
+
+# Validation
+
+Executed:
+
+```bash
+TMPDIR=$PWD/.tmp \
+CARGO_HOME=$PWD/.cargo-home-temp \
+CARGO_NET_GIT_FETCH_WITH_CLI=true \
+RUSTC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc \
+RUSTDOC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc \
+/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo check -p agenthub-codex-acp
+```
+
+```bash
+TMPDIR=$PWD/.tmp \
+CARGO_HOME=$PWD/.cargo-home-temp \
+CARGO_NET_GIT_FETCH_WITH_CLI=true \
+RUSTC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc \
+RUSTDOC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc \
+/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo check -p agenthub-codex-acp --tests
+```
+
+Result:
+
+- both focused ACP checks passed on the `rust-v0.130.0` dependency graph
+- the adapter compiles after forwarding `started_at_ms` through approval request
+  translations
+- the ACP test target also compiles after updating test-only approval fixtures
+
+# Follow-Ups
+
+None for the Rust ACP adapter slice in this change.


### PR DESCRIPTION
## Summary

- upgrade `agenthub-codex-acp` from `openai/codex@rust-v0.129.0` to `rust-v0.130.0`
- refresh `Cargo.lock` onto the `0.130.0` graph
- forward the new approval-event `started_at_ms` field through the ACP adapter and test fixtures
- add a rollout journal for the upgrade

## Why

AgentHub keeps the ACP adapter close to the upstream Codex release train so the
app-server bridge does not accumulate protocol drift.

For `0.130.0`, the first adapter breakage was narrow: approval-related protocol
events now require `started_at_ms`. This PR keeps the upgrade focused by wiring
that field through the existing translation path without changing approval
behavior.

## Related

- Related issue: none

## Testing

```bash
RUSTC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc \
RUSTDOC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc \
/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo check -p agenthub-codex-acp
```

```bash
TMPDIR=$PWD/.tmp \
CARGO_HOME=$PWD/.cargo-home-temp \
CARGO_NET_GIT_FETCH_WITH_CLI=true \
RUSTC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc \
RUSTDOC=/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc \
/home/hawkingrei/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo check -p agenthub-codex-acp --tests
```
