### PR TITLE
chore(acp): upgrade codex to 0.132

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,8 +2461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2480,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2528,8 +2528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2595,8 +2595,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2621,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -2645,8 +2645,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "axum",
@@ -2681,8 +2681,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2696,8 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2714,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2724,8 +2724,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2738,8 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2755,8 +2755,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "serde",
  "serde_json",
@@ -2765,8 +2765,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -2785,8 +2785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2811,8 +2811,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2835,8 +2835,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2852,13 +2852,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 
 [[package]]
 name = "codex-config"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2901,8 +2901,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2915,8 +2915,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3013,8 +3013,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3049,8 +3049,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3079,14 +3079,15 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
  "base64 0.22.1",
  "bytes",
+ "codex-api",
  "codex-app-server-protocol",
  "codex-client",
  "codex-file-system",
@@ -3111,8 +3112,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -3127,8 +3128,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3137,17 +3138,18 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
+ "async-trait",
  "codex-protocol",
  "codex-tools",
 ]
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3157,8 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3170,8 +3172,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3183,8 +3185,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3196,8 +3198,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -3211,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3222,8 +3224,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "notify",
  "tokio",
@@ -3232,8 +3234,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3256,9 +3258,10 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
+ "async-trait",
  "codex-core",
  "codex-extension-api",
  "codex-protocol",
@@ -3266,8 +3269,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3288,8 +3291,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "keyring",
  "tracing",
@@ -3297,8 +3300,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "clap",
  "codex-process-hardening",
@@ -3317,8 +3320,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3351,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3382,8 +3385,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3407,8 +3410,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "codex-core",
@@ -3427,8 +3430,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3440,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3471,8 +3474,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -3493,8 +3496,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3506,8 +3509,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3526,8 +3529,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3556,8 +3559,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3588,8 +3591,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -3599,16 +3602,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3644,8 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3655,8 +3658,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "axum",
@@ -3690,8 +3693,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3714,8 +3717,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3729,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3746,8 +3749,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "age",
  "anyhow",
@@ -3765,8 +3768,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3784,8 +3787,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3804,8 +3807,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3814,8 +3817,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3836,16 +3839,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3863,8 +3866,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "codex-app-server-protocol",
@@ -3883,8 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-io",
  "tokio",
@@ -3894,8 +3897,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "dirs",
  "dunce",
@@ -3906,16 +3909,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "lru",
  "sha1",
@@ -3924,8 +3927,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3936,8 +3939,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3945,8 +3948,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3958,8 +3961,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3967,8 +3970,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3976,8 +3979,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3986,8 +3989,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -3998,8 +4001,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4014,21 +4017,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4037,13 +4040,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "02d0ab56b9201fbb6f8e0e9be914c19053058eb1",
+    commit = "13595c36e218fcbd13df118eeadf00d4eb0e6d31",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -922,12 +922,17 @@ impl PromptState {
             }
             EventMsg::UserMessage(UserMessageEvent {
                 message,
-                images: _,
+                images,
+                image_details,
                 text_elements: _,
-                local_images: _,
-                ..
+                local_images,
+                local_image_details,
             }) => {
-                info!("User message: {message:?}");
+                info!(
+                    "User message: {message:?}, image_count: {}, image_details: {image_details:?}, local_image_count: {}, local_image_details: {local_image_details:?}",
+                    images.as_ref().map_or(0, Vec::len),
+                    local_images.len(),
+                );
             }
             EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent {
                 thread_id,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -83,6 +83,8 @@ fn format_thread_goal_update(event: &ThreadGoalUpdatedEvent) -> String {
         ThreadGoalStatus::Active => "active",
         ThreadGoalStatus::Paused => "paused",
         ThreadGoalStatus::BudgetLimited => "budget limited",
+        ThreadGoalStatus::Blocked => "blocked",
+        ThreadGoalStatus::UsageLimited => "usage limited",
         ThreadGoalStatus::Complete => "complete",
     };
 
@@ -923,6 +925,7 @@ impl PromptState {
                 images: _,
                 text_elements: _,
                 local_images: _,
+                ..
             }) => {
                 info!("User message: {message:?}");
             }
@@ -4488,6 +4491,7 @@ fn build_prompt_items_with_trusted_root(
             )),
             ContentBlock::Image(image_block) => Some(UserInput::Image {
                 image_url: format!("data:{};base64,{}", image_block.mime_type, image_block.data),
+                detail: None,
             }),
             ContentBlock::ResourceLink(ResourceLink { name, uri, .. }) => Some(UserInput::Text {
                 text: format_uri_as_link(Some(name), uri),

--- a/docs/journal/2026-05-20-codex-132-upgrade.md
+++ b/docs/journal/2026-05-20-codex-132-upgrade.md
@@ -1,0 +1,43 @@
+# Summary
+
+AgentHub's Codex ACP adapter now targets Codex `rust-v0.132.0`.
+
+# Background
+
+The repository had already moved to Codex `rust-v0.131.0`. This upgrade refreshes
+both the Cargo git dependencies and the Bazel `codex_src` pin while adapting the
+ACP bridge to Codex 0.132 protocol changes.
+
+# Scope
+
+- Updated `agenthub-codex-acp` Codex git dependencies from `rust-v0.131.0` to
+  `rust-v0.132.0`.
+- Updated `Cargo.lock` to the upstream `rust-v0.132.0` release commit
+  `13595c36e218fcbd13df118eeadf00d4eb0e6d31`.
+- Updated `MODULE.bazel` `codex_src` to the upstream `rust-v0.132.0` tag target.
+- Adapted ACP bridge code for Codex 0.132 thread-goal status and image prompt
+  model changes.
+
+# Key Decisions
+
+- Keep the ACP bridge tolerant of newly added user-message image metadata by
+  ignoring unknown fields when converting Codex events into AgentHub thread
+  records.
+- Populate Codex image prompt items with `detail: None` until AgentHub exposes a
+  richer image-detail selection contract.
+- Treat the new `blocked` and `usage limited` thread-goal statuses as first-class
+  status strings in the thread formatter to preserve user-visible progress
+  reporting.
+
+# Validation
+
+```bash
+cargo check -p agenthub-codex-acp
+cargo check -p agenthub-codex-acp --tests
+cargo test -p agenthub-codex-acp
+```
+
+# Follow-Ups
+
+- Run the normal repository CI after this lands to cover non-ACP packages and
+  Bazel integration.


### PR DESCRIPTION
chore(acp): upgrade codex to 0.132

## What Changed

- bumped `agenthub-codex-acp` Codex git dependencies from `rust-v0.131.0` to
  `rust-v0.132.0`
- refreshed `Cargo.lock` to the upstream `rust-v0.132.0` release commit
  `13595c36e218fcbd13df118eeadf00d4eb0e6d31`
- updated `MODULE.bazel` `codex_src` to the same upstream release commit
- adapted the ACP thread bridge for the new thread-goal statuses and image input
  shape introduced by Codex 0.132
- added a rollout journal for the upgrade

## Why

`main` was already on Codex `rust-v0.131.0`. The next ACP upgrade needed to keep
the embedded Codex client and Bazel source pin aligned with the upstream 0.132
release while preserving AgentHub's existing ACP behavior.

## Impact

- ACP sessions now run against Codex `0.132.0`
- thread goal updates continue rendering cleanly when Codex emits `blocked` or
  `usage limited`
- user-image prompt items remain accepted by the upstream 0.132 protocol without
  requiring any new AgentHub-side configuration

## Validation

- `cargo check -p agenthub-codex-acp`
- `cargo check -p agenthub-codex-acp --tests`
- `TMPDIR=/home/hawkingrei/devel/opensource/agenthub/.tmp cargo test -p agenthub-codex-acp`

