### PR TITLE
feat(team): add mailbox takeover flow

### DIFF
--- a/docs/features/team-mailbox-intake-and-ownership.md
+++ b/docs/features/team-mailbox-intake-and-ownership.md
@@ -233,6 +233,8 @@ processing without one of these outcomes:
 
 - user-visible reply emitted successfully;
 - work transferred explicitly to another actor with preserved reply obligation;
+- claimed work taken over explicitly by another actor with preserved reply obligation and topic
+  ownership;
 - message marked ignored with an explicit allowed reason;
 - issue escalated to coordinator or human operator with visible evidence.
 
@@ -252,13 +254,16 @@ Current minimum operator contract:
 - operators may explicitly escalate reply-required human mailbox work to the coordinator; this
   releases the original item and reissues the open reply obligation to the coordinator mailbox
   instead of pretending the work is completed;
+- operators may explicitly take over actively claimed reply-required work for another actor; this
+  releases the original item as `taken_over`, reissues the open reply obligation to the target
+  actor, and moves the topic claim owner to that target actor;
 - `ignored` clears the item from open-obligation and unread-actionable summaries;
 - `completed` is only valid when user-visible reply evidence already exists; unresolved
   reply-obligation rows should not offer `completed` as a direct operator action;
 - `watching`, `claimed`, and `released` remain operator-visible mailbox states and do not satisfy
   the user-visible reply requirement on their own;
-- transfer and cross-actor takeover remain distinct follow-up flows and must not be conflated with
-  the current triage-state surface.
+- transfer and cross-actor takeover are distinct flows and are not conflated with the triage-state
+  surface.
 
 ### 9) Inbox Ordering Contract
 

--- a/docs/journal/2026-05-30-team-mailbox-phase3-takeover-slice.md
+++ b/docs/journal/2026-05-30-team-mailbox-phase3-takeover-slice.md
@@ -1,0 +1,49 @@
+# Team Mailbox Phase 3 Takeover Slice
+
+## Summary
+
+Added an explicit takeover path for actively claimed reply-required Team mailbox work. Takeover now
+releases the original actor's item with a `taken_over` resolution, creates a new target-actor
+mailbox item that preserves the reply obligation, and moves the topic claim owner to the target
+actor.
+
+## Background
+
+Phase 3 already separated normal triage from reply-required escalation and general transfer. The
+remaining ownership gap was cross-actor takeover: a second actor still could not silently claim an
+active topic, but operators also lacked an explicit outcome that both preserved the human reply
+obligation and reassigned topic ownership.
+
+## Scope
+
+- Added the run message takeover API for claimed reply-required mailbox items.
+- Recorded takeover as `mailbox_resolution.kind = "taken_over"` on the source item.
+- Recorded target-side takeover metadata under `mailbox_takeover`.
+- Preserved the open reply obligation on the target actor.
+- Kept ordinary parallel claim attempts as conflicts.
+
+## Key Decisions
+
+- Takeover is a separate endpoint instead of another triage disposition. Triage remains the actor's
+  handling state, while takeover is an operator-level ownership reassignment outcome.
+- Takeover requires a currently claimed topic. Unclaimed handoff remains the transfer flow.
+- The target item is inserted as claimed so the thread owner and mailbox handling state agree
+  immediately after takeover.
+
+## Validation
+
+Focused checks:
+
+```bash
+cargo fmt --all --check
+cargo test -p agenthub team_run_messages_api_triage_surfaces_takeover_state -- --nocapture
+cargo test -p agenthub actor_mailbox_service_claims_topics_and_prevents_parallel_takeover -- --nocapture
+git -c core.fsmonitor=false diff --check
+```
+
+## Follow-Ups
+
+- Continue normalizing future human, trigger, and webhook intake into the canonical inbound
+  envelope.
+- Continue extending the `requires_user_visible_reply` invariant beyond the currently guarded
+  completion and reassignment paths.

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -384,6 +384,12 @@ pub struct TransferTeamRunMessageRequest {
     pub target_actor_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct TakeoverTeamRunMessageRequest {
+    pub actor_id: String,
+    pub target_actor_id: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct TeamRunSnapshotResponse {
     pub run: TeamRunRecord,
@@ -568,6 +574,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/runs/{run_id}/messages/{message_id}/transfer",
             post(transfer_team_run_message),
+        )
+        .route(
+            "/runs/{run_id}/messages/{message_id}/takeover",
+            post(takeover_team_run_message),
         )
         .with_state(state)
 }
@@ -2007,6 +2017,40 @@ async fn transfer_team_run_message(
     for actor_id in actor_ids {
         let result = service
             .transfer_reply_required_message(
+                &run_id,
+                &actor_id,
+                ACTOR_MAIN_PEER_ID,
+                message_id,
+                target_actor_id,
+            )
+            .await;
+        match result {
+            Ok(message) => return Ok(Json(message)),
+            Err(err) if err.code == ActorServiceErrorCode::NotFound => continue,
+            Err(err) => return Err(map_actor_service_api_error(err)),
+        }
+    }
+    Err(ApiError::not_found("message not found"))
+}
+
+async fn takeover_team_run_message(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((run_id, message_id)): Path<(String, i64)>,
+    Json(payload): Json<TakeoverTeamRunMessageRequest>,
+) -> Result<Json<TeamActorMessageRecord>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    let (_run, member_ids) = load_run_and_member_ids_for_user(&state, &run_id, &user).await?;
+    let actor_ids =
+        resolve_run_mailbox_query_actor_ids(payload.actor_id.as_str(), &member_ids, &user)?;
+    let target_actor_id = payload.target_actor_id.trim();
+    if target_actor_id.is_empty() {
+        return Err(ApiError::bad_request("target_actor_id is required"));
+    }
+    let service = state.teams.actor_mailbox_service();
+    for actor_id in actor_ids {
+        let result = service
+            .takeover_reply_required_message(
                 &run_id,
                 &actor_id,
                 ACTOR_MAIN_PEER_ID,

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -46,8 +46,8 @@ use super::{
     ListTeamRunEventsQuery, ListTeamRunInboxQuery, ListTeamRunsQuery, ListTeamTaskMessagesQuery,
     ListTeamTasksQuery, ReplyTeamThreadRequest, ResumeTeamRunStepRequest, SearchTeamMessagesQuery,
     SendTeamRunMessageRequest, SendTeamTaskMessageRequest, SetTeamRunStepInputRequiredRequest,
-    StartTeamRunStepRequest, SubmitTeamRunStepRequest, TeamMemberSpec,
-    TeamMessageSearchHitResponse, TeamRunSnapshotQuery, TeamTaskDetailResponse,
+    StartTeamRunStepRequest, SubmitTeamRunStepRequest, TakeoverTeamRunMessageRequest,
+    TeamMemberSpec, TeamMessageSearchHitResponse, TeamRunSnapshotQuery, TeamTaskDetailResponse,
     TransferTeamRunMessageRequest, TriageTeamRunMessageRequest, UpdateTeamSpecRequest,
     UpdateTeamTaskRequest, ack_team_run_message, cancel_team_run, compile_team_task_run_preview,
     complete_team_run_step, create_team, create_team_channel, create_team_run, delete_team,
@@ -60,8 +60,9 @@ use super::{
     normalize_team_spec, parse_message_archive_source_kind, reply_team_thread, require_user,
     restart_team_run, resume_team_run, resume_team_run_step, search_team_messages,
     send_team_run_message, send_team_task_message, set_team_run_step_input_required, start_team,
-    start_team_run_step, stop_team, submit_team_run_step, transfer_team_run_message,
-    triage_team_run_message, update_team_spec, update_team_task, validate_team_spec,
+    start_team_run_step, stop_team, submit_team_run_step, takeover_team_run_message,
+    transfer_team_run_message, triage_team_run_message, update_team_spec, update_team_task,
+    validate_team_spec,
 };
 
 #[derive(Default)]

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -4096,7 +4096,8 @@ async fn team_run_messages_api_triage_surfaces_takeover_state() {
                 "entrypoint":"planner",
                 "members":[
                     {"member_id":"planner","role":"coordinator"},
-                    {"member_id":"worker-1","role":"worker"}
+                    {"member_id":"worker-1","role":"worker"},
+                    {"member_id":"worker-2","role":"worker"}
                 ]
             }),
         }),
@@ -4165,6 +4166,22 @@ async fn team_run_messages_api_triage_surfaces_takeover_state() {
     .expect("insert human takeover message")
     .last_insert_rowid();
 
+    let unclaimed_takeover = takeover_team_run_message(
+        State(state.clone()),
+        headers.clone(),
+        Path((run.id.clone(), message_id)),
+        Json(TakeoverTeamRunMessageRequest {
+            actor_id: "worker-1".to_string(),
+            target_actor_id: "worker-2".to_string(),
+        }),
+    )
+    .await
+    .expect_err("takeover requires an active source claim");
+    assert_eq!(
+        unclaimed_takeover.into_response().status(),
+        StatusCode::BAD_REQUEST
+    );
+
     let Json(claimed) = triage_team_run_message(
         State(state.clone()),
         headers.clone(),
@@ -4214,25 +4231,33 @@ async fn team_run_messages_api_triage_surfaces_takeover_state() {
     );
     assert_eq!(claimed_message.thread_owner_actor_id.as_deref(), Some("worker-1"));
 
-    let Json(released) = triage_team_run_message(
+    let Json(taken_over) = takeover_team_run_message(
         State(state.clone()),
         headers.clone(),
         Path((run.id.clone(), message_id)),
-        Json(TriageTeamRunMessageRequest {
+        Json(TakeoverTeamRunMessageRequest {
             actor_id: "worker-1".to_string(),
-            disposition: "released".to_string(),
+            target_actor_id: "worker-2".to_string(),
         }),
     )
     .await
-    .expect("release mailbox topic");
+    .expect("take over mailbox topic");
+    assert_eq!(taken_over.to_actor_id, "worker-2");
     assert_eq!(
-        released.handling_disposition,
-        agenthub_team_actor::ActorMessageHandlingDisposition::Released
+        taken_over.handling_disposition,
+        agenthub_team_actor::ActorMessageHandlingDisposition::Claimed
     );
-    assert_eq!(released.thread_claim_status, None);
-    assert_eq!(released.thread_owner_actor_id, None);
+    assert_eq!(
+        taken_over.thread_claim_status,
+        Some(agenthub_team_actor::ActorThreadClaimStatus::Claimed)
+    );
+    assert_eq!(taken_over.thread_owner_actor_id.as_deref(), Some("worker-2"));
+    assert_eq!(
+        taken_over.payload["mailbox_takeover"]["kind"],
+        json!("taken_over")
+    );
 
-    let Json(snapshot_released) = get_team_run_snapshot(
+    let Json(snapshot_taken_over) = get_team_run_snapshot(
         State(state),
         headers,
         Path(run.id),
@@ -4242,20 +4267,44 @@ async fn team_run_messages_api_triage_surfaces_takeover_state() {
         }),
     )
     .await
-    .expect("get snapshot after release");
-    assert_eq!(snapshot_released.mailbox.open_reply_obligation_count, 1);
-    let released_message = snapshot_released
+    .expect("get snapshot after takeover");
+    assert_eq!(snapshot_taken_over.mailbox.open_reply_obligation_count, 1);
+    assert_eq!(
+        snapshot_taken_over.mailbox.open_reply_obligations[0].agent_actor_id,
+        "worker-2"
+    );
+    let source_message = snapshot_taken_over
         .mailbox
         .recent_messages
         .iter()
         .find(|message| message.message_id == message_id)
-        .expect("find released snapshot message");
+        .expect("find source snapshot message");
     assert_eq!(
-        released_message.handling_disposition,
+        source_message.handling_disposition,
         agenthub_team_actor::ActorMessageHandlingDisposition::Released
     );
-    assert_eq!(released_message.thread_claim_status, None);
-    assert_eq!(released_message.thread_owner_actor_id, None);
+    assert_eq!(
+        source_message.payload["mailbox_resolution"]["kind"],
+        json!("taken_over")
+    );
+    let takeover_message = snapshot_taken_over
+        .mailbox
+        .recent_messages
+        .iter()
+        .find(|message| message.message_id == taken_over.message_id)
+        .expect("find takeover snapshot message");
+    assert_eq!(
+        takeover_message.handling_disposition,
+        agenthub_team_actor::ActorMessageHandlingDisposition::Claimed
+    );
+    assert_eq!(
+        takeover_message.thread_claim_status,
+        Some(agenthub_team_actor::ActorThreadClaimStatus::Claimed)
+    );
+    assert_eq!(
+        takeover_message.thread_owner_actor_id.as_deref(),
+        Some("worker-2")
+    );
 }
 
 #[tokio::test]

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -22,7 +22,9 @@ pub(super) use super::mailbox_sqlite::{
 };
 pub(super) use super::mailbox_store::{SqlActorMailboxStore, SqlActorMailboxStoreError};
 pub(super) use super::mailbox_store_inbox_enrichment::enrich_actor_messages;
-pub(super) use super::mailbox_threads::apply_thread_claim_transition;
+pub(super) use super::mailbox_threads::{
+    apply_thread_claim_takeover, apply_thread_claim_transition,
+};
 use super::{TeamManager, TeamReplyObligationSummary};
 use crate::team::TeamActorMessageTransport;
 use tokio::sync::Semaphore;
@@ -31,6 +33,7 @@ pub(super) const TEAM_SPECIAL_USER_ACTOR_ALIAS: &str = "user";
 pub(super) const TEAM_SPECIAL_USER_ACTOR_PREFIX: &str = "user:";
 pub(super) const MAILBOX_RESOLUTION_ESCALATED: &str = "escalated";
 pub(super) const MAILBOX_RESOLUTION_TRANSFERRED: &str = "transferred";
+pub(super) const MAILBOX_RESOLUTION_TAKEN_OVER: &str = "taken_over";
 const MAILBOX_RUN_EVENT_ARCHIVE_MAX_CONCURRENCY: usize = 4;
 pub(super) const ACTOR_THREAD_CLAIM_DEFAULT_LEASE_SECS: i64 = 30 * 60;
 

--- a/src/team/manager/mailbox_errors.rs
+++ b/src/team/manager/mailbox_errors.rs
@@ -148,7 +148,21 @@ pub(super) fn map_actor_service_error(err: anyhow::Error) -> ActorServiceError {
     {
         return ActorServiceError::new(
             ActorServiceErrorCode::UnprocessableEntity,
-            "reply-required mailbox work cannot be completed before a visible reply is emitted or the item is explicitly escalated/transferred",
+            "reply-required mailbox work cannot be completed before a visible reply is emitted or the item is explicitly escalated/transferred/taken over",
+        );
+    }
+    if err
+        .downcast_ref::<SqlActorMailboxStoreError>()
+        .is_some_and(|cause| {
+            matches!(
+                cause,
+                SqlActorMailboxStoreError::ThreadClaimTakeoverRequired
+            )
+        })
+    {
+        return ActorServiceError::new(
+            ActorServiceErrorCode::BadRequest,
+            "mailbox takeover requires a currently claimed topic",
         );
     }
     if err
@@ -210,6 +224,9 @@ pub(super) fn map_actor_mailbox_store_error(
             }
             SqlActorMailboxStoreError::ThreadClaimOwnershipRequired => {
                 anyhow::Error::new(SqlActorMailboxStoreError::ThreadClaimOwnershipRequired)
+            }
+            SqlActorMailboxStoreError::ThreadClaimTakeoverRequired => {
+                anyhow::Error::new(SqlActorMailboxStoreError::ThreadClaimTakeoverRequired)
             }
             SqlActorMailboxStoreError::ReplyRequiredVisibleOutcomeMissing => {
                 anyhow::Error::new(SqlActorMailboxStoreError::ReplyRequiredVisibleOutcomeMissing)

--- a/src/team/manager/mailbox_reply_obligation_payloads.rs
+++ b/src/team/manager/mailbox_reply_obligation_payloads.rs
@@ -1,5 +1,6 @@
 use super::mailbox::{
-    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TAKEN_OVER, MAILBOX_RESOLUTION_TRANSFERRED,
+    ReplyActorPairKey,
 };
 use super::mailbox_payloads::is_human_actor_id;
 use super::mailbox_reply_obligation_snapshot_conversion::resolve_canonical_chat_reply_from_snapshot;
@@ -75,7 +76,11 @@ pub(super) fn reply_obligation_snapshot_is_terminal(
         ActorMessageHandlingDisposition::Released
     ) && matches!(
         message.mailbox_resolution_kind.as_deref(),
-        Some(MAILBOX_RESOLUTION_ESCALATED | MAILBOX_RESOLUTION_TRANSFERRED)
+        Some(
+            MAILBOX_RESOLUTION_ESCALATED
+                | MAILBOX_RESOLUTION_TRANSFERRED
+                | MAILBOX_RESOLUTION_TAKEN_OVER,
+        )
     )
 }
 

--- a/src/team/manager/mailbox_reply_obligations.rs
+++ b/src/team/manager/mailbox_reply_obligations.rs
@@ -1,7 +1,8 @@
 use serde_json::{Map, Value};
 
 use super::mailbox::{
-    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TAKEN_OVER, MAILBOX_RESOLUTION_TRANSFERRED,
+    ReplyActorPairKey,
 };
 use super::mailbox_reply_obligation_snapshot_conversion::mailbox_resolution_kind;
 use crate::team::TeamActorMessageRecord;
@@ -37,7 +38,11 @@ pub(super) fn reply_obligation_is_terminal(message: &TeamActorMessageRecord) -> 
         ActorMessageHandlingDisposition::Released
     ) && matches!(
         mailbox_resolution_kind(&message.payload),
-        Some(MAILBOX_RESOLUTION_ESCALATED | MAILBOX_RESOLUTION_TRANSFERRED)
+        Some(
+            MAILBOX_RESOLUTION_ESCALATED
+                | MAILBOX_RESOLUTION_TRANSFERRED
+                | MAILBOX_RESOLUTION_TAKEN_OVER,
+        )
     )
 }
 
@@ -111,6 +116,32 @@ pub(super) fn build_transferred_mailbox_payload(
             "target_actor_id": target_actor_id,
             "transferred_by_actor_id": transferred_by_actor_id,
             "transferred_at": transferred_at
+        }),
+    );
+    Value::Object(payload_obj)
+}
+
+pub(super) fn build_taken_over_mailbox_payload(
+    source_payload: &Value,
+    source_message_id: i64,
+    source_actor_id: &str,
+    target_actor_id: &str,
+    taken_over_by_actor_id: &str,
+    taken_over_at: i64,
+) -> Value {
+    let mut payload_obj = match source_payload {
+        Value::Object(map) => map.clone(),
+        _ => Map::new(),
+    };
+    payload_obj.insert(
+        "mailbox_takeover".to_string(),
+        serde_json::json!({
+            "kind": MAILBOX_RESOLUTION_TAKEN_OVER,
+            "source_message_id": source_message_id,
+            "source_actor_id": source_actor_id,
+            "target_actor_id": target_actor_id,
+            "taken_over_by_actor_id": taken_over_by_actor_id,
+            "taken_over_at": taken_over_at
         }),
     );
     Value::Object(payload_obj)

--- a/src/team/manager/mailbox_service_escalation.rs
+++ b/src/team/manager/mailbox_service_escalation.rs
@@ -1,8 +1,9 @@
 use chrono::Utc;
 
 use super::mailbox::{
-    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TRANSFERRED, apply_thread_claim_transition,
-    fetch_enriched_message_by_id, fetch_message_for_actor, map_actor_service_error,
+    MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_TAKEN_OVER, MAILBOX_RESOLUTION_TRANSFERRED,
+    apply_thread_claim_takeover, apply_thread_claim_transition, fetch_enriched_message_by_id,
+    fetch_message_for_actor, map_actor_service_error,
 };
 use super::mailbox_service::TeamActorMailboxService;
 use crate::team::{TeamActorMessageRecord, TeamActorMessageStatus};
@@ -61,6 +62,59 @@ impl TeamActorMailboxService {
             message_id,
             target_actor_id,
             MAILBOX_RESOLUTION_TRANSFERRED,
+        )
+        .await
+    }
+
+    pub async fn takeover_reply_required_message(
+        &self,
+        run_id: &str,
+        actor_id: &str,
+        peer_id: &str,
+        message_id: i64,
+        target_actor_id: &str,
+    ) -> Result<TeamActorMessageRecord, agenthub_team_actor::ActorServiceError> {
+        let member_specs = self
+            .load_member_specs_for_run(run_id)
+            .await
+            .map_err(map_actor_service_error)?;
+        let target_actor_id = target_actor_id.trim();
+        if target_actor_id.is_empty() {
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                "target_actor_id is required",
+            ));
+        }
+        if target_actor_id == actor_id {
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                "reply-required mailbox work cannot be taken over by the acting actor",
+            ));
+        }
+        if !member_specs
+            .iter()
+            .any(|member| member.member_id == target_actor_id)
+        {
+            let valid_member_ids = member_specs
+                .iter()
+                .map(|member| member.member_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(agenthub_team_actor::ActorServiceError::new(
+                agenthub_team_actor::ActorServiceErrorCode::BadRequest,
+                format!(
+                    "target_actor_id `{}` must reference a canonical team member_id; valid member_ids: {}",
+                    target_actor_id, valid_member_ids
+                ),
+            ));
+        }
+        self.reassign_reply_required_message(
+            run_id,
+            actor_id,
+            peer_id,
+            message_id,
+            target_actor_id,
+            MAILBOX_RESOLUTION_TAKEN_OVER,
         )
         .await
     }
@@ -158,7 +212,7 @@ impl TeamActorMailboxService {
         {
             return Err(agenthub_team_actor::ActorServiceError::new(
                 agenthub_team_actor::ActorServiceErrorCode::BadRequest,
-                "only human-originated reply-required mailbox work can be escalated or transferred",
+                "only human-originated reply-required mailbox work can be escalated, transferred, or taken over",
             ));
         }
         if super::mailbox_reply_obligations::reply_obligation_is_terminal(&message) {
@@ -206,6 +260,16 @@ impl TeamActorMailboxService {
                         now,
                     )
                 }
+                MAILBOX_RESOLUTION_TAKEN_OVER => {
+                    super::mailbox_reply_obligations::build_taken_over_mailbox_payload(
+                        &message.payload,
+                        message.message_id,
+                        actor_id,
+                        target_actor_id,
+                        target_actor_id,
+                        now,
+                    )
+                }
                 _ => unreachable!(),
             },
         );
@@ -217,7 +281,9 @@ impl TeamActorMailboxService {
                 )
             })?;
 
-        if message.handling_disposition == ActorMessageHandlingDisposition::Claimed {
+        if message.handling_disposition == ActorMessageHandlingDisposition::Claimed
+            && resolution_kind != MAILBOX_RESOLUTION_TAKEN_OVER
+        {
             apply_thread_claim_transition(
                 &mut tx,
                 &message,
@@ -295,12 +361,43 @@ impl TeamActorMailboxService {
         .execute(&mut *tx)
         .await
         .map_err(|err| map_actor_service_error(anyhow::Error::new(err)))?;
-        let escalated_message_id = inserted.last_insert_rowid();
+        let reassigned_message_id = inserted.last_insert_rowid();
+        if resolution_kind == MAILBOX_RESOLUTION_TAKEN_OVER {
+            sqlx::query(
+                r#"
+                UPDATE team_actor_messages
+                SET
+                    handling_disposition = 'claimed',
+                    handled_by_actor_id = ?1,
+                    handled_at = ?2
+                WHERE id = ?3
+                  AND run_id = ?4
+                  AND to_actor_id = ?1
+                "#,
+            )
+            .bind(target_actor_id)
+            .bind(now)
+            .bind(reassigned_message_id)
+            .bind(run_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|err| map_actor_service_error(anyhow::Error::new(err)))?;
+            apply_thread_claim_takeover(
+                &mut tx,
+                &message,
+                run_id,
+                target_actor_id,
+                reassigned_message_id,
+                now,
+            )
+            .await
+            .map_err(|err| map_actor_service_error(anyhow::Error::new(err)))?;
+        }
 
         tx.commit()
             .await
             .map_err(|err| map_actor_service_error(anyhow::Error::new(err)))?;
-        fetch_enriched_message_by_id(&self.manager.db, escalated_message_id)
+        fetch_enriched_message_by_id(&self.manager.db, reassigned_message_id)
             .await
             .map_err(|err| map_actor_service_error(anyhow::Error::new(err)))
     }

--- a/src/team/manager/mailbox_store.rs
+++ b/src/team/manager/mailbox_store.rs
@@ -24,13 +24,15 @@ pub(super) enum SqlActorMailboxStoreError {
     #[error("actor message idempotency conflict")]
     IdempotencyConflict,
     #[error(
-        "reply-required mailbox work cannot be completed before a visible reply is emitted or the item is explicitly escalated/transferred"
+        "reply-required mailbox work cannot be completed before a visible reply is emitted or the item is explicitly escalated/transferred/taken over"
     )]
     ReplyRequiredVisibleOutcomeMissing,
     #[error("reply-required mailbox work is already assigned to coordinator")]
     ReplyRequiredEscalationAlreadyAtCoordinator,
     #[error("reply-required mailbox escalation target is unavailable")]
     ReplyRequiredEscalationTargetUnavailable,
+    #[error("mailbox takeover requires a claimed topic")]
+    ThreadClaimTakeoverRequired,
     #[error("thread topic is already claimed by actor `{owner_actor_id}`")]
     ThreadClaimConflict { owner_actor_id: String },
     #[error("thread topic must be claimed by the acting actor")]

--- a/src/team/manager/mailbox_threads.rs
+++ b/src/team/manager/mailbox_threads.rs
@@ -186,6 +186,93 @@ pub(super) async fn apply_thread_claim_transition(
     Ok(())
 }
 
+pub(super) async fn apply_thread_claim_takeover(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    source_message: &TeamActorMessageRecord,
+    run_id: &str,
+    target_actor_id: &str,
+    target_message_id: i64,
+    claimed_at: i64,
+) -> Result<(), SqlActorMailboxStoreError> {
+    if source_message.handling_disposition != ActorMessageHandlingDisposition::Claimed {
+        return Err(SqlActorMailboxStoreError::ThreadClaimTakeoverRequired);
+    }
+    let explicit_task_id =
+        fetch_latest_task_link_for_message(tx, run_id, source_message.message_id)
+            .await?
+            .map(|link| link.task_id);
+    let Some(topic) = derive_actor_message_topic_metadata(
+        source_message.message_id,
+        &source_message.payload,
+        explicit_task_id.as_deref(),
+    ) else {
+        return Err(SqlActorMailboxStoreError::ThreadClaimTakeoverRequired);
+    };
+    let existing = sqlx::query(
+        r#"
+        SELECT owner_actor_id, claim_status, lease_expires_at
+        FROM team_actor_thread_claims
+        WHERE run_id = ?1 AND topic_key = ?2
+        LIMIT 1
+        "#,
+    )
+    .bind(run_id)
+    .bind(&topic.topic_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    let Some(existing) = existing else {
+        return Err(SqlActorMailboxStoreError::ThreadClaimTakeoverRequired);
+    };
+    let owner_actor_id: String = existing.get("owner_actor_id");
+    let claim_status_raw: String = existing.get("claim_status");
+    let lease_expires_at = existing
+        .try_get::<Option<i64>, _>("lease_expires_at")
+        .unwrap_or(None);
+    let is_active = parse_actor_thread_claim_status(&claim_status_raw)
+        == Some(ActorThreadClaimStatus::Claimed)
+        && lease_expires_at.is_none_or(|value| value > claimed_at);
+    if !is_active || owner_actor_id != source_message.to_actor_id {
+        return Err(SqlActorMailboxStoreError::ThreadClaimTakeoverRequired);
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO team_actor_thread_claims (
+            run_id,
+            topic_key,
+            task_id,
+            root_message_id,
+            owner_actor_id,
+            claim_status,
+            claimed_message_id,
+            claimed_at,
+            lease_expires_at,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, 'claimed', ?6, ?7, ?8, ?7)
+        ON CONFLICT(run_id, topic_key) DO UPDATE SET
+            task_id = excluded.task_id,
+            root_message_id = excluded.root_message_id,
+            owner_actor_id = excluded.owner_actor_id,
+            claim_status = excluded.claim_status,
+            claimed_message_id = excluded.claimed_message_id,
+            claimed_at = excluded.claimed_at,
+            lease_expires_at = excluded.lease_expires_at,
+            updated_at = excluded.updated_at
+        "#,
+    )
+    .bind(run_id)
+    .bind(&topic.topic_key)
+    .bind(&topic.task_id)
+    .bind(topic.root_message_id)
+    .bind(target_actor_id)
+    .bind(target_message_id)
+    .bind(claimed_at)
+    .bind(claimed_at + ACTOR_THREAD_CLAIM_DEFAULT_LEASE_SECS)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 pub(super) fn ensure_idempotency_compatible(
     cmd: &SendActorMessageCommand,
     existing: &TeamActorMessageRecord,


### PR DESCRIPTION
## Summary

- add explicit Team mailbox takeover API for actively claimed reply-required work
- preserve the human reply obligation on the target actor and move the thread claim owner
- document the takeover slice in the mailbox spec and rollout journal

## Related Issues

- Follows `docs/todo.md` P1 Team mailbox phase 3 work.

## Testing

- `cargo fmt --all --check`
- `cargo test -p agenthub team_run_messages_api_triage_surfaces_takeover_state -- --nocapture`
- `cargo test -p agenthub actor_mailbox_service_claims_topics_and_prevents_parallel_takeover -- --nocapture`
- `git -c core.fsmonitor=false diff --check`
