### PR TITLE
fix(docs): patch userdocs ws dependency

### DIFF
--- a/userdocs/package-lock.json
+++ b/userdocs/package-lock.json
@@ -18090,9 +18090,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/userdocs/package.json
+++ b/userdocs/package.json
@@ -15,6 +15,9 @@
     "react-dom": "^18.2.0"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "webpack-dev-server": {
+      "ws": "^8.20.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- patch the vulnerable `webpack-dev-server -> ws` chain in `userdocs`
- keep the PR scoped to the docs lockfile and override only

## Why
- resolves Dependabot alert #64 (`ws` in `userdocs/package-lock.json`)
- avoids the much larger Codex/Rust dependency upgrade required for the other alerts

## Validation
- `cd userdocs && npm install`
- `cd userdocs && npm ls ws` shows `webpack-dev-server -> ws@8.20.1`
- npm audit reported `found 0 vulnerabilities` during install
