### PR TITLE
chore(acp): upgrade codex to 0.131

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "codex-config",
  "codex-core",
  "codex-exec-server",
+ "codex-extension-api",
  "codex-features",
  "codex-feedback",
  "codex-login",
@@ -2460,8 +2461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2479,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2498,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2527,8 +2528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2547,15 +2548,19 @@ dependencies = [
  "codex-core",
  "codex-core-plugins",
  "codex-exec-server",
+ "codex-extension-api",
  "codex-external-agent-migration",
  "codex-external-agent-sessions",
  "codex-features",
  "codex-feedback",
  "codex-file-search",
+ "codex-file-watcher",
  "codex-git-utils",
+ "codex-guardian",
  "codex-hooks",
  "codex-login",
  "codex-mcp",
+ "codex-memories-extension",
  "codex-memories-write",
  "codex-model-provider",
  "codex-models-manager",
@@ -2590,8 +2595,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2601,6 +2606,8 @@ dependencies = [
  "codex-exec-server",
  "codex-feedback",
  "codex-protocol",
+ "codex-uds",
+ "codex-utils-absolute-path",
  "codex-utils-rustls-provider",
  "futures",
  "serde",
@@ -2614,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2638,8 +2645,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2674,8 +2681,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2689,8 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2707,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2717,8 +2724,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2731,8 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2748,8 +2755,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,20 +2764,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-builtin-mcps"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
-dependencies = [
- "anyhow",
- "codex-memories-mcp",
- "codex-utils-absolute-path",
- "tokio",
-]
-
-[[package]]
 name = "codex-chatgpt"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2789,8 +2785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2815,8 +2811,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2839,8 +2835,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2856,13 +2852,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 
 [[package]]
 name = "codex-config"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2887,6 +2883,7 @@ dependencies = [
  "prost",
  "schemars 0.8.22",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
@@ -2904,19 +2901,22 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
  "serde",
+ "serde_json",
+ "sha1",
+ "tracing",
  "urlencoding",
 ]
 
 [[package]]
 name = "codex-core"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2938,6 +2938,7 @@ dependencies = [
  "codex-core-skills",
  "codex-exec-server",
  "codex-execpolicy",
+ "codex-extension-api",
  "codex-features",
  "codex-feedback",
  "codex-git-utils",
@@ -2971,7 +2972,6 @@ dependencies = [
  "codex-utils-path",
  "codex-utils-plugins",
  "codex-utils-pty",
- "codex-utils-readiness",
  "codex-utils-stream-parser",
  "codex-utils-string",
  "codex-utils-template",
@@ -2979,7 +2979,6 @@ dependencies = [
  "csv",
  "dirs",
  "dunce",
- "env-flags",
  "eventsource-stream",
  "futures",
  "http 1.4.0",
@@ -2987,7 +2986,6 @@ dependencies = [
  "image",
  "indexmap 2.14.0",
  "libc",
- "notify",
  "once_cell",
  "openssl-sys",
  "rand 0.9.4",
@@ -3015,8 +3013,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3051,8 +3049,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3081,11 +3079,12 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "codex-app-server-protocol",
@@ -3095,11 +3094,12 @@ dependencies = [
  "codex-sandboxing",
  "codex-utils-absolute-path",
  "codex-utils-pty",
+ "codex-utils-rustls-provider",
  "futures",
+ "prost",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -3111,8 +3111,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3127,8 +3127,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3136,9 +3136,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-extension-api"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+dependencies = [
+ "codex-protocol",
+ "codex-tools",
+]
+
+[[package]]
 name = "codex-external-agent-migration"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3148,8 +3157,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3161,8 +3170,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3174,8 +3183,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3187,8 +3196,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3202,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3212,9 +3221,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-file-watcher"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+dependencies = [
+ "notify",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-git-utils"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3236,9 +3255,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-guardian"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+dependencies = [
+ "codex-core",
+ "codex-extension-api",
+ "codex-protocol",
+]
+
+[[package]]
 name = "codex-hooks"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3259,8 +3288,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "keyring",
  "tracing",
@@ -3268,8 +3297,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "clap",
  "codex-process-hardening",
@@ -3288,8 +3317,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3322,14 +3351,13 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-channel",
  "codex-api",
  "codex-async-utils",
- "codex-builtin-mcps",
  "codex-config",
  "codex-exec-server",
  "codex-login",
@@ -3354,14 +3382,15 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-arg0",
  "codex-config",
  "codex-core",
  "codex-exec-server",
+ "codex-extension-api",
  "codex-login",
  "codex-protocol",
  "codex-utils-cli",
@@ -3377,14 +3406,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-memories-mcp"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+name = "codex-memories-extension"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
- "anyhow",
+ "async-trait",
+ "codex-core",
+ "codex-extension-api",
+ "codex-features",
+ "codex-memories-read",
+ "codex-tools",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
- "rmcp 0.15.0",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -3394,8 +3427,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3407,8 +3440,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3438,8 +3471,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -3460,8 +3493,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3473,8 +3506,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3493,8 +3526,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3523,8 +3556,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3555,8 +3588,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -3566,16 +3599,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3585,7 +3618,6 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-string",
- "codex-utils-template",
  "encoding_rs",
  "globset",
  "icu_decimal",
@@ -3612,8 +3644,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3623,11 +3655,12 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "codex-api",
  "codex-client",
@@ -3657,8 +3690,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3681,12 +3714,13 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "codex-code-mode",
  "codex-protocol",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "tracing",
@@ -3695,8 +3729,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3712,8 +3746,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "age",
  "anyhow",
@@ -3731,8 +3765,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3750,8 +3784,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3770,8 +3804,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3780,8 +3814,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3802,16 +3836,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3819,6 +3853,7 @@ dependencies = [
  "codex-protocol",
  "codex-rollout",
  "codex-state",
+ "codex-utils-path",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3828,25 +3863,28 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
+ "async-trait",
  "codex-app-server-protocol",
  "codex-code-mode",
  "codex-features",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-pty",
+ "codex-utils-string",
  "rmcp 0.15.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "codex-uds"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "async-io",
  "tokio",
@@ -3856,8 +3894,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "dirs",
  "dunce",
@@ -3868,16 +3906,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "lru",
  "sha1",
@@ -3886,19 +3924,20 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "clap",
  "codex-protocol",
+ "codex-shell-command",
  "serde",
  "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3906,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3919,8 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3928,8 +3967,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3937,8 +3976,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3947,8 +3986,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -3959,8 +3998,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3974,33 +4013,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-utils-readiness"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
-dependencies = [
- "async-trait",
- "thiserror 2.0.18",
- "time",
- "tokio",
-]
-
-[[package]]
 name = "codex-utils-rustls-provider"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4009,13 +4037,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.130.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.130.0#58573da43ab697e8b79f152c53df4b42230395a8"
+version = "0.131.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5984,12 +6012,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "env-flags"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd0e7fc632dec5e6c9396a27bc9f9975b4e039720e1fd3e34021d3ce28c415"
 
 [[package]]
 name = "equator"
@@ -13543,6 +13565,16 @@ dependencies = [
  "indexmap 2.14.0",
  "itoa",
  "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
  "serde_core",
 ]
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "08ad4f5f5abf9c4844d9ccd0e2c6b364d8460d46",
+    commit = "02d0ab56b9201fbb6f8e0e9be914c19053058eb1",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,23 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.130.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -63,6 +63,10 @@ use crate::build_environment_manager;
 use crate::thread::CodexThreadImpl;
 
 const ACP_CLIENT_NAME: &str = "agenthub-codex-acp";
+const DYNAMIC_TOOL_CALLBACK_UNSUPPORTED_MESSAGE: &str =
+    "dynamic tool callbacks are not supported by agenthub-codex-acp";
+const ATTESTATION_GENERATION_UNSUPPORTED_MESSAGE: &str =
+    "attestation generation is not supported by agenthub-codex-acp";
 // The in-process client exposes event reads and server-request replies through
 // the same client object. Do not hold its mutex forever while waiting for
 // provider events, otherwise permission replies and interrupts can be starved.
@@ -1037,11 +1041,13 @@ impl AppServerCodexThread {
                 }))
             }
             ServerRequest::DynamicToolCall { request_id, .. } => {
-                self.reject_server_request(
-                    request_id,
-                    "dynamic tool callbacks are not supported by agenthub-codex-acp",
-                )
-                .await?;
+                self.reject_server_request(request_id, DYNAMIC_TOOL_CALLBACK_UNSUPPORTED_MESSAGE)
+                    .await?;
+                Ok(None)
+            }
+            ServerRequest::AttestationGenerate { request_id, .. } => {
+                self.reject_server_request(request_id, ATTESTATION_GENERATION_UNSUPPORTED_MESSAGE)
+                    .await?;
                 Ok(None)
             }
             ServerRequest::ChatgptAuthTokensRefresh { .. }
@@ -2226,6 +2232,7 @@ fn prepare_submission_start(
                     thread_id: state.thread_id.clone(),
                     input: items.clone().into_iter().map(Into::into).collect(),
                     cwd: Some(state.config.cwd.to_path_buf()),
+                    runtime_workspace_roots: None,
                     approval_policy: Some(state.config.permissions.approval_policy.value().into()),
                     approvals_reviewer: Some(state.config.approvals_reviewer.into()),
                     sandbox_policy: Some(
@@ -2745,6 +2752,7 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
         config: Arc::new(config.clone()),
         cli_overrides: Vec::new(),
         loader_overrides: LoaderOverrides::default(),
+        strict_config: false,
         cloud_requirements: CloudRequirementsLoader::default(),
         feedback: CodexFeedback::new(),
         log_db: None,
@@ -3303,6 +3311,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn unsupported_server_request_messages_stay_explicit() {
+        assert_eq!(
+            DYNAMIC_TOOL_CALLBACK_UNSUPPORTED_MESSAGE,
+            "dynamic tool callbacks are not supported by agenthub-codex-acp"
+        );
+        assert_eq!(
+            ATTESTATION_GENERATION_UNSUPPORTED_MESSAGE,
+            "attestation generation is not supported by agenthub-codex-acp"
+        );
+    }
+
+    #[tokio::test]
+    async fn attestation_generate_requests_are_rejected() {
+        let state = test_state_with_active_turn(None).await;
+        let config = state.config.clone();
+        let client = start_client(&config).await.expect("start client");
+        let request_handle = client.request_handle();
+        let thread = AppServerCodexThread::new(
+            client,
+            request_handle,
+            "thread-1".to_string(),
+            config,
+            1,
+            ThreadStatus::Idle,
+            Vec::new(),
+        );
+
+        let result = thread
+            .translate_server_request(ServerRequest::AttestationGenerate {
+                request_id: RequestId::Integer(7),
+                params: codex_app_server_protocol::AttestationGenerateParams {},
+            })
+            .await;
+
+        assert!(matches!(result, Ok(None)));
+    }
+
     #[tokio::test]
     async fn submission_id_for_turn_falls_back_to_turn_id_when_local_state_is_missing() {
         let state = test_state_with_active_turn(None).await;
@@ -3532,6 +3578,30 @@ mod tests {
             prepared,
             Some(PreparedSubmissionStart::TurnStart { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn prepare_submission_start_leaves_runtime_workspace_roots_unset() {
+        let mut state = test_state_with_active_turn(None).await;
+
+        let prepared = prepare_submission_start(
+            &mut state,
+            "submission-runtime-roots",
+            &Op::UserInput {
+                items: Vec::new(),
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                environments: None,
+            },
+        )
+        .expect("prepare submission")
+        .expect("turn start");
+
+        let PreparedSubmissionStart::TurnStart { params, .. } = prepared else {
+            panic!("expected turn start");
+        };
+        assert_eq!(params.cwd, Some(state.config.cwd.to_path_buf()));
+        assert_eq!(params.runtime_workspace_roots, None);
     }
 
     #[test]

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -15,6 +15,7 @@ use codex_core::{
     RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
     find_thread_path_by_id_str, parse_cursor, thread_store_from_config,
 };
+use codex_extension_api::empty_extension_registry;
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -81,10 +82,12 @@ impl CodexAgent {
             auth_manager.clone(),
             SessionSource::Unknown,
             build_environment_manager(&config).await?,
+            empty_extension_registry(),
             None,
             thread_store_from_config(&config, None),
             None,
             "agenthub-codex-acp".to_string(),
+            None,
         );
         Ok(Self {
             auth_manager,
@@ -120,7 +123,6 @@ impl CodexAgent {
         mcp_servers: Vec<McpServer>,
     ) -> Result<Config, Error> {
         let mut config = self.config.clone();
-        config.include_apply_patch_tool = true;
         config.cwd = cwd
             .to_path_buf()
             .try_into()
@@ -210,6 +212,7 @@ fn codex_mcp_server_config(cwd: &Path, mcp_server: McpServer) -> Option<(String,
             enabled_tools: None,
             disabled_reason: None,
             scopes: None,
+            oauth: None,
             oauth_resource: None,
             tools: HashMap::new(),
         },
@@ -941,6 +944,7 @@ mod tests {
     };
     use codex_config::types::McpServerTransportConfig;
     use codex_core::RolloutRecorder;
+    use codex_core::config::ConfigBuilder;
     use codex_protocol::{
         ThreadId,
         models::{
@@ -953,6 +957,25 @@ mod tests {
         },
     };
     use std::{collections::HashMap, path::PathBuf};
+
+    #[tokio::test]
+    async fn codex_agent_new_initializes_thread_manager() {
+        let codex_home =
+            std::env::temp_dir().join(format!("agenthub-codex-home-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home).expect("create codex home");
+        let config = ConfigBuilder::default()
+            .codex_home(codex_home.clone())
+            .fallback_cwd(Some(codex_home))
+            .build()
+            .await
+            .expect("build config");
+
+        let agent = super::CodexAgent::new(config)
+            .await
+            .expect("create codex agent");
+
+        assert!(agent.sessions.borrow().is_empty());
+    }
 
     #[test]
     fn codex_mcp_http_servers_keep_parallel_tool_calls_disabled() {
@@ -968,6 +991,7 @@ mod tests {
 
         assert_eq!(name, "AgentHub_Tools");
         assert!(!config.supports_parallel_tool_calls);
+        assert_eq!(config.oauth, None);
         let McpServerTransportConfig::StreamableHttp {
             url, http_headers, ..
         } = config.transport
@@ -996,6 +1020,7 @@ mod tests {
 
         assert_eq!(name, "Mailbox_Bridge");
         assert!(!config.supports_parallel_tool_calls);
+        assert_eq!(config.oauth, None);
         let McpServerTransportConfig::Stdio {
             command,
             args,

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -9,7 +9,7 @@ use agent_client_protocol::schema::{
 use agent_client_protocol::{Agent, Client, ConnectionTo};
 use codex_core::config::ManagedFeatures;
 use codex_core::config::{Config, ConfigOverrides};
-use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
+use codex_exec_server::{EnvironmentManager, ExecServerRuntimePaths};
 use codex_features::{Feature, Features};
 use codex_utils_cli::CliConfigOverrides;
 use std::fmt;
@@ -97,9 +97,14 @@ pub(crate) async fn build_environment_manager(
             "failed to resolve exec-server runtime paths: {err}"
         ))
     })?;
-    Ok(Arc::new(
-        EnvironmentManager::new(EnvironmentManagerArgs::new(runtime_paths)).await,
-    ))
+    EnvironmentManager::from_codex_home(&config.codex_home, runtime_paths)
+        .await
+        .map(Arc::new)
+        .map_err(|err| {
+            agent_client_protocol::Error::internal_error().data(format!(
+                "failed to initialize exec-server environment: {err}"
+            ))
+        })
 }
 
 #[cfg(test)]
@@ -605,8 +610,9 @@ mod tests {
         resolve_agenthub_multi_agent_enabled_override, responses_websocket_feature_opt_in_enabled,
         rewrite_misleading_timeout_message, should_disable_implicit_responses_websockets,
     };
+    use codex_core::config::ConfigBuilder;
     use codex_features::{Feature, Features};
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::{Arc, Mutex, MutexGuard};
     use tracing::Level;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -712,6 +718,25 @@ mod tests {
                 "THIRD_PARTY_NOTICES.md missing {expected}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn build_environment_manager_initializes_from_codex_home() {
+        let codex_home =
+            std::env::temp_dir().join(format!("agenthub-codex-home-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home).expect("create codex home");
+        let config = ConfigBuilder::default()
+            .codex_home(codex_home.clone())
+            .fallback_cwd(Some(codex_home))
+            .build()
+            .await
+            .expect("build config");
+
+        let manager = super::build_environment_manager(&config)
+            .await
+            .expect("environment manager");
+
+        assert_eq!(Arc::strong_count(&manager), 1);
     }
 
     #[test]

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1276,8 +1276,6 @@ impl PromptState {
             | EventMsg::HookCompleted(..)
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
-            // Revisit when we can emit status updates
-            | EventMsg::SkillsUpdateAvailable
             | EventMsg::RawResponseItem(..)
             | EventMsg::SessionConfigured(..)
             // TODO: Subagent UI?
@@ -3091,8 +3089,7 @@ impl<A: Auth> ThreadActor<A> {
             .iter()
             .find(|preset| {
                 &preset.approval == self.config.permissions.approval_policy.get()
-                    && &preset.permission_profile
-                        == self.config.permissions.permission_profile.get()
+                    && &preset.permission_profile == self.config.permissions.permission_profile()
             })
             .or_else(|| {
                 // When the project is untrusted, the above code won't match
@@ -3659,10 +3656,8 @@ impl<A: Auth> ThreadActor<A> {
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         self.config
             .permissions
-            .permission_profile
-            .set(preset.permission_profile.clone())
+            .set_permission_profile(preset.permission_profile.clone())
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
-        self.config.permissions.active_permission_profile = None;
 
         match legacy_sandbox_policy {
             SandboxPolicy::DangerFullAccess

--- a/docs/journal/2026-05-19-codex-131-upgrade.md
+++ b/docs/journal/2026-05-19-codex-131-upgrade.md
@@ -1,0 +1,40 @@
+# Summary
+
+AgentHub's Codex ACP adapter now targets Codex `rust-v0.131.0`.
+
+# Background
+
+The repository had already moved to Codex `rust-v0.130.0`. The next upgrade needed
+to refresh both the Cargo git dependencies and the Bazel `codex_src` archive while
+adapting the ACP bridge to Codex 0.131 API changes.
+
+# Scope
+
+- Updated `agenthub-codex-acp` Codex git dependencies from `rust-v0.130.0` to
+  `rust-v0.131.0`.
+- Updated `MODULE.bazel` `codex_src` to the upstream `rust-v0.131.0` tag target.
+- Adapted ACP bridge code for Codex 0.131 app-server, permission, MCP, and
+  environment-manager API changes.
+
+# Key Decisions
+
+- Use Codex's empty extension registry for AgentHub ACP sessions. AgentHub does
+  not register Codex extension contributors yet, so an empty registry preserves
+  the existing behavior while satisfying the new `ThreadManager` constructor.
+- Reject app-server attestation requests explicitly because AgentHub ACP does not
+  implement attestation generation.
+- Keep app-server config loading non-strict for the embedded client to preserve
+  the existing permissive adapter behavior.
+
+# Validation
+
+```bash
+cargo check -p agenthub-codex-acp
+cargo check -p agenthub-codex-acp --tests
+cargo test -p agenthub-codex-acp
+```
+
+# Follow-Ups
+
+- Run the normal repository CI after this lands to cover non-ACP packages and
+  Bazel integration.


### PR DESCRIPTION
## Summary

- upgrade AgentHub's Codex ACP adapter dependencies to Codex `rust-v0.131.0`
- update the Bazel `codex_src` pin to the matching upstream tag target
- adapt ACP bridge code for Codex 0.131 API changes around app-server requests, environment management, extension registry setup, MCP server config, and permission profiles
- add a rollout journal with local validation evidence

## Purpose

Keep AgentHub's embedded Codex ACP adapter current with the upstream Codex 0.131 API while preserving the existing ACP behavior.

## Related Issues

None.

## Testing

```bash
cargo fmt --check
cargo check -p agenthub-codex-acp
cargo check -p agenthub-codex-acp --tests
cargo test -p agenthub-codex-acp
```

Attempted:

```bash
bazel test //agenthub-codex-acp:agenthub_codex_acp_tests
```

The local Bazel run was interrupted after it stayed in crate splicing / `cargo fetch` loading for several minutes. CI should provide the full Bazel coverage for the PR.
