### PR TITLE
chore(acp): upgrade codex to 0.133

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,8 +2461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2480,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2528,8 +2528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2595,8 +2595,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2621,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2645,8 +2645,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2681,8 +2681,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2696,8 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2714,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2724,8 +2724,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2738,8 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2755,8 +2755,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2765,8 +2765,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2785,8 +2785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2811,8 +2811,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2823,6 +2823,7 @@ dependencies = [
  "codex-login",
  "codex-otel",
  "codex-protocol",
+ "codex-utils-absolute-path",
  "hmac 0.12.1",
  "serde",
  "serde_json",
@@ -2835,8 +2836,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2852,13 +2853,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-config"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2878,6 +2879,7 @@ dependencies = [
  "dunce",
  "futures",
  "gethostname",
+ "indexmap 2.14.0",
  "libc",
  "multimap",
  "prost",
@@ -2901,8 +2903,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -2915,8 +2917,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3013,8 +3015,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3035,6 +3037,7 @@ dependencies = [
  "dirs",
  "flate2",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tar",
@@ -3049,8 +3052,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3079,8 +3082,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3112,8 +3115,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3128,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3138,8 +3141,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3148,8 +3151,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3159,8 +3162,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3172,8 +3175,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3185,8 +3188,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3198,8 +3201,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3213,8 +3216,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3224,8 +3227,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "notify",
  "tokio",
@@ -3234,8 +3237,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3258,8 +3261,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-core",
@@ -3269,8 +3272,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3290,9 +3293,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-install-context"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
+dependencies = [
+ "codex-utils-absolute-path",
+ "codex-utils-home-dir",
+]
+
+[[package]]
 name = "codex-keyring-store"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "keyring",
  "tracing",
@@ -3300,10 +3312,11 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "clap",
+ "codex-install-context",
  "codex-process-hardening",
  "codex-protocol",
  "codex-sandboxing",
@@ -3320,8 +3333,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3354,8 +3367,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3385,8 +3398,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3410,8 +3423,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-core",
@@ -3430,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3443,8 +3456,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3474,8 +3487,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -3496,8 +3509,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3509,8 +3522,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3529,8 +3542,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3559,8 +3572,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3591,8 +3604,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -3602,16 +3615,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3647,8 +3660,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3658,8 +3671,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3693,8 +3706,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3717,8 +3730,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3732,8 +3745,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3749,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "age",
  "anyhow",
@@ -3768,8 +3781,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3787,8 +3800,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,8 +3820,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3817,8 +3830,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3839,16 +3852,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3866,8 +3879,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-app-server-protocol",
@@ -3875,6 +3888,7 @@ dependencies = [
  "codex-features",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
  "codex-utils-pty",
  "codex-utils-string",
  "rmcp 0.15.0",
@@ -3886,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-io",
  "tokio",
@@ -3897,8 +3911,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "dirs",
  "dunce",
@@ -3909,16 +3923,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "lru",
  "sha1",
@@ -3927,8 +3941,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3939,8 +3953,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3948,8 +3962,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3961,8 +3975,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3970,8 +3984,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3979,8 +3993,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3989,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -4001,8 +4015,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4017,21 +4031,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4040,13 +4054,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.132.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4066,7 +4080,6 @@ dependencies = [
  "tokio",
  "windows 0.58.0",
  "windows-sys 0.52.0",
- "winres",
 ]
 
 [[package]]
@@ -5610,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "diplomat"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adb46b05e2f53dcf6a7dfc242e4ce9eb60c369b6b6eb10826a01e93167f59c6"
+checksum = "7935649d00000f5c5d735448ad3dc07b9738160727017914cf42138b8e8e6611"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -5622,15 +5635,15 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0569bd3caaf13829da7ee4e83dbf9197a0e1ecd72772da6d08f0b4c9285c8d29"
+checksum = "970ac38ad677632efcee6d517e783958da9bc78ec206d8d5e35b459ffc5e4864"
 
 [[package]]
 name = "diplomat_core"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51731530ed7f2d4495019abc7df3744f53338e69e2863a6a64ae91821c763df1"
+checksum = "9cf41b94101a4bce993febaf0098092b0bb31deaf0ecaf6e0a2562465f61b383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8184,9 +8197,9 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
+checksum = "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -8201,18 +8214,19 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d"
+checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -8220,14 +8234,16 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38c52231bc348f9b982c1868a2af3195199623007ba2c7650f432038f5b3e8e"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
 dependencies = [
+ "displaydoc",
  "fixed_decimal",
  "icu_decimal_data",
  "icu_locale",
  "icu_locale_core",
+ "icu_plurals",
  "icu_provider",
  "writeable",
  "zerovec",
@@ -8235,15 +8251,15 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2905b4044eab2dd848fe84199f9195567b63ab3a93094711501363f63546fef7"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
 
 [[package]]
 name = "icu_locale"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -8270,15 +8286,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -8290,15 +8306,34 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -8310,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
@@ -14670,14 +14705,14 @@ dependencies = [
 
 [[package]]
 name = "temporal_capi"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a151e402c2bdb6a3a2a2f3f225eddaead2e7ce7dd5d3fa2090deb11b17aa4ed8"
+checksum = "8a2a1f001e756a9f5f2d175a9965c4c0b3a054f09f30de3a75ab49765f2deb36"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
  "icu_calendar",
- "icu_locale",
+ "icu_locale_core",
  "num-traits",
  "temporal_rs",
  "timezone_provider",
@@ -14687,13 +14722,14 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88afde3bd75d2fc68d77a914bece426aa08aa7649ffd0cdd4a11c3d4d33474d1"
+checksum = "9a902a45282e5175186b21d355efc92564601efe6e2d92818dc9e333d50bd4de"
 dependencies = [
+ "calendrical_calculations",
  "core_maths",
  "icu_calendar",
- "icu_locale",
+ "icu_locale_core",
  "ixdtf",
  "num-traits",
  "timezone_provider",
@@ -14833,9 +14869,9 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9ba0000e9e73862f3e7ca1ff159e2ddf915c9d8bb11e38a7874760f445d993"
+checksum = "c48f9b04628a2b813051e4dfe97c65281e49625eabd09ec343190e31e399a8c2"
 dependencies = [
  "tinystr",
  "zerotrie",
@@ -15730,9 +15766,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "146.4.0"
+version = "147.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97bcac5cdc5a195a4813f1855a6bc658f240452aac36caa12fd6c6f16026ab1"
+checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
 dependencies = [
  "bindgen",
  "bitflags 2.11.1",
@@ -16628,15 +16664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17081,9 +17108,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zoneinfo64"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2e5597efbe7c421da8a7fd396b20b571704e787c21a272eecf35dfe9d386f0"
+checksum = "ed6eb2607e906160c457fd573e9297e65029669906b9ac8fb1b5cd5e055f0705"
 dependencies = [
  "calendrical_calculations",
  "icu_locale_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # Pin problematic transitive dependencies
-icu_calendar = "=2.1.1"
-icu_decimal = "=2.1.1"
+icu_calendar = "=2.2.1"
+icu_decimal = "=2.2.0"
 superboring = "=0.1.11"
 
 uuid = { version = "1", features = ["v4", "v7", "serde"] }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "13595c36e218fcbd13df118eeadf00d4eb0e6d31",
+    commit = "9474e5cfc4494b0ba319352aa86ce436c59e65c8",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -1061,7 +1061,8 @@ impl AppServerCodexThread {
         notification: ServerNotification,
     ) -> Result<Option<Event>, CodexErr> {
         match notification {
-            ServerNotification::ThreadNameUpdated(_) => Ok(None),
+            ServerNotification::ThreadNameUpdated(_)
+            | ServerNotification::ThreadSettingsUpdated(_) => Ok(None),
             ServerNotification::FileChangePatchUpdated(payload) => {
                 let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
                 Ok(submission_id.map(|id| Event {
@@ -1319,6 +1320,7 @@ impl AppServerCodexThread {
                                 arguments: Some(arguments),
                             },
                             mcp_app_resource_uri,
+                            plugin_id: None,
                         }),
                     }),
                     (
@@ -1550,6 +1552,7 @@ impl AppServerCodexThread {
                                     arguments: Some(arguments),
                                 },
                                 mcp_app_resource_uri,
+                                plugin_id: None,
                                 duration: duration_ms
                                     .and_then(|ms| u64::try_from(ms).ok())
                                     .map(Duration::from_millis)
@@ -1800,30 +1803,17 @@ impl CodexThreadImpl for AppServerCodexThread {
             | Op::ThreadRollback { .. }) => self.submit_prompt_like(submission_id, op).await,
             Op::Interrupt => self.interrupt_active_turn().await,
             Op::Shutdown => self.shutdown_thread().await,
-            Op::OverrideTurnContext {
-                cwd,
-                approval_policy,
-                approvals_reviewer,
-                sandbox_policy,
-                model,
-                effort,
-                summary,
-                collaboration_mode: _,
-                personality,
-                windows_sandbox_level: _,
-                service_tier,
-                permission_profile: _,
-            } => {
+            Op::ThreadSettings { thread_settings } => {
                 self.override_turn_context(OverrideTurnContextArgs {
-                    cwd,
-                    approval_policy,
-                    approvals_reviewer,
-                    sandbox_policy,
-                    model,
-                    effort,
-                    summary,
-                    personality,
-                    service_tier,
+                    cwd: thread_settings.cwd,
+                    approval_policy: thread_settings.approval_policy,
+                    approvals_reviewer: thread_settings.approvals_reviewer,
+                    sandbox_policy: thread_settings.sandbox_policy,
+                    model: thread_settings.model,
+                    effort: thread_settings.effort,
+                    summary: thread_settings.summary,
+                    personality: thread_settings.personality,
+                    service_tier: thread_settings.service_tier,
                 })
                 .await
             }
@@ -3499,6 +3489,7 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: Default::default(),
             },
         )
         .expect_err("dirty custom tool history should block new turns");
@@ -3571,6 +3562,7 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: Default::default(),
             },
         )
         .expect("undo should clear the local pending tool guard");
@@ -3592,6 +3584,7 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: Default::default(),
             },
         )
         .expect("prepare submission")

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -242,12 +242,18 @@ enum PreparedSubmissionStart {
 
 struct OverrideTurnContextArgs {
     cwd: Option<PathBuf>,
+    workspace_roots: Option<Vec<codex_utils_absolute_path::AbsolutePathBuf>>,
+    profile_workspace_roots: Option<Vec<codex_utils_absolute_path::AbsolutePathBuf>>,
     approval_policy: Option<codex_protocol::protocol::AskForApproval>,
     approvals_reviewer: Option<codex_protocol::config_types::ApprovalsReviewer>,
     sandbox_policy: Option<codex_protocol::protocol::SandboxPolicy>,
+    permission_profile: Option<codex_protocol::models::PermissionProfile>,
+    active_permission_profile: Option<codex_protocol::models::ActivePermissionProfile>,
+    windows_sandbox_level: Option<codex_protocol::config_types::WindowsSandboxLevel>,
     model: Option<String>,
     effort: Option<Option<ReasoningEffort>>,
     summary: Option<ReasoningSummary>,
+    collaboration_mode: Option<codex_protocol::config_types::CollaborationMode>,
     personality: Option<codex_protocol::config_types::Personality>,
     service_tier: Option<Option<String>>,
 }
@@ -667,6 +673,12 @@ impl AppServerCodexThread {
                     .set_legacy_sandbox_policy(sandbox_policy, updated_config.cwd.as_path())
                     .map_err(|err| CodexErr::Fatal(err.to_string()))?;
             }
+            if let Some(permission_profile) = args.permission_profile {
+                updated_config
+                    .permissions
+                    .set_permission_profile(permission_profile)
+                    .map_err(|err| CodexErr::Fatal(err.to_string()))?;
+            }
             if let Some(model) = args.model {
                 updated_config.model = Some(model);
             }
@@ -681,6 +693,31 @@ impl AppServerCodexThread {
             }
             if let Some(service_tier) = args.service_tier {
                 updated_config.service_tier = service_tier;
+            }
+            if args.workspace_roots.is_some() {
+                warn!(
+                    "ignoring ThreadSettings.workspace_roots because app-server resume params do not expose runtime workspace roots through the ACP adapter yet"
+                );
+            }
+            if args.profile_workspace_roots.is_some() {
+                warn!(
+                    "ignoring ThreadSettings.profile_workspace_roots because app-server resume params do not expose profile workspace roots through the ACP adapter yet"
+                );
+            }
+            if args.active_permission_profile.is_some() {
+                warn!(
+                    "ignoring ThreadSettings.active_permission_profile because the ACP adapter currently reapplies only the resolved permission profile snapshot"
+                );
+            }
+            if args.windows_sandbox_level.is_some() {
+                warn!(
+                    "ignoring ThreadSettings.windows_sandbox_level because the ACP adapter does not currently project Windows sandbox level into app-server resume params"
+                );
+            }
+            if args.collaboration_mode.is_some() {
+                warn!(
+                    "ignoring ThreadSettings.collaboration_mode because the ACP adapter does not currently project collaboration mode into app-server resume params"
+                );
             }
 
             let request_id = next_request_id(&mut state);
@@ -1806,12 +1843,18 @@ impl CodexThreadImpl for AppServerCodexThread {
             Op::ThreadSettings { thread_settings } => {
                 self.override_turn_context(OverrideTurnContextArgs {
                     cwd: thread_settings.cwd,
+                    workspace_roots: thread_settings.workspace_roots,
+                    profile_workspace_roots: thread_settings.profile_workspace_roots,
                     approval_policy: thread_settings.approval_policy,
                     approvals_reviewer: thread_settings.approvals_reviewer,
                     sandbox_policy: thread_settings.sandbox_policy,
+                    permission_profile: thread_settings.permission_profile,
+                    active_permission_profile: thread_settings.active_permission_profile,
+                    windows_sandbox_level: thread_settings.windows_sandbox_level,
                     model: thread_settings.model,
                     effort: thread_settings.effort,
                     summary: thread_settings.summary,
+                    collaboration_mode: thread_settings.collaboration_mode,
                     personality: thread_settings.personality,
                     service_tier: thread_settings.service_tier,
                 })

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -97,7 +97,7 @@ pub(crate) async fn build_environment_manager(
             "failed to resolve exec-server runtime paths: {err}"
         ))
     })?;
-    EnvironmentManager::from_codex_home(&config.codex_home, runtime_paths)
+    EnvironmentManager::from_codex_home(&config.codex_home, Some(runtime_paths))
         .await
         .map(Arc::new)
         .map_err(|err| {

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -52,8 +52,9 @@ use codex_protocol::{
         ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent, ReviewDecision,
         ReviewOutputEvent, ReviewRequest, ReviewTarget, RolloutItem, SandboxPolicy,
         StreamErrorEvent, TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
-        TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
-        ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
+        ThreadSettingsOverrides, TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent,
+        TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent,
+        WebSearchBeginEvent, WebSearchEndEvent,
     },
     request_permissions::{
         PermissionGrantScope, RequestPermissionsEvent, RequestPermissionsResponse,
@@ -883,6 +884,7 @@ impl PromptState {
             | EventMsg::TurnComplete(..)
             | EventMsg::TurnDiff(..)
             | EventMsg::TurnAborted(..)
+            | EventMsg::ThreadSettingsApplied(..)
             | EventMsg::EnteredReviewMode(..)
             | EventMsg::ExitedReviewMode(..)
             | EventMsg::ShutdownComplete => {
@@ -997,6 +999,9 @@ impl PromptState {
                 client
                     .send_agent_text(format_thread_goal_update(&event))
                     .await;
+            }
+            EventMsg::ThreadSettingsApplied(event) => {
+                info!("Thread settings applied: {:?}", event.thread_settings);
             }
             EventMsg::PlanUpdate(UpdatePlanArgs { explanation, plan }) => {
                 // Send this to the client via session/update notification
@@ -3332,19 +3337,24 @@ impl<A: Auth> ThreadActor<A> {
         self.thread
             .submit(
                 "config".to_string(),
-                Op::OverrideTurnContext {
-                    cwd: None,
-                    approval_policy: None,
-                    approvals_reviewer: None,
-                    sandbox_policy: None,
-                    model: Some(model_to_use.clone()),
-                    effort: Some(effort_to_use),
-                    summary: None,
-                    collaboration_mode: None,
-                    personality: None,
-                    windows_sandbox_level: None,
-                    service_tier: None,
-                    permission_profile: None,
+                Op::ThreadSettings {
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: None,
+                        workspace_roots: None,
+                        profile_workspace_roots: None,
+                        approval_policy: None,
+                        approvals_reviewer: None,
+                        sandbox_policy: None,
+                        permission_profile: None,
+                        active_permission_profile: None,
+                        windows_sandbox_level: None,
+                        model: Some(model_to_use.clone()),
+                        effort: Some(effort_to_use),
+                        summary: None,
+                        service_tier: None,
+                        collaboration_mode: None,
+                        personality: None,
+                    },
                 },
             )
             .await
@@ -3383,19 +3393,24 @@ impl<A: Auth> ThreadActor<A> {
         self.thread
             .submit(
                 "config".to_string(),
-                Op::OverrideTurnContext {
-                    cwd: None,
-                    approval_policy: None,
-                    approvals_reviewer: None,
-                    sandbox_policy: None,
-                    model: None,
-                    effort: Some(Some(effort)),
-                    summary: None,
-                    collaboration_mode: None,
-                    personality: None,
-                    windows_sandbox_level: None,
-                    service_tier: None,
-                    permission_profile: None,
+                Op::ThreadSettings {
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: None,
+                        workspace_roots: None,
+                        profile_workspace_roots: None,
+                        approval_policy: None,
+                        approvals_reviewer: None,
+                        sandbox_policy: None,
+                        permission_profile: None,
+                        active_permission_profile: None,
+                        windows_sandbox_level: None,
+                        model: None,
+                        effort: Some(Some(effort)),
+                        summary: None,
+                        service_tier: None,
+                        collaboration_mode: None,
+                        personality: None,
+                    },
                 },
             )
             .await
@@ -3508,6 +3523,7 @@ impl<A: Auth> ThreadActor<A> {
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
                         environments: None,
+                        thread_settings: ThreadSettingsOverrides::default(),
                     }
                 }
                 "review" => {
@@ -3560,6 +3576,7 @@ impl<A: Auth> ThreadActor<A> {
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
                         environments: None,
+                        thread_settings: ThreadSettingsOverrides::default(),
                     }
                 }
             }
@@ -3569,6 +3586,7 @@ impl<A: Auth> ThreadActor<A> {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: ThreadSettingsOverrides::default(),
             }
         }
 
@@ -3639,19 +3657,24 @@ impl<A: Auth> ThreadActor<A> {
         self.thread
             .submit(
                 "config".to_string(),
-                Op::OverrideTurnContext {
-                    cwd: None,
-                    approval_policy: Some(preset.approval),
-                    approvals_reviewer: None,
-                    sandbox_policy: Some(legacy_sandbox_policy.clone()),
-                    model: None,
-                    effort: None,
-                    summary: None,
-                    collaboration_mode: None,
-                    personality: None,
-                    windows_sandbox_level: None,
-                    service_tier: None,
-                    permission_profile: None,
+                Op::ThreadSettings {
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: None,
+                        workspace_roots: None,
+                        profile_workspace_roots: None,
+                        approval_policy: Some(preset.approval),
+                        approvals_reviewer: None,
+                        sandbox_policy: Some(legacy_sandbox_policy.clone()),
+                        permission_profile: None,
+                        active_permission_profile: None,
+                        windows_sandbox_level: None,
+                        model: None,
+                        effort: None,
+                        summary: None,
+                        service_tier: None,
+                        collaboration_mode: None,
+                        personality: None,
+                    },
                 },
             )
             .await
@@ -3708,19 +3731,24 @@ impl<A: Auth> ThreadActor<A> {
         self.thread
             .submit(
                 "config".to_string(),
-                Op::OverrideTurnContext {
-                    cwd: None,
-                    approval_policy: None,
-                    approvals_reviewer: None,
-                    sandbox_policy: None,
-                    model: Some(model_to_use.clone()),
-                    effort: Some(effort_to_use),
-                    summary: None,
-                    collaboration_mode: None,
-                    personality: None,
-                    windows_sandbox_level: None,
-                    service_tier: None,
-                    permission_profile: None,
+                Op::ThreadSettings {
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: None,
+                        workspace_roots: None,
+                        profile_workspace_roots: None,
+                        approval_policy: None,
+                        approvals_reviewer: None,
+                        sandbox_policy: None,
+                        permission_profile: None,
+                        active_permission_profile: None,
+                        windows_sandbox_level: None,
+                        model: Some(model_to_use.clone()),
+                        effort: Some(effort_to_use),
+                        summary: None,
+                        service_tier: None,
+                        collaboration_mode: None,
+                        personality: None,
+                    },
                 },
             )
             .await
@@ -5007,6 +5035,7 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: ThreadSettingsOverrides::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -5283,6 +5312,7 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 environments: None,
+                thread_settings: ThreadSettingsOverrides::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -6149,7 +6179,7 @@ mod tests {
                 | Op::RequestPermissionsResponse { .. }
                 | Op::PatchApproval { .. }
                 | Op::Interrupt
-                | Op::OverrideTurnContext { .. } => {}
+                | Op::ThreadSettings { .. } => {}
                 Op::Shutdown => {
                     if let Some(active_prompt_id) = self.active_prompt_id.lock().unwrap().take() {
                         self.op_tx
@@ -7384,6 +7414,7 @@ mod tests {
                             call_id: "call-1".to_string(),
                             invocation: invocation.clone(),
                             mcp_app_resource_uri: Some(resource_uri.clone()),
+                            plugin_id: None,
                         }),
                     )
                     .await;
@@ -7395,6 +7426,7 @@ mod tests {
                             call_id: "call-1".to_string(),
                             invocation,
                             mcp_app_resource_uri: Some(resource_uri.clone()),
+                            plugin_id: None,
                             duration: Duration::from_millis(5),
                             result: Ok(CallToolResult {
                                 content: vec![serde_json::to_value(ContentBlock::Text(
@@ -7876,7 +7908,7 @@ mod tests {
         drop(submission_ids);
 
         let ops = thread.ops.lock().unwrap();
-        assert!(matches!(ops.as_slice(), [Op::OverrideTurnContext { .. }]));
+        assert!(matches!(ops.as_slice(), [Op::ThreadSettings { .. }]));
 
         Ok(())
     }
@@ -7970,8 +8002,11 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert!(matches!(
             ops.as_slice(),
-            [Op::OverrideTurnContext {
-                model: Some(model),
+            [Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    model: Some(model),
+                    ..
+                },
                 ..
             }] if model == "test-model"
         ));
@@ -8011,8 +8046,11 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert!(matches!(
             ops.as_slice(),
-            [Op::OverrideTurnContext {
-                model: Some(model),
+            [Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    model: Some(model),
+                    ..
+                },
                 ..
             }] if model == "test-model"
         ));

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -3339,21 +3339,9 @@ impl<A: Auth> ThreadActor<A> {
                 "config".to_string(),
                 Op::ThreadSettings {
                     thread_settings: ThreadSettingsOverrides {
-                        cwd: None,
-                        workspace_roots: None,
-                        profile_workspace_roots: None,
-                        approval_policy: None,
-                        approvals_reviewer: None,
-                        sandbox_policy: None,
-                        permission_profile: None,
-                        active_permission_profile: None,
-                        windows_sandbox_level: None,
                         model: Some(model_to_use.clone()),
                         effort: Some(effort_to_use),
-                        summary: None,
-                        service_tier: None,
-                        collaboration_mode: None,
-                        personality: None,
+                        ..Default::default()
                     },
                 },
             )
@@ -3395,21 +3383,8 @@ impl<A: Auth> ThreadActor<A> {
                 "config".to_string(),
                 Op::ThreadSettings {
                     thread_settings: ThreadSettingsOverrides {
-                        cwd: None,
-                        workspace_roots: None,
-                        profile_workspace_roots: None,
-                        approval_policy: None,
-                        approvals_reviewer: None,
-                        sandbox_policy: None,
-                        permission_profile: None,
-                        active_permission_profile: None,
-                        windows_sandbox_level: None,
-                        model: None,
                         effort: Some(Some(effort)),
-                        summary: None,
-                        service_tier: None,
-                        collaboration_mode: None,
-                        personality: None,
+                        ..Default::default()
                     },
                 },
             )
@@ -3659,21 +3634,9 @@ impl<A: Auth> ThreadActor<A> {
                 "config".to_string(),
                 Op::ThreadSettings {
                     thread_settings: ThreadSettingsOverrides {
-                        cwd: None,
-                        workspace_roots: None,
-                        profile_workspace_roots: None,
                         approval_policy: Some(preset.approval),
-                        approvals_reviewer: None,
                         sandbox_policy: Some(legacy_sandbox_policy.clone()),
-                        permission_profile: None,
-                        active_permission_profile: None,
-                        windows_sandbox_level: None,
-                        model: None,
-                        effort: None,
-                        summary: None,
-                        service_tier: None,
-                        collaboration_mode: None,
-                        personality: None,
+                        ..Default::default()
                     },
                 },
             )
@@ -3733,21 +3696,9 @@ impl<A: Auth> ThreadActor<A> {
                 "config".to_string(),
                 Op::ThreadSettings {
                     thread_settings: ThreadSettingsOverrides {
-                        cwd: None,
-                        workspace_roots: None,
-                        profile_workspace_roots: None,
-                        approval_policy: None,
-                        approvals_reviewer: None,
-                        sandbox_policy: None,
-                        permission_profile: None,
-                        active_permission_profile: None,
-                        windows_sandbox_level: None,
                         model: Some(model_to_use.clone()),
                         effort: Some(effort_to_use),
-                        summary: None,
-                        service_tier: None,
-                        collaboration_mode: None,
-                        personality: None,
+                        ..Default::default()
                     },
                 },
             )

--- a/docs/journal/2026-05-22-codex-133-upgrade.md
+++ b/docs/journal/2026-05-22-codex-133-upgrade.md
@@ -1,0 +1,55 @@
+# Summary
+
+AgentHub's Codex ACP adapter now targets Codex `rust-v0.133.0`.
+
+# Background
+
+The repository was previously pinned to Codex `rust-v0.132.0`. This upgrade
+refreshes both the Cargo git dependencies and the Bazel `codex_src` pin while
+adapting the ACP bridge to Codex 0.133 protocol changes.
+
+# Scope
+
+- Updated `agenthub-codex-acp` Codex git dependencies from `rust-v0.132.0` to
+  `rust-v0.133.0`.
+- Updated `Cargo.lock` to the upstream `rust-v0.133.0` release commit
+  `9474e5cfc4494b0ba319352aa86ce436c59e65c8`.
+- Updated `MODULE.bazel` `codex_src` to the same upstream release commit.
+- Adapted ACP bridge code for Codex 0.133 thread settings and MCP tool event
+  shape changes.
+- Refreshed root ICU pins so the workspace lockfile can resolve Codex 0.133's
+  newer `v8`/ICU dependency graph.
+
+# Key Decisions
+
+- Translate legacy ACP config updates onto Codex 0.133's new
+  `Op::ThreadSettings` contract instead of keeping a local compatibility shim
+  around `Op::OverrideTurnContext`.
+- Keep prompt submissions explicit by populating
+  `thread_settings: ThreadSettingsOverrides::default()` for all local
+  `Op::UserInput` constructors.
+- Preserve MCP event compatibility by setting the newly added optional
+  `plugin_id` field to `None` until AgentHub exposes plugin-aware MCP reporting.
+- Treat app-server `ThreadSettingsUpdated` notifications as a no-op in this
+  slice; the ACP bridge now accepts the new notification without trying to
+  project the full app-server thread settings snapshot into user-facing session
+  updates.
+- Bump the root workspace's ICU overrides to `icu_calendar = 2.2.1` and
+  `icu_decimal = 2.2.0` because the previous `2.1.1` pins prevented Cargo from
+  resolving Codex 0.133's transitive `v8` dependency tree.
+
+# Validation
+
+```bash
+cargo check -p agenthub-codex-acp
+cargo check -p agenthub-codex-acp --tests
+cargo test -p agenthub-codex-acp
+```
+
+# Follow-Ups
+
+- Run the normal repository CI after this lands to cover non-ACP packages and
+  Bazel integration on the refreshed Codex 0.133 lockfile.
+- Decide separately whether AgentHub should surface app-server
+  `ThreadSettingsUpdated` notifications as a user-visible ACP session event or
+  continue treating them as internal runtime metadata.


### PR DESCRIPTION
chore(acp): upgrade codex to 0.133

## Summary

- upgrade `agenthub-codex-acp` Codex dependencies from `rust-v0.132.0` to `rust-v0.133.0`
- refresh `Cargo.lock` and `MODULE.bazel` to upstream commit `9474e5cfc4494b0ba319352aa86ce436c59e65c8`
- adapt the ACP bridge for Codex 0.133 protocol changes around `ThreadSettings`, MCP `plugin_id`, and app-server thread settings notifications
- bump the workspace ICU overrides needed to resolve the refreshed Codex dependency graph
- add a rollout journal for the upgrade slice

## Validation

```bash
cargo check -p agenthub-codex-acp
cargo check -p agenthub-codex-acp --tests
cargo test -p agenthub-codex-acp
```
