### PR TITLE
docs(nodes): close node startup boundary TODO

### DIFF
--- a/docs/journal/2026-04-26-node-startup-boundary-verification.md
+++ b/docs/journal/2026-04-26-node-startup-boundary-verification.md
@@ -5,6 +5,7 @@
 - tightened focused Rust coverage around node-vs-main startup boundaries
 - confirmed the existing implementation already enforces the intended node-mode
   contract; the missing gap was regression coverage, not a new runtime fix
+- closed the active TODO after PR #425 passed the full check matrix
 
 ## Scope
 
@@ -32,8 +33,27 @@ These tests lock the most important startup boundaries:
 - `cargo test -p agenthub validate_startup_config_ -- --nocapture`
 - `cargo test -p agenthub state::tests::setup_database_ -- --nocapture`
 - `cargo test -p agenthub state::tests::initialize_services_ -- --nocapture`
+- PR CI: `gh pr checks 425 | cat`
 
-## Follow-up
+```text
+Bazel Build              pass
+Bazel Build and Test     pass
+Bazel Coverage           pass
+Bazel Test (Crates)      pass
+Bazel Test (Root)        pass
+Cargo Clippy             pass
+Distributed P2P Pipeline pass
+Rust (Cargo)             pass
+Rust (Coverage)          pass
+Rust (Fmt)               pass
+Rust (Proto Check)       pass
+Rust (gRPC Integration)  pass
+Web                      pass
+Web E2E                  pass
+codecov/patch            pass
+codecov/project          pass
+```
 
-- This does not close the broader TODO by itself; push/PR CI evidence still
-  needs to be recorded before the TODO can be removed.
+## Follow-Ups
+
+None.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -70,7 +70,6 @@ Stable contracts:
 
 Matrix to keep current across CI and at least one real multi-node rollout:
 
-- [ ] `P1` Node startup boundaries: `server.role = "node"` boots internal gRPC only, skips main-only startup side effects, and fails fast when `server.node_id` is missing or `internal_grpc.enabled` is false. Existing notes: [journal/2026-04-05-node-mode-startup-boundary.md](journal/2026-04-05-node-mode-startup-boundary.md).
 - [ ] `P1` Token-first Agent Node join: root `Agents` surfaces node bootstrap token/details, Admin join exposes token/link without QR onboarding, and user docs match the current `internal_grpc.bootstrap.token` contract. Existing notes: [journal/2026-04-17-node-join-token-flow.md](journal/2026-04-17-node-join-token-flow.md).
 - [ ] `P1` Refreshed agent-node deployment docs: `userdocs/docs/deployment/overview-and-topology.md`, `userdocs/docs/core/agent-nodes.md`, and `userdocs/docs/getting-started/configuration-basics.md` match current `internal_grpc` config shape, remote-node registration flow, and remote-target startup behavior.
 - [ ] `P1` Remote-node transport posture: validate relay dedupe and timestamp-window policy in staging, design same-port HTTP plus gRPC multiplexing, and define the production identity path for long-term mTLS rollout.


### PR DESCRIPTION
## Summary

- Record PR #425 check evidence in the node startup boundary verification journal.
- Remove the completed `Node startup boundaries` item from `docs/todo.md`.

## Purpose

The node startup boundary implementation and focused regression tests already landed in PR #300 and PR #425. The remaining TODO only required push/PR CI evidence before it could be closed.

## Related Issues

- None.

## Testing

- `git diff --check`
- `gh pr checks 425 | cat`
