### PR TITLE
fix(team): improve thread pane layout and mentions

### DIFF
--- a/web/src/pages/team/TeamThreadContainer.tsx
+++ b/web/src/pages/team/TeamThreadContainer.tsx
@@ -1,16 +1,40 @@
 import React, { useCallback, useMemo } from "react";
 import { TeamThreadPane } from "./team_thread_pane";
 import {
+  HUMAN_MAILBOX_ACTOR_ID,
   formatTs,
   resolveChatMessageText,
   resolveThreadRootMessageIdFromPayload,
 } from "./page_helpers";
 import { buildTeamWorkspacePath } from "../team_page";
-import type { MentionCandidate } from "./mailbox_helpers";
+import {
+  createDisplayNameLookup,
+  isHumanMailboxActor,
+  normalizeRawMentionActorId,
+  resolveDisplayName,
+  type MentionCandidate,
+} from "./mailbox_helpers";
 import {
   useTeamConversationContext,
   useTeamWorkspaceShell,
 } from "./team_workspace_context";
+
+function collectThreadMentionActorIds(text: string): string[] {
+  const actorIds = new Set<string>();
+  for (const match of text.matchAll(/<at>\s*([A-Za-z0-9._:-]+)\s*<\/at>/gi)) {
+    const actorId = match[1]?.trim();
+    if (actorId) {
+      actorIds.add(actorId);
+    }
+  }
+  for (const match of text.matchAll(/(^|[\s([{'"])@([A-Za-z0-9._:-]+)/g)) {
+    const actorId = normalizeRawMentionActorId(match[2] ?? "");
+    if (actorId) {
+      actorIds.add(actorId);
+    }
+  }
+  return [...actorIds];
+}
 
 export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
   const {
@@ -35,6 +59,68 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
   } = useTeamWorkspaceShell();
   const channelLabel = selectedChannelItem?.label ?? "";
   const replyBusy = busy === "send-thread-reply";
+  const liveStateByMemberId = useMemo(
+    () => new Map(selectedTeamMemberLiveStates.map((member) => [member.member_id, member])),
+    [selectedTeamMemberLiveStates]
+  );
+  const resolveThreadActorLabel = useCallback(
+    (actorId: string | null | undefined): string | null => {
+      const normalizedActorId = actorId?.trim();
+      if (!normalizedActorId) {
+        return null;
+      }
+      const exactDisplayName = resolveDisplayName(
+        normalizedActorId,
+        mailboxDisplayNameByActorId,
+        ""
+      );
+      if (exactDisplayName) {
+        return exactDisplayName;
+      }
+      if (isHumanMailboxActor(normalizedActorId, HUMAN_MAILBOX_ACTOR_ID)) {
+        return resolveDisplayName(
+          HUMAN_MAILBOX_ACTOR_ID,
+          mailboxDisplayNameByActorId,
+          "You"
+        );
+      }
+      const agentName = liveStateByMemberId.get(normalizedActorId)?.agent_name?.trim();
+      return agentName || normalizedActorId;
+    },
+    [liveStateByMemberId, mailboxDisplayNameByActorId]
+  );
+  const threadDisplayNameByActorId = useMemo(() => {
+    const humanDisplayName = resolveDisplayName(
+      HUMAN_MAILBOX_ACTOR_ID,
+      mailboxDisplayNameByActorId,
+      "You"
+    );
+    return createDisplayNameLookup([
+      ...Object.entries(mailboxDisplayNameByActorId),
+      ...selectedTeamMemberLiveStates.map(
+        (member): [string, string] => [
+          member.member_id,
+          member.agent_name?.trim() || member.member_id,
+        ]
+      ),
+      ...taskMessages
+        .filter((message) => isHumanMailboxActor(message.from_actor_id, HUMAN_MAILBOX_ACTOR_ID))
+        .map((message): [string, string] => [message.from_actor_id, humanDisplayName]),
+      ...taskMessages.flatMap((message) =>
+        collectThreadMentionActorIds(resolveChatMessageText(message.payload) ?? "").map(
+          (actorId): [string, string] => [
+            actorId,
+            resolveThreadActorLabel(actorId) ?? actorId,
+          ]
+        )
+      ),
+    ]);
+  }, [
+    mailboxDisplayNameByActorId,
+    resolveThreadActorLabel,
+    selectedTeamMemberLiveStates,
+    taskMessages,
+  ]);
   const threadMentionCandidates = useMemo<MentionCandidate[]>(
     () =>
       selectedTeamMemberLiveStates.map((member) => {
@@ -68,11 +154,11 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
         )
         .map((msg) => ({
           messageId: msg.message_id,
-          authorLabel: msg.from_actor_id,
+          authorLabel: resolveThreadActorLabel(msg.from_actor_id),
           createdAt: msg.created_at,
           text: resolveChatMessageText(msg.payload) ?? "",
         })),
-    [routeThreadRootMessageId, taskMessages]
+    [resolveThreadActorLabel, routeThreadRootMessageId, taskMessages]
   );
 
   const buildCurrentThreadlessPath = useCallback(() => {
@@ -118,7 +204,7 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
     <TeamThreadPane
       channelLabel={channelLabel}
       rootMessageId={activeThreadRootMessage?.message_id ?? routeThreadRootMessageId}
-      rootAuthorLabel={activeThreadRootMessage?.from_actor_id ?? null}
+      rootAuthorLabel={resolveThreadActorLabel(activeThreadRootMessage?.from_actor_id)}
       rootCreatedAt={activeThreadRootMessage?.created_at ?? null}
       rootText={activeThreadRootMessage ? resolveChatMessageText(activeThreadRootMessage.payload) : null}
       replies={activeThreadReplies}
@@ -127,6 +213,7 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
       onSendReply={onSendThreadReply}
       replyBusy={replyBusy}
       mentionCandidates={threadMentionCandidates}
+      displayNameByActorId={threadDisplayNameByActorId}
       formatTs={formatTs}
       onViewInChannel={onViewInChannel}
       onClose={onClose}

--- a/web/src/pages/team/TeamThreadContainer.tsx
+++ b/web/src/pages/team/TeamThreadContainer.tsx
@@ -95,7 +95,7 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
       mailboxDisplayNameByActorId,
       "You"
     );
-    return createDisplayNameLookup([
+    const entries: [string, string][] = [
       ...Object.entries(mailboxDisplayNameByActorId),
       ...selectedTeamMemberLiveStates.map(
         (member): [string, string] => [
@@ -103,21 +103,35 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
           member.agent_name?.trim() || member.member_id,
         ]
       ),
-      ...taskMessages
-        .filter((message) => isHumanMailboxActor(message.from_actor_id, HUMAN_MAILBOX_ACTOR_ID))
-        .map((message): [string, string] => [message.from_actor_id, humanDisplayName]),
-      ...taskMessages.flatMap((message) =>
-        collectThreadMentionActorIds(resolveChatMessageText(message.payload) ?? "").map(
-          (actorId): [string, string] => [
-            actorId,
-            resolveThreadActorLabel(actorId) ?? actorId,
-          ]
-        )
-      ),
-    ]);
+    ];
+
+    if (routeThreadRootMessageId == null) {
+      return createDisplayNameLookup(entries);
+    }
+
+    for (const message of taskMessages) {
+      const isRoot = message.message_id === routeThreadRootMessageId;
+      const isReply =
+        message.route === "team_thread_reply" &&
+        resolveThreadRootMessageIdFromPayload(message.payload) === routeThreadRootMessageId;
+      if (!isRoot && !isReply) {
+        continue;
+      }
+      if (isHumanMailboxActor(message.from_actor_id, HUMAN_MAILBOX_ACTOR_ID)) {
+        entries.push([message.from_actor_id, humanDisplayName]);
+      }
+      for (const actorId of collectThreadMentionActorIds(
+        resolveChatMessageText(message.payload) ?? ""
+      )) {
+        entries.push([actorId, resolveThreadActorLabel(actorId) ?? actorId]);
+      }
+    }
+
+    return createDisplayNameLookup(entries);
   }, [
     mailboxDisplayNameByActorId,
     resolveThreadActorLabel,
+    routeThreadRootMessageId,
     selectedTeamMemberLiveStates,
     taskMessages,
   ]);

--- a/web/src/pages/team/mailbox_helpers.test.ts
+++ b/web/src/pages/team/mailbox_helpers.test.ts
@@ -235,6 +235,23 @@ describe("mailbox helpers", () => {
     expect(markdown).toContain("@worker-1");
   });
 
+  it("keeps sentence punctuation outside raw mention actor ids", () => {
+    const rendered = renderMarkdownWithMentions(
+      "ping @worker-agent. then @coordinator-agent.",
+      {
+        "worker-agent": "Worker Agent",
+        "coordinator-agent": "Coordinator Agent",
+      }
+    );
+
+    expect(rendered).toContain('data-team-agent-mention-id="worker-agent"');
+    expect(rendered).toContain("@Worker Agent</button>.");
+    expect(rendered).toContain('data-team-agent-mention-id="coordinator-agent"');
+    expect(rendered).toContain("@Coordinator Agent</button>.");
+    expect(rendered).not.toContain('data-team-agent-mention-id="worker-agent."');
+    expect(rendered).not.toContain("@worker-agent.");
+  });
+
   it("does not convert raw mentions inside markdown code spans or links into chips", () => {
     const rendered = renderMarkdownWithMentions(
       "`@worker-1` and [profile](https://example.com/@worker-1)"

--- a/web/src/pages/team/mailbox_helpers.test.ts
+++ b/web/src/pages/team/mailbox_helpers.test.ts
@@ -259,6 +259,18 @@ describe("mailbox helpers", () => {
     expect(normalizeRawMentionActorId("worker-agent:")).toBe("worker-agent:");
   });
 
+  it("leaves punctuation-only raw mentions as plain text", () => {
+    const rendered = renderMarkdownWithMentions("ping @. then continue");
+    expect(rendered).toContain("@.");
+    expect(rendered).not.toContain("team-mention");
+  });
+
+  it("leaves a bare at-sign as plain text", () => {
+    const rendered = renderMarkdownWithMentions("ping @ then continue");
+    expect(rendered).toContain("@");
+    expect(rendered).not.toContain("team-mention");
+  });
+
   it("renders canonical mentions with display-name lookup values", () => {
     const rendered = renderMarkdownWithMentions("hello <at>worker-agent</at>", {
       "worker-agent": "Worker Agent",

--- a/web/src/pages/team/mailbox_helpers.test.ts
+++ b/web/src/pages/team/mailbox_helpers.test.ts
@@ -12,6 +12,7 @@ import {
   countUnreadConversationMessages,
   extractMentionedActorIds,
   mergeMailboxMessages,
+  normalizeRawMentionActorId,
   renderMarkdownWithMentions,
   renderPlainTextWithMentions,
   resolveChatMessageText,
@@ -250,6 +251,22 @@ describe("mailbox helpers", () => {
     expect(rendered).toContain("@Coordinator Agent</button>.");
     expect(rendered).not.toContain('data-team-agent-mention-id="worker-agent."');
     expect(rendered).not.toContain("@worker-agent.");
+  });
+
+  it("normalizes raw mention ids without swallowing sentence punctuation", () => {
+    expect(normalizeRawMentionActorId("worker-agent.")).toBe("worker-agent");
+    expect(normalizeRawMentionActorId(" coordinator-agent.. ")).toBe("coordinator-agent");
+    expect(normalizeRawMentionActorId("worker-agent:")).toBe("worker-agent:");
+  });
+
+  it("renders canonical mentions with display-name lookup values", () => {
+    const rendered = renderMarkdownWithMentions("hello <at>worker-agent</at>", {
+      "worker-agent": "Worker Agent",
+    });
+
+    expect(rendered).toContain('data-team-agent-mention-id="worker-agent"');
+    expect(rendered).toContain("@Worker Agent");
+    expect(rendered).not.toContain("@worker-agent");
   });
 
   it("does not convert raw mentions inside markdown code spans or links into chips", () => {

--- a/web/src/pages/team/mailbox_helpers.ts
+++ b/web/src/pages/team/mailbox_helpers.ts
@@ -74,6 +74,10 @@ export function createDisplayNameLookup(
   return lookup;
 }
 
+export function normalizeRawMentionActorId(rawActorId: string): string {
+  return rawActorId.trim().replace(/\.+$/, "");
+}
+
 export function isHumanMailboxActor(
   actorId: string | null | undefined,
   humanActorId: string
@@ -477,8 +481,14 @@ function replaceRawMentionsWithTokens(text: string): string {
       cursor += 1;
       continue;
     }
-    const actorId = text.slice(cursor + 1, end).trim();
-    chunks.push(`%%AGH_AT_MENTION:${actorId}%%`);
+    const rawActorId = text.slice(cursor + 1, end).trim();
+    const actorId = normalizeRawMentionActorId(rawActorId);
+    if (!actorId) {
+      chunks.push(`@${rawActorId}`);
+      cursor = end;
+      continue;
+    }
+    chunks.push(`%%AGH_AT_MENTION:${actorId}%%${rawActorId.slice(actorId.length)}`);
     cursor = end;
   }
   return chunks.join("");

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -257,6 +257,39 @@ describe("TeamThreadPane", () => {
     expect(html).toContain(longRootText);
   });
 
+  it("truncates source preview input before resolving mentions", () => {
+    const rootText = `${"source ".repeat(90)} <at>worker-agent</at>`;
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# review"
+            rootMessageId={89}
+            rootAuthorLabel="coordinator"
+            rootCreatedAt={1713480000000}
+            rootText={rootText}
+            replies={[]}
+            replyDraft=""
+            onReplyDraftChange={vi.fn()}
+            onSendReply={vi.fn()}
+            replyBusy={false}
+            displayNameByActorId={{ "worker-agent": "Worker Agent" }}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const sourcePreview = container.querySelector(
+      '[data-team-surface="thread-source-preview"]'
+    );
+    expect(sourcePreview?.textContent).not.toContain("Worker Agent");
+    expect(container.textContent).toContain("@Worker Agent");
+  });
+
   it("shows the empty state when no thread root is selected", () => {
     const html = renderToStaticMarkup(
       <MantineProvider>

--- a/web/src/pages/team/team_thread_pane.test.tsx
+++ b/web/src/pages/team/team_thread_pane.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamThreadPane } from "./team_thread_pane";
 import {
   TEAM_THREAD_CHANNEL_BADGE_CLASS,
+  TEAM_THREAD_BODY_CLASS,
   TEAM_THREAD_MESSAGE_AVATAR_CLASS,
   TEAM_THREAD_MESSAGE_BUBBLE_CLASS,
   TEAM_THREAD_PANE_CLASS,
@@ -113,10 +114,57 @@ describe("TeamThreadPane", () => {
     expect(html).toContain("@name to reply · Enter to reply");
     expect(html).toContain("Reply");
     expectStaticClassTokens(html, TEAM_THREAD_PANE_CLASS);
+    expectStaticClassTokens(html, TEAM_THREAD_BODY_CLASS);
+    expect(html).toContain('data-team-surface="thread-scroll"');
+    expect(html).not.toContain("max-w-[360px]");
     expectStaticClassTokens(html, TEAM_THREAD_CHANNEL_BADGE_CLASS);
     expectStaticClassTokens(html, TEAM_THREAD_SOURCE_CARD_CLASS);
     expectStaticClassTokens(html, TEAM_THREAD_MESSAGE_AVATAR_CLASS);
     expectStaticClassTokens(html, TEAM_THREAD_MESSAGE_BUBBLE_CLASS);
+  });
+
+  it("keeps long reply threads in a constrained scroll region", () => {
+    const replies = Array.from({ length: 24 }, (_, index) => ({
+      messageId: index + 100,
+      authorLabel: `worker-${index + 1}`,
+      createdAt: 1713480060000 + index,
+      text: `Long thread reply ${index + 1}.`,
+    }));
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamThreadPane
+            channelLabel="# all"
+            rootMessageId={42}
+            rootAuthorLabel="coordinator"
+            rootCreatedAt={1713480000000}
+            rootText="Investigate the regression in a focused thread."
+            replies={replies}
+            replyDraft=""
+            onReplyDraftChange={vi.fn()}
+            onSendReply={vi.fn()}
+            replyBusy={false}
+            formatTs={() => "2026/4/19 00:00:00"}
+            onViewInChannel={vi.fn()}
+            onClose={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const pane = container.querySelector('[data-team-surface="thread-pane"]');
+    expect(pane?.className).toContain("w-full");
+    expect(pane?.className).toContain("flex-1");
+    expect(pane?.className).not.toContain("max-w-[360px]");
+
+    const scrollRegion = container.querySelector('[data-team-surface="thread-scroll"]');
+    expect(scrollRegion?.className).toContain("min-h-0");
+    expect(scrollRegion?.className).toContain("flex-1");
+    expect(scrollRegion?.className).toContain("overflow-y-auto");
+    expect(scrollRegion?.className).toContain("overscroll-contain");
+    expect(container.textContent).toContain("24 replies");
+    expect(container.textContent).toContain("Long thread reply 24.");
   });
 
   it("keeps the reply composer available when the root has no chat text body", () => {

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -135,7 +135,8 @@ function formatThreadSourcePreview(
   if (!normalized) {
     return null;
   }
-  const displayText = formatThreadPreviewMentionText(normalized, displayNameByActorId);
+  const truncatedInput = normalized.length > 500 ? normalized.slice(0, 500) : normalized;
+  const displayText = formatThreadPreviewMentionText(truncatedInput, displayNameByActorId);
   if (displayText.length <= 120) {
     return displayText;
   }
@@ -323,7 +324,10 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                 <span className={TEAM_THREAD_SOURCE_VALUE_CLASS}>{sourceSummary}</span>
               </div>
               {sourcePreview ? (
-                <div className={TEAM_THREAD_SOURCE_PREVIEW_CLASS}>
+                <div
+                  className={TEAM_THREAD_SOURCE_PREVIEW_CLASS}
+                  data-team-surface="thread-source-preview"
+                >
                   {sourcePreview}
                 </div>
               ) : null}

--- a/web/src/pages/team/team_thread_pane.tsx
+++ b/web/src/pages/team/team_thread_pane.tsx
@@ -14,6 +14,9 @@ import {
   applyMentionAtTag,
   canonicalizeMentionDraft,
   type MentionCandidate,
+  normalizeRawMentionActorId,
+  renderMarkdownWithMentions,
+  resolveDisplayName,
   resolveMentionDraftQuery,
 } from "./mailbox_helpers";
 import {
@@ -83,6 +86,7 @@ type TeamThreadPaneProps = {
   onViewInChannel: () => void;
   onClose: () => void;
   mentionCandidates?: MentionCandidate[];
+  displayNameByActorId?: Record<string, string>;
 };
 
 function formatThreadReplyCount(count: number): string {
@@ -99,15 +103,43 @@ function formatThreadSourceSummary(
   return `From ${authorLabel} · #${rootMessageId}`;
 }
 
-function formatThreadSourcePreview(rootText: string | null): string | null {
+function formatThreadPreviewMentionText(
+  text: string,
+  displayNameByActorId?: Record<string, string>
+): string {
+  return text
+    .replace(/<at>\s*([A-Za-z0-9._:-]+)\s*<\/at>/gi, (_match, actorId: string) => {
+      const label = resolveDisplayName(actorId, displayNameByActorId, actorId);
+      return `@${label}`;
+    })
+    .replace(
+      /(^|[\s([{'"])@([A-Za-z0-9._:-]+)/g,
+      (_match, prefix: string, actorId: string) => {
+        const normalizedActorId = normalizeRawMentionActorId(actorId);
+        const suffix = actorId.slice(normalizedActorId.length);
+        const label = resolveDisplayName(
+          normalizedActorId,
+          displayNameByActorId,
+          normalizedActorId || actorId
+        );
+        return `${prefix}@${label}${suffix}`;
+      }
+    );
+}
+
+function formatThreadSourcePreview(
+  rootText: string | null,
+  displayNameByActorId?: Record<string, string>
+): string | null {
   const normalized = rootText?.replace(/\s+/g, " ").trim();
   if (!normalized) {
     return null;
   }
-  if (normalized.length <= 120) {
-    return normalized;
+  const displayText = formatThreadPreviewMentionText(normalized, displayNameByActorId);
+  if (displayText.length <= 120) {
+    return displayText;
   }
-  return `${normalized.slice(0, 117).trimEnd()}...`;
+  return `${displayText.slice(0, 117).trimEnd()}...`;
 }
 
 export const TeamThreadPane = React.memo(function TeamThreadPane({
@@ -125,6 +157,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
   onViewInChannel,
   onClose,
   mentionCandidates = [],
+  displayNameByActorId,
 }: TeamThreadPaneProps) {
   const hasSelectedRoot = rootMessageId != null;
   const replyTextareaRef = React.useRef<HTMLTextAreaElement | null>(null);
@@ -135,7 +168,11 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
   );
   const replyCountLabel = formatThreadReplyCount(replies.length);
   const sourceSummary = formatThreadSourceSummary(rootAuthorLabel, rootMessageId);
-  const sourcePreview = formatThreadSourcePreview(rootText);
+  const sourcePreview = formatThreadSourcePreview(rootText, displayNameByActorId);
+  const renderThreadMessageHtml = React.useCallback(
+    (text: string) => renderMarkdownWithMentions(text, displayNameByActorId),
+    [displayNameByActorId]
+  );
   // Keep transcript display data stable while the reply draft changes so
   // typing in the composer does not rebuild every visible thread row.
   const rootRenderMessage = React.useMemo<TeamThreadRenderMessage | null>(() => {
@@ -313,7 +350,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
         </div>
       </ToolbarRow>
 
-      <div className={TEAM_THREAD_BODY_CLASS}>
+      <div className={TEAM_THREAD_BODY_CLASS} data-team-surface="thread-scroll">
         {!hasSelectedRoot ? (
           <EmptyState
             title="Select a channel message"
@@ -349,6 +386,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                     <TeamThreadRichText
                       className={TEAM_THREAD_RICH_TEXT_CLASS}
                       text={rootRenderMessage.text}
+                      renderSanitizedHtml={renderThreadMessageHtml}
                     />
                   ) : (
                     <div className={TEAM_THREAD_MISSING_TEXT_CLASS}>
@@ -387,6 +425,7 @@ export const TeamThreadPane = React.memo(function TeamThreadPane({
                         <TeamThreadRichText
                           className={TEAM_THREAD_RICH_TEXT_CLASS}
                           text={reply.text}
+                          renderSanitizedHtml={renderThreadMessageHtml}
                         />
                       </ConversationBubble>
                     </div>

--- a/web/src/pages/team/team_workbench_content.test.tsx
+++ b/web/src/pages/team/team_workbench_content.test.tsx
@@ -177,6 +177,8 @@ describe("team_workbench_content", () => {
     expect(withThread).toContain("data-testid=\"thread-pane\"");
     expect(withThread).toContain("max-h-[40vh]");
     expect(withThread).toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(withThread).toContain("w-full");
+    expect(withThread).toContain("lg:h-full");
     expect(withThread).toContain("lg:min-w-0");
     expect(withThread).toContain("flex-col");
     expect(withThread).not.toContain("overflow-y-auto");

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -258,7 +258,7 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
                   </div>
                   {threadPane && (
                     <div
-                      className="flex max-h-[40vh] min-h-0 shrink-0 flex-col overflow-hidden lg:max-h-none lg:min-w-0"
+                      className="flex max-h-[40vh] min-h-0 w-full shrink-0 flex-col overflow-hidden lg:h-full lg:max-h-none lg:min-w-0"
                       data-team-surface="thread-dock"
                     >
                       {threadPane}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2719,6 +2719,8 @@ describe("team panels interactions", () => {
   });
 
   it("TeamThreadContainer only renders routed thread replies for the active thread", () => {
+    const navigateTeamRoute = vi.fn();
+    const setChannelFocusMessageId = vi.fn();
     const taskMessages = [
       buildTaskMessage(1, {
         from_actor_id: "coordinator-agent",
@@ -2794,12 +2796,12 @@ describe("team panels interactions", () => {
       busy: null,
       routeThreadRootMessageId: 1,
       channelFocusMessageId: null,
-      setChannelFocusMessageId: vi.fn(),
+      setChannelFocusMessageId,
       effectiveSelectedTeamId: "team-1",
       routeWorkspaceLens: "channels",
       routeChannelId: "all",
       activeChannelConversationTaskId: "task-1",
-      navigateTeamRoute: vi.fn(),
+      navigateTeamRoute,
       isCompactWorkbench: false,
       selectedChannelItem: undefined,
       workspaceTasks: [],
@@ -2841,6 +2843,17 @@ describe("team panels interactions", () => {
     expect(container.textContent).not.toContain("user:u-1");
     expect(container.textContent).not.toContain("Channel message with a thread id should stay out.");
     expect(container.textContent).not.toContain("Different thread reply should stay out.");
+
+    clickElement(findButtonByText(container, "View in channel"));
+    expect(setChannelFocusMessageId).toHaveBeenCalledWith(1);
+    expect(navigateTeamRoute).toHaveBeenCalledWith(
+      "/workspace/teams/team-1?task=task-1"
+    );
+
+    clickElement(findButtonByText(container, "Close thread"));
+    expect(navigateTeamRoute).toHaveBeenLastCalledWith(
+      "/workspace/teams/team-1?task=task-1"
+    );
   });
 
   it("TeamThreadContainer stays hidden when no thread root is selected", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2725,7 +2725,7 @@ describe("team panels interactions", () => {
         route: "group_chat",
         payload: {
           type: "chat_message",
-          text: "Root message for @worker-agent and @user:u-1.",
+          text: "Root message for @worker-agent, <at>coordinator-agent</at>, and @user:u-1.",
         },
       }),
       buildTaskMessage(2, {
@@ -2841,6 +2841,136 @@ describe("team panels interactions", () => {
     expect(container.textContent).not.toContain("user:u-1");
     expect(container.textContent).not.toContain("Channel message with a thread id should stay out.");
     expect(container.textContent).not.toContain("Different thread reply should stay out.");
+  });
+
+  it("TeamThreadContainer stays hidden when no thread root is selected", () => {
+    const workspaceContext: TeamWorkspaceContextValue = {
+      selectedConversation: null,
+      developerMode: false,
+      token: "token",
+      tasksLoading: false,
+      onRefreshTasks: vi.fn(),
+      taskMessageDraft: "",
+      setTaskMessageDraft: vi.fn(),
+      onSendTaskMessage: vi.fn(),
+      taskMessages: [
+        buildTaskMessage(1, {
+          from_actor_id: "coordinator-agent",
+          route: "group_chat",
+          payload: {
+            type: "chat_message",
+            text: "Hidden channel message",
+          },
+        }),
+      ],
+      conversationMailboxMessages: [],
+      snapshot: null,
+      mailboxDisplayNameByActorId: {
+        "coordinator-agent": "Coordinator Agent",
+      },
+      selectedTeamMemberLiveStates: [],
+      taskConversationMemberIds: [],
+      activeConversationTitle: "# all",
+      selectedConversationMatchesChannelLane: true,
+      taskMessagesLoading: false,
+      busy: null,
+      routeThreadRootMessageId: null,
+      channelFocusMessageId: null,
+      setChannelFocusMessageId: vi.fn(),
+      effectiveSelectedTeamId: "team-1",
+      routeWorkspaceLens: "channels",
+      routeChannelId: "all",
+      activeChannelConversationTaskId: "task-1",
+      navigateTeamRoute: vi.fn(),
+      isCompactWorkbench: false,
+      selectedChannelItem: undefined,
+      workspaceTasks: [],
+      selectedTaskId: "",
+      setSelectedTaskId: vi.fn(),
+      onSelectConversationSubject: vi.fn(),
+      runs: [],
+      onOpenTaskRun: vi.fn(),
+      compilePreviewContextId: "",
+      setCompilePreviewContextId: vi.fn(),
+      onCompileTaskRunPreview: vi.fn(),
+      canCompileTask: false,
+      compiledRunPreview: null,
+      onUseCompiledRunPayload: vi.fn(),
+      onCreateRunFromCompiledPreview: vi.fn(),
+      onSendThreadReply: vi.fn(),
+      threadReplyDraft: "",
+      setThreadReplyDraft: vi.fn(),
+    };
+
+    renderWithMantine(
+      root,
+      <TeamWorkspaceProvider value={workspaceContext}>
+        <TeamThreadContainer />
+      </TeamWorkspaceProvider>
+    );
+
+    expect(container.querySelector('[data-team-surface="thread-pane"]')).toBeNull();
+    expect(container.textContent).not.toContain("Hidden channel message");
+  });
+
+  it("TeamThreadContainer keeps a routed thread shell while the root message is missing", () => {
+    const workspaceContext: TeamWorkspaceContextValue = {
+      selectedConversation: null,
+      developerMode: false,
+      token: "token",
+      tasksLoading: false,
+      onRefreshTasks: vi.fn(),
+      taskMessageDraft: "",
+      setTaskMessageDraft: vi.fn(),
+      onSendTaskMessage: vi.fn(),
+      taskMessages: [],
+      conversationMailboxMessages: [],
+      snapshot: null,
+      mailboxDisplayNameByActorId: {},
+      selectedTeamMemberLiveStates: [],
+      taskConversationMemberIds: [],
+      activeConversationTitle: "# all",
+      selectedConversationMatchesChannelLane: true,
+      taskMessagesLoading: false,
+      busy: null,
+      routeThreadRootMessageId: 404,
+      channelFocusMessageId: null,
+      setChannelFocusMessageId: vi.fn(),
+      effectiveSelectedTeamId: "team-1",
+      routeWorkspaceLens: "channels",
+      routeChannelId: "all",
+      activeChannelConversationTaskId: "task-1",
+      navigateTeamRoute: vi.fn(),
+      isCompactWorkbench: false,
+      selectedChannelItem: undefined,
+      workspaceTasks: [],
+      selectedTaskId: "",
+      setSelectedTaskId: vi.fn(),
+      onSelectConversationSubject: vi.fn(),
+      runs: [],
+      onOpenTaskRun: vi.fn(),
+      compilePreviewContextId: "",
+      setCompilePreviewContextId: vi.fn(),
+      onCompileTaskRunPreview: vi.fn(),
+      canCompileTask: false,
+      compiledRunPreview: null,
+      onUseCompiledRunPayload: vi.fn(),
+      onCreateRunFromCompiledPreview: vi.fn(),
+      onSendThreadReply: vi.fn(),
+      threadReplyDraft: "",
+      setThreadReplyDraft: vi.fn(),
+    };
+
+    renderWithMantine(
+      root,
+      <TeamWorkspaceProvider value={workspaceContext}>
+        <TeamThreadContainer />
+      </TeamWorkspaceProvider>
+    );
+
+    expect(container.querySelector('[data-team-surface="thread-pane"]')).not.toBeNull();
+    expect(container.textContent).toContain("From Unknown · #404");
+    expect(container.textContent).toContain("Original content is not available in chat text form.");
   });
 
   it("TeamWorkbenchContainer fails fast when the workbench context slice is missing", () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2723,14 +2723,26 @@ describe("team panels interactions", () => {
       buildTaskMessage(1, {
         from_actor_id: "coordinator-agent",
         route: "group_chat",
-        payload: { type: "chat_message", text: "Root message." },
+        payload: {
+          type: "chat_message",
+          text: "Root message for @worker-agent and @user:u-1.",
+        },
       }),
       buildTaskMessage(2, {
         from_actor_id: "worker-agent",
         route: "team_thread_reply",
         payload: {
           type: "chat_message",
-          text: "Visible thread reply.",
+          text: "Visible thread reply for @coordinator-agent.",
+          thread_root_message_id: 1,
+        },
+      }),
+      buildTaskMessage(5, {
+        from_actor_id: "user:u-1",
+        route: "team_thread_reply",
+        payload: {
+          type: "chat_message",
+          text: "Human follow-up for @worker-agent.",
           thread_root_message_id: 1,
         },
       }),
@@ -2765,8 +2777,16 @@ describe("team panels interactions", () => {
       taskMessages,
       conversationMailboxMessages: [],
       snapshot: null,
-      mailboxDisplayNameByActorId: {},
-      selectedTeamMemberLiveStates: [],
+      mailboxDisplayNameByActorId: {
+        user: "You",
+        "worker-agent": "Worker Agent",
+      },
+      selectedTeamMemberLiveStates: [
+        buildMemberLiveState({
+          member_id: "coordinator-agent",
+          agent_name: "Coordinator Agent",
+        }),
+      ],
       taskConversationMemberIds: [],
       activeConversationTitle: "# all",
       selectedConversationMatchesChannelLane: true,
@@ -2807,8 +2827,18 @@ describe("team panels interactions", () => {
       </TeamWorkspaceProvider>
     );
 
-    expect(container.textContent).toContain("Root message.");
-    expect(container.textContent).toContain("Visible thread reply.");
+    expect(container.textContent).toContain("Root message for");
+    expect(container.textContent).toContain("Visible thread reply for");
+    expect(container.textContent).toContain("Human follow-up for");
+    expect(container.textContent).toContain("Coordinator Agent");
+    expect(container.textContent).toContain("Worker Agent");
+    expect(container.textContent).toContain("You");
+    expect(container.textContent).toContain("@Coordinator Agent");
+    expect(container.textContent).toContain("@Worker Agent");
+    expect(container.textContent).toContain("@You");
+    expect(container.textContent).not.toContain("coordinator-agent");
+    expect(container.textContent).not.toContain("worker-agent");
+    expect(container.textContent).not.toContain("user:u-1");
     expect(container.textContent).not.toContain("Channel message with a thread id should stay out.");
     expect(container.textContent).not.toContain("Different thread reply should stay out.");
   });

--- a/web/src/ui/tailwind_classes.ts
+++ b/web/src/ui/tailwind_classes.ts
@@ -499,7 +499,7 @@ export const TEAM_MEMBER_ACP_INPUT_DOCK_SHELL_CLASS = "mt-1.5 shrink-0";
 export const TEAM_MEMBER_ACP_SENDING_TEXT_CLASS = "mt-1.5";
 
 export const TEAM_THREAD_PANE_CLASS =
-  "flex min-h-0 w-full max-w-[360px] shrink-0 flex-col overflow-hidden border-notion-border/80";
+  "flex h-full min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden border-notion-border/80";
 
 export const TEAM_THREAD_HEADER_CLASS =
   "items-start gap-2 border-b border-notion-border/70 px-2.5 py-2";
@@ -537,7 +537,8 @@ export const TEAM_THREAD_HEADER_BUTTON_CLASS = "px-1.5 text-[10px] text-notion-t
 
 export const TEAM_THREAD_HEADER_ICON_CLASS = "text-[10px]";
 
-export const TEAM_THREAD_BODY_CLASS = "flex min-h-0 flex-1 flex-col overflow-y-auto px-2.5 py-2";
+export const TEAM_THREAD_BODY_CLASS =
+  "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-2.5 py-2 pr-1.5";
 
 export const TEAM_THREAD_EMPTY_STATE_CLASS = "border-0 bg-transparent px-0 py-0";
 


### PR DESCRIPTION
## Summary

- widen the Team channel thread pane so it fills the right-side dock instead of staying capped at 360px
- keep long thread reply lists inside a constrained scroll region
- render thread author names and inline `@` mentions with display names instead of raw actor ids
- keep sentence punctuation outside raw mention actor ids during mention tokenization

## Tests

- `npm run test -- src/pages/team_panels.test.tsx src/pages/team/team_thread_pane.test.tsx src/pages/team/team_workbench_content.test.tsx src/pages/team/team_thread_rich_text.test.tsx src/pages/team/mailbox_helpers.test.ts`
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `git diff --check`

## Related Issues

- None
