### PR TITLE
feat(message-store): add backend-agnostic storage-tiering foundation crate

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -24,6 +24,7 @@ env:
     //crates/agenthub-logging:agenthub_logging_tests
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
     //crates/agenthub-message-archive:agenthub_message_archive_tests
+    //crates/agenthub-message-store:agenthub_message_store_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests
@@ -40,6 +41,7 @@ env:
     //crates/agenthub-logging:agenthub_logging_tests
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
     //crates/agenthub-message-archive:agenthub_message_archive_tests
+    //crates/agenthub-message-store:agenthub_message_store_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agenthub-message-store"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "zstd",
+]
+
+[[package]]
 name = "agenthub-push"
 version = "0.1.0"
 dependencies = [
@@ -10023,7 +10033,7 @@ dependencies = [
  "encoding_rs_io",
  "glob",
  "log",
- "memmap2 0.9.10",
+ "memmap2",
  "num_cpus",
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/agenthub-db",
     "crates/agenthub-pyroscope",
     "crates/agenthub-message-archive",
+    "crates/agenthub-message-store",
 ]
 exclude = ["cmd/agenthub"]
 

--- a/crates/agenthub-message-store/BUILD.bazel
+++ b/crates/agenthub-message-store/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "agenthub_message_store",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "agenthub_message_store",
+    edition = "2024",
+    aliases = aliases(),
+    deps = all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "agenthub_message_store_tests",
+    crate = ":agenthub_message_store",
+    edition = "2024",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/agenthub-message-store/Cargo.toml
+++ b/crates/agenthub-message-store/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "agenthub-message-store"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+zstd = "0.13"

--- a/crates/agenthub-message-store/src/body_store.rs
+++ b/crates/agenthub-message-store/src/body_store.rs
@@ -1,0 +1,112 @@
+//! The message body store abstraction.
+//!
+//! The body store is keyed by [`AuthorityMessageId`], so one logical message stores exactly one body
+//! even when it fans out to many actors/channels. This is the backend-agnostic boundary the
+//! storage-tiering spec requires: the production backend is RocksDB (compression handled by SST block
+//! compression), but the trait keeps callers and tests independent of it.
+
+use std::collections::BTreeMap;
+
+use thiserror::Error;
+
+use crate::ids::AuthorityMessageId;
+
+#[derive(Debug, Error)]
+pub enum BodyStoreError {
+    #[error("body store backend failure: {0}")]
+    Backend(String),
+}
+
+/// Stores and retrieves message bodies keyed by the canonical logical-message identity.
+pub trait MessageBodyStore {
+    /// Store the body for `id`. Idempotent for a given logical message: a logical message has one
+    /// immutable body, so re-putting the same id is a no-op-equivalent overwrite and never creates a
+    /// second copy.
+    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError>;
+
+    /// Fetch the body for `id`, or `None` if absent.
+    fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError>;
+
+    /// Whether a body exists for `id`.
+    fn contains(&self, id: &AuthorityMessageId) -> bool;
+
+    /// Number of distinct logical-message bodies held.
+    fn len(&self) -> usize;
+
+    /// Whether the store holds no bodies.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// In-memory reference implementation used by tests and as the abstraction's executable contract.
+#[derive(Debug, Default)]
+pub struct InMemoryBodyStore {
+    bodies: BTreeMap<AuthorityMessageId, Vec<u8>>,
+}
+
+impl InMemoryBodyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MessageBodyStore for InMemoryBodyStore {
+    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+        self.bodies.insert(id.clone(), body.to_vec());
+        Ok(())
+    }
+
+    fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
+        Ok(self.bodies.get(id).cloned())
+    }
+
+    fn contains(&self, id: &AuthorityMessageId) -> bool {
+        self.bodies.contains_key(id)
+    }
+
+    fn len(&self) -> usize {
+        self.bodies.len()
+    }
+}
+
+/// A body store wrapper that fails the next `n` writes, used to exercise the outbox replay path.
+#[cfg(test)]
+#[derive(Debug)]
+pub struct FailingBodyStore {
+    inner: InMemoryBodyStore,
+    fail_next: usize,
+}
+
+#[cfg(test)]
+impl FailingBodyStore {
+    pub fn new(fail_next: usize) -> Self {
+        Self {
+            inner: InMemoryBodyStore::new(),
+            fail_next,
+        }
+    }
+}
+
+#[cfg(test)]
+impl MessageBodyStore for FailingBodyStore {
+    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+        if self.fail_next > 0 {
+            self.fail_next -= 1;
+            return Err(BodyStoreError::Backend("injected failure".to_string()));
+        }
+        self.inner.put_body(id, body)
+    }
+
+    fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
+        self.inner.get_body(id)
+    }
+
+    fn contains(&self, id: &AuthorityMessageId) -> bool {
+        self.inner.contains(id)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}

--- a/crates/agenthub-message-store/src/ids.rs
+++ b/crates/agenthub-message-store/src/ids.rs
@@ -1,0 +1,52 @@
+//! Message identity newtypes.
+//!
+//! The storage-tiering contract distinguishes two ids (see
+//! `docs/features/message-storage-tiering.md` and
+//! `docs/features/logical-message-metadata-contract.md`):
+//!
+//! - [`AuthorityMessageId`] is the canonical logical-message identity. There is exactly one body per
+//!   `AuthorityMessageId`, so it is the body-store key.
+//! - [`DeliveryMessageId`] identifies one delivery / fan-out attempt. It labels a delivery index row
+//!   and must never be used as the body key, otherwise fan-out would duplicate a body.
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical logical-message identity. One body per id.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AuthorityMessageId(String);
+
+/// Per-delivery / fan-out id. Identifies a delivery index row, never the body.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DeliveryMessageId(String);
+
+impl AuthorityMessageId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl DeliveryMessageId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Compact presentation hint stored in a delivery index row so ordered list views can render an icon
+/// or summary without fetching the body.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageKind {
+    Text,
+    ToolCall,
+    Event,
+    Thought,
+    System,
+}

--- a/crates/agenthub-message-store/src/keys.rs
+++ b/crates/agenthub-message-store/src/keys.rs
@@ -1,0 +1,79 @@
+//! Delivery-index key encoding and the body key.
+//!
+//! Keys are raw byte strings so that a bytewise (lexicographic) range scan over a prefix returns rows
+//! in chronological order. The ordering guarantee holds *within one prefix* (for example one channel):
+//! the prefix bytes are identical and only the fixed-width [`encode_sort_id`] suffix varies, so
+//! bytewise order equals the authority sequence order.
+//!
+//! `sort_id` is an authority-assigned monotonic sequence, not a wall-clock timestamp: multiple
+//! authority tables (and, later, multiple nodes) cannot rely on clock ordering. It is encoded
+//! big-endian so the byte order matches the numeric order.
+//!
+//! Id components (group/channel/agent/run/actor ids) are treated as opaque tokens that do not contain
+//! the [`SEP`] byte.
+
+use crate::ids::AuthorityMessageId;
+
+/// Separator between key components.
+const SEP: u8 = b'/';
+
+/// Fixed-width, bytewise-order-preserving encoding of an authority sequence.
+pub fn encode_sort_id(seq: u64) -> [u8; 8] {
+    seq.to_be_bytes()
+}
+
+fn join(parts: &[&[u8]], sort_id: Option<[u8; 8]>) -> Vec<u8> {
+    let mut key = Vec::new();
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            key.push(SEP);
+        }
+        key.extend_from_slice(part);
+    }
+    if let Some(sort_id) = sort_id {
+        key.push(SEP);
+        key.extend_from_slice(&sort_id);
+    }
+    key
+}
+
+/// `msg/by_channel/<group_id>/<channel_id>/<sort_id>`
+pub fn channel_key(group_id: &str, channel_id: &str, seq: u64) -> Vec<u8> {
+    join(
+        &[
+            b"msg/by_channel",
+            group_id.as_bytes(),
+            channel_id.as_bytes(),
+        ],
+        Some(encode_sort_id(seq)),
+    )
+}
+
+/// `msg/by_agent/<agent_id>/<sort_id>`
+pub fn agent_key(agent_id: &str, seq: u64) -> Vec<u8> {
+    join(
+        &[b"msg/by_agent", agent_id.as_bytes()],
+        Some(encode_sort_id(seq)),
+    )
+}
+
+/// `msg/by_run/<run_id>/<sort_id>`
+pub fn run_key(run_id: &str, seq: u64) -> Vec<u8> {
+    join(
+        &[b"msg/by_run", run_id.as_bytes()],
+        Some(encode_sort_id(seq)),
+    )
+}
+
+/// `inbox/by_actor/<actor_id>/<sort_id>` — unified chronological inbox across runs.
+pub fn inbox_key(actor_id: &str, seq: u64) -> Vec<u8> {
+    join(
+        &[b"inbox/by_actor", actor_id.as_bytes()],
+        Some(encode_sort_id(seq)),
+    )
+}
+
+/// `body/by_message/<authority_message_id>` — the body key. One body per logical message.
+pub fn body_key(id: &AuthorityMessageId) -> Vec<u8> {
+    join(&[b"body/by_message", id.as_str().as_bytes()], None)
+}

--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -1,0 +1,251 @@
+//! Foundation types for AgentHub message storage tiering.
+//!
+//! This crate is the backend-agnostic core of the storage-tiering design
+//! (`docs/features/message-storage-tiering.md`): the body-free delivery index row
+//! ([`MessageRef`]), the ordered-key encoding ([`keys`]), the body-store abstraction keyed by the
+//! canonical logical-message identity ([`MessageBodyStore`]), and the durability outbox
+//! ([`BodyOutbox`]).
+//!
+//! It intentionally contains no RocksDB dependency. The RocksDB backend (where SST block compression
+//! shrinks bodies at rest) implements [`MessageBodyStore`] in a follow-up, so the native dependency
+//! stays isolated behind this boundary as the spec requires.
+
+pub mod body_store;
+pub mod ids;
+pub mod keys;
+pub mod outbox;
+pub mod reference;
+
+pub use body_store::{BodyStoreError, InMemoryBodyStore, MessageBodyStore};
+pub use ids::{AuthorityMessageId, DeliveryMessageId, MessageKind};
+pub use outbox::BodyOutbox;
+pub use reference::MessageRef;
+
+#[cfg(test)]
+mod tests {
+    use super::body_store::FailingBodyStore;
+    use super::*;
+
+    fn sample_ref() -> MessageRef {
+        MessageRef {
+            message_id: DeliveryMessageId::new("delivery-1"),
+            authority_message_id: AuthorityMessageId::new("auth-1"),
+            archive_document_id: Some("doc-1".to_string()),
+            created_at: 1_700_000_000,
+            source_kind: "team_conversation_messages".to_string(),
+            message_kind: MessageKind::Text,
+            correlation_id: Some("corr-1".to_string()),
+            group_id: None,
+            run_id: Some("run-1".to_string()),
+            conversation_id: Some("conv-1".to_string()),
+            agent_id: None,
+        }
+    }
+
+    #[test]
+    fn sort_id_encoding_preserves_bytewise_order() {
+        // Within one prefix the fixed-width sort_id suffix must sort bytewise the same as numerically.
+        let seqs = [0u64, 1, 2, 255, 256, 65_535, 65_536, u64::MAX - 1, u64::MAX];
+        for window in seqs.windows(2) {
+            let lo = keys::encode_sort_id(window[0]);
+            let hi = keys::encode_sort_id(window[1]);
+            assert!(
+                lo < hi,
+                "encoded {} should sort before {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    fn channel_keys_sort_in_sequence_order_within_a_channel() {
+        let mut keys_in_order: Vec<Vec<u8>> = (0..200u64)
+            .map(|seq| keys::channel_key("group-a", "chan-1", seq))
+            .collect();
+        let expected = keys_in_order.clone();
+        keys_in_order.sort();
+        assert_eq!(
+            keys_in_order, expected,
+            "bytewise sort must match sequence order"
+        );
+    }
+
+    #[test]
+    fn prefixes_do_not_collide_across_namespaces_or_ids() {
+        let channel = keys::channel_key("g", "c", 7);
+        let agent = keys::agent_key("c", 7);
+        let run = keys::run_key("c", 7);
+        let inbox = keys::inbox_key("c", 7);
+        let other_channel = keys::channel_key("g", "c2", 7);
+        let all = [&channel, &agent, &run, &inbox, &other_channel];
+        for (i, a) in all.iter().enumerate() {
+            for (j, b) in all.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "keys for different namespaces/ids must differ");
+                    assert!(
+                        !a.starts_with(b) && !b.starts_with(a),
+                        "no key may be a prefix of another distinct namespace key"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn keys_are_deterministic_across_replay() {
+        assert_eq!(
+            keys::channel_key("g", "c", 42),
+            keys::channel_key("g", "c", 42)
+        );
+        let id = AuthorityMessageId::new("auth-9");
+        assert_eq!(keys::body_key(&id), keys::body_key(&id));
+    }
+
+    #[test]
+    fn body_key_uses_authority_message_id() {
+        let id = AuthorityMessageId::new("auth-xyz");
+        let key = keys::body_key(&id);
+        assert!(key.starts_with(b"body/by_message/"));
+        assert!(key.ends_with(b"auth-xyz"));
+    }
+
+    #[test]
+    fn message_ref_round_trips_and_carries_no_body() {
+        let original = sample_ref();
+        let bytes = original.to_bytes().expect("serialize");
+        let decoded = MessageRef::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(original, decoded);
+        // A representative body string must not leak into the index row encoding.
+        let encoded = String::from_utf8(bytes).unwrap();
+        assert!(!encoded.contains("the full body text"));
+        assert!(!encoded.contains("\"body\""));
+    }
+
+    #[test]
+    fn fan_out_stores_one_body_per_authority_message() {
+        // One logical message delivered to three actors -> three index rows, one body.
+        let authority = AuthorityMessageId::new("auth-fanout");
+        let body = b"shared meeting summary body";
+        let mut store = InMemoryBodyStore::new();
+
+        for actor in ["actor-a", "actor-b", "actor-c"] {
+            // Each delivery row references the same authority id.
+            let _row = MessageRef {
+                message_id: DeliveryMessageId::new(format!("delivery-{actor}")),
+                authority_message_id: authority.clone(),
+                ..sample_ref()
+            };
+            store.put_body(&authority, body).expect("put");
+        }
+
+        assert_eq!(store.len(), 1, "fan-out must not duplicate the body");
+        assert_eq!(
+            store.get_body(&authority).unwrap().as_deref(),
+            Some(&body[..])
+        );
+    }
+
+    #[test]
+    fn outbox_stages_inside_authority_then_drains_to_store() {
+        let id = AuthorityMessageId::new("auth-drain");
+        let body = b"durable body";
+        let mut outbox = BodyOutbox::new();
+        let mut store = InMemoryBodyStore::new();
+
+        outbox.stage(&id, body);
+        assert_eq!(outbox.pending_len(), 1);
+        assert!(!store.contains(&id));
+
+        let confirmed = outbox.drain_into(&mut store);
+        assert_eq!(confirmed, 1);
+        assert!(outbox.is_empty(), "confirmed bodies leave the outbox");
+        assert_eq!(store.get_body(&id).unwrap().as_deref(), Some(&body[..]));
+    }
+
+    #[test]
+    fn body_survives_store_failure_and_is_recovered_by_replay() {
+        // Simulate a cf_body write failure after the authority commit: the body stays in the outbox
+        // and a later drain recovers it. No body is lost.
+        let id = AuthorityMessageId::new("auth-replay");
+        let body = b"body that must not be lost";
+        let mut outbox = BodyOutbox::new();
+        let mut store = FailingBodyStore::new(1); // first write fails
+
+        outbox.stage(&id, body);
+        let confirmed = outbox.drain_into(&mut store);
+        assert_eq!(confirmed, 0, "the failing write confirms nothing");
+        assert!(
+            outbox.contains(&id),
+            "the body stays pending after a failed write"
+        );
+        assert_eq!(store.len(), 0);
+
+        // Retry (e.g. background drainer after a crash) succeeds.
+        let confirmed = outbox.drain_into(&mut store);
+        assert_eq!(confirmed, 1);
+        assert!(outbox.is_empty());
+        assert_eq!(store.get_body(&id).unwrap().as_deref(), Some(&body[..]));
+    }
+
+    // --- Compression validation -------------------------------------------------------------------
+    //
+    // The storage-tiering pivot (design B) puts bodies in RocksDB so SST *block* compression shrinks
+    // them. The key claim is that aggregating many short chat messages into a block compresses far
+    // better than compressing each short message on its own. These tests validate that premise on a
+    // representative chat corpus using the same zstd algorithm RocksDB would use, so the expected
+    // win is measured rather than assumed.
+
+    fn chat_corpus() -> Vec<String> {
+        // Realistic, repetitive chat-like traffic: short human/agent lines and small tool-call JSON.
+        let speakers = ["alice", "bob", "agent-claude", "agent-codex"];
+        let phrases = [
+            "Can you take a look at the failing test in the storage module?",
+            "Sure, I'll check the dual-write path and report back.",
+            "The transcript looks good, shipping the change now.",
+            "Please rebase onto main and re-run the bazel crate tests.",
+            "Done. CI is green and the PR is ready for review.",
+        ];
+        let mut out = Vec::new();
+        for i in 0..60u32 {
+            let speaker = speakers[(i as usize) % speakers.len()];
+            let phrase = phrases[(i as usize) % phrases.len()];
+            out.push(format!(
+                "{{\"speaker\":\"{speaker}\",\"seq\":{i},\"text\":\"{phrase}\"}}"
+            ));
+        }
+        out
+    }
+
+    fn zstd_len(bytes: &[u8]) -> usize {
+        zstd::bulk::compress(bytes, 3).expect("zstd compress").len()
+    }
+
+    #[test]
+    fn block_aggregated_compression_beats_per_message_and_raw() {
+        let corpus = chat_corpus();
+        let raw_total: usize = corpus.iter().map(|m| m.len()).sum();
+
+        // Per-message: compress each short message independently (no cross-message context).
+        let per_message_total: usize = corpus.iter().map(|m| zstd_len(m.as_bytes())).sum();
+
+        // Block-aggregated: concatenate then compress once, the way an SST data block shares context
+        // across many small records.
+        let aggregated = corpus.join("\n");
+        let aggregated_total = zstd_len(aggregated.as_bytes());
+
+        // Block aggregation must beat per-message compression, and must shrink the raw bytes.
+        assert!(
+            aggregated_total < per_message_total,
+            "block-aggregated ({aggregated_total}) must beat per-message ({per_message_total})"
+        );
+        assert!(
+            aggregated_total < raw_total,
+            "block-aggregated ({aggregated_total}) must shrink raw ({raw_total})"
+        );
+
+        // Conservative floor on the realized saving for this repetitive chat corpus.
+        let ratio = aggregated_total as f64 / raw_total as f64;
+        assert!(ratio < 0.6, "expected >40% saving, got ratio {ratio:.3}");
+    }
+}

--- a/crates/agenthub-message-store/src/outbox.rs
+++ b/crates/agenthub-message-store/src/outbox.rs
@@ -1,0 +1,62 @@
+//! The SQLite-staged body outbox.
+//!
+//! The body is primary data. To keep it durable across the window between the authority commit and the
+//! body store's durable ack, the write path stages the body in this outbox *inside* the authority
+//! transaction. A background drain moves staged bodies into the body store and only clears an outbox
+//! row once the store durably acknowledges it. So a body store write failure (or a crash mid-write)
+//! never loses a body: it survives in the outbox until a later drain succeeds.
+//!
+//! This type models that staging/drain contract. The production backing is a SQLite table
+//! (`message_body_outbox`); this in-memory model is the executable contract and the test double.
+
+use std::collections::BTreeMap;
+
+use crate::body_store::MessageBodyStore;
+use crate::ids::AuthorityMessageId;
+
+/// Bodies staged but not yet confirmed in the body store.
+#[derive(Debug, Default)]
+pub struct BodyOutbox {
+    pending: BTreeMap<AuthorityMessageId, Vec<u8>>,
+}
+
+impl BodyOutbox {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stage a body for `id`. Called inside the authority transaction. Idempotent per logical message.
+    pub fn stage(&mut self, id: &AuthorityMessageId, body: &[u8]) {
+        self.pending.insert(id.clone(), body.to_vec());
+    }
+
+    /// Number of bodies awaiting confirmation in the body store.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Whether `id` is still awaiting confirmation.
+    pub fn contains(&self, id: &AuthorityMessageId) -> bool {
+        self.pending.contains_key(id)
+    }
+
+    /// Drain pending bodies into `store`. Each body is written to the store; an outbox row is removed
+    /// only when its write succeeds (durable ack). A failed write leaves the row pending for a later
+    /// retry, so no body is lost. Returns the number of bodies confirmed in this drain.
+    pub fn drain_into<S: MessageBodyStore>(&mut self, store: &mut S) -> usize {
+        let mut confirmed = Vec::new();
+        for (id, body) in &self.pending {
+            if store.put_body(id, body).is_ok() {
+                confirmed.push(id.clone());
+            }
+        }
+        for id in &confirmed {
+            self.pending.remove(id);
+        }
+        confirmed.len()
+    }
+}

--- a/crates/agenthub-message-store/src/reference.rs
+++ b/crates/agenthub-message-store/src/reference.rs
@@ -1,0 +1,44 @@
+//! The body-free delivery index row.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{AuthorityMessageId, DeliveryMessageId, MessageKind};
+
+/// A compact, body-free row stored in the delivery index.
+///
+/// It carries enough metadata to render an ordered list without fetching the body, plus the
+/// [`AuthorityMessageId`] needed to locate the body in the body store. By construction it has no body
+/// field: full bodies live only in the body store.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageRef {
+    /// Per-delivery id for this index row.
+    pub message_id: DeliveryMessageId,
+    /// Canonical logical-message identity; the body-store key.
+    pub authority_message_id: AuthorityMessageId,
+    /// Optional pointer to the LanceDB archive document.
+    pub archive_document_id: Option<String>,
+    /// Authority-assigned creation time (epoch).
+    pub created_at: i64,
+    /// Origin of the row, e.g. `team_conversation_messages`.
+    pub source_kind: String,
+    /// Presentation hint for list rendering.
+    pub message_kind: MessageKind,
+    pub correlation_id: Option<String>,
+    pub group_id: Option<String>,
+    pub run_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub agent_id: Option<String>,
+}
+
+impl MessageRef {
+    /// Serialize for storage. The encoding is deliberately behind this method so the physical format
+    /// can be made more compact later without changing call sites.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize a stored row.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+}

--- a/docs/journal/2026-06-10-message-store-foundation-crate.md
+++ b/docs/journal/2026-06-10-message-store-foundation-crate.md
@@ -1,0 +1,58 @@
+# Summary
+
+Added `agenthub-message-store`, the backend-agnostic foundation crate for the message storage-tiering
+design (compress chat/message bodies by moving them into RocksDB). This is the first implementation
+step toward [features/message-storage-tiering.md](../features/message-storage-tiering.md); it carries
+no RocksDB dependency yet.
+
+# Background
+
+The storage-tiering spec pivoted to "design B": message bodies move out of SQLite authority rows into a
+RocksDB body store (`cf_body`) where SST block compression shrinks them, while a body-free delivery
+index (`cf_index`) keeps ordered reads cheap. RocksDB is a native C++ dependency that needs separate
+Bazel `crate.annotation` wiring (like `aws-lc-sys`/`v8`) plus cross-compiled release coverage, so the
+spec requires isolating it behind a backend boundary. This crate establishes that boundary first.
+
+# Scope
+
+- New workspace crate `crates/agenthub-message-store` (Cargo + Bazel `BUILD.bazel`), registered in the
+  Bazel crate test/coverage target lists.
+- `ids`: `AuthorityMessageId` (canonical logical-message identity, the body key) vs `DeliveryMessageId`
+  (per-delivery/fan-out id), plus `MessageKind`.
+- `keys`: authority-assigned monotonic `sort_id` encoded big-endian (bytewise-order-preserving), and the
+  ordered index key builders (`msg/by_channel`, `msg/by_agent`, `msg/by_run`, `inbox/by_actor`) plus the
+  `body/by_message/<authority_message_id>` body key.
+- `reference`: `MessageRef`, the body-free delivery index row, with `to_bytes`/`from_bytes`.
+- `body_store`: `MessageBodyStore` trait keyed by `AuthorityMessageId` (one body per logical message) and
+  an `InMemoryBodyStore` reference implementation.
+- `outbox`: `BodyOutbox`, the SQLite-staged durability outbox — stage inside the authority transaction,
+  drain into the store, clear only on durable ack, so a store-write failure or crash never loses a body.
+
+# Key Decisions
+
+- Key the body store by `authority_message_id`, not `message_id`, so fan-out to multiple actors stores
+  exactly one body (matches the review fix on the spec).
+- `sort_id` is an authority-assigned monotonic sequence, not a wall-clock timestamp, so ordering stays
+  stable across authority tables and (later) nodes.
+- Keep this crate free of RocksDB; the RocksDB backend implements `MessageBodyStore` in a follow-up PR
+  where the native dependency and Bazel wiring are handled.
+- Validate the compression premise in-crate with a test that measures zstd on a representative chat
+  corpus, showing block-aggregated compression (what RocksDB SST does) beats per-message compression on
+  short chat lines.
+
+# Validation
+
+- `cargo test -p agenthub-message-store` (10 tests): sort_id bytewise ordering, channel-key sequence
+  ordering, prefix non-collision, deterministic/replayable keys, body key = authority id, `MessageRef`
+  round-trip + body-free, fan-out one-body-per-message, outbox stage/drain, outbox failure replay, and
+  the block-vs-per-message compression-ratio check.
+- `cargo fmt -p agenthub-message-store -- --check` and `cargo clippy -p agenthub-message-store
+  --all-targets` are clean.
+- Bazel: `//crates/agenthub-message-store:agenthub_message_store_tests` added to `bazel.yml`
+  crate-test and coverage target lists.
+
+# Follow-Up
+
+- Implement the RocksDB backend of `MessageBodyStore` (`cf_body` + `cf_index`) behind a feature flag,
+  with SST zstd + bottommost zstd, plus the dual-body migration write path. Tracked in
+  [todo.md](../todo.md) under Message Storage.


### PR DESCRIPTION
## Summary

First implementation step for `docs/features/message-storage-tiering.md` — the goal is **compressing chat/message bodies at rest** by moving them into RocksDB. This PR adds the backend-agnostic foundation crate `agenthub-message-store`; it has **no RocksDB dependency**.

RocksDB is a native C++ dep that needs separate Bazel `crate.annotation` wiring (like `aws-lc-sys`/`v8`) plus cross-compiled release coverage, and the spec requires isolating it behind a backend boundary. This crate establishes that boundary so the RocksDB backend can land as a focused follow-up.

## What's here

- **`ids`** — `AuthorityMessageId` (canonical logical-message identity = the body key) vs `DeliveryMessageId` (per-delivery/fan-out id); `MessageKind`.
- **`keys`** — authority-assigned monotonic `sort_id` encoded big-endian (bytewise-order-preserving), ordered index key builders, and the `body/by_message/<authority_message_id>` body key.
- **`reference`** — `MessageRef`, the body-free delivery index row.
- **`body_store`** — `MessageBodyStore` trait keyed by `AuthorityMessageId` (one body per logical message, so fan-out never duplicates) + `InMemoryBodyStore`.
- **`outbox`** — `BodyOutbox`: stage the body inside the authority transaction, drain into the store, clear only on durable ack — so a store-write failure or a crash never loses a body.

## Tests

`cargo test -p agenthub-message-store` — 10 tests green; `cargo fmt --check` and `cargo clippy --all-targets` clean. Covers sort_id ordering, key prefix non-collision/determinism, body-free `MessageRef` round-trip, fan-out one-body-per-message, outbox stage/drain, body-survives-failure replay, and a block-vs-per-message zstd compression check on a chat corpus. Bazel target wired into `bazel.yml`. Journal added.

## Scope / non-goals

No RocksDB, no SQLite write-path changes, no migration — those are the next PR (RocksDB backend implementing `MessageBodyStore` with `cf_body`/`cf_index` + SST zstd, behind a feature flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)