### PR TITLE
docs(nodes): document remote-node transport posture

### DIFF
--- a/docs/features/distributed-node-architecture.md
+++ b/docs/features/distributed-node-architecture.md
@@ -55,7 +55,8 @@ The architecture therefore needs a phased plan that keeps today's encrypted gRPC
 
 ### Current Implementation Status
 
-As of `2026-03-19`, phases `0` and `1` are implemented in the main codebase:
+As of `2026-06-09`, phases `0` and `1` are implemented in the main codebase and the
+remote-node transport posture is stable enough for small-cluster production trials:
 
 - phase 0 abstraction freeze now has concrete runtime surfaces in:
   - `src/internal/p2p.rs`
@@ -72,6 +73,46 @@ One implementation boundary is intentionally explicit:
 - destination-local mailbox delivery still keeps `to_peer_id = main` so inbox lookup semantics remain local
 - source node identity is preserved on delivered messages via `from_peer_id`
 - explicit `target_node_id` continues to live in route/envelope metadata instead of overloading the destination-local mailbox partition key
+
+### Remote-Node Transport Posture
+
+The current production posture is `HTTPS gRPC on a dedicated internal port`.
+
+Required behavior:
+
+- remote-node mailbox and agent-control payloads use authenticated internal `gRPC`
+- relay sends are at-least-once; receivers must make duplicate delivery harmless
+- `idempotency_key`, `source_node_id`, `target_node_id`, `issued_at`, and `expires_at`
+  remain first-class transport metadata, not optional debug fields
+- stale transport credentials or stale relay envelopes must be rejected before business payload handling
+- registered node routing is pinned to the main-owned `agent_nodes` row; route JSON cannot override TLS file paths or silently redirect to a different target
+- destination-local delivery strips the cross-node route and stores a local mailbox row after successful relay
+
+Dedupe and timestamp-window policy:
+
+- the canonical dedupe key is the transport `idempotency_key`
+- when an old relay route does not carry a first-class `idempotency_key`, the receiver may fall back to `(source_node_id, message_id)` for compatibility
+- the recommended timestamp skew window is `+-120s`
+- accepted dedupe keys should be retained for at least `24h` or the configured retry horizon, whichever is longer
+- duplicate deliveries should return success after skipping business processing so relay retries can converge without creating extra mailbox rows
+- rejected stale, duplicate, or signature-invalid deliveries should be auditable by reason
+
+Same-port HTTP plus gRPC multiplexing is a future deployment simplification, not the current
+canonical runtime mode. The design target is:
+
+- one public listener can accept browser HTTP/SSE and internal gRPC on the same TLS endpoint
+- ALPN and `Content-Type: application/grpc` decide the gRPC path; normal HTTP requests continue to route through the web/API stack
+- internal gRPC authentication and authorization stay identical whether the listener is dedicated or multiplexed
+- node-only mode may still expose only the internal gRPC service even when the implementation uses a shared accept loop
+- rollout must preserve the dedicated-port mode as the conservative fallback until reverse-proxy behavior is validated
+
+Long-term identity path:
+
+1. phase 1 keeps a shared cluster signing secret plus TLS/mTLS transport because it is operationally small
+2. each node already carries stable `node_id`, route metadata, scoped claims, and key identifiers so later credentials can bind to node identity
+3. the next identity step should add main-issued, short-lived node credentials tied to `node_id`, `audience`, `scope`, and `expires_at`
+4. production mTLS should then bind the certificate subject/SAN or SPIFFE-like URI to the same `node_id`
+5. once revocation and rotation are available, the shared secret becomes bootstrap/recovery material rather than the steady-state trust root
 
 ### Phase Breakdown
 
@@ -294,9 +335,13 @@ Even in phase 1, messages and envelopes should carry fields that keep later migr
 ## Contracts
 
 - `node <-> node` mailbox and agent-control business traffic must use authenticated `gRPC`
+- the current canonical deployment uses a dedicated internal `https://` gRPC endpoint; same-port HTTP plus gRPC multiplexing is an explicit future-compatible design target
 - `gossip` is a metadata plane only and must not carry mailbox business payloads
 - the control plane remains authoritative for registry, bootstrap, policy, and audit
 - phase 1 may use a cluster-wide shared signing key, but protocol shapes must remain compatible with per-node identity in later phases
+- receivers must enforce timestamp windows and idempotency dedupe before applying remote mailbox business logic
+- route-level TLS file paths are not accepted; TLS material comes from cluster-level internal gRPC configuration
+- node registry rows are routing authority, not credential stores
 - cross-node broadcast must aggregate by target node before local per-member fanout
 - nodes may use gossip-derived membership and load information only as routing hints, never as a standalone trust source
 - phase boundaries are driven by protocol stability and operational readiness, not by implementation convenience
@@ -312,6 +357,13 @@ Phase 1:
 
 - 2-node blackbox `gRPC` p2p pipeline
 - point-to-point retry/idempotency coverage
+- relay route hardening coverage for registry target pinning, TLS material sourcing, and rejected route-level TLS paths
+- staging smoke with one main node and one remote node:
+  - duplicate relay retry does not create duplicate destination mailbox rows
+  - stale timestamp outside `+-120s` is rejected
+  - valid retry inside the allowed window converges to delivered/acked state
+  - node-only process does not expose the public HTTP/UI surface
+- deployment review for dedicated-port `https://` gRPC and the future same-port multiplexing fallback plan
 
 Phase 2:
 
@@ -342,6 +394,7 @@ Phase 6:
 - node revoke / deny-list propagation
 - spoofed membership advertisement rejection
 - replayed credential rejection
+- certificate identity and token `node_id` mismatch rejection
 
 Recommended implementation commands should be added as each phase lands; phase 1 currently depends on:
 
@@ -353,6 +406,9 @@ cargo test --locked --test distributed_p2p_pipeline -- --nocapture
 
 - phase 1 intentionally trades strict zero trust for lower bootstrap complexity
 - that simplification is acceptable only if message/envelope schemas already include forward-compatible identity and scope fields
+- production small-cluster deployments should prefer private-network `https://` gRPC targets and root-managed node registry entries
+- same-port HTTP plus gRPC multiplexing should be introduced only after reverse-proxy behavior, ALPN forwarding, and node-only mode boundaries have dedicated validation
+- the mTLS long-term path should bind certificate identity to the same `node_id` used by registry rows and scoped credentials
 - gossip should be introduced only when node count and fanout patterns justify it
 - when large fanout appears, the preferred model is `gossip descriptor + gRPC payload`, not `gossip payload flood`
 - debugging and auditability must remain possible across every phase; this is another reason not to use gossip as the primary mailbox transport
@@ -365,7 +421,9 @@ cargo test --locked --test distributed_p2p_pipeline -- --nocapture
 - phase 3 can become a thin wrapper with little value if planners keep bypassing `MembershipView`
 - phase 4 gossip-based load hints can become stale and cause suboptimal routing under rapid cluster churn
 - phase 6 identity migration will still require a careful bootstrap and revocation design
+- same-port multiplexing can be proxy-sensitive and should not replace dedicated internal gRPC until deployed HTTP/SSE and gRPC behavior are validated together
 
 ## Source Journals
 
 - `docs/journal/2026-03-19-distributed-node-architecture.md`
+- `docs/journal/2026-06-09-remote-node-transport-posture.md`

--- a/docs/features/distributed-node-architecture.md
+++ b/docs/features/distributed-node-architecture.md
@@ -92,7 +92,7 @@ Dedupe and timestamp-window policy:
 
 - the canonical dedupe key is the transport `idempotency_key`
 - when an old relay route does not carry a first-class `idempotency_key`, the receiver may fall back to `(source_node_id, message_id)` for compatibility
-- the recommended timestamp skew window is `+-120s`
+- the recommended timestamp skew window is `±120s`
 - accepted dedupe keys should be retained for at least `24h` or the configured retry horizon, whichever is longer
 - duplicate deliveries should return success after skipping business processing so relay retries can converge without creating extra mailbox rows
 - rejected stale, duplicate, or signature-invalid deliveries should be auditable by reason
@@ -110,7 +110,7 @@ Long-term identity path:
 
 1. phase 1 keeps a shared cluster signing secret plus TLS/mTLS transport because it is operationally small
 2. each node already carries stable `node_id`, route metadata, scoped claims, and key identifiers so later credentials can bind to node identity
-3. the next identity step should add main-issued, short-lived node credentials tied to `node_id`, `audience`, `scope`, and `expires_at`
+3. the next identity step should add main-issued, short-lived node credentials tied to `node_id`, `audience`, `scope`, `issued_at`, and `expires_at`
 4. production mTLS should then bind the certificate subject/SAN or SPIFFE-like URI to the same `node_id`
 5. once revocation and rotation are available, the shared secret becomes bootstrap/recovery material rather than the steady-state trust root
 
@@ -360,7 +360,7 @@ Phase 1:
 - relay route hardening coverage for registry target pinning, TLS material sourcing, and rejected route-level TLS paths
 - staging smoke with one main node and one remote node:
   - duplicate relay retry does not create duplicate destination mailbox rows
-  - stale timestamp outside `+-120s` is rejected
+  - stale timestamp outside `±120s` is rejected
   - valid retry inside the allowed window converges to delivered/acked state
   - node-only process does not expose the public HTTP/UI surface
 - deployment review for dedicated-port `https://` gRPC and the future same-port multiplexing fallback plan

--- a/docs/journal/2026-06-04-team-node-continuity-rollup.md
+++ b/docs/journal/2026-06-04-team-node-continuity-rollup.md
@@ -56,4 +56,5 @@ printed a local update-check config-store permission warning, which does not aff
 ## Follow-Ups
 
 - Real multi-node Team direct-mailbox routing still needs deployed verification.
-- Remote-node transport posture remains open for staging validation, same-port HTTP/gRPC multiplexing design, and long-term production identity/mTLS rollout.
+- Remote-node transport posture is superseded by `docs/journal/2026-06-09-remote-node-transport-posture.md`
+  and the canonical deployment contract in `docs/features/distributed-node-architecture.md`.

--- a/docs/journal/2026-06-09-remote-node-transport-posture.md
+++ b/docs/journal/2026-06-09-remote-node-transport-posture.md
@@ -37,7 +37,7 @@ it was the missing operator-facing transport posture:
 4. The canonical dedupe key is transport `idempotency_key`; compatibility may
    fall back to `(source_node_id, message_id)` when legacy metadata lacks a
    first-class idempotency key.
-5. The recommended timestamp skew window is `+-120s`, with accepted dedupe keys
+5. The recommended timestamp skew window is `±120s`, with accepted dedupe keys
    retained for at least `24h` or the configured retry horizon.
 6. The long-term identity path is main-issued short-lived node credentials plus
    mTLS certificate identity bound to the same `node_id`.

--- a/docs/journal/2026-06-09-remote-node-transport-posture.md
+++ b/docs/journal/2026-06-09-remote-node-transport-posture.md
@@ -1,0 +1,64 @@
+# Remote Node Transport Posture
+
+## Summary
+
+Closed the remote-node transport posture TODO by moving the durable deployment
+and protocol posture into canonical docs and user-facing deployment guidance.
+
+## Background
+
+Phase 0/1 distributed-node work already had runtime coverage for encrypted gRPC
+remote agent control, mailbox relay, node-local data isolation, and the blackbox
+distributed p2p pipeline. The remaining P1 tail was not another runtime change;
+it was the missing operator-facing transport posture:
+
+- relay dedupe and timestamp-window policy
+- dedicated-port gRPC versus future same-port HTTP/gRPC multiplexing
+- the production identity path from shared-secret phase 1 to per-node mTLS
+
+## Scope
+
+- `docs/features/distributed-node-architecture.md`
+- `userdocs/docs/deployment/remote-node-transport.md`
+- `userdocs/docs/deployment/overview-and-topology.md`
+- `userdocs/docs/deployment/production-checklist.md`
+- `userdocs/docs/core/agent-nodes.md`
+- `userdocs/sidebars.js`
+- `docs/todo.md`
+
+## Key Decisions
+
+1. The current canonical production posture is a dedicated internal `https://`
+   gRPC endpoint for remote-node traffic.
+2. Same-port HTTP plus gRPC multiplexing is a future-compatible design target,
+   not the current conservative default.
+3. Remote mailbox relay is at-least-once; receivers must enforce timestamp
+   windows and idempotency before applying mailbox business effects.
+4. The canonical dedupe key is transport `idempotency_key`; compatibility may
+   fall back to `(source_node_id, message_id)` when legacy metadata lacks a
+   first-class idempotency key.
+5. The recommended timestamp skew window is `+-120s`, with accepted dedupe keys
+   retained for at least `24h` or the configured retry horizon.
+6. The long-term identity path is main-issued short-lived node credentials plus
+   mTLS certificate identity bound to the same `node_id`.
+
+## Validation
+
+```bash
+git diff --check
+cargo fmt --check
+npm --prefix userdocs run build
+```
+
+Existing runtime evidence remains the phase 1 gate:
+
+```bash
+cargo test --locked --test distributed_p2p_pipeline -- --nocapture
+```
+
+## Follow-Ups
+
+- Implement and validate same-port HTTP plus gRPC multiplexing before changing
+  the recommended deployment default.
+- Add per-node credential issuance, rotation, revocation, and certificate
+  identity binding before replacing the shared-secret trust root.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,19 +57,6 @@ Stable contracts:
 - [ ] `P1` Verify remote Team direct-mailbox routing on real multi-node teams: after the local API regression and routing fix in [journal/2026-05-26-team-remote-direct-mailbox-routing.md](journal/2026-05-26-team-remote-direct-mailbox-routing.md), confirm direct single-member delivery still preserves mention metadata plus summary/`detail_ref` payloads when the recipient agent is remote and transport falls back to p2p relay in a real multi-node rollout. Existing notes: [journal/2026-03-26-team-direct-mailbox-summary-first.md](journal/2026-03-26-team-direct-mailbox-summary-first.md).
 - [ ] `P2` Verify Team agent self-maintenance and deferred follow-up flows: `profile_patch_proposal`, `agent_time_trigger_*`, and operator-controlled `agent_loop` should behave consistently without blocking normal task progress.
 
-## Distributed, Nodes, And Release Matrix
-
-Stable contracts:
-
-- [features/agent-nodes.md](features/agent-nodes.md)
-- [features/distributed-node-architecture.md](features/distributed-node-architecture.md)
-- [features/distributed-node-registry-and-gossip.md](features/distributed-node-registry-and-gossip.md)
-- [features/logical-message-metadata-contract.md](features/logical-message-metadata-contract.md)
-
-Matrix to keep current across CI and at least one real multi-node rollout:
-
-- [ ] `P1` Remote-node transport posture: validate relay dedupe and timestamp-window policy in staging, design same-port HTTP plus gRPC multiplexing, and define the production identity path for long-term mTLS rollout.
-
 ## Observability, CI, And Docs
 
 - [ ] `P1` Verify deployed Pyroscope bootstrap: full configuration starts one process-wide profiler agent, partial configuration warns and keeps the service running, and shutdown stops the profiler cleanly. Stable contract: [features/pyroscope-profiling.md](features/pyroscope-profiling.md).

--- a/userdocs/docs/core/agent-nodes.md
+++ b/userdocs/docs/core/agent-nodes.md
@@ -518,6 +518,9 @@ Remote execution preserves the actor model:
 
 This ensures remote execution feels like `AgentHub`, not a different product.
 
+For deployment-level transport rules, timestamp-window policy, and the mTLS
+identity roadmap, see [Remote Node Transport](../deployment/remote-node-transport.md).
+
 ## Health Checking
 
 ### Manual Health Check

--- a/userdocs/docs/deployment/overview-and-topology.md
+++ b/userdocs/docs/deployment/overview-and-topology.md
@@ -59,6 +59,9 @@ Use this when execution must span multiple machines:
 - Register remote Agent Nodes from the `Agents` page
 - Use encrypted gRPC between AgentHub and nodes
 - Configure a node-specific default worktree root when remote filesystems differ
+- Keep the current production posture on a dedicated internal `https://` gRPC
+  port; same-port HTTP plus gRPC multiplexing is a future-compatible design
+  target, not the conservative default.
 
 #### Distributed node prerequisites
 
@@ -117,6 +120,9 @@ Operational notes:
 - Remote-target agent creation fails fast when internal gRPC peer config is not
   available, so this should be treated as a deployment precondition rather than
   a runtime toggle.
+- Remote mailbox relay is at-least-once. Keep clocks synchronized and use the
+  documented idempotency/timestamp policy so retries do not create duplicate
+  destination mailbox rows.
 
 #### Recommended rollout order
 
@@ -169,5 +175,6 @@ cargo run -- -c /path/to/config.toml
 ## Related Pages
 
 - [Production Checklist](./production-checklist.md)
+- [Remote Node Transport](./remote-node-transport.md)
 - [Troubleshooting](../operations/troubleshooting.md)
 - [Configuration Basics](../getting-started/configuration-basics.md)

--- a/userdocs/docs/deployment/production-checklist.md
+++ b/userdocs/docs/deployment/production-checklist.md
@@ -22,6 +22,21 @@ Use this checklist before and after deploying AgentHub in a shared environment.
 - Enforce strong user credentials and periodic rotation.
 - Avoid putting sensitive directories under `safe_paths`.
 
+## Remote Node Baseline
+
+When remote Agent Nodes are enabled:
+
+- Keep node-only processes on internal `https://` gRPC endpoints.
+- Register remote nodes from the main control plane; do not treat registry rows
+  as credential storage.
+- Keep internal gRPC `issuer`, `audience`, and `shared_secret` aligned across
+  peers until per-node identity is available.
+- Keep node clocks synchronized so timestamp-window validation is reliable.
+- Smoke test duplicate relay retries in staging and confirm they do not create
+  duplicate destination mailbox rows.
+- Keep the dedicated gRPC port until same-port HTTP plus gRPC multiplexing has
+  been validated with your reverse proxy.
+
 ## Data and Backup
 
 AgentHub persists runtime data under `~/.agenthub/` by default.
@@ -60,4 +75,5 @@ If smoke checks fail or critical flows regress:
 ## Related Pages
 
 - [Deployment Overview and Topology](./overview-and-topology.md)
+- [Remote Node Transport](./remote-node-transport.md)
 - [Security and Path Safety](../operations/security-and-path-safety.md)

--- a/userdocs/docs/deployment/remote-node-transport.md
+++ b/userdocs/docs/deployment/remote-node-transport.md
@@ -45,7 +45,7 @@ and dedupe repeated delivery before processing the business payload.
 
 Recommended policy:
 
-- accept relay timestamps only inside a `+-120s` skew window
+- accept relay timestamps only inside a `±120s` skew window
 - use the transport `idempotency_key` as the canonical dedupe key
 - for compatibility with old relay metadata, fall back to `(source_node_id,
   message_id)` only when no first-class `idempotency_key` is present
@@ -93,7 +93,7 @@ The long-term path is:
    `audience`, `scope`, `issued_at`, and `expires_at`
 3. bind production mTLS certificate identity to the same `node_id`
 4. reject requests where token identity and certificate identity disagree
-5. add rotation and revocation before treating per-node identity as the steady
+5. add rotation and revocation before treating per-node identity as the steady-
    state trust root
 
 Until that path is complete, treat the shared secret as sensitive cluster-wide

--- a/userdocs/docs/deployment/remote-node-transport.md
+++ b/userdocs/docs/deployment/remote-node-transport.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 3
+---
+
+# Remote Node Transport
+
+Use this page when deploying AgentHub with remote Agent Nodes.
+
+AgentHub remote-node traffic currently uses authenticated `https://` gRPC on an
+internal endpoint. Browser HTTP, API, and SSE traffic still belong to the main
+control-plane web listener.
+
+## Current Production Posture
+
+The recommended deployment shape is:
+
+- one `main` AgentHub process serving the web UI and API
+- one or more `node` AgentHub processes serving internal gRPC only
+- private-network `https://` gRPC targets for every registered node
+- root-managed node registry rows for `grpc_target`, `tls_server_name`, and
+  optional `default_worktree_root`
+- shared internal gRPC auth/TLS configuration across the small cluster
+
+Do not expose the node-only gRPC listener as a public browser endpoint. Node
+mode is for execution and internal control traffic only.
+
+## Required Transport Rules
+
+Remote-node deployments should enforce these rules:
+
+| Rule | Requirement |
+|------|-------------|
+| Endpoint scheme | Use `https://` for registered `grpc_target` values. |
+| Registry authority | Register routes from the main control plane; do not rely on route JSON overrides. |
+| TLS material | Store TLS files in internal gRPC config, not in node registry rows or relay payloads. |
+| Bootstrap | Use `Agents -> Join node with token` to copy bootstrap details. |
+| Runtime auth | Keep `issuer`, `audience`, and `shared_secret` aligned across peers today. |
+| Dedupe | Treat remote delivery as at-least-once and make duplicate sends harmless. |
+| Clock skew | Reject stale relay credentials or envelopes outside the allowed timestamp window. |
+
+## Dedupe and Timestamp Window
+
+Remote mailbox relay can retry. Receivers must therefore reject stale requests
+and dedupe repeated delivery before processing the business payload.
+
+Recommended policy:
+
+- accept relay timestamps only inside a `+-120s` skew window
+- use the transport `idempotency_key` as the canonical dedupe key
+- for compatibility with old relay metadata, fall back to `(source_node_id,
+  message_id)` only when no first-class `idempotency_key` is present
+- retain accepted dedupe keys for at least `24h` or the configured retry horizon,
+  whichever is longer
+- return success for duplicates after skipping business processing
+- log rejected deliveries with a reason such as `expired`, `duplicate`, or
+  `signature_mismatch`
+
+The goal is at-least-once transport with effectively-once mailbox effects.
+
+## Dedicated Port vs Same-Port Multiplexing
+
+The supported deployment mode today is a dedicated internal gRPC port, for
+example:
+
+```toml
+[internal_grpc]
+enabled = true
+listen = "0.0.0.0:50051"
+```
+
+Same-port HTTP plus gRPC multiplexing is a future deployment simplification.
+The intended design is:
+
+- one TLS listener can accept browser HTTP/SSE and internal gRPC
+- ALPN and `Content-Type: application/grpc` route gRPC requests to the internal
+  service
+- normal HTTP requests continue to route to the web/API stack
+- internal gRPC authz stays the same as the dedicated-port mode
+- node-only mode still avoids exposing the public web/API surface
+
+Keep the dedicated-port mode until your reverse proxy and AgentHub build both
+validate same-port behavior.
+
+## Identity and mTLS Roadmap
+
+The current small-cluster model uses a shared signing secret plus TLS or mTLS.
+This keeps rollout simple, but it is not the final identity model.
+
+The long-term path is:
+
+1. keep stable `server.node_id` values and registry rows for every node
+2. issue short-lived credentials from the main control plane with `node_id`,
+   `audience`, `scope`, `issued_at`, and `expires_at`
+3. bind production mTLS certificate identity to the same `node_id`
+4. reject requests where token identity and certificate identity disagree
+5. add rotation and revocation before treating per-node identity as the steady
+   state trust root
+
+Until that path is complete, treat the shared secret as sensitive cluster-wide
+material and rotate it with the same care as an API signing key.
+
+## Preflight Checklist
+
+Before adding a remote node:
+
+1. Confirm the main control plane has `internal_grpc.enabled = true`.
+2. Confirm the remote process uses `server.role = "node"` and a non-`main`
+   `server.node_id`.
+3. Confirm the registered `grpc_target` is reachable from the main process.
+4. Confirm the certificate validates with the configured `tls_server_name`.
+5. Confirm auth `issuer`, `audience`, and `shared_secret` match on both peers.
+6. Confirm clocks are synchronized with NTP or an equivalent time source.
+7. Confirm the remote node's worktree root exists and is inside `safe_paths`.
+
+## Smoke Test
+
+After registration:
+
+1. Create one remote-target agent from the `Agents` page.
+2. Start it and verify the card shows `node:<id>`.
+3. Send a short input and confirm output appears in the main UI.
+4. Confirm the remote node keeps local runtime data while the main control plane
+   keeps the catalog view.
+5. Run a mailbox or Team flow that targets the remote agent and confirm the
+   message is delivered and can be acknowledged.
+6. Retry the same relay delivery in staging and confirm it does not create a
+   duplicate destination mailbox row.
+
+## Related Pages
+
+- [Deployment Overview and Topology](./overview-and-topology.md)
+- [Production Checklist](./production-checklist.md)
+- [Agent Nodes and Remote Execution](../core/agent-nodes.md)

--- a/userdocs/sidebars.js
+++ b/userdocs/sidebars.js
@@ -45,6 +45,7 @@ const sidebars = {
       items: [
         'deployment/overview-and-topology',
         'deployment/production-checklist',
+        'deployment/remote-node-transport',
         'deployment/vercel-static-userdocs',
       ],
     },


### PR DESCRIPTION
## Summary

- documents the remote-node transport posture in the distributed node architecture spec
- adds a user-facing Remote Node Transport deployment page and links it from existing docs
- records the closeout journal and removes the completed P1 TODO item

## Purpose

Close the `P1 Remote-node transport posture` backlog item by making the current deployment contract explicit: dedicated internal `https://` gRPC, relay timestamp/dedupe expectations, future same-port HTTP/gRPC multiplexing direction, and the long-term per-node identity/mTLS path.

## Related Issues

- None

## Testing

```bash
git diff --check
cargo fmt --check
npm --prefix userdocs run build
```

`npm --prefix userdocs run build` completed successfully. Docusaurus printed a local update-check config-store permission warning, which does not affect the generated static files.
