### PR TITLE
feat(team): add mailbox reply transfer flow

### DIFF
--- a/docs/journal/2026-05-28-team-mailbox-phase3-transfer-slice.md
+++ b/docs/journal/2026-05-28-team-mailbox-phase3-transfer-slice.md
@@ -1,0 +1,24 @@
+# Team Mailbox Phase 3 Transfer Slice
+
+## Summary
+
+This slice adds one explicit mailbox transfer path for reply-required human-originated work.
+
+- a claimed or pending reply-required mailbox item can now be transferred from one team member to
+  another canonical team member without pretending the work is completed;
+- the original mailbox item is released with `mailbox_resolution.kind = transferred`;
+- the reply obligation is reissued as a new pending mailbox message for the target actor;
+- reply-obligation summaries treat `released + transferred` as terminal for the source item.
+
+## Scope
+
+This change does not close Team mailbox phase 3.
+
+It only covers explicit actor-to-actor transfer for reply-required mailbox work. Remaining phase 3
+items still include broader inbound-envelope normalization, wider `requires_user_visible_reply`
+coverage, and distinct cross-actor takeover semantics.
+
+## Validation
+
+- focused API regression for transfer reassigning the open reply obligation to the target actor
+- existing escalation and triage reply-obligation tests remain the adjacent coverage surface

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -378,6 +378,12 @@ pub struct EscalateTeamRunMessageRequest {
     pub actor_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct TransferTeamRunMessageRequest {
+    pub actor_id: String,
+    pub target_actor_id: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct TeamRunSnapshotResponse {
     pub run: TeamRunRecord,
@@ -558,6 +564,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/runs/{run_id}/messages/{message_id}/escalate",
             post(escalate_team_run_message),
+        )
+        .route(
+            "/runs/{run_id}/messages/{message_id}/transfer",
+            post(transfer_team_run_message),
         )
         .with_state(state)
 }
@@ -1968,6 +1978,40 @@ async fn escalate_team_run_message(
                 &actor_id,
                 ACTOR_MAIN_PEER_ID,
                 message_id,
+            )
+            .await;
+        match result {
+            Ok(message) => return Ok(Json(message)),
+            Err(err) if err.code == ActorServiceErrorCode::NotFound => continue,
+            Err(err) => return Err(map_actor_service_api_error(err)),
+        }
+    }
+    Err(ApiError::not_found("message not found"))
+}
+
+async fn transfer_team_run_message(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((run_id, message_id)): Path<(String, i64)>,
+    Json(payload): Json<TransferTeamRunMessageRequest>,
+) -> Result<Json<TeamActorMessageRecord>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    let (_run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
+    let actor_ids =
+        resolve_run_mailbox_query_actor_ids(payload.actor_id.as_str(), &member_ids, &user)?;
+    let target_actor_id = payload.target_actor_id.trim();
+    if target_actor_id.is_empty() {
+        return Err(ApiError::bad_request("target_actor_id is required"));
+    }
+    let service = state.teams.actor_mailbox_service();
+    for actor_id in actor_ids {
+        let result = service
+            .transfer_reply_required_message(
+                &run_id,
+                &actor_id,
+                ACTOR_MAIN_PEER_ID,
+                message_id,
+                target_actor_id,
             )
             .await;
         match result {

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -48,10 +48,10 @@ use super::{
     SendTeamRunMessageRequest, SendTeamTaskMessageRequest, SetTeamRunStepInputRequiredRequest,
     StartTeamRunStepRequest, SubmitTeamRunStepRequest, TeamMemberSpec,
     TeamMessageSearchHitResponse, TeamRunSnapshotQuery, TeamTaskDetailResponse,
-    TriageTeamRunMessageRequest, UpdateTeamSpecRequest, UpdateTeamTaskRequest,
-    ack_team_run_message, cancel_team_run, compile_team_task_run_preview, complete_team_run_step,
-    create_team, create_team_channel, create_team_run, delete_team, delete_team_channel,
-    ensure_team_shared_thread, escalate_team_run_message, fail_team_run_step,
+    TransferTeamRunMessageRequest, TriageTeamRunMessageRequest, UpdateTeamSpecRequest,
+    UpdateTeamTaskRequest, ack_team_run_message, cancel_team_run, compile_team_task_run_preview,
+    complete_team_run_step, create_team, create_team_channel, create_team_run, delete_team,
+    delete_team_channel, ensure_team_shared_thread, escalate_team_run_message, fail_team_run_step,
     flush_team_run_context, force_new_session_for_team_member, get_team, get_team_run,
     get_team_run_snapshot, get_team_runtime, get_team_shared_thread, get_team_task,
     list_team_channels, list_team_run_events, list_team_run_inbox, list_team_run_steps,
@@ -60,8 +60,8 @@ use super::{
     normalize_team_spec, parse_message_archive_source_kind, reply_team_thread, require_user,
     restart_team_run, resume_team_run, resume_team_run_step, search_team_messages,
     send_team_run_message, send_team_task_message, set_team_run_step_input_required, start_team,
-    start_team_run_step, stop_team, submit_team_run_step, triage_team_run_message,
-    update_team_spec, update_team_task, validate_team_spec,
+    start_team_run_step, stop_team, submit_team_run_step, transfer_team_run_message,
+    triage_team_run_message, update_team_spec, update_team_task, validate_team_spec,
 };
 
 #[derive(Default)]

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -3909,6 +3909,179 @@ async fn team_run_messages_api_escalation_reassigns_open_reply_obligation_to_coo
 }
 
 #[tokio::test]
+async fn team_run_messages_api_transfer_reassigns_open_reply_obligation_to_target_actor() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "actor-mailbox-transfer-team".to_string(),
+            description: Some("transfer reassigns reply obligation".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[
+                    {"member_id":"planner","role":"coordinator"},
+                    {"member_id":"worker-1","role":"worker"},
+                    {"member_id":"worker-2","role":"worker"}
+                ]
+            }),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    let Json(run) = create_team_run(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(CreateTeamRunRequest {
+            context_id: Some("ctx-message-transfer".to_string()),
+            input: Some(json!({"prompt":"transfer reply obligation"})),
+        }),
+    )
+    .await
+    .expect("create run");
+
+    let now = Utc::now().timestamp();
+    let payload_json = json!({
+        "type":"chat_message",
+        "text":"Please hand this customer reply to worker two.",
+        "source_kind":"human",
+        "source_surface":"conversation",
+        "conversation_id":"conv-transfer-1",
+        "requires_user_visible_reply": true,
+        "reply_target": {
+            "surface":"conversation",
+            "conversation_id":"conv-transfer-1",
+            "task_message_id": 1
+        }
+    })
+    .to_string();
+    let original_message_id = sqlx::query(
+        r#"
+        INSERT INTO team_actor_messages (
+            run_id,
+            from_actor_id,
+            to_actor_id,
+            channel,
+            transport,
+            route_json,
+            payload_json,
+            idempotency_key,
+            status,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, NULL, 'pending', ?7)
+        "#,
+    )
+    .bind(&run.id)
+    .bind("user")
+    .bind("worker-1")
+    .bind("default")
+    .bind("local")
+    .bind(&payload_json)
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .expect("insert human mailbox message")
+    .last_insert_rowid();
+
+    let Json(transferred) = transfer_team_run_message(
+        State(state.clone()),
+        headers.clone(),
+        Path((run.id.clone(), original_message_id)),
+        Json(TransferTeamRunMessageRequest {
+            actor_id: "worker-1".to_string(),
+            target_actor_id: "worker-2".to_string(),
+        }),
+    )
+    .await
+    .expect("transfer mailbox obligation");
+    assert_eq!(transferred.to_actor_id, "worker-2");
+    assert_eq!(transferred.status, agenthub_team_actor::ActorMessageStatus::Pending);
+    assert_eq!(
+        transferred.payload["mailbox_transfer"]["kind"],
+        json!("transferred")
+    );
+
+    let Json(worker_one_pending_after) = list_team_run_inbox(
+        State(state.clone()),
+        headers.clone(),
+        Path(run.id.clone()),
+        Query(ListTeamRunInboxQuery {
+            actor_id: "worker-1".to_string(),
+            limit: Some(100),
+            after_id: None,
+            include_delivered: Some(false),
+        }),
+    )
+    .await
+    .expect("list worker-1 inbox after transfer");
+    assert!(worker_one_pending_after.is_empty());
+
+    let Json(worker_two_pending_after) = list_team_run_inbox(
+        State(state.clone()),
+        headers.clone(),
+        Path(run.id.clone()),
+        Query(ListTeamRunInboxQuery {
+            actor_id: "worker-2".to_string(),
+            limit: Some(100),
+            after_id: None,
+            include_delivered: Some(false),
+        }),
+    )
+    .await
+    .expect("list worker-2 inbox after transfer");
+    assert_eq!(worker_two_pending_after.len(), 1);
+    assert_eq!(worker_two_pending_after[0].message_id, transferred.message_id);
+
+    let original_resolution_kind = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT json_extract(payload_json, '$.mailbox_resolution.kind')
+        FROM team_actor_messages
+        WHERE id = ?1
+        "#,
+    )
+    .bind(original_message_id)
+    .fetch_one(&state.db)
+    .await
+    .expect("load original message resolution kind");
+    assert_eq!(original_resolution_kind, "transferred");
+
+    let Json(snapshot_after) = get_team_run_snapshot(
+        State(state),
+        headers,
+        Path(run.id),
+        Query(TeamRunSnapshotQuery {
+            event_limit: Some(100),
+            message_limit: Some(100),
+        }),
+    )
+    .await
+    .expect("get snapshot after transfer");
+    assert_eq!(snapshot_after.mailbox.open_reply_obligation_count, 1);
+    assert_eq!(snapshot_after.mailbox.open_reply_obligations.len(), 1);
+    assert_eq!(
+        snapshot_after.mailbox.open_reply_obligations[0].agent_actor_id,
+        "worker-2"
+    );
+    let worker_one_after = snapshot_after
+        .members
+        .iter()
+        .find(|member| member.member_id == "worker-1")
+        .expect("find worker-1 after transfer");
+    assert_eq!(worker_one_after.reply_obligation_count, 0);
+    let worker_two_after = snapshot_after
+        .members
+        .iter()
+        .find(|member| member.member_id == "worker-2")
+        .expect("find worker-2 after transfer");
+    assert_eq!(worker_two_after.reply_obligation_count, 1);
+}
+
+#[tokio::test]
 async fn team_run_messages_api_triage_surfaces_takeover_state() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -30,6 +30,7 @@ use tokio::sync::Semaphore;
 pub(super) const TEAM_SPECIAL_USER_ACTOR_ALIAS: &str = "user";
 pub(super) const TEAM_SPECIAL_USER_ACTOR_PREFIX: &str = "user:";
 pub(super) const MAILBOX_RESOLUTION_ESCALATED: &str = "escalated";
+pub(super) const MAILBOX_RESOLUTION_TRANSFERRED: &str = "transferred";
 const MAILBOX_RUN_EVENT_ARCHIVE_MAX_CONCURRENCY: usize = 4;
 pub(super) const ACTOR_THREAD_CLAIM_DEFAULT_LEASE_SECS: i64 = 30 * 60;
 

--- a/src/team/manager/mailbox_errors.rs
+++ b/src/team/manager/mailbox_errors.rs
@@ -156,20 +156,6 @@ pub(super) fn map_actor_service_error(err: anyhow::Error) -> ActorServiceError {
         .is_some_and(|cause| {
             matches!(
                 cause,
-                SqlActorMailboxStoreError::ReplyRequiredEscalationUnsupported
-            )
-        })
-    {
-        return ActorServiceError::new(
-            ActorServiceErrorCode::BadRequest,
-            "only human-originated reply-required mailbox work can be escalated",
-        );
-    }
-    if err
-        .downcast_ref::<SqlActorMailboxStoreError>()
-        .is_some_and(|cause| {
-            matches!(
-                cause,
                 SqlActorMailboxStoreError::ReplyRequiredEscalationAlreadyAtCoordinator
             )
         })
@@ -227,9 +213,6 @@ pub(super) fn map_actor_mailbox_store_error(
             }
             SqlActorMailboxStoreError::ReplyRequiredVisibleOutcomeMissing => {
                 anyhow::Error::new(SqlActorMailboxStoreError::ReplyRequiredVisibleOutcomeMissing)
-            }
-            SqlActorMailboxStoreError::ReplyRequiredEscalationUnsupported => {
-                anyhow::Error::new(SqlActorMailboxStoreError::ReplyRequiredEscalationUnsupported)
             }
             SqlActorMailboxStoreError::ReplyRequiredEscalationAlreadyAtCoordinator => {
                 anyhow::Error::new(

--- a/src/team/manager/mailbox_reply_obligation_payloads.rs
+++ b/src/team/manager/mailbox_reply_obligation_payloads.rs
@@ -1,4 +1,6 @@
-use super::mailbox::{MAILBOX_RESOLUTION_ESCALATED, ReplyActorPairKey};
+use super::mailbox::{
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+};
 use super::mailbox_payloads::is_human_actor_id;
 use super::mailbox_reply_obligation_snapshot_conversion::resolve_canonical_chat_reply_from_snapshot;
 use super::mailbox_reply_obligation_snapshots::ReplyObligationMessageSnapshot;
@@ -69,14 +71,11 @@ pub(super) fn reply_obligation_snapshot_is_terminal(
         return true;
     }
     matches!(
-        (
-            message.handling_disposition.clone(),
-            message.mailbox_resolution_kind.as_deref(),
-        ),
-        (
-            ActorMessageHandlingDisposition::Released,
-            Some(MAILBOX_RESOLUTION_ESCALATED)
-        )
+        message.handling_disposition,
+        ActorMessageHandlingDisposition::Released
+    ) && matches!(
+        message.mailbox_resolution_kind.as_deref(),
+        Some(MAILBOX_RESOLUTION_ESCALATED | MAILBOX_RESOLUTION_TRANSFERRED)
     )
 }
 

--- a/src/team/manager/mailbox_reply_obligations.rs
+++ b/src/team/manager/mailbox_reply_obligations.rs
@@ -1,6 +1,8 @@
 use serde_json::{Map, Value};
 
-use super::mailbox::{MAILBOX_RESOLUTION_ESCALATED, ReplyActorPairKey};
+use super::mailbox::{
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+};
 use super::mailbox_reply_obligation_snapshot_conversion::mailbox_resolution_kind;
 use crate::team::TeamActorMessageRecord;
 use agenthub_team_actor::{ActorIdentityKind, ActorMessageHandlingDisposition};
@@ -31,14 +33,11 @@ pub(super) fn reply_obligation_is_terminal(message: &TeamActorMessageRecord) -> 
         return true;
     }
     matches!(
-        (
-            message.handling_disposition.clone(),
-            mailbox_resolution_kind(&message.payload),
-        ),
-        (
-            ActorMessageHandlingDisposition::Released,
-            Some(MAILBOX_RESOLUTION_ESCALATED)
-        )
+        message.handling_disposition,
+        ActorMessageHandlingDisposition::Released
+    ) && matches!(
+        mailbox_resolution_kind(&message.payload),
+        Some(MAILBOX_RESOLUTION_ESCALATED | MAILBOX_RESOLUTION_TRANSFERRED)
     )
 }
 
@@ -86,6 +85,32 @@ pub(super) fn build_escalated_mailbox_payload(
             "target_actor_id": target_actor_id,
             "escalated_by_actor_id": escalated_by_actor_id,
             "escalated_at": escalated_at
+        }),
+    );
+    Value::Object(payload_obj)
+}
+
+pub(super) fn build_transferred_mailbox_payload(
+    source_payload: &Value,
+    source_message_id: i64,
+    source_actor_id: &str,
+    target_actor_id: &str,
+    transferred_by_actor_id: &str,
+    transferred_at: i64,
+) -> Value {
+    let mut payload_obj = match source_payload {
+        Value::Object(map) => map.clone(),
+        _ => Map::new(),
+    };
+    payload_obj.insert(
+        "mailbox_transfer".to_string(),
+        serde_json::json!({
+            "kind": MAILBOX_RESOLUTION_TRANSFERRED,
+            "source_message_id": source_message_id,
+            "source_actor_id": source_actor_id,
+            "target_actor_id": target_actor_id,
+            "transferred_by_actor_id": transferred_by_actor_id,
+            "transferred_at": transferred_at
         }),
     );
     Value::Object(payload_obj)

--- a/src/team/manager/mailbox_service_escalation.rs
+++ b/src/team/manager/mailbox_service_escalation.rs
@@ -1,8 +1,8 @@
 use chrono::Utc;
 
 use super::mailbox::{
-    MAILBOX_RESOLUTION_ESCALATED, apply_thread_claim_transition, fetch_enriched_message_by_id,
-    fetch_message_for_actor, map_actor_service_error,
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, apply_thread_claim_transition,
+    fetch_enriched_message_by_id, fetch_message_for_actor, map_actor_service_error,
 };
 use super::mailbox_service::TeamActorMailboxService;
 use crate::team::{TeamActorMessageRecord, TeamActorMessageStatus};
@@ -12,6 +12,59 @@ use agenthub_team_actor::{
 };
 
 impl TeamActorMailboxService {
+    pub async fn transfer_reply_required_message(
+        &self,
+        run_id: &str,
+        actor_id: &str,
+        peer_id: &str,
+        message_id: i64,
+        target_actor_id: &str,
+    ) -> Result<TeamActorMessageRecord, agenthub_team_actor::ActorServiceError> {
+        let member_specs = self
+            .load_member_specs_for_run(run_id)
+            .await
+            .map_err(map_actor_service_error)?;
+        let target_actor_id = target_actor_id.trim();
+        if target_actor_id.is_empty() {
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                "target_actor_id is required",
+            ));
+        }
+        if target_actor_id == actor_id {
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                "reply-required mailbox work cannot be transferred to the acting actor",
+            ));
+        }
+        if !member_specs
+            .iter()
+            .any(|member| member.member_id == target_actor_id)
+        {
+            let valid_member_ids = member_specs
+                .iter()
+                .map(|member| member.member_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                format!(
+                    "target_actor_id `{}` must reference a canonical team member_id; valid member_ids: {}",
+                    target_actor_id, valid_member_ids
+                ),
+            ));
+        }
+        self.reassign_reply_required_message(
+            run_id,
+            actor_id,
+            peer_id,
+            message_id,
+            target_actor_id,
+            MAILBOX_RESOLUTION_TRANSFERRED,
+        )
+        .await
+    }
+
     pub async fn escalate_reply_required_message_to_coordinator(
         &self,
         run_id: &str,
@@ -38,19 +91,42 @@ impl TeamActorMailboxService {
             )));
         }
 
+        self.reassign_reply_required_message(
+            run_id,
+            actor_id,
+            peer_id,
+            message_id,
+            &coordinator_actor_id,
+            MAILBOX_RESOLUTION_ESCALATED,
+        )
+        .await
+    }
+
+    async fn reassign_reply_required_message(
+        &self,
+        run_id: &str,
+        actor_id: &str,
+        peer_id: &str,
+        message_id: i64,
+        target_actor_id: &str,
+        resolution_kind: &str,
+    ) -> Result<TeamActorMessageRecord, agenthub_team_actor::ActorServiceError> {
+        let target_actor_id_owned = target_actor_id.to_string();
         let delivery = self
             .manager
-            .resolve_mailbox_recipient_deliveries(std::slice::from_ref(&coordinator_actor_id))
+            .resolve_mailbox_recipient_deliveries(std::slice::from_ref(&target_actor_id_owned))
             .await
             .map_err(map_actor_service_error)?
             .into_iter()
             .next()
             .ok_or_else(|| {
-                map_actor_service_error(anyhow::Error::new(
-                    super::mailbox::SqlActorMailboxStoreError::ReplyRequiredEscalationTargetUnavailable,
-                ))
+                agenthub_team_actor::ActorServiceError::new(
+                    agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                    format!(
+                        "run team cannot resolve mailbox delivery target for actor `{target_actor_id}`"
+                    ),
+                )
             })?;
-
         let now = Utc::now().timestamp();
         let route_json = delivery
             .route
@@ -80,9 +156,10 @@ impl TeamActorMailboxService {
         if super::mailbox_reply_obligations::reply_actor_pair_for_inbound_obligation(&message)
             .is_none()
         {
-            return Err(map_actor_service_error(anyhow::Error::new(
-                super::mailbox::SqlActorMailboxStoreError::ReplyRequiredEscalationUnsupported,
-            )));
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                "only human-originated reply-required mailbox work can be escalated or transferred",
+            ));
         }
         if super::mailbox_reply_obligations::reply_obligation_is_terminal(&message) {
             return Err(agenthub_team_actor::ActorServiceError::new(
@@ -93,9 +170,9 @@ impl TeamActorMailboxService {
 
         let release_payload = super::mailbox_reply_obligations::build_mailbox_resolution_payload(
             &message.payload,
-            MAILBOX_RESOLUTION_ESCALATED,
+            resolution_kind,
             actor_id,
-            &coordinator_actor_id,
+            target_actor_id,
             now,
         );
         let released_payload_json = serde_json::to_string(&release_payload).map_err(|err| {
@@ -104,25 +181,41 @@ impl TeamActorMailboxService {
                 err.to_string(),
             )
         })?;
-        let escalated_payload = normalize_actor_message_envelope_payload(
+        let reassigned_payload = normalize_actor_message_envelope_payload(
             &message.from_actor_id,
-            &coordinator_actor_id,
+            target_actor_id,
             &message.message_kind,
-            super::mailbox_reply_obligations::build_escalated_mailbox_payload(
-                &message.payload,
-                message.message_id,
-                actor_id,
-                &coordinator_actor_id,
-                actor_id,
-                now,
-            ),
+            match resolution_kind {
+                MAILBOX_RESOLUTION_ESCALATED => {
+                    super::mailbox_reply_obligations::build_escalated_mailbox_payload(
+                        &message.payload,
+                        message.message_id,
+                        actor_id,
+                        target_actor_id,
+                        actor_id,
+                        now,
+                    )
+                }
+                MAILBOX_RESOLUTION_TRANSFERRED => {
+                    super::mailbox_reply_obligations::build_transferred_mailbox_payload(
+                        &message.payload,
+                        message.message_id,
+                        actor_id,
+                        target_actor_id,
+                        actor_id,
+                        now,
+                    )
+                }
+                _ => unreachable!(),
+            },
         );
-        let escalated_payload_json = serde_json::to_string(&escalated_payload).map_err(|err| {
-            agenthub_team_actor::ActorServiceError::new(
-                agenthub_team_actor::ActorServiceErrorCode::Internal,
-                err.to_string(),
-            )
-        })?;
+        let reassigned_payload_json =
+            serde_json::to_string(&reassigned_payload).map_err(|err| {
+                agenthub_team_actor::ActorServiceError::new(
+                    agenthub_team_actor::ActorServiceErrorCode::Internal,
+                    err.to_string(),
+                )
+            })?;
 
         if message.handling_disposition == ActorMessageHandlingDisposition::Claimed {
             apply_thread_claim_transition(
@@ -190,12 +283,12 @@ impl TeamActorMailboxService {
         .bind(run_id)
         .bind(&message.from_actor_id)
         .bind(&message.from_peer_id)
-        .bind(&coordinator_actor_id)
+        .bind(target_actor_id)
         .bind(&delivery.to_peer_id)
         .bind(&message.channel)
         .bind(transport_raw)
         .bind(route_json)
-        .bind(escalated_payload_json)
+        .bind(reassigned_payload_json)
         .bind(message.message_kind.as_str())
         .bind(status_raw)
         .bind(now)

--- a/src/team/manager/mailbox_store.rs
+++ b/src/team/manager/mailbox_store.rs
@@ -27,8 +27,6 @@ pub(super) enum SqlActorMailboxStoreError {
         "reply-required mailbox work cannot be completed before a visible reply is emitted or the item is explicitly escalated/transferred"
     )]
     ReplyRequiredVisibleOutcomeMissing,
-    #[error("only human-originated reply-required mailbox work can be escalated")]
-    ReplyRequiredEscalationUnsupported,
     #[error("reply-required mailbox work is already assigned to coordinator")]
     ReplyRequiredEscalationAlreadyAtCoordinator,
     #[error("reply-required mailbox escalation target is unavailable")]


### PR DESCRIPTION
feat(team): add mailbox reply transfer flow

## Summary

- add an explicit mailbox transfer endpoint for reply-required human-originated work
- reissue the reply obligation to another canonical team member without marking the original work completed
- treat released plus transferred mailbox items as terminal in reply-obligation summaries

## Testing

- cargo fmt --all --check
- git -c core.fsmonitor=false diff --check
- cargo test -p agenthub team_run_messages_api_transfer_reassigns_open_reply_obligation_to_target_actor --target-dir /Users/weizhenwang/devel/opensource/agenthub/target/codex-mailbox-transfer -- --nocapture *(blocked locally by no space left on device during cold compile)*
