### PR TITLE
chore(codex): upgrade adapter to 136

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "jsonrpcmsg",
- "rmcp 1.6.0",
+ "rmcp",
  "rustc-hash 2.1.2",
  "schemars 1.2.1",
  "serde",
@@ -848,7 +848,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2597,8 +2597,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2616,8 +2616,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2635,8 +2635,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2665,8 +2665,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2695,6 +2695,7 @@ dependencies = [
  "codex-git-utils",
  "codex-guardian",
  "codex-hooks",
+ "codex-image-generation-extension",
  "codex-login",
  "codex-mcp",
  "codex-memories-extension",
@@ -2734,8 +2735,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2760,8 +2761,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "clap",
@@ -2770,7 +2771,7 @@ dependencies = [
  "codex-shell-command",
  "codex-utils-absolute-path",
  "inventory",
- "rmcp 0.15.0",
+ "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2784,8 +2785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "axum",
@@ -2820,8 +2821,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2835,8 +2836,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2853,8 +2854,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2863,8 +2864,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2877,8 +2878,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2894,8 +2895,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "serde",
  "serde_json",
@@ -2904,8 +2905,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "clap",
@@ -2924,8 +2925,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2950,8 +2951,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-requirements"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2975,11 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
- "async-channel",
- "async-trait",
  "codex-protocol",
  "deno_core_icudata",
  "serde",
@@ -2992,13 +2991,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 
 [[package]]
 name = "codex-config"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,8 +3041,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -3056,8 +3055,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3133,7 +3132,7 @@ dependencies = [
  "rand 0.9.4",
  "regex-lite",
  "reqwest 0.12.28",
- "rmcp 0.15.0",
+ "rmcp",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3155,8 +3154,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3192,8 +3191,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3222,8 +3221,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3255,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "clap",
@@ -3271,8 +3270,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3281,8 +3280,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3291,8 +3290,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3302,8 +3301,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3315,8 +3314,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3328,8 +3327,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3341,8 +3340,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "clap",
@@ -3356,8 +3355,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -3367,8 +3366,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "notify",
  "tokio",
@@ -3377,8 +3376,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3401,8 +3400,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-core",
@@ -3412,8 +3411,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3433,9 +3432,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-image-generation-extension"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
+dependencies = [
+ "async-trait",
+ "codex-api",
+ "codex-core",
+ "codex-extension-api",
+ "codex-features",
+ "codex-login",
+ "codex-model-provider",
+ "codex-model-provider-info",
+ "codex-protocol",
+ "codex-tools",
+ "http 1.4.0",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-install-context"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3443,8 +3463,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "keyring",
  "tracing",
@@ -3452,8 +3472,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3473,8 +3493,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3507,8 +3527,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3525,7 +3545,7 @@ dependencies = [
  "codex-utils-plugins",
  "futures",
  "regex-lite",
- "rmcp 0.15.0",
+ "rmcp",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3538,8 +3558,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3551,7 +3571,7 @@ dependencies = [
  "codex-protocol",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
- "rmcp 0.15.0",
+ "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -3563,8 +3583,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-core",
@@ -3584,8 +3604,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3594,8 +3614,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3625,8 +3645,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -3647,8 +3667,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3660,8 +3680,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3680,8 +3700,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3710,8 +3730,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3742,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -3753,16 +3773,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3798,8 +3818,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3809,8 +3829,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "axum",
@@ -3827,8 +3847,8 @@ dependencies = [
  "futures",
  "keyring",
  "oauth2",
- "reqwest 0.12.28",
- "rmcp 0.15.0",
+ "reqwest 0.13.3",
+ "rmcp",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3844,8 +3864,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3869,8 +3889,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3884,8 +3904,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3901,8 +3921,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "age",
  "anyhow",
@@ -3920,8 +3940,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3939,8 +3959,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3959,8 +3979,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3969,8 +3989,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3991,16 +4011,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4019,8 +4039,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-app-server-protocol",
@@ -4032,7 +4052,7 @@ dependencies = [
  "codex-utils-pty",
  "codex-utils-string",
  "jsonptr",
- "rmcp 0.15.0",
+ "rmcp",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4042,8 +4062,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-io",
  "tokio",
@@ -4053,8 +4073,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "dirs",
  "dunce",
@@ -4065,16 +4085,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4083,8 +4103,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4095,8 +4115,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4104,8 +4124,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4117,8 +4137,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4126,8 +4146,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4135,8 +4155,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4145,8 +4165,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -4157,8 +4177,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4173,21 +4193,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4196,13 +4216,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "async-trait",
  "codex-api",
@@ -4217,12 +4237,13 @@ dependencies = [
  "http 1.4.0",
  "schemars 0.8.22",
  "serde_json",
+ "url",
 ]
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.135.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.135.0#4daceea869704f9f35e0a3949fc34711ef978a4e"
+version = "0.136.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.136.0#7ca611348db9446711ed16ed81c84095e3721cee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4737,7 +4758,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5835,7 +5856,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6225,7 +6246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8269,7 +8290,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8364,7 +8385,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -8828,7 +8849,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8942,7 +8963,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10742,7 +10763,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10885,7 +10906,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -12167,7 +12188,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12205,7 +12226,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -12879,7 +12900,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -12910,16 +12931,19 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -12971,12 +12995,11 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmcp"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
- "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -12988,9 +13011,9 @@ dependencies = [
  "pastey 0.2.2",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.4",
- "reqwest 0.12.28",
- "rmcp-macros 0.15.0",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -13006,45 +13029,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmcp"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "futures",
- "pastey 0.2.2",
- "pin-project-lite",
- "rmcp-macros 1.6.0",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -13193,7 +13181,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13252,7 +13240,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14188,7 +14176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15073,7 +15061,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15137,7 +15125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15906,7 +15894,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16339,6 +16327,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16581,7 +16582,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "4daceea869704f9f35e0a3949fc34711ef978a4e",
+    commit = "7ca611348db9446711ed16ed81c84095e3721cee",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.135.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.136.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -366,6 +366,7 @@ impl AppServerCodexThread {
                     expected_turn_id: turn_id,
                     responsesapi_client_metadata,
                     additional_context: None,
+                    client_user_message_id: None,
                 },
             })
             .await;
@@ -2267,6 +2268,7 @@ fn prepare_submission_start(
                     thread_id: state.thread_id.clone(),
                     input: items.clone().into_iter().map(Into::into).collect(),
                     additional_context: None,
+                    client_user_message_id: None,
                     cwd: Some(state.config.cwd.to_path_buf()),
                     runtime_workspace_roots: None,
                     approval_policy: Some(state.config.permissions.approval_policy.value().into()),

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -930,6 +930,7 @@ impl PromptState {
                 text_elements: _,
                 local_images,
                 local_image_details,
+                ..
             }) => {
                 info!(
                     "User message: {message:?}, image_count: {}, image_details: {image_details:?}, local_image_count: {}, local_image_details: {local_image_details:?}",

--- a/docs/journal/2026-06-02-codex-136-upgrade.md
+++ b/docs/journal/2026-06-02-codex-136-upgrade.md
@@ -1,0 +1,57 @@
+# Codex 136 Upgrade
+
+## Summary
+
+AgentHub's Codex ACP adapter now targets upstream Codex `rust-v0.136.0`.
+
+## Background
+
+The repository previously targeted Codex `rust-v0.135.0`. This upgrade keeps
+the ACP adapter aligned with the upstream Codex release train while preserving
+the existing AgentHub turn-start and turn-steer behavior.
+
+## Scope
+
+- Updated `agenthub-codex-acp` Codex git dependencies from `rust-v0.135.0` to
+  `rust-v0.136.0`.
+- Refreshed `Cargo.lock` to the upstream `rust-v0.136.0` release commit
+  `7ca611348db9446711ed16ed81c84095e3721cee`.
+- Updated `MODULE.bazel` `codex_src` to the same upstream release commit.
+- Updated the shared `rmcp` lock from `1.6.0` to `1.7.0`, matching the new
+  Codex app-server protocol requirement.
+- Adapted ACP bridge code for Codex `0.136` protocol changes:
+  - `TurnStartParams` and `TurnSteerParams` now receive
+    `client_user_message_id: None`.
+  - `UserMessageEvent` matching ignores the new upstream client field.
+
+## Key Decisions
+
+- Keep `client_user_message_id` unset until AgentHub has a durable
+  client-originated message id surface that should be forwarded to Codex.
+- Keep event handling non-exhaustive for user-message events so future upstream
+  metadata additions do not break AgentHub when the adapter does not need the
+  new field.
+- Keep the Bazel `codex_src` pin on the peeled release commit rather than the
+  annotated tag object.
+
+## Validation
+
+```bash
+cargo check -p agenthub-codex-acp
+cargo check -p agenthub-codex-acp --tests
+```
+
+Local full test attempt:
+
+```bash
+cargo test -p agenthub-codex-acp
+```
+
+This command did not reach test execution in the local worktree because archive
+generation failed with `No space left on device`. CI should provide the full
+test signal after the branch is pushed.
+
+## Follow-Ups
+
+- Run normal repository CI to cover full adapter tests and Bazel integration on
+  the refreshed Codex `0.136.0` lockfile.


### PR DESCRIPTION
## Summary

- Upgrade `agenthub-codex-acp` Codex git dependencies from `rust-v0.135.0` to `rust-v0.136.0`.
- Refresh `Cargo.lock` and the Bazel `codex_src` pin to upstream commit `7ca611348db9446711ed16ed81c84095e3721cee`.
- Adapt the ACP bridge for new Codex 0.136 turn/user-message fields.
- Record the upgrade in `docs/journal/2026-06-02-codex-136-upgrade.md`.

## Purpose

Keep AgentHub's Codex ACP adapter aligned with the upstream Codex release train while preserving existing turn start, turn steer, and user-message handling behavior.

## Related Issues

- None.

## Testing

- `cargo check -p agenthub-codex-acp`
- `cargo check -p agenthub-codex-acp --tests`
- `cargo fmt --all --check`
- `git -c core.fsmonitor=false diff --check`
- Attempted `cargo test -p agenthub-codex-acp`; local archive generation failed with `No space left on device` before test execution. CI should provide the full test signal.
