### PR TITLE
chore(rust): bump toolchain to 1.96.0

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Setup Bazel
@@ -78,7 +78,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Setup Bazel
@@ -102,7 +102,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Setup Bazel
@@ -124,7 +124,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Setup Bazel

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
           components: clippy

--- a/.github/workflows/distributed-p2p.yml
+++ b/.github/workflows/distributed-p2p.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Verify internal protobuf codegen

--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -42,7 +42,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
           targets: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
           targets: ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
           components: rustfmt
@@ -33,7 +33,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Rust cache
@@ -50,7 +50,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Rust cache
@@ -70,7 +70,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Rust cache
@@ -91,7 +91,7 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           profile: minimal
       - name: Rust cache

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ git_repository(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
-    versions = ["1.95.0"],
+    versions = ["1.96.0"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/agenthub-codex-acp/rust-toolchain.toml
+++ b/agenthub-codex-acp/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustc", "cargo", "std", "rustfmt", "clippy"]

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -4,7 +4,7 @@ This guide covers local source development for AgentHub contributors.
 
 ## Requirements
 
-- Rust 1.95.0
+- Rust 1.96.0
 - Node.js 20+
 - Bazel / Bazelisk (optional, for Bazel-driven checks)
 - Git

--- a/docs/journal/2026-06-02-rust-196-baseline.md
+++ b/docs/journal/2026-06-02-rust-196-baseline.md
@@ -1,0 +1,48 @@
+# Rust 1.96 Baseline
+
+## Summary
+
+Raised the AgentHub Rust baseline from `1.95.0` to `1.96.0`.
+
+## Background
+
+The repository keeps Rust pinned in both Cargo/rustup-facing files and Bazel CI
+configuration. Keeping those pins aligned avoids local/CI drift and keeps Bazel
+as a viable build path alongside normal Rust workflows.
+
+## Scope
+
+- Root `rust-toolchain.toml`
+- `agenthub-codex-acp/rust-toolchain.toml`
+- Bazel Rust toolchain version in `MODULE.bazel`
+- GitHub Actions Rust setup pins
+- Developer and user-facing baseline documentation
+- Focused test assertion cleanup using Rust 1.96 `assert_matches!`
+
+## Key Decisions
+
+1. Keep a single workspace Rust baseline: `1.96.0`.
+2. Preserve historical journal entries that recorded the previous `1.95.0`
+   rollout.
+3. Update visible setup documentation so operators and contributors install the
+   same version used by CI.
+4. Use `assert_matches!` only in focused tests where the improved failure output
+   is useful and does not widen production MSRV-sensitive code paths.
+
+## Validation
+
+```bash
+rg -n -F "1.95.0" . --hidden --glob '!Cargo.lock' --glob '!.git/**'
+cargo fmt --all
+cargo test worker_runtime_adjust_rejects_workdir_outside_safe_paths
+cargo test member_agent_lookup_maps_row_not_found_to_missing_member_agent
+git diff --check
+```
+
+Only historical journal entries should still mention `1.95.0` after the text
+audit.
+
+## Follow-Ups
+
+- Run full `cargo check` and `bazel test //...` validation in CI or a wider
+  local verification pass.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/src/team/runtime/tests.rs
+++ b/src/team/runtime/tests.rs
@@ -4,6 +4,7 @@ use super::repair::{
 };
 use super::types::TeamRuntimeStartError;
 use crate::path_utils::expand_tilde;
+use core::assert_matches;
 use sqlx::Error as SqlxError;
 
 #[test]
@@ -32,7 +33,7 @@ fn worker_runtime_adjust_rejects_workdir_outside_safe_paths() {
     let typed = err
         .downcast_ref::<TeamRuntimeStartError>()
         .expect("typed runtime error");
-    assert!(matches!(typed, TeamRuntimeStartError::InvalidConfig(_)));
+    assert_matches!(typed, TeamRuntimeStartError::InvalidConfig(_));
 }
 
 #[test]
@@ -49,10 +50,7 @@ fn member_agent_lookup_maps_row_not_found_to_missing_member_agent() {
     let typed = err
         .downcast_ref::<TeamRuntimeStartError>()
         .expect("typed runtime error");
-    assert!(matches!(
-        typed,
-        TeamRuntimeStartError::MissingMemberAgent(_)
-    ));
+    assert_matches!(typed, TeamRuntimeStartError::MissingMemberAgent(_));
 }
 
 #[test]

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ Current release binaries are available for:
 
 ### Prerequisites
 
-- Rust `1.95.0` (stable toolchain baseline)
+- Rust `1.96.0` (stable toolchain baseline)
 - Node.js 20+
 - Git
 

--- a/userdocs/docs/overview/feature-overview.md
+++ b/userdocs/docs/overview/feature-overview.md
@@ -68,7 +68,7 @@ Recent merges worth knowing before rollout or operator training:
 - **Token-based Agent Node onboarding**: remote node join now uses explicit
   bootstrap tokens from the `Agents` page instead of QR-style node onboarding.
 - **Rust / Codex baseline refresh**: local builds and bundled ACP integration
-  now track Rust `1.95.0` and the official Codex `0.121.x` line.
+  now track Rust `1.96.0` and the official Codex `0.121.x` line.
 
 ## Installable Web App And Push
 


### PR DESCRIPTION
## Summary

- bump the root, ACP adapter, Bazel, and GitHub Actions Rust pins to `1.96.0`
- update developer and user-facing Rust baseline documentation
- use Rust 1.96 `assert_matches!` in focused runtime tests for better failure diagnostics
- add a dated journal entry for the baseline upgrade and validation evidence

## Purpose

Keep local Cargo/rustup workflows, Bazel toolchains, and CI setup aligned on one Rust baseline.
The small `assert_matches!` cleanup exercises a new Rust 1.96 stable macro without widening production API or runtime behavior.

## Related Issues

None.

## Testing

- `rustc --version`
- `cargo fmt --all`
- `cargo test worker_runtime_adjust_rejects_workdir_outside_safe_paths`
- `cargo test member_agent_lookup_maps_row_not_found_to_missing_member_agent`
- `git diff --check`

Full `cargo check` and `bazel test //...` are left for CI or a wider validation pass.
