### PR TITLE
test(team): isolate self-review permission guard

### DIFF
--- a/src/internal/service/tests/permission_review.rs
+++ b/src/internal/service/tests/permission_review.rs
@@ -413,7 +413,7 @@ async fn internal_grpc_permission_review_respond_keeps_pending_reviewer_guard() 
             acp_session_id: "acp-session-pending-1",
             requester_actor_id: "planner",
             requester_role: "coordinator",
-            review_target_actor_id: Some("reviewer"),
+            review_target_actor_id: Some("requester"),
             tool_call_id: "tool-call-pending-1",
             status: "pending",
         },


### PR DESCRIPTION
test(team): isolate self-review permission guard

## Summary

- align the self-review regression seed so the active reviewer matches the requester
- keep the test focused on the self-review guard instead of depending on guard ordering

## Testing

- cargo fmt --all --check
- cargo test -p agenthub internal_grpc_permission_review_respond_rejects_requester_self_review -- --nocapture *(blocked locally by /private/tmp disk exhaustion during cold compile)*
