### PR TITLE
docs(ci): close distributed p2p p0 rollout

### DIFF
--- a/docs/journal/2026-03-19-distributed-p2p-pipeline.md
+++ b/docs/journal/2026-03-19-distributed-p2p-pipeline.md
@@ -28,6 +28,33 @@
 cargo test --locked --test distributed_p2p_pipeline -- --nocapture
 ```
 
+## P0 Closure Evidence (2026-06-02)
+
+The phase 0/1 rollout gates are green on both the final PR pass and the post-merge
+`main` push for commit `1d973f4a4b4bdee861863a973f77123c79ec9bea`.
+
+PR #706 evidence:
+
+- Distributed P2P Pipeline: `https://github.com/hawkingrei/agenthub/actions/runs/26807605199/job/79029012765`
+- Bazel Test (Root): `https://github.com/hawkingrei/agenthub/actions/runs/26807605152/job/79029012880`
+- Bazel Test (Crates): `https://github.com/hawkingrei/agenthub/actions/runs/26807605152/job/79029012741`
+- Rust (Cargo): `https://github.com/hawkingrei/agenthub/actions/runs/26807605183/job/79029012943`
+- Rust (Proto Check): `https://github.com/hawkingrei/agenthub/actions/runs/26807605183/job/79029012952`
+
+Post-merge `main` evidence:
+
+- Distributed P2P Pipeline: `https://github.com/hawkingrei/agenthub/actions/runs/26808585470/job/79032335858`
+- Rust (gRPC Integration): `https://github.com/hawkingrei/agenthub/actions/runs/26808585469/job/79032334692`
+- Rust (Proto Check): `https://github.com/hawkingrei/agenthub/actions/runs/26808585469/job/79032334770`
+- Bazel Test (Root): `https://github.com/hawkingrei/agenthub/actions/runs/26808585629/job/79032335506`
+- Bazel Test (Crates): `https://github.com/hawkingrei/agenthub/actions/runs/26808585629/job/79032335566`
+
+This closes the active P0 rollout item for remote agent control, mailbox relay
+plus ack, node-local data isolation, the blackbox distributed p2p pipeline, and
+wire-compatibility coverage. Remaining distributed-node work stays tracked as
+P1 follow-ups for startup boundaries, token-first join, deployment docs, and
+transport posture.
+
 ## Notes
 
 - `src/internal/client.rs` still keeps the faster in-process transport regression coverage for tight feedback loops

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -72,7 +72,6 @@ Stable contracts:
 
 Matrix to keep current across CI and at least one real multi-node rollout:
 
-- [ ] `P0` Distributed node phase 0/1 rollout: remote agent start/input/events, mailbox relay plus ack, node-local data isolation, `tests/distributed_p2p_pipeline.rs`, and wire-compatibility tests stay green on both `push` and `pull_request`; record workflow run IDs in the related journal.
 - [ ] `P1` Node startup boundaries: `server.role = "node"` boots internal gRPC only, skips main-only startup side effects, and fails fast when `server.node_id` is missing or `internal_grpc.enabled` is false. Existing notes: [journal/2026-04-05-node-mode-startup-boundary.md](journal/2026-04-05-node-mode-startup-boundary.md).
 - [ ] `P1` Token-first Agent Node join: root `Agents` surfaces node bootstrap token/details, Admin join exposes token/link without QR onboarding, and user docs match the current `internal_grpc.bootstrap.token` contract. Existing notes: [journal/2026-04-17-node-join-token-flow.md](journal/2026-04-17-node-join-token-flow.md).
 - [ ] `P1` Refreshed agent-node deployment docs: `userdocs/docs/deployment/overview-and-topology.md`, `userdocs/docs/core/agent-nodes.md`, and `userdocs/docs/getting-started/configuration-basics.md` match current `internal_grpc` config shape, remote-node registration flow, and remote-target startup behavior.


### PR DESCRIPTION
## Summary

- record PR and post-merge `main` evidence for the distributed node phase 0/1 rollout
- remove the completed P0 distributed node rollout item from `docs/todo.md`
- leave remaining distributed-node work tracked as the existing P1 follow-ups

## Purpose

The active P0 item required the blackbox distributed p2p pipeline and wire-compatibility coverage to stay green on both `pull_request` and `push`, with workflow run IDs recorded in the related journal.

## Related Issue

None.

## Testing

- `git -c core.fsmonitor=false diff --check`
- PR #706 checks passed, including Distributed P2P Pipeline and Bazel/Rust gates
- Post-merge `main` checks passed for Distributed P2P Pipeline, Rust gRPC Integration, Rust Proto Check, Bazel Test (Root), and Bazel Test (Crates)
