### PR TITLE
fix(actor): serialize inbox receive ack

### DIFF
--- a/docs/journal/2026-05-31-team-actor-inbox-serial-ack.md
+++ b/docs/journal/2026-05-31-team-actor-inbox-serial-ack.md
@@ -1,0 +1,43 @@
+# Team Actor Inbox Serial Ack
+
+## Summary
+
+Actor CLI inbox receive now accepts pending mailbox messages serially instead of acking and
+triaging multiple messages concurrently. This keeps the actor-facing receive path stable when the
+runtime peer is backed by SQLite and ack/triage performs multiple writes.
+
+## Background
+
+The receive helper previously used bounded concurrency for pending-message ack. That preserved
+output ordering after sorting, but concurrent ack/triage mutations can still collide with
+SQLite-backed runtime control and surface a generic internal mailbox failure.
+
+## Scope
+
+- Process pending inbox messages one at a time during `actor receive`.
+- Keep response ordering unchanged for multiple pending messages.
+- Preserve the existing claim-first triage behavior and conflict fallback to `watching`.
+- Surface generic internal mailbox error details instead of replacing them with an opaque message.
+
+## Key Decisions
+
+- Serial receive is preferred over retrying write-lock failures because actor receive is an
+  interactive control path and correctness is more important than parallel ack throughput.
+- The existing not-found behavior remains unchanged: if a message disappears before ack, receive
+  keeps the original item in the response.
+- Read-only database errors keep their explicit operator-facing message; other internal failures
+now include the causal error text for diagnosis.
+
+## Validation
+
+Focused checks:
+
+```bash
+cargo test -p agenthub receive_actor_inbox -- --nocapture
+cargo test -p agenthub map_actor_service_error -- --nocapture
+cargo test -p agenthub internal_grpc_team_context_and_task_controls_are_wire_compatible -- --nocapture
+```
+
+## Follow-Ups
+
+- Continue the mailbox phase 3 terminal-outcome invariant audit from `docs/todo.md`.

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -406,6 +406,9 @@ mod tests {
         claim_conflict_ids: Arc<std::collections::HashSet<i64>>,
         triage_attempts:
             Arc<StdMutex<Vec<(i64, agenthub_team_actor::ActorMessageHandlingDisposition)>>>,
+        fail_on_concurrent_mutation: bool,
+        mutation_hold_ms: u64,
+        active_mutations: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     #[derive(Clone)]
@@ -441,6 +444,26 @@ mod tests {
             &self,
             request: ActorAckRequest,
         ) -> Result<ActorAckResponse, ActorServiceError> {
+            let active = if self.fail_on_concurrent_mutation {
+                Some(
+                    self.active_mutations
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                        + 1,
+                )
+            } else {
+                None
+            };
+            if active.is_some() && self.mutation_hold_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(self.mutation_hold_ms)).await;
+            }
+            if active.is_some_and(|count| count > 1) {
+                self.active_mutations
+                    .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                return Err(ActorServiceError::new(
+                    ActorServiceErrorCode::Internal,
+                    "database is locked",
+                ));
+            }
             if let Some(delay_ms) = self.ack_delays_ms.get(&request.message_id) {
                 tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
             }
@@ -464,6 +487,12 @@ mod tests {
                     delivered_at: Some(100),
                     ..message
                 },
+            })
+            .inspect(|_| {
+                if active.is_some() {
+                    self.active_mutations
+                        .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                }
             })
         }
 
@@ -1904,6 +1933,9 @@ mod tests {
             ack_delays_ms: Arc::new(HashMap::new()),
             claim_conflict_ids: Arc::new(std::collections::HashSet::new()),
             triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: false,
+            mutation_hold_ms: 0,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
         let response = load_actor_inbox(
             &service,
@@ -1937,6 +1969,9 @@ mod tests {
             ack_delays_ms: Arc::new(HashMap::new()),
             claim_conflict_ids: Arc::new(std::collections::HashSet::new()),
             triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: false,
+            mutation_hold_ms: 0,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
         let response = receive_actor_inbox(
             &service,
@@ -1964,7 +1999,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn receive_actor_inbox_preserves_message_order_with_concurrent_ack() {
+    async fn receive_actor_inbox_preserves_message_order_when_multiple_messages_are_pending() {
         let service = MockMailboxService {
             inbox: vec![
                 mock_inbox_message(7, ActorMessageStatus::Pending),
@@ -1974,6 +2009,9 @@ mod tests {
             ack_delays_ms: Arc::new(HashMap::from([(7, 50_u64), (8, 0_u64)])),
             claim_conflict_ids: Arc::new(std::collections::HashSet::new()),
             triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: false,
+            mutation_hold_ms: 0,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
         let response = receive_actor_inbox(
             &service,
@@ -1986,7 +2024,7 @@ mod tests {
             },
         )
         .await
-        .expect("receive inbox concurrently");
+        .expect("receive inbox");
         assert_eq!(response.pending_count, 0);
         assert_eq!(response.messages.len(), 2);
         assert_eq!(response.messages[0].message_id, 7);
@@ -2006,6 +2044,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn receive_actor_inbox_avoids_concurrent_mutations_for_sqlite_like_services() {
+        let service = MockMailboxService {
+            inbox: vec![
+                mock_inbox_message(7, ActorMessageStatus::Pending),
+                mock_inbox_message(8, ActorMessageStatus::Pending),
+            ],
+            acked_ids: Arc::new(StdMutex::new(Vec::new())),
+            ack_delays_ms: Arc::new(HashMap::new()),
+            claim_conflict_ids: Arc::new(std::collections::HashSet::new()),
+            triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: true,
+            mutation_hold_ms: 25,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+        let response = receive_actor_inbox(
+            &service,
+            ActorInboxRequest {
+                run_id: "run-1".to_string(),
+                actor_id: "worker".to_string(),
+                cursor: None,
+                limit: Some(20),
+                states: Some(vec![ActorMessageStatus::Pending]),
+            },
+        )
+        .await
+        .expect("serial receive inbox should tolerate sqlite-like write locking");
+        assert_eq!(response.pending_count, 0);
+        assert_eq!(response.messages.len(), 2);
+        assert!(response.messages.iter().all(
+            |message| message.handling_disposition == ActorMessageHandlingDisposition::Claimed
+        ));
+        assert_eq!(
+            service
+                .active_mutations
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn receive_actor_inbox_falls_back_to_watching_when_claim_conflicts() {
         let service = MockMailboxService {
             inbox: vec![mock_inbox_message(7, ActorMessageStatus::Pending)],
@@ -2013,6 +2091,9 @@ mod tests {
             ack_delays_ms: Arc::new(HashMap::new()),
             claim_conflict_ids: Arc::new(std::collections::HashSet::from([7])),
             triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: false,
+            mutation_hold_ms: 0,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
         let response = receive_actor_inbox(
             &service,
@@ -2060,6 +2141,9 @@ mod tests {
             ack_delays_ms: Arc::new(HashMap::new()),
             claim_conflict_ids: Arc::new(std::collections::HashSet::new()),
             triage_attempts: Arc::new(StdMutex::new(Vec::new())),
+            fail_on_concurrent_mutation: false,
+            mutation_hold_ms: 0,
+            active_mutations: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
         let responses = ack_actor_messages(&service, "run-1", "worker", &[11, 12])
             .await

--- a/src/actor_cli/runtime.rs
+++ b/src/actor_cli/runtime.rs
@@ -5,13 +5,10 @@ use agenthub_team_actor::{
     ActorMessageHandlingDisposition, ActorMessageStatus, ActorServiceError, ActorServiceErrorCode,
     ActorTriageRequest,
 };
-use futures::{StreamExt, TryStreamExt, stream};
 
 use crate::actor_runtime_env::connect_runtime_internal_mailbox_service;
 use crate::internal::auth::InternalAction;
 use crate::internal::client::InternalGrpcMailboxClient;
-
-const RECEIVE_ACK_CONCURRENCY: usize = 8;
 
 async fn triage_received_message<S: ActorMailboxService + ?Sized>(
     service: &S,
@@ -124,38 +121,34 @@ pub(super) async fn receive_actor_inbox<S: ActorMailboxService + ?Sized>(
     let response = service.actor_inbox(request).await?;
     let pending_count = response.pending_count;
     let next_cursor = response.next_cursor;
-    // Ack pending messages with bounded concurrency but preserve inbox output ordering.
-    let mut indexed_messages = stream::iter(response.messages.into_iter().enumerate())
-        .map(|(idx, message)| {
-            let run_id = run_id.clone();
-            async move {
-                if message.status != ActorMessageStatus::Pending {
-                    return Ok((idx, message, false));
-                }
-                let acked = service
-                    .actor_ack(ActorAckRequest {
-                        run_id,
-                        actor_id: message.to_actor_id.clone(),
-                        message_id: message.message_id,
-                        ack_token: None,
-                        result: None,
-                    })
-                    .await;
-                match acked {
-                    Ok(acked) => triage_received_message(service, acked)
-                        .await
-                        .map(|message| (idx, message, true)),
-                    Err(err) if err.code == ActorServiceErrorCode::NotFound => {
-                        Ok((idx, message, false))
-                    }
-                    Err(err) => Err(err),
-                }
+    // Process mailbox acceptance serially so SQLite-backed runtime control does not
+    // trip over write-lock contention while ack/triage mutates multiple rows.
+    let mut indexed_messages = Vec::new();
+    for (idx, message) in response.messages.into_iter().enumerate() {
+        if message.status != ActorMessageStatus::Pending {
+            indexed_messages.push((idx, message, false));
+            continue;
+        }
+        let acked = service
+            .actor_ack(ActorAckRequest {
+                run_id: run_id.clone(),
+                actor_id: message.to_actor_id.clone(),
+                message_id: message.message_id,
+                ack_token: None,
+                result: None,
+            })
+            .await;
+        match acked {
+            Ok(acked) => {
+                let message = triage_received_message(service, acked).await?;
+                indexed_messages.push((idx, message, true));
             }
-        })
-        .buffer_unordered(RECEIVE_ACK_CONCURRENCY)
-        .try_collect::<Vec<_>>()
-        .await?;
-    indexed_messages.sort_by_key(|(idx, _, _)| *idx);
+            Err(err) if err.code == ActorServiceErrorCode::NotFound => {
+                indexed_messages.push((idx, message, false));
+            }
+            Err(err) => return Err(err),
+        }
+    }
     let acked_pending = indexed_messages
         .iter()
         .filter(|(_, _, acked)| *acked)

--- a/src/team/manager/mailbox_errors.rs
+++ b/src/team/manager/mailbox_errors.rs
@@ -216,9 +216,13 @@ pub(super) fn map_actor_service_error(err: anyhow::Error) -> ActorServiceError {
             "mailbox write failed: attempt to write a readonly database",
         );
     }
+    let detail_chain = err
+        .chain()
+        .map(|cause| cause.to_string())
+        .collect::<Vec<_>>();
     ActorServiceError::new(
         ActorServiceErrorCode::Internal,
-        "internal actor mailbox error",
+        format!("internal actor mailbox error: {}", detail_chain.join(" | ")),
     )
 }
 

--- a/src/team/manager/mailbox_tests.rs
+++ b/src/team/manager/mailbox_tests.rs
@@ -125,6 +125,17 @@ fn map_actor_service_error_surfaces_readonly_database_failures() {
 }
 
 #[test]
+fn map_actor_service_error_preserves_internal_error_details() {
+    let mapped = map_actor_service_error(anyhow::anyhow!("database is locked"));
+
+    assert_eq!(mapped.code, ActorServiceErrorCode::Internal);
+    assert_eq!(
+        mapped.message,
+        "internal actor mailbox error: database is locked"
+    );
+}
+
+#[test]
 fn human_visible_chat_reply_requires_local_non_human_to_human_chat_message() {
     let payload = json!({
         "type": "chat_message",


### PR DESCRIPTION
## Summary

- serialize `actor receive` pending-message ack/triage to avoid SQLite-style write-lock contention
- keep inbox output ordering, not-found handling, and claim-conflict fallback behavior intact
- include internal mailbox error details for non-readonly failures and record the validation journal

## Motivation

`actor receive` is an interactive control path. The previous bounded-concurrency ack path could
race multiple ack/triage writes against a SQLite-backed runtime peer, turning normal receive into
an opaque internal mailbox failure. Serializing acceptance keeps correctness stable while preserving
the existing triage semantics.

## Related Issues

- None

## Testing

```bash
cargo test -p agenthub receive_actor_inbox -- --nocapture
cargo test -p agenthub internal_grpc_team_context_and_task_controls_are_wire_compatible -- --nocapture
cargo test -p agenthub map_actor_service_error -- --nocapture
cargo fmt --all --check
git -c core.fsmonitor=false diff --check
cargo clippy -p agenthub --all-targets -- -D warnings
```
