### PR TITLE
fix(team): fail closed reply completion guard

### DIFF
--- a/docs/journal/2026-05-31-team-mailbox-terminal-reply-evidence.md
+++ b/docs/journal/2026-05-31-team-mailbox-terminal-reply-evidence.md
@@ -24,6 +24,8 @@ Team mailbox contract.
   `escalated`, `transferred`, and `taken_over` mailbox resolutions.
 - Project `mailbox_resolution.reason` through both in-memory and SQL snapshot
   loaders so the lightweight summary path enforces the same rule.
+- Reject completion guard checks when the target reply-required message is not
+  explicitly matched to visible reply credit during traversal.
 
 ## Key Decisions
 
@@ -36,6 +38,11 @@ Team mailbox contract.
 - This slice does not close the whole phase 3 audit. It narrows the remaining
   work to any future terminal outcomes that can end human-visible work without
   explicit evidence.
+- Completion guard checks now fail closed when the target message is skipped as
+  already terminal or is otherwise absent from the reply-obligation traversal,
+  unless the target terminal message has an explicit visible reply credit. A
+  terminal ignored/escalated/transferred/taken-over source cannot later be
+  converted into `completed` without visible reply evidence.
 
 ## Validation
 
@@ -43,6 +50,9 @@ Team mailbox contract.
 cargo test -p agenthub summarize_open_reply_obligations -- --nocapture
 cargo test -p agenthub team_run_messages_api_triage_ignored_clears_open_reply_obligation_without_visible_reply -- --nocapture
 cargo test -p agenthub team_run_messages_api_triage_resolves_open_reply_obligation -- --nocapture
+cargo test -p agenthub actor_mailbox_service_rejects_complete_after_terminal_ignore_without_visible_reply -- --nocapture
+cargo test -p agenthub actor_mailbox_service_allows_complete_after_terminal_ignore_with_visible_reply -- --nocapture
+cargo test -p agenthub actor_mailbox_service_completed_claim_remains_visible_in_history -- --nocapture
 cargo fmt --all --check
 git -c core.fsmonitor=false diff --check
 cargo clippy -p agenthub --all-targets -- -D warnings

--- a/src/team/manager/mailbox_reply_obligation_summary.rs
+++ b/src/team/manager/mailbox_reply_obligation_summary.rs
@@ -74,6 +74,11 @@ pub(super) fn has_visible_reply_credit_for_message(
             continue;
         };
         if reply_obligation_snapshot_is_terminal(message) {
+            if message.message_id == target_message_id {
+                return visible_reply_credits
+                    .get(&pair_key)
+                    .is_some_and(|credits| *credits > 0);
+            }
             continue;
         }
         if let Some(credits) = visible_reply_credits.get_mut(&pair_key)
@@ -89,5 +94,5 @@ pub(super) fn has_visible_reply_credit_for_message(
             return false;
         }
     }
-    true
+    false
 }

--- a/src/team/manager/tests/mailbox_basic_cases.rs
+++ b/src/team/manager/tests/mailbox_basic_cases.rs
@@ -1026,6 +1026,174 @@ async fn actor_mailbox_service_requires_active_owner_for_release_and_complete() 
 }
 
 #[tokio::test]
+async fn actor_mailbox_service_rejects_complete_after_terminal_ignore_without_visible_reply() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+    let service = manager.actor_mailbox_service();
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "actor-mailbox-terminal-ignore-complete-team".to_string(),
+            description: Some("team for terminal ignore completion guard".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner"},{"member_id":"reviewer"}]
+            }),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some("ctx-msg-terminal-ignore-complete"),
+            json!({"payload":"start"}),
+        )
+        .await
+        .expect("create run");
+
+    let sent = manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "user:alice",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "reviewer",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"Need update",
+                "requires_user_visible_reply":true
+            }),
+            idempotency_key: Some("msg-terminal-ignore-complete-1"),
+            message_kind: None,
+        })
+        .await
+        .expect("send inbound obligation");
+
+    service
+        .actor_triage(ActorTriageRequest {
+            run_id: run.id.clone(),
+            actor_id: "reviewer".to_string(),
+            message_id: sent.message_id,
+            disposition: ActorMessageHandlingDisposition::Ignored,
+            reason: Some("duplicate request".to_string()),
+        })
+        .await
+        .expect("ignore with reason");
+
+    let complete_err = service
+        .actor_triage(ActorTriageRequest {
+            run_id: run.id,
+            actor_id: "reviewer".to_string(),
+            message_id: sent.message_id,
+            disposition: ActorMessageHandlingDisposition::Completed,
+            reason: None,
+        })
+        .await
+        .expect_err("terminal ignored work should still require visible reply evidence");
+    assert_eq!(
+        complete_err.code,
+        ActorServiceErrorCode::UnprocessableEntity
+    );
+}
+
+#[tokio::test]
+async fn actor_mailbox_service_allows_complete_after_terminal_ignore_with_visible_reply() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+    let service = manager.actor_mailbox_service();
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "actor-mailbox-terminal-ignore-visible-reply-team".to_string(),
+            description: Some("team for terminal ignore with visible reply".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner"},{"member_id":"reviewer"}]
+            }),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some("ctx-msg-terminal-ignore-visible-reply"),
+            json!({"payload":"start"}),
+        )
+        .await
+        .expect("create run");
+
+    let sent = manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "user:alice",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "reviewer",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"Need update",
+                "requires_user_visible_reply":true
+            }),
+            idempotency_key: Some("msg-terminal-ignore-visible-reply-1"),
+            message_kind: None,
+        })
+        .await
+        .expect("send inbound obligation");
+
+    service
+        .actor_triage(ActorTriageRequest {
+            run_id: run.id.clone(),
+            actor_id: "reviewer".to_string(),
+            message_id: sent.message_id,
+            disposition: ActorMessageHandlingDisposition::Ignored,
+            reason: Some("duplicate request".to_string()),
+        })
+        .await
+        .expect("ignore with reason");
+
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "reviewer",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "user:alice",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"Here is the update"
+            }),
+            idempotency_key: Some("msg-terminal-ignore-visible-reply-2"),
+            message_kind: None,
+        })
+        .await
+        .expect("send visible reply");
+
+    let completed = service
+        .actor_triage(ActorTriageRequest {
+            run_id: run.id,
+            actor_id: "reviewer".to_string(),
+            message_id: sent.message_id,
+            disposition: ActorMessageHandlingDisposition::Completed,
+            reason: None,
+        })
+        .await
+        .expect("visible reply should allow completion");
+    assert_eq!(
+        completed.disposition,
+        ActorMessageHandlingDisposition::Completed
+    );
+}
+
+#[tokio::test]
 async fn actor_mailbox_service_completed_claim_remains_visible_in_history() {
     let db = setup_test_db().await;
     let manager = TeamManager::new(db.clone());


### PR DESCRIPTION
## Summary

- make reply-required completion guard fail closed when the target message is not explicitly matched to visible reply credit
- prevent terminal ignored work from being converted to `completed` without a visible reply
- add a mailbox service regression and update the terminal reply evidence journal

## Purpose

This closes another Team mailbox phase 3 edge case: a reply-required item that already reached an explicit terminal resolution should not later be marked `completed` just because the completion guard skipped it during traversal.

## Related Issues

None.

## Testing

```bash
cargo test -p agenthub actor_mailbox_service_rejects_complete_after_terminal_ignore_without_visible_reply -- --nocapture
cargo test -p agenthub actor_mailbox_service_completed_claim_remains_visible_in_history -- --nocapture
cargo test -p agenthub summarize_open_reply_obligations -- --nocapture
cargo fmt --all --check
git -c core.fsmonitor=false diff --check
cargo clippy -p agenthub --all-targets -- -D warnings
```
