### PR TITLE
feat(acp): add provider metadata allowlist

### DIFF
--- a/crates/agenthub-diagnostics/src/lib.rs
+++ b/crates/agenthub-diagnostics/src/lib.rs
@@ -847,11 +847,20 @@ pub mod agent_trace {
         PROVIDER_METADATA_ID_FIELDS
             .iter()
             .filter_map(|field| {
-                object
-                    .get(*field)
-                    .and_then(Value::as_str)
-                    .filter(|value| !value.trim().is_empty())
-                    .map(|value| ((*field).to_string(), value.to_string()))
+                let value = object.get(*field)?;
+                let metadata_value = match value {
+                    Value::String(raw) => {
+                        let trimmed = raw.trim();
+                        if trimmed.is_empty() {
+                            return None;
+                        }
+                        trimmed.to_string()
+                    }
+                    Value::Number(number) => number.to_string(),
+                    Value::Bool(flag) => flag.to_string(),
+                    _ => return None,
+                };
+                Some(((*field).to_string(), metadata_value))
             })
             .collect()
     }
@@ -1182,9 +1191,11 @@ pub mod agent_trace {
                 r#"{
                     "type":"item_completed",
                     "thread_id":"thread-1",
-                    "turn_id":"turn-1",
+                    "turn_id":7,
                     "item_id":"item-1",
                     "tool_call_id":"tool-1",
+                    "request_id":42,
+                    "client_id":true,
                     "content":"private model output",
                     "arguments":{"path":"/private/file"},
                     "raw_output":"private tool output",
@@ -1214,17 +1225,30 @@ pub mod agent_trace {
             );
             assert_eq!(
                 latest.provider_metadata.get("turn_id").map(String::as_str),
-                Some("turn-1")
+                Some("7")
+            );
+            assert_eq!(
+                latest
+                    .provider_metadata
+                    .get("request_id")
+                    .map(String::as_str),
+                Some("42")
+            );
+            assert_eq!(
+                latest
+                    .provider_metadata
+                    .get("client_id")
+                    .map(String::as_str),
+                Some("true")
             );
             assert_eq!(
                 latest.provider_metadata.get("item_id").map(String::as_str),
                 Some("item-1")
             );
             assert!(
-                latest
+                !latest
                     .provider_metadata
-                    .get("unreviewed_internal_id")
-                    .is_none()
+                    .contains_key("unreviewed_internal_id")
             );
             assert!(latest.redacted_fields.contains(&"content".to_string()));
             assert!(latest.redacted_fields.contains(&"arguments".to_string()));

--- a/crates/agenthub-diagnostics/src/lib.rs
+++ b/crates/agenthub-diagnostics/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(debug_assertions)]
 pub mod agent_trace {
     use std::{
+        collections::BTreeMap,
         path::{Path, PathBuf},
         time::Duration,
     };
@@ -14,6 +15,24 @@ pub mod agent_trace {
     };
 
     const DEFAULT_EVENT_LIMIT: i64 = 16;
+    const PROVIDER_METADATA_ID_FIELDS: &[&str] = &[
+        "call_id",
+        "client_id",
+        "conversation_id",
+        "elicitation_id",
+        "item_id",
+        "permission_id",
+        "provider_id",
+        "provider_session_id",
+        "request_id",
+        "response_id",
+        "session_id",
+        "submission_id",
+        "thread_id",
+        "tool_call_id",
+        "trace_id",
+        "turn_id",
+    ];
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct AgentTraceRequest {
@@ -166,6 +185,8 @@ pub mod agent_trace {
         pub status: Option<String>,
         pub tool_call_id: Option<String>,
         pub permission_id: Option<String>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        pub provider_metadata: BTreeMap<String, String>,
         pub redacted_fields: Vec<String>,
     }
 
@@ -350,6 +371,15 @@ pub mod agent_trace {
                 event.tool_call_id.as_deref().unwrap_or("<none>"),
                 event.permission_id.as_deref().unwrap_or("<none>")
             ));
+            if !event.provider_metadata.is_empty() {
+                let metadata = event
+                    .provider_metadata
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                lines.push(format!("events.latest.provider_metadata: {metadata}"));
+            }
         }
         lines.push(format!(
             "permissions.pending_count: {}",
@@ -772,11 +802,26 @@ pub mod agent_trace {
             .as_ref()
             .and_then(Value::as_object)
             .map(|object| {
-                ["text", "content", "raw_input", "raw_output", "tool_call"]
-                    .into_iter()
-                    .filter(|field| object.contains_key(*field))
-                    .map(str::to_string)
-                    .collect()
+                [
+                    "text",
+                    "content",
+                    "message",
+                    "messages",
+                    "input",
+                    "output",
+                    "raw_input",
+                    "raw_output",
+                    "tool_call",
+                    "tool_calls",
+                    "tool_result",
+                    "tool_results",
+                    "arguments",
+                    "args",
+                ]
+                .into_iter()
+                .filter(|field| object.contains_key(*field))
+                .map(str::to_string)
+                .collect()
             })
             .unwrap_or_default();
 
@@ -790,8 +835,25 @@ pub mod agent_trace {
             status,
             tool_call_id,
             permission_id,
+            provider_metadata: provider_metadata_from_event(parsed.as_ref()),
             redacted_fields,
         }
+    }
+
+    fn provider_metadata_from_event(parsed: Option<&Value>) -> BTreeMap<String, String> {
+        let Some(object) = parsed.and_then(Value::as_object) else {
+            return BTreeMap::new();
+        };
+        PROVIDER_METADATA_ID_FIELDS
+            .iter()
+            .filter_map(|field| {
+                object
+                    .get(*field)
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .map(|value| ((*field).to_string(), value.to_string()))
+            })
+            .collect()
     }
 
     fn value_to_short_string(value: &Value) -> Option<String> {
@@ -1107,6 +1169,71 @@ pub mod agent_trace {
             assert_eq!(latest.event_type.as_deref(), Some("tool_call_update"));
             assert_eq!(latest.tool_call_id.as_deref(), Some("tool-large"));
             assert!(latest.redacted_fields.contains(&"raw_input".to_string()));
+            let _ = std::fs::remove_dir_all(event_dir);
+        }
+
+        #[tokio::test]
+        async fn agent_trace_event_metadata_allowlist_keeps_ids_and_redacts_bodies() {
+            let pool = test_pool().await;
+            insert_agent_fixture(&pool).await;
+            let event_dir = test_event_dir();
+            insert_event(
+                &event_dir,
+                r#"{
+                    "type":"item_completed",
+                    "thread_id":"thread-1",
+                    "turn_id":"turn-1",
+                    "item_id":"item-1",
+                    "tool_call_id":"tool-1",
+                    "content":"private model output",
+                    "arguments":{"path":"/private/file"},
+                    "raw_output":"private tool output",
+                    "unreviewed_internal_id":"must-not-leak"
+                }"#,
+            )
+            .await;
+
+            let report = collect_from_pool(
+                &pool,
+                event_dir.clone(),
+                AgentTraceRequest {
+                    agent_id: Some("worker".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("collect trace");
+
+            let latest = report.events.latest.as_ref().expect("latest event");
+            assert_eq!(
+                latest
+                    .provider_metadata
+                    .get("thread_id")
+                    .map(String::as_str),
+                Some("thread-1")
+            );
+            assert_eq!(
+                latest.provider_metadata.get("turn_id").map(String::as_str),
+                Some("turn-1")
+            );
+            assert_eq!(
+                latest.provider_metadata.get("item_id").map(String::as_str),
+                Some("item-1")
+            );
+            assert!(
+                latest
+                    .provider_metadata
+                    .get("unreviewed_internal_id")
+                    .is_none()
+            );
+            assert!(latest.redacted_fields.contains(&"content".to_string()));
+            assert!(latest.redacted_fields.contains(&"arguments".to_string()));
+            assert!(latest.redacted_fields.contains(&"raw_output".to_string()));
+            assert!(
+                !serde_json::to_string(latest)
+                    .expect("serialize event")
+                    .contains("private model output")
+            );
             let _ = std::fs::remove_dir_all(event_dir);
         }
 

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -190,6 +190,12 @@ ACP permission requests are first-class runtime records:
   - whether each custom tool call has observed a matching output item before turn completion,
     compaction, resume, or shutdown
   - the last Codex `EventMsg` class and timestamp seen by the adapter
+- Provider-native metadata exposed through `agenthub doctor agent-trace` must use an explicit
+  allowlist. Safe fields are limited to identifiers and counters needed to correlate provider
+  state, such as ACP session id, provider session id, Codex thread/turn/item/request/submission ids,
+  tool-call/permission ids, event classes, timestamps, and queue counts. Diagnostics must not
+  serialize prompt text, message bodies, tool arguments, tool outputs, command error messages, or
+  arbitrary provider JSON fields.
 - Codex `ReviewDecision::Abort` is a whole-turn interrupt in upstream Codex core. AgentHub's
   provider adapter must not expose it as the default "No" permission-review option and must not map
   permission timeout or failed review delivery to it. Ordinary denial should map to
@@ -237,6 +243,11 @@ ACP permission requests are first-class runtime records:
   - updating `codex_acp_default_mode` changes persisted agent configuration without restarting or
     controlling the active provider session
   - web create/edit controls send the startup mode and label it as restart-required configuration
+- Focused `agenthub-diagnostics` / `agenthub` tests:
+  - `agent-trace` event summaries extract only allowlisted provider-native ids from persisted ACP
+    JSON and mark body-like fields as redacted
+  - live ACP provider diagnostics preserve safe ids/counters while omitting command error messages
+    and other body-like text
 
 ## Operational Notes
 
@@ -273,6 +284,9 @@ ACP permission requests are first-class runtime records:
 - Treat Codex app-server/protocol state as an adapter-local observability source. It can explain
   Codex-specific failures such as missing custom-tool outputs, but it should not become the primary
   AgentHub runtime contract while Gemini/Kimi and future providers still rely on ACP.
+- Treat provider-native diagnostics as a correlation aid, not a data dump. Adding a new field to
+  `agent-trace` requires updating the allowlist and confirming the field cannot carry prompt,
+  message, tool argument, or tool output bodies.
 - When a Codex ACP agent appears stuck after permission timeout, first verify the option id and
   submitted Codex decision. If the persisted option is `abort` or the adapter submits
   `ReviewDecision::Abort`, the adapter is using interrupt semantics and should be fixed before
@@ -313,3 +327,4 @@ ACP permission requests are first-class runtime records:
 - `docs/journal/2026-05-09-acp-permission-tool-call-settlement.md`
 - `docs/journal/2026-05-13-acp-permission-deny-drain.md`
 - `docs/journal/2026-05-15-codex-acp-prompt-steering.md`
+- `docs/journal/2026-06-03-acp-provider-metadata-allowlist.md`

--- a/docs/journal/2026-06-03-acp-provider-metadata-allowlist.md
+++ b/docs/journal/2026-06-03-acp-provider-metadata-allowlist.md
@@ -7,10 +7,24 @@ explicit allowlist. The diagnostic path keeps IDs and runtime counters that help
 turns, while avoiding prompt text, message bodies, tool arguments, tool outputs, and command error
 messages.
 
-## Implementation
+## Background
+
+ACP long-session debugging needs provider-native ids to correlate AgentHub events with provider
+runtime state. Before this change, live provider diagnostics could serialize the broader ACP
+diagnostic object, which made the safe boundary depend on every field staying body-free.
+
+## Scope
+
+This checkpoint covers `agenthub doctor agent-trace` event summaries, live ACP provider diagnostic
+details, and the stable ACP runtime documentation. It does not change provider runtime behavior,
+permission handling, or ACP event persistence.
+
+## Key decisions
 
 - Added `AgentTraceEvent.provider_metadata` for allowlisted provider-native event identifiers:
   session/thread/turn/item/request/submission/tool-call/permission ids and related trace ids.
+- Allowlisted provider metadata accepts only scalar strings, numbers, and booleans; objects and
+  arrays are ignored because they can carry prompt, message, or tool payload bodies.
 - Expanded event redaction markers for body-like fields such as `message`, `input`, `output`,
   `arguments`, and tool-result payloads.
 - Replaced live ACP provider `details` serialization with a hand-built safe diagnostic object:
@@ -31,10 +45,10 @@ Recommended command set for this slice:
 cargo test -p agenthub-diagnostics agent_trace_event_metadata_allowlist_keeps_ids_and_redacts_bodies
 cargo test -p agenthub provider_diagnostics_details_redact_error_messages_and_keep_safe_ids
 cargo fmt --all --check
-cargo clippy -p agenthub --all-targets -- -D warnings
+cargo clippy --locked --workspace --all-targets -- -D warnings
 ```
 
-## Follow-Up
+## Follow-ups
 
 No active TODO remains for the provider-native metadata allowlist. Future provider metadata fields
 must be added by extending the allowlist and proving they cannot carry prompt, message, tool

--- a/docs/journal/2026-06-03-acp-provider-metadata-allowlist.md
+++ b/docs/journal/2026-06-03-acp-provider-metadata-allowlist.md
@@ -1,0 +1,41 @@
+# ACP Provider Metadata Allowlist
+
+## Summary
+
+`agenthub doctor agent-trace` now exposes provider-native correlation metadata only through an
+explicit allowlist. The diagnostic path keeps IDs and runtime counters that help debug stuck ACP
+turns, while avoiding prompt text, message bodies, tool arguments, tool outputs, and command error
+messages.
+
+## Implementation
+
+- Added `AgentTraceEvent.provider_metadata` for allowlisted provider-native event identifiers:
+  session/thread/turn/item/request/submission/tool-call/permission ids and related trace ids.
+- Expanded event redaction markers for body-like fields such as `message`, `input`, `output`,
+  `arguments`, and tool-result payloads.
+- Replaced live ACP provider `details` serialization with a hand-built safe diagnostic object:
+  counts, channel state, submission ids, provider event class/timestamp, pending tool-call ids,
+  stale-prompt counters, and command error kind only.
+- Updated the ACP runtime spec to make provider-native diagnostics an explicit allowlist contract.
+
+## Validation
+
+Focused tests cover the stable boundary:
+
+- `agent_trace_event_metadata_allowlist_keeps_ids_and_redacts_bodies`
+- `provider_diagnostics_details_redact_error_messages_and_keep_safe_ids`
+
+Recommended command set for this slice:
+
+```bash
+cargo test -p agenthub-diagnostics agent_trace_event_metadata_allowlist_keeps_ids_and_redacts_bodies
+cargo test -p agenthub provider_diagnostics_details_redact_error_messages_and_keep_safe_ids
+cargo fmt --all --check
+cargo clippy -p agenthub --all-targets -- -D warnings
+```
+
+## Follow-Up
+
+No active TODO remains for the provider-native metadata allowlist. Future provider metadata fields
+must be added by extending the allowlist and proving they cannot carry prompt, message, tool
+argument, or tool output bodies.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,7 +43,6 @@ Stable contracts:
 Matrix to keep current across real long-running Codex and non-Codex sessions:
 
 - [ ] `P1` Verify deployed ACP long-session browser behavior under real long output histories: the shipped stick-to-bottom, permission-history jump/copy, stale-session `send input` recovery, debug/runtime-metrics surfaces, and provider session switching should stay stable during real Codex and non-Codex sessions.
-- [ ] `P1` Provider-native metadata allowlist: define one reviewed safe metadata contract for ACP adapters, then surface provider-native turn/thread/session ids in `agenthub doctor agent-trace` only for fields that can be exposed without serializing prompt, message, tool argument, or tool output bodies.
 - [ ] `P2` Provider-driven config selectors: verify real Gemini and Kimi ACP sessions end to end so upstream `config_options` render `mode`/`model` controls, `Set Model` / `Set Mode` works without manual ID entry, and selected values remain stable across reconnects.
 - [ ] `P2` Polish ACP-native Codex `request_user_input` UX after the inline card rollout: cover richer note-entry flows in browser-level fixtures and decide whether pending questions should bypass prompt-text serialization entirely.
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -501,6 +501,49 @@ fn acp_accepts_best_effort_hint(
         && diagnostics.stale_prompt.is_none()
 }
 
+fn safe_acp_provider_diagnostics_details(diagnostics: &AcpHandleDiagnostics) -> serde_json::Value {
+    serde_json::json!({
+        "session_id": &diagnostics.session_id,
+        "command_channel_closed": diagnostics.command_channel_closed,
+        "command_channel_capacity": diagnostics.command_channel_capacity,
+        "command_channel_max_capacity": diagnostics.command_channel_max_capacity,
+        "active_prompt_count": diagnostics.active_prompt_count,
+        "pending_command_count": diagnostics.pending_command_count,
+        "pending_permission_count": diagnostics.pending_permission_count,
+        "active_submission_ids": &diagnostics.active_submission_ids,
+        "last_submission_id": &diagnostics.last_submission_id,
+        "last_provider_event_type": &diagnostics.last_provider_event_type,
+        "last_provider_event_at": diagnostics.last_provider_event_at,
+        "pending_tool_call_count": diagnostics.pending_tool_call_count,
+        "pending_tool_calls": diagnostics
+            .pending_tool_calls
+            .iter()
+            .map(|tool_call| {
+                serde_json::json!({
+                    "tool_call_id": &tool_call.tool_call_id,
+                    "status": &tool_call.status,
+                    "updated_at": tool_call.updated_at,
+                })
+            })
+            .collect::<Vec<_>>(),
+        "stale_prompt": diagnostics.stale_prompt.as_ref().map(|stale| {
+            serde_json::json!({
+                "active_prompt_count": stale.active_prompt_count,
+                "pending_permission_count": stale.pending_permission_count,
+                "stale_for_seconds": stale.stale_for_seconds,
+                "last_activity_at": stale.last_activity_at,
+                "active_submission_ids": &stale.active_submission_ids,
+            })
+        }),
+        "last_command_error": diagnostics.last_command_error.as_ref().map(|error| {
+            serde_json::json!({
+                "command_kind": &error.command_kind,
+            })
+        }),
+        "last_command_error_at": diagnostics.last_command_error_at,
+    })
+}
+
 fn is_agent_user_message(message: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(message)
         .ok()
@@ -1764,10 +1807,7 @@ impl AgentManager {
                 } else {
                     "idle"
                 };
-                (
-                    status,
-                    serde_json::to_value(diagnostics).unwrap_or_default(),
-                )
+                (status, safe_acp_provider_diagnostics_details(&diagnostics))
             }
             AgentInput::Stdin(_) => (
                 "non_acp",

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -501,6 +501,7 @@ fn acp_accepts_best_effort_hint(
         && diagnostics.stale_prompt.is_none()
 }
 
+#[cfg(any(debug_assertions, test))]
 fn safe_acp_provider_diagnostics_details(diagnostics: &AcpHandleDiagnostics) -> serde_json::Value {
     serde_json::json!({
         "session_id": &diagnostics.session_id,

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -9,11 +9,12 @@ use super::{
     AGENT_LOOP_MESSAGE_ID_PREFIX, AgentOutput, AgentRecord, AgentStatus, OutputStream,
     WorktreeMode, acp_accepts_best_effort_hint, build_runtime_start_policy,
     ensure_team_runtime_workspace_layout, is_agent_loop_activity_output,
-    should_rearm_agent_loop_for_output, status_to_str, stream_from_str,
+    safe_acp_provider_diagnostics_details, should_rearm_agent_loop_for_output, status_to_str,
+    stream_from_str,
 };
 use crate::acp::{
     AcpActorSkillContext, AcpCommandErrorDiagnostic, AcpHandleDiagnostics, AcpPromptDeliveryPolicy,
-    AcpRuntimeLocation, AcpStalePromptDiagnostic,
+    AcpRuntimeLocation, AcpStalePromptDiagnostic, AcpToolCallDiagnostic,
 };
 use crate::path_utils::expand_tilde;
 use std::sync::Mutex;
@@ -220,6 +221,44 @@ fn best_effort_mailbox_hints_respect_provider_prompt_policy() {
         &previous_error,
         AcpPromptDeliveryPolicy::StrictFifo
     ));
+}
+
+#[test]
+fn provider_diagnostics_details_redact_error_messages_and_keep_safe_ids() {
+    let mut diagnostics = idle_acp_hint_diagnostics();
+    diagnostics.active_submission_ids = vec!["submission-1".to_string()];
+    diagnostics.last_submission_id = Some("submission-0".to_string());
+    diagnostics.last_provider_event_type = Some("turn_started".to_string());
+    diagnostics.pending_tool_calls = vec![AcpToolCallDiagnostic {
+        tool_call_id: "tool-1".to_string(),
+        status: "running".to_string(),
+        updated_at: Some(123),
+    }];
+    diagnostics.pending_tool_call_count = diagnostics.pending_tool_calls.len();
+    diagnostics.stale_prompt = Some(AcpStalePromptDiagnostic {
+        active_prompt_count: 1,
+        pending_permission_count: 0,
+        stale_for_seconds: 300,
+        last_activity_at: Some(100),
+        active_submission_ids: vec!["submission-1".to_string()],
+    });
+    diagnostics.last_command_error = Some(AcpCommandErrorDiagnostic {
+        command_kind: "prompt".to_string(),
+        message: "prompt body and tool arguments must stay private".to_string(),
+    });
+
+    let details = safe_acp_provider_diagnostics_details(&diagnostics);
+
+    assert_eq!(details["session_id"], "session-1");
+    assert_eq!(details["active_submission_ids"][0], "submission-1");
+    assert_eq!(details["pending_tool_calls"][0]["tool_call_id"], "tool-1");
+    assert_eq!(details["last_command_error"]["command_kind"], "prompt");
+    assert!(details["last_command_error"].get("message").is_none());
+    assert!(
+        !details
+            .to_string()
+            .contains("prompt body and tool arguments must stay private")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add an explicit provider-native metadata allowlist to `agenthub doctor agent-trace` event summaries.
- Replace live ACP provider diagnostics `details` serialization with a hand-built safe snapshot.
- Document the ACP provider metadata contract and close the active TODO item.

## Purpose

`agent-trace` needs enough provider-native ids to correlate stuck ACP turns, but it must not dump
prompt text, message bodies, tool arguments, tool outputs, or command error messages. This PR keeps
safe ids/counters while making redaction the default boundary.

## Related Issue

- None

## Tests

- `cargo test -p agenthub-diagnostics agent_trace_event_metadata_allowlist_keeps_ids_and_redacts_bodies`
- `cargo test -p agenthub provider_diagnostics_details_redact_error_messages_and_keep_safe_ids`
- `cargo fmt --all --check`
- `git -c core.fsmonitor=false diff --check`
- `cargo check -p agenthub-diagnostics`
- `cargo check -p agenthub`
- `cargo clippy -p agenthub --all-targets -- -D warnings`
