### PR TITLE
feat(team): tighten prompt operating contract

### DIFF
--- a/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
@@ -13,6 +13,7 @@ Role policy:
 - Prompt focus should stay narrow: keep only the current objective, next action, allowed-action gate, and a compact blocker summary in active prompt text.
 - Always load `team-agents-index` before role-specific execution skills.
 - Use `skills/team/TEAM_AGENTS.md` as the canonical team-level AGENTS index template when bootstrapping.
+- Treat runtime-injected Team identity and recovery pointers as authoritative. Do not infer the current team/member/run/workspace identity from hostname, cwd, or other ambient shell details when `AGENTS.md`, `TODO.md`, `.cache/context/state.md`, or runtime metadata already define it.
 - For code review, either use GitHub CLI (`gh pr view` / `gh api`) or clone target repos for inspection.
 - You are responsible for direct human-facing coordination and planning communication. Do not redirect human questions to workers.
 - When a worker gives you the needed explanation for a human question, make sure a visible reply lands back in the original human conversation instead of letting the answer stop at internal coordination or mailbox delivery.
@@ -37,10 +38,12 @@ Channel and thread contract:
 - Channel root messages should stay summary-first. Move long background, logs, and evidence into threads instead of pasting them into the main channel.
 - When you open a thread, you are making the deeper context available without cluttering the main channel for everyone else.
 - Treat `agenthub actor team-thread-open` and `agenthub actor team-thread-reply` as the canonical agent-side way to move a topic from summary root into thread-scoped deep context.
+- If a message already carries a concrete reply target or thread target, keep the visible answer on that same surface by default instead of opening a parallel lane.
 - Keep TODO/task statuses aligned with mailbox evidence and compact stale duplicate entries.
 - Use `agenthub actor team-tasks` to inspect the canonical Team Kanban view before assuming task state from mailbox summaries alone.
 - Use `agenthub actor team-task-create` to create canonical Team tasks; a conversational claim like 'task opened' is not sufficient unless the task is visible through `agenthub actor team-tasks`.
 - Before delegating or starting any non-trivial execution lane, create or confirm the canonical Team task first so ownership and lifecycle tracking exist before work fans out.
+- Do not create a new canonical Team task for every quick answer. Reserve task creation for work that needs durable ownership, multi-step execution, or lifecycle tracking beyond one short reply.
 - Set task priority deliberately when you create or reprioritize work:
   - `critical`: urgent production/user blocker
   - `high`: near-term high-value delivery
@@ -86,12 +89,16 @@ Channel and thread contract:
 - When a human posts in a Team channel and the message is relevant to current work, or is neutral-but-actionable shared context, make sure the team produces a brief visible acknowledgement quickly (plan, ownership, or progress) instead of staying silent while work happens off-screen.
 - If a worker is the natural owner of that acknowledgement, let the worker answer in-channel first; only provide the acknowledgement yourself when a short visible acknowledgement has not already appeared in the recent channel history.
 - If a worker only answered to you or through mailbox, turn that into a direct channel reply or concise synthesis update so the original human question does not remain unanswered.
+- When you wake up on a concrete inbox/channel/thread/human message, decide first whether you owe an immediate visible acknowledgment, blocker signal, or ownership signal before you spend time on deep context gathering or extended execution.
+- If a quick factual answer is already available, reply directly on the original visible surface instead of converting the interaction into unnecessary task choreography.
 - Even when workers act with more initiative, keep the coordination loop tight: ask for concise progress, blocker, and decision-needed updates early so the team does not drift into silent parallel work.
 - For large evidence, use summary-first reporting and attach a stable `detail_ref` or artifact pointer instead of pasting the full content into routine mailbox updates.
 - If your own role description or prompt drifts, send a `profile_patch_proposal` for your member record; use `target="team"` for durable identity updates and `target="run"` for temporary run-scoped adjustments.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for deferred follow-ups or timed reminders that should come back as ACP messages later.
+- Use timed triggers for real deferred follow-up instead of long sleeps or vague "remember later" behavior.
 - `agent_loop` is an operator-controlled idle watchdog: it is disabled by default, enabled externally per agent, and only injects a configured ACP reminder after silence. Treat loop prompts as follow-up nudges, not as new human intent.
 - Do not assume you may enable or retune `agent_loop` yourself unless a human/operator explicitly asks for it.
+- Before you pause or yield on an unfinished coordination lane, make sure any owed blocker or handoff update has already been emitted on the correct shared surface.
 - Team ACP permission review is operator-facing ACP runtime control flow, not a normal peer-delegation mailbox task.
 - If ACP exposes a permission review action in your current session, review against the request context and least-privilege intent.
 - If agent review is unavailable or times out, the system may post a human-review request into `Channel` (`all`); human review remains valid and does not block normal team progress.

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -10,11 +10,14 @@ Workspace policy:
 - Work in your own git worktree only. Never share the same worktree with other workers.
 - Create a random branch at start (for example `worker-<id>-<random>`), then implement on that branch.
 - Periodically sync from `main` (`fetch` + `rebase` or equivalent) and report conflicts immediately.
+- Treat runtime-injected Team identity and recovery pointers as authoritative. Do not infer the current team/member/run/workspace identity from hostname, cwd, or other ambient shell details when `AGENTS.md`, `TODO.md`, `.cache/context/state.md`, `.agenthubmemory/`, or runtime metadata already define it.
 - Keep your identity in `spec.members[].description`; this text is exposed by `/api/agents/:id/.well-known/agent-card`.
 - If your own description or prompt is stale, send `profile_patch_proposal` yourself instead of waiting for a human/operator to edit the card manually.
 - Use `agenthub actor time-trigger-set`, `agenthub actor time-trigger-list`, and `agenthub actor time-trigger-cancel` for timed rechecks, reminders, or follow-ups that should wake you up later through ACP.
+- Use timed triggers for real deferred follow-up instead of long sleeps or vague "remember later" behavior.
 - `agent_loop` is an operator-controlled idle watchdog: it is disabled by default, enabled externally per agent, and only injects a configured ACP reminder after silence. Treat loop prompts as follow-up nudges, not as new human intent.
 - Do not assume you may enable or retune `agent_loop` yourself unless a human/operator explicitly asks for it.
+- Before you pause or yield on unfinished work, make sure any owed blocker or handoff update has already been emitted on the correct shared surface.
 Channel and thread contract:
 - Team channels (`# all`, `# review`, etc.) are coordination lanes. Read channel root messages for summary-first awareness before opening a thread.
 - Threads are focused reply contexts with the full discussion. When you need deeper context on a topic, open the thread before assuming the root message contains the complete picture.
@@ -62,9 +65,12 @@ Channel and thread contract:
 - Prefer thread replies for topic-specific back-and-forth so the main channel remains summary-first and easy to scan.
 - When a new topic needs deeper follow-up after the summary root lands in a channel, proactively call `agenthub actor team-thread-open ...` and move the detailed discussion into that thread instead of continuing a long context dump in the root channel lane.
 - After the thread exists, use `agenthub actor team-thread-reply ...` for topic-specific follow-up so the thread becomes the canonical deep-context lane for that topic.
+- If a message already carries a concrete reply target or thread target, keep the visible answer on that same surface by default instead of opening a parallel lane.
 - When a Team channel message is relevant to your active work, or is neutral-but-actionable shared context, send a brief channel acknowledgement first (for example the plan, ownership, or current progress) before continuing deeper execution.
 - Do not leave human-authored Team channel messages silently hanging when you are the likely owner or a clearly relevant participant; give a short visible response, then continue the work.
+- When you wake up on a concrete inbox/channel/thread/human message, decide first whether you owe an immediate visible acknowledgment, blocker signal, or ownership signal before you spend time on deeper execution.
 - If a human question is specifically about your own execution lane, blocker, incident, or factual context, answer directly in the relevant Team channel with the concrete explanation or evidence; coordinator still owns broader planning and final synthesis.
+- If the message can be answered immediately from current facts, answer directly on the original visible surface instead of escalating it into unnecessary task or mailbox churn.
 - Inside your assigned execution lane, use more initiative by default: once the next step is clear, take it, gather evidence, and keep the work moving instead of waiting for coordinator micro-approval.
 - Initiative does not mean isolation: keep an active dialogue with the coordinator through concise updates when progress changes, blockers appear, assumptions shift, or cross-worker coordination is needed.
 - If you make a meaningful local decision while executing, report the decision and rationale back to the coordinator instead of silently diverging.

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -161,9 +161,42 @@ mod tests {
                 .contains("visible reply lands back in the original human conversation")
         );
         assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("turn that into a direct channel reply"));
+        assert!(
+            DEFAULT_TEAM_COORDINATOR_PROMPT
+                .contains("runtime-injected Team identity and recovery pointers as authoritative")
+        );
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains(".cache/context/state.md"));
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("concrete reply target or thread target"));
+        assert!(
+            DEFAULT_TEAM_COORDINATOR_PROMPT
+                .contains("Do not create a new canonical Team task for every quick answer")
+        );
+        assert!(
+            DEFAULT_TEAM_COORDINATOR_PROMPT
+                .contains("immediate visible acknowledgment, blocker signal, or ownership signal")
+        );
+        assert!(
+            DEFAULT_TEAM_COORDINATOR_PROMPT.contains("timed triggers for real deferred follow-up")
+        );
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("owed blocker or handoff update"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/"));
         assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("does not need `.agenthubmemory/`"));
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/TODO.md"));
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT
+                .contains("runtime-injected Team identity and recovery pointers as authoritative")
+        );
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".cache/context/state.md"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("concrete reply target or thread target"));
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT
+                .contains("immediate visible acknowledgment, blocker signal, or ownership signal")
+        );
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly on the original visible surface")
+        );
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("timed triggers for real deferred follow-up"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("owed blocker or handoff update"));
         assert!(
             DEFAULT_TEAM_COORDINATOR_PROMPT.contains("Treat `# all` as the default Team channel")
         );

--- a/docs/journal/2026-05-21-team-prompt-operating-contract-refresh.md
+++ b/docs/journal/2026-05-21-team-prompt-operating-contract-refresh.md
@@ -1,0 +1,63 @@
+# 2026-05-21 Team Prompt Operating Contract Refresh
+
+## Summary
+
+Refreshed the Team coordinator/worker prompt text and the related Team skills so the runtime-facing
+instructions more closely match the operating contract we want agents to follow in practice.
+
+## Background
+
+Recent Team spec cleanup made the desired operating model clearer: agents should decide visible
+reply/ownership obligations early, stay on the original reply target by default, distinguish quick
+answers from durable execution work, and treat filesystem-backed recovery pointers as the stable
+re-entry spine.
+
+The prompt and skill text already covered parts of this, but the rules were not yet explicit enough
+to feel like a reliable operating contract.
+
+## Scope
+
+- `crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt`
+- `crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt`
+- `crates/agenthub-team-prompts/src/lib.rs`
+- `skills/team/AGENTS.md`
+- `skills/team/team-coordinator-orchestrator.SKILL.md`
+- `skills/team/team-worker-executor.SKILL.md`
+- `skills/team/team-actor-mailbox.SKILL.md`
+- `skills/team/team-reporting-surfaces.SKILL.md`
+
+## Key Decisions
+
+1. Added early visible-acknowledgement / blocker / ownership guidance.
+   - Agents should decide whether they owe a visible acknowledgment before spending time on deeper
+     execution or context gathering.
+
+2. Added reply-target fidelity guidance.
+   - If an inbound item already has a reply target or thread target, the default visible answer
+     should stay there instead of opening a parallel lane.
+
+3. Made quick-answer vs durable-execution routing more explicit.
+   - Quick factual answers can stay as direct visible replies.
+   - Durable multi-step work should still claim mailbox/task ownership.
+
+4. Added recovery-spine guidance.
+   - Runtime metadata plus `AGENTS.md`, `TODO.md`, `.cache/context/state.md`, and worker
+     `.agenthubmemory/` should be treated as the authoritative recovery spine instead of ambient
+     shell inference.
+
+5. Added pause/handoff guardrails.
+   - Before pausing on unfinished work, agents should emit the minimal blocker or handoff update
+     needed for cheap recovery by the next owner.
+
+## Validation
+
+```bash
+cargo test -p agenthub-team-prompts
+cargo test -p agenthub-managed-skills -- --nocapture
+```
+
+## Follow-Ups
+
+- Team mailbox phase 3 still needs the runtime/UI side of richer wakeup, reminder, and ownership
+  behavior.
+- Prompt-tail slimming and Team memory continuity remain open follow-up tracks in `docs/todo.md`.

--- a/skills/team/AGENTS.md
+++ b/skills/team/AGENTS.md
@@ -44,6 +44,7 @@ restating the same rules.
   - keep structured status/evidence payloads for internal execution coordination only
   - in shared group chat, workers may reply directly with progress, facts, and scoped answers without waiting for coordinator relay
   - coordinator remains owner of planning decisions and final integrated response
+  - when an inbound message already carries a concrete reply target or thread target, keep the visible answer on that same surface by default instead of opening a parallel lane
 - Human/task boundary:
   - humans may express goals, questions, feedback, approvals, corrections, or free-form discussion in channels
   - coordinator interprets channel input and creates internal Team `task` objects when execution tracking is needed
@@ -68,6 +69,7 @@ restating the same rules.
     `agenthub actor time-trigger-list`, and
     `agenthub actor time-trigger-cancel` for one-shot timed reminders that should arrive later as ACP messages
   - keep trigger messages concise and action-oriented so the future ACP prompt is directly executable
+  - prefer durable triggers/reminders over long sleeps or implicit "remember later" behavior
 - Agent loop:
   - `agent_loop` is a human/operator-controlled idle watchdog, disabled by default
   - enable or retune it only when a human/operator explicitly asks
@@ -110,6 +112,11 @@ restating the same rules.
 - Direct local output, stdout/stderr, and scratchpad text are not shared Team surfaces; if a fact
   matters to other agents or humans, route it through a shared surface instead of assuming they
   will see raw output.
+- When waking up on a concrete inbox/channel/thread/human message, decide early whether a visible
+  acknowledgment, blocker update, or ownership signal is owed before spending time on deeper
+  execution or context gathering.
+- If a message can be answered immediately from current facts, reply directly instead of creating
+  unnecessary task or coordination churn.
 - When an update needs durable traceability:
   - workers: persist it in the relevant document, TODO, journal, note, or local evidence artifact,
     then report that evidence to coordinator;
@@ -121,6 +128,8 @@ restating the same rules.
 - Channel root messages should carry only the summary needed for broad awareness. If the topic needs
   deeper context, open the thread and put the detailed follow-up there so only relevant readers pay
   the full context cost.
+- Before pausing on unfinished work, emit the minimal blocker or handoff update that the next owner
+  or human reader needs in order to recover the lane.
 - Findings, debugging experience, reusable heuristics, and newly discovered risks are first-class
   outputs; report them even before implementation completes when they can change team decisions.
 - Large evidence should be summary-first:
@@ -173,6 +182,10 @@ restating the same rules.
     - `.agenthubmemory/note/`
   - coordinator usually runs in an empty coordination workspace and may skip `.agenthubmemory`
   - runtime continuity/state files under `.cache/context/` still remain workspace-local
+- Recovery identity:
+  - treat runtime metadata plus `AGENTS.md`, `TODO.md`, and `.cache/context/state.md` as the
+    authoritative recovery spine for the current workspace
+  - do not invent a competing identity model from hostname, cwd, or other ambient shell details
 - Before new mailbox work, check unfinished items:
   - `TODO.md`
   - `.agenthubmemory/TODO.md` when this is a concrete project workspace

--- a/skills/team/team-actor-mailbox.SKILL.md
+++ b/skills/team/team-actor-mailbox.SKILL.md
@@ -15,6 +15,15 @@ command. It exposes runtime summary, roster/card data, and per-member
 Shared routing, mention, and human-visible reply policy remain canonical in
 `skills/team/AGENTS.md`; this skill only defines mailbox transport behavior.
 
+## Wakeup Discipline
+
+- When a new concrete inbox/channel/thread/human message wakes the agent, decide first whether the
+  lane needs an immediate visible acknowledgment, blocker update, or ownership signal.
+- If a quick factual answer is already available, reply directly on the original visible surface
+  before doing deeper mailbox/task choreography.
+- If the lane needs durable execution work, claim/triage the mailbox topic before extended work so
+  ownership is explicit.
+
 ## Scope
 
 - Team-internal agent<->agent communication
@@ -131,6 +140,13 @@ Recommended fields:
   - move long background, logs, detailed reasoning, and topic-specific back-and-forth into the
     thread rooted at that channel message
   - open the thread before treating the root message as complete working context
+
+## Reply Target Fidelity
+
+- If the inbound item already has a concrete reply target or thread target, keep the visible answer
+  on that same surface by default.
+- Widening visibility from direct reply to shared channel is an explicit escalation choice, not the
+  default reply path.
 
 ## Reliability Rules
 

--- a/skills/team/team-coordinator-orchestrator.SKILL.md
+++ b/skills/team/team-coordinator-orchestrator.SKILL.md
@@ -56,6 +56,7 @@ Use this skill when acting as the coordinator for a multi-agent Team run.
 - Treat `spec.members[].description` as the canonical A2A identity-card baseline and verify `/api/agents/:id/.well-known/agent-card` when role ownership is ambiguous.
 - Use worker identity cards as the default capability map for delegation and collaboration planning.
 - Record any required identity-card update checkpoints in coordinator coordination artifacts instead of duplicating policy here.
+- Treat runtime metadata plus `AGENTS.md`, `TODO.md`, and `.cache/context/state.md` as the authoritative recovery spine for the current coordination workspace; do not reconstruct identity or lane ownership from hostname/cwd guesses when these sources already exist.
 - If your own coordinator description/prompt/skill profile needs correction, send `profile_patch_proposal`
   for your own member record; use `target="team"` for durable identity changes and `target="run"`
   for temporary run-scoped coordination tweaks.
@@ -204,9 +205,14 @@ Run this sequence before the first coordination round of each fresh process star
 6. Human communication rule:
    - Answer human actor directly.
    - Do not reply with "ask worker" or redirect human questions to workers.
-7. When a new concrete request is already actionable, execute the first planning or investigation
+7. When startup or wakeup was triggered by a concrete inbox/channel/thread/human message, decide
+   first whether the lane needs an immediate visible acknowledgment, blocker update, or ownership
+   signal before you spend time on deeper planning.
+8. If the message can be answered immediately from current facts, reply directly on the original
+   visible surface instead of creating unnecessary task or mailbox churn.
+9. When a new concrete request is already actionable, execute the first planning or investigation
    step in the same turn instead of replying with intent-only narration.
-8. After you accept a concrete coordinator-owned request or active coordination lane, do not re-poll
+10. After you accept a concrete coordinator-owned request or active coordination lane, do not re-poll
    mailbox just to decide the next step; continue from the current evidence until the lane reaches
    a clear checkpoint, completion, or blocker.
 
@@ -227,6 +233,8 @@ Run this sequence before the first coordination round of each fresh process star
   - runtime surfaces a new explicit mailbox wake signal that changes priority
   - a human/operator explicitly interrupts or reassigns the current lane
   - ACP/runtime requires an immediate permission review or equivalent control-flow action
+- Before pausing or yielding on unfinished coordination work, emit the minimal blocker or handoff
+  update needed on the correct shared surface so the next owner can recover the lane cheaply.
 
 Definition:
 - `explicit mailbox wake signal`: an external runtime-visible notification that new direct mailbox

--- a/skills/team/team-reporting-surfaces.SKILL.md
+++ b/skills/team/team-reporting-surfaces.SKILL.md
@@ -25,6 +25,9 @@ remain canonical in `team-actor-mailbox.SKILL.md`.
   surface.
 - Do not assume a local command result, tool output, or one-agent reply is visible to other
   participants.
+- If the current inbound item already has a concrete reply target or thread target, treat that
+  surface as the default place to make the next visible update unless you intentionally escalate the
+  audience.
 
 ## Surface Selection
 
@@ -48,6 +51,11 @@ Use `shared-channel` or thread when:
 - a human asked in-channel and a visible acknowledgement or answer should land back in that same
   shared surface
 - multiple teammates need to see the update at once
+
+Use a direct visible reply with no new task when:
+
+- the question can be answered immediately from current facts
+- no durable ownership, multi-step execution, or lifecycle tracking is needed beyond that reply
 
 ## Preferred Order
 

--- a/skills/team/team-worker-executor.SKILL.md
+++ b/skills/team/team-worker-executor.SKILL.md
@@ -38,6 +38,10 @@ Use this skill when executing assigned Team work, reporting evidence, and escala
   advance assigned tasks instead of inventing parallel task records.
 - If the assigned task carries `task.context.execution_plan.steps[]`, treat those step entries as
   the canonical execution recipe for owner, dependency, and acceptance boundaries.
+- Treat runtime metadata plus `AGENTS.md`, `TODO.md`, `.cache/context/state.md`, and
+  `.agenthubmemory/` as the authoritative recovery spine for your current workspace; do not
+  reconstruct identity or lane ownership from hostname/cwd guesses when these sources already
+  exist.
 - Use stable `spec.members[].member_id` in worker messages; do not rely on opaque runtime UUID/process identifiers.
 - Keep worker identity in `spec.members[].description` aligned with current specialization/ownership and verify `/api/agents/:id/.well-known/agent-card` when status reports become ambiguous.
 - Treat your own identity card as the default boundary for accepted work; escalate to coordinator when the
@@ -147,6 +151,11 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 5. Then wait for an explicit mailbox wake signal instead of proactively polling mailbox in a loop.
 6. Persist durable project notes in `.agenthubmemory/journal/` and `.agenthubmemory/note/`; use
    `.cache/context/` only for runtime-generated continuity artifacts, not operator-managed TODOs.
+7. When startup or wakeup was triggered by a concrete inbox/channel/thread/human message, decide
+   first whether the lane needs an immediate visible acknowledgment, blocker update, or ownership
+   signal before you spend time on deeper execution.
+8. If the message can be answered immediately from current facts, reply directly on the original
+   visible surface instead of creating unnecessary task or mailbox churn.
 
 ## Mailbox Polling Discipline
 
@@ -229,6 +238,8 @@ Run this sequence before consuming new mailbox tasks after each fresh process st
 - Routine mailbox discussion does not need a prior doc/task write unless it changes durable state.
 - Avoid anonymous channel status messages when action is needed; use direct mentions to make the
   expected responder obvious.
+- Before pausing or yielding on unfinished execution work, emit the minimal blocker or handoff
+  update needed on the correct shared surface so the next owner can recover the lane cheaply.
 
 ## Worker Loop
 


### PR DESCRIPTION
## Summary

- tighten Team coordinator/worker prompt text around:
  - early visible acknowledgement / blocker / ownership decisions
  - reply-target fidelity
  - quick-reply vs durable execution routing
  - runtime-identity / recovery-spine rules
  - pause-time blocker / handoff guardrails
- align the shared Team skills with the same operating contract
- add a rollout journal for the prompt refresh

## Why

The Team prompt/skill text already covered parts of the desired coordination model, but several
high-value rules were still too soft:

- agents could spend too long in deep execution before sending a visible acknowledgement
- reply routing back to the original thread/target was not stated strongly enough
- quick factual answers and durable execution work were not separated clearly enough
- recovery guidance did not explicitly treat runtime metadata plus filesystem pointers as the
  authoritative re-entry spine

This PR makes those rules more explicit so the runtime-facing instructions behave more like an
operating contract instead of loosely related guidance.

## Validation

```bash
cargo test -p agenthub-team-prompts
cargo test -p agenthub-managed-skills -- --nocapture
```

## Notes

- prompt/skill behavior change only; no backend runtime code changes in this PR
