### PR TITLE
feat(acp): add generic codex adapter

### DIFF
--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build agenthub-acp (cross)
         if: matrix.cross
         run: |
-          cross build --locked --release --target ${{ matrix.target }} -p agenthub-acp-adapter
+          cross build --locked --release --target ${{ matrix.target }} -p agenthub-acp-adapter --features release-vendored-openssl
 
       - name: Package
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build agenthub-acp (cross)
         if: matrix.cross
         run: |
-          cross build --locked --release --target ${{ matrix.target }} -p agenthub-acp-adapter
+          cross build --locked --release --target ${{ matrix.target }} -p agenthub-acp-adapter --features release-vendored-openssl
 
       - name: Package
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,11 @@ dependencies = [
 name = "agenthub-acp-adapter"
 version = "0.1.0"
 dependencies = [
+ "agenthub-codex-acp",
  "anyhow",
  "clap",
  "claude-code-acp-rs",
+ "codex-utils-cli",
  "tokio",
 ]
 

--- a/agenthub-codex-acp/README.md
+++ b/agenthub-codex-acp/README.md
@@ -6,8 +6,14 @@ permissions, commands, plans, modes, and MCP servers.
 
 ## Usage
 
-Select `agenthub-codex-acp` as the command in the AgentHub create page.
-You can also run it directly:
+For new AgentHub agents, prefer the generic adapter command:
+
+```
+agenthub-acp codex
+```
+
+This compatibility binary remains supported for existing configurations and can
+still be run directly:
 
 ```
 agenthub-codex-acp

--- a/crates/agenthub-acp-adapter/BUILD.bazel
+++ b/crates/agenthub-acp-adapter/BUILD.bazel
@@ -10,7 +10,9 @@ rust_library(
     crate_root = "src/lib.rs",
     edition = "2024",
     aliases = aliases(),
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(normal = True) + [
+        "//agenthub-codex-acp:agenthub_codex_acp",
+    ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
 )
 
@@ -34,6 +36,8 @@ rust_test(
         normal_dev = True,
         proc_macro_dev = True,
     ),
-    deps = all_crate_deps(normal_dev = True),
+    deps = all_crate_deps(normal_dev = True) + [
+        "//agenthub-codex-acp:agenthub_codex_acp",
+    ],
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -17,10 +17,16 @@ name = "agenthub_acp_adapter"
 path = "src/lib.rs"
 
 [dependencies]
+agenthub-codex-acp = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.137.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+
+[features]
+default = []
+release-vendored-openssl = ["agenthub-codex-acp/release-vendored-openssl"]
 
 [lints.rust]
 let-underscore = "warn"

--- a/crates/agenthub-acp-adapter/src/lib.rs
+++ b/crates/agenthub-acp-adapter/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 use claude_code_acp::Cli as UpstreamCli;
+use codex_utils_cli::CliConfigOverrides;
 
 const UPSTREAM_DEFAULT_OTEL_SERVICE_NAME: &str = "claude-code-acp-rs";
 const AGENTHUB_OTEL_SERVICE_NAME: &str = "agenthub-acp";
@@ -16,8 +17,18 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum ProviderCommand {
+    /// Run Codex through AgentHub's ACP server mode.
+    Codex(CodexCli),
+
     /// Run Claude Code through ACP server mode.
     Claude(ClaudeCli),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct CodexCli {
+    /// Override a Codex configuration value, using the same key=value format as codex -c.
+    #[arg(short = 'c', long = "config", value_name = "key=value", action = clap::ArgAction::Append)]
+    pub config_overrides: Vec<String>,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -55,6 +66,14 @@ pub struct ClaudeCli {
     pub otel_service_name: String,
 }
 
+impl From<CodexCli> for CliConfigOverrides {
+    fn from(cli: CodexCli) -> Self {
+        Self {
+            raw_overrides: cli.config_overrides,
+        }
+    }
+}
+
 impl From<ClaudeCli> for UpstreamCli {
     fn from(cli: ClaudeCli) -> Self {
         let diagnostic = cli.diagnostic || cli.log_dir.is_some() || cli.log_file.is_some();
@@ -74,6 +93,10 @@ impl From<ClaudeCli> for UpstreamCli {
 
 pub async fn run_with_cli(cli: Cli) -> anyhow::Result<()> {
     match cli.provider {
+        ProviderCommand::Codex(codex) => {
+            agenthub_codex_acp::run_main(None, CliConfigOverrides::from(codex)).await?;
+            Ok(())
+        }
         ProviderCommand::Claude(claude) => {
             let upstream_cli = UpstreamCli::from(claude);
             claude_code_acp::run_acp_with_cli(&upstream_cli).await
@@ -98,10 +121,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn maps_codex_config_overrides() {
+        let Cli {
+            provider: ProviderCommand::Codex(codex),
+        } = Cli::parse_from([
+            "agenthub-acp",
+            "codex",
+            "-c",
+            "model=gpt-5",
+            "--config",
+            "sandbox_mode=workspace-write",
+        ])
+        else {
+            panic!("expected codex provider");
+        };
+        let overrides = CliConfigOverrides::from(codex);
+        assert_eq!(
+            overrides.raw_overrides,
+            vec![
+                "model=gpt-5".to_string(),
+                "sandbox_mode=workspace-write".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn maps_to_upstream_acp_mode() {
         let Cli {
             provider: ProviderCommand::Claude(claude),
-        } = Cli::parse_from(["agenthub-acp", "claude"]);
+        } = Cli::parse_from(["agenthub-acp", "claude"])
+        else {
+            panic!("expected claude provider");
+        };
         let upstream = UpstreamCli::from(claude);
         assert!(upstream.acp);
         assert!(upstream.prompt.is_none());
@@ -112,7 +163,10 @@ mod tests {
     fn keeps_upstream_acp_flag_compatible() {
         let Cli {
             provider: ProviderCommand::Claude(claude),
-        } = Cli::parse_from(["agenthub-acp", "claude", "--acp"]);
+        } = Cli::parse_from(["agenthub-acp", "claude", "--acp"])
+        else {
+            panic!("expected claude provider");
+        };
         let upstream = UpstreamCli::from(claude);
         assert!(upstream.acp);
         assert!(upstream.prompt.is_none());
@@ -136,7 +190,10 @@ mod tests {
             "http://localhost:4317",
             "--otel-service-name",
             "custom-claude",
-        ]);
+        ])
+        else {
+            panic!("expected claude provider");
+        };
         let upstream = UpstreamCli::from(claude);
         assert!(upstream.acp);
         assert!(upstream.diagnostic);
@@ -163,7 +220,10 @@ mod tests {
             "claude",
             "--log-dir",
             "/tmp/agenthub-claude",
-        ]);
+        ])
+        else {
+            panic!("expected claude provider");
+        };
         let upstream = UpstreamCli::from(claude);
         assert!(upstream.diagnostic);
         assert_eq!(
@@ -173,7 +233,10 @@ mod tests {
 
         let Cli {
             provider: ProviderCommand::Claude(claude),
-        } = Cli::parse_from(["agenthub-acp", "claude", "--log-file", "claude.log"]);
+        } = Cli::parse_from(["agenthub-acp", "claude", "--log-file", "claude.log"])
+        else {
+            panic!("expected claude provider");
+        };
         let upstream = UpstreamCli::from(claude);
         assert!(upstream.diagnostic);
         assert_eq!(upstream.log_file, Some("claude.log".to_string()));

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -63,11 +63,12 @@ ACP runtime concerns should stay split across three orthogonal layers:
 
 Codex and Claude are special cases inside the provider adapter layer:
 
-- `agenthub-codex-acp` uses the upstream Codex app-server/thread protocol internally, but
-  AgentHub's main process and web surfaces should continue to consume ACP requests, ACP
-  notifications, and AgentHub-normalized ACP event JSON as the stable boundary. Codex-native state
-  may be exposed only through explicit diagnostics metadata, not by making the primary runtime path
-  Codex-specific.
+- `agenthub-acp codex` is AgentHub's canonical distributed Codex ACP adapter path. It reuses the
+  same adapter implementation as the compatibility `agenthub-codex-acp` binary, which uses the
+  upstream Codex app-server/thread protocol internally. AgentHub's main process and web surfaces
+  should continue to consume ACP requests, ACP notifications, and AgentHub-normalized ACP event JSON
+  as the stable boundary. Codex-native state may be exposed only through explicit diagnostics
+  metadata, not by making the primary runtime path Codex-specific.
 - `agenthub-acp claude` is AgentHub's distributed Claude ACP adapter path. It wraps the Rust
   `claude-code-acp-rs` library and always starts ACP server mode for AgentHub-managed sessions,
   while still leaving Claude credentials and model settings in the adapter-supported Anthropic
@@ -212,6 +213,10 @@ ACP permission requests are first-class runtime records:
   not an abort/cancel outcome.
 - Gemini/Kimi/Claude ACP presets should preserve session clear and provider-specific defaults without regressing core ACP flow.
 - Gemini CLI bootstrap should track the current upstream ACP contract (`gemini --acp`) while continuing to tolerate the legacy `--experimental-acp` flag in provider detection for backward compatibility.
+- Codex ACP support has a canonical AgentHub-distributed command: `agenthub-acp codex`.
+  Compatibility detection still recognizes `agenthub-codex-acp` and `codex-acp` as Codex ACP
+  runtimes, and releases must keep packaging `agenthub-codex-acp` until a reviewed deprecation
+  window completes.
 - Claude ACP support has a canonical AgentHub-distributed command: `agenthub-acp claude`.
   Compatibility detection still recognizes `claude-agent-acp` as an ACP runtime directly, and
   recognizes `claude-code-acp-rs` only when launched with `--acp` so headless or diagnostic Claude
@@ -229,6 +234,8 @@ ACP permission requests are first-class runtime records:
 - `pnpm -C web run lint`
 - `pnpm -C web run build`
 - `pnpm -C web exec vitest run src/acp_panel.test.tsx src/acp_debug.test.tsx src/acp_conversation_render.test.tsx src/acp_conversation.interaction.test.tsx src/hooks/use_acp_conversation.test.ts`
+- `cargo check -p agenthub-acp-adapter`
+- `cargo test -p agenthub-acp-adapter`
 - `cargo check -p agenthub-codex-acp`
 - `cargo test -p agenthub-codex-acp`
 - Focused `agenthub-codex-acp` tests for live-turn tool-call completeness:
@@ -266,19 +273,20 @@ ACP permission requests are first-class runtime records:
 - Keep ACP contracts provider-agnostic at system boundary; isolate provider drift in adapter modules.
 - Prefer additive compatibility changes when protocol evolves.
 - AgentHub owns Codex subagent enablement through `codex_acp.multi_agent_enabled` (default
-  `true`). When launching `agenthub-codex-acp`, AgentHub should pass an explicit
+  `true`). When launching Codex ACP through `agenthub-acp codex`, `agenthub-codex-acp`, or another
+  recognized Codex ACP command, AgentHub should pass an explicit
   `AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED=1|0` child-process env override so ACP sessions expose
-  Codex `Feature::Collab` deterministically without depending on per-user
-  `~/.codex/config.toml` toggles.
+  Codex `Feature::Collab` deterministically without depending on per-user `~/.codex/config.toml`
+  toggles.
 - `agenthub-acp` should materialize AgentHub-managed Codex skills under
   `~/.agents/skills/agenthub-runtime/.../SKILL.md` during ACP session bootstrap, then inject those
-  file-backed skills through ACP `<skill>` wrappers so `agenthub-codex-acp` can translate them into
+  file-backed skills through ACP `<skill>` wrappers so the Codex adapter can translate them into
   native Codex `UserInput::Skill` items.
 - Global managed-skill paths should stay on the home-rooted forms only: canonical absolute paths,
   with `~/...` accepted as a compatibility spelling before translation. Repo-local
   `<workdir>/.agents/skills/**/SKILL.md` remains an independent discovery path and should not be
   rewritten into the managed global namespace.
-- `agenthub-codex-acp` must keep ACP request/response I/O alive on a dedicated runtime thread so
+- The Codex ACP adapter must keep ACP request/response I/O alive on a dedicated runtime thread so
   ACP-backed filesystem reads can safely round-trip while tool handlers synchronously verify or
   patch existing files.
 - Dynamic actor runtime fields such as `team_id`, `current_run_id`, and continuity summaries should
@@ -341,3 +349,4 @@ ACP permission requests are first-class runtime records:
 - `docs/journal/2026-05-15-codex-acp-prompt-steering.md`
 - `docs/journal/2026-06-03-acp-provider-metadata-allowlist.md`
 - `docs/journal/2026-06-10-claude-acp-provider-support.md`
+- `docs/journal/2026-06-11-generic-codex-acp-entrypoint.md`

--- a/docs/journal/2026-06-10-claude-acp-provider-support.md
+++ b/docs/journal/2026-06-10-claude-acp-provider-support.md
@@ -47,9 +47,9 @@ copying provider implementation code into AgentHub.
   files.
 - The adapter depends on the published `claude-code-acp-rs` library with default features disabled,
   avoiding a build-time bundled-Claude-CLI copy step in AgentHub's default Cargo/Bazel graph.
-- `agenthub-codex-acp` remains as the compatibility Codex entrypoint for this rollout. A future
-  follow-up can add `agenthub-acp codex` once the Codex adapter CLI can be folded without breaking
-  existing configs.
+- `agenthub-codex-acp` remains as the compatibility Codex entrypoint for this rollout. The
+  follow-up `agenthub-acp codex` path is tracked in
+  [2026-06-11-generic-codex-acp-entrypoint.md](2026-06-11-generic-codex-acp-entrypoint.md).
 
 ## Validation
 

--- a/docs/journal/2026-06-11-generic-codex-acp-entrypoint.md
+++ b/docs/journal/2026-06-11-generic-codex-acp-entrypoint.md
@@ -1,0 +1,54 @@
+# Generic Codex ACP Entrypoint
+
+## Summary
+
+AgentHub now supports `agenthub-acp codex` as the canonical Codex ACP adapter command while keeping
+`agenthub-codex-acp` packaged and recognized for existing configurations. The generic adapter
+entrypoint dispatches to the same AgentHub Codex ACP implementation, so the provider boundary stays
+ACP JSON-RPC over the child process stream and does not fork Codex runtime behavior.
+
+## Background
+
+`agenthub-acp claude` introduced the provider-selected adapter binary. Codex still used the older
+dedicated binary as the default preset, leaving the generic adapter incomplete and forcing operators
+to remember provider-specific binary names. This rollout folds Codex into the generic command
+without removing the compatibility binary.
+
+## Scope
+
+- Add an `agenthub-acp codex` subcommand that forwards Codex `-c/--config key=value` overrides.
+- Detect `agenthub-acp codex` as the Codex provider in the backend and web UI.
+- Keep `agenthub-codex-acp` and `codex-acp` as recognized compatibility commands.
+- Change the default Codex web preset to `agenthub-acp codex`.
+- Keep release packaging for both `agenthub-acp` and `agenthub-codex-acp`.
+- Carry Codex release-only vendored OpenSSL through the `agenthub-acp-adapter` cross build.
+
+## Key Decisions
+
+- The generic command reuses `agenthub_codex_acp::run_main` instead of moving Codex protocol logic
+  into the generic adapter crate.
+- The compatibility `agenthub-codex-acp` binary remains the path that owns upstream Codex `arg0`
+  dispatch behavior. `agenthub-acp codex` is the AgentHub-managed adapter entrypoint.
+- AgentHub must not rewrite `agenthub-acp codex` to `codex_acp.binary`; that override remains for
+  legacy or custom Codex ACP commands.
+- `agenthub-codex-acp` stays in release artifacts until a later reviewed deprecation window.
+
+## Validation
+
+Focused checks:
+
+```bash
+cargo test -p agenthub-acp-adapter
+cargo check -p agenthub-acp-adapter
+cargo test acp_provider_for_agent_requires_expected_args -- --nocapture
+npm --prefix web run test -- src/agent_presets.test.ts src/components/agent_node_detail_shared.test.ts
+npm --prefix web run build
+npm --prefix userdocs run build
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Run real long-session smoke coverage for Codex and non-Codex ACP providers under the existing
+  long-session browser verification TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,7 +43,6 @@ Stable contracts:
 Matrix to keep current across real long-running Codex and non-Codex sessions:
 
 - [ ] `P1` Verify deployed ACP long-session browser behavior under real long output histories: the shipped stick-to-bottom, permission-history jump/copy, stale-session `send input` recovery, debug/runtime-metrics surfaces, and provider session switching should stay stable during real Codex and non-Codex sessions.
-- [ ] `P1` Fold Codex into the generic ACP adapter entrypoint: add `agenthub-acp codex` without breaking existing `agenthub-codex-acp` configs, migrate defaults/docs only after parity validation, and keep `package_binary "agenthub-codex-acp"` until a reviewed deprecation window completes. Stable contract: [features/acp-runtime.md](features/acp-runtime.md); rollout context: [journal/2026-06-10-claude-acp-provider-support.md](journal/2026-06-10-claude-acp-provider-support.md).
 - [ ] `P2` Provider-driven config selectors: verify real Gemini and Kimi ACP sessions end to end so upstream `config_options` render `mode`/`model` controls, `Set Model` / `Set Mode` works without manual ID entry, and selected values remain stable across reconnects.
 - [ ] `P2` Polish ACP-native Codex `request_user_input` UX after the inline card rollout: cover richer note-entry flows in browser-level fixtures and decide whether pending questions should bypass prompt-text serialization entirely.
 

--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -80,7 +80,7 @@ impl AgentManager {
             return command.to_string();
         }
         let configured = &self.codex_acp_binary;
-        if configured == command {
+        if !should_use_configured_codex_binary(configured, command) {
             return command.to_string();
         }
         let configured_path = Path::new(configured);
@@ -142,9 +142,18 @@ pub(super) fn acp_provider_spec_for_agent_with_binary(
 
 fn agenthub_acp_provider_spec_for_args(args: &[String]) -> Option<AcpProviderSpec> {
     match args.first().map(|arg| arg.as_str()) {
+        Some("codex") => Some(AcpProviderSpec::CODEX),
         Some("claude") => Some(AcpProviderSpec::CLAUDE),
         _ => None,
     }
+}
+
+fn should_use_configured_codex_binary(codex_acp_binary: &str, command: &str) -> bool {
+    if command == codex_acp_binary {
+        return false;
+    }
+    let command_name = Path::new(command).file_name().and_then(|n| n.to_str());
+    command_name != Some("agenthub-acp")
 }
 
 pub(super) fn default_env_for_acp_provider(
@@ -203,6 +212,7 @@ mod tests {
     use super::{
         ACP_PROVIDER_CODEX, AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED_ENV, AcpProviderSpec,
         acp_provider_spec_for_agent_with_binary, default_env_for_acp_provider,
+        should_use_configured_codex_binary,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -240,6 +250,22 @@ mod tests {
         );
         assert_ne!(provider.map(|spec| spec.id), Some(ACP_PROVIDER_CODEX));
         assert!(default_env_for_acp_provider(provider, true).is_empty());
+    }
+
+    #[test]
+    fn generic_codex_adapter_does_not_resolve_to_legacy_configured_binary() {
+        assert!(!should_use_configured_codex_binary(
+            "/opt/agenthub/bin/agenthub-codex-acp",
+            "agenthub-acp"
+        ));
+        assert!(!should_use_configured_codex_binary(
+            "/opt/agenthub/bin/agenthub-codex-acp",
+            "/usr/local/bin/agenthub-acp"
+        ));
+        assert!(should_use_configured_codex_binary(
+            "/opt/agenthub/bin/agenthub-codex-acp",
+            "codex-acp"
+        ));
     }
 
     #[test]

--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -105,7 +105,7 @@ pub(super) fn acp_provider_spec_for_agent_with_binary(
     command: &str,
     args: &[String],
 ) -> Option<AcpProviderSpec> {
-    let command_name = Path::new(command).file_name().and_then(|n| n.to_str());
+    let command_name = command_executable_name(command);
     if command_name == Some("agenthub-acp") {
         return agenthub_acp_provider_spec_for_args(args);
     }
@@ -152,7 +152,7 @@ fn should_use_configured_codex_binary(codex_acp_binary: &str, command: &str) -> 
     if command == codex_acp_binary {
         return false;
     }
-    let command_name = Path::new(command).file_name().and_then(|n| n.to_str());
+    let command_name = command_executable_name(command);
     command_name != Some("agenthub-acp")
 }
 
@@ -186,16 +186,14 @@ fn acp_provider_for_command_with_binary(
     if command == codex_acp_binary {
         return Some(AcpProviderSpec::CODEX);
     }
-    let command_name = Path::new(command).file_name().and_then(|n| n.to_str())?;
+    let command_name = command_executable_name(command)?;
     match command_name {
         "gemini" => Some(AcpProviderSpec::GEMINI),
         "kimi" => Some(AcpProviderSpec::KIMI),
         "claude-agent-acp" | "claude-code-acp-rs" => Some(AcpProviderSpec::CLAUDE),
         "agenthub-codex-acp" | "codex-acp" => Some(AcpProviderSpec::CODEX),
         name => {
-            let target_name = Path::new(codex_acp_binary)
-                .file_name()
-                .and_then(|n| n.to_str());
+            let target_name = command_executable_name(codex_acp_binary);
             if target_name == Some(name) {
                 Some(AcpProviderSpec::CODEX)
             } else {
@@ -203,6 +201,14 @@ fn acp_provider_for_command_with_binary(
             }
         }
     }
+}
+
+fn command_executable_name(command: &str) -> Option<&str> {
+    let name = command.rsplit(['/', '\\']).next()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.strip_suffix(".exe").unwrap_or(name))
 }
 
 #[cfg(test)]
@@ -261,6 +267,10 @@ mod tests {
         assert!(!should_use_configured_codex_binary(
             "/opt/agenthub/bin/agenthub-codex-acp",
             "/usr/local/bin/agenthub-acp"
+        ));
+        assert!(!should_use_configured_codex_binary(
+            r"C:\agenthub\agenthub-codex-acp.exe",
+            r"C:\agenthub\agenthub-acp.exe"
         ));
         assert!(should_use_configured_codex_binary(
             "/opt/agenthub/bin/agenthub-codex-acp",

--- a/src/agent/manager/tests.rs
+++ b/src/agent/manager/tests.rs
@@ -346,6 +346,10 @@ fn acp_provider_for_agent_requires_expected_args() {
         Some(ACP_PROVIDER_CLAUDE)
     );
     assert_eq!(
+        acp_provider_for_agent_with_binary(codex_bin, "agenthub-acp", &["codex".to_string()]),
+        Some(ACP_PROVIDER_CODEX)
+    );
+    assert_eq!(
         acp_provider_for_agent_with_binary(codex_bin, "agenthub-acp", &["unknown".to_string()]),
         None
     );

--- a/userdocs/docs/core/run-and-interact.md
+++ b/userdocs/docs/core/run-and-interact.md
@@ -34,6 +34,15 @@ let you:
 These controls are runtime-specific. Codex, Gemini, Claude, and other ACP
 providers may surface different option sets.
 
+## Codex ACP Runtimes
+
+For new Codex agents, use the generic AgentHub adapter command:
+
+| Adapter | Command | Notes |
+|---------|---------|-------|
+| AgentHub Codex ACP | `agenthub-acp codex` | Recommended. Shipped with AgentHub and backed by the AgentHub Codex adapter. |
+| AgentHub Codex ACP compatibility | `agenthub-codex-acp` | Existing configurations continue to work and the binary remains packaged. |
+
 ## Claude ACP Runtimes
 
 AgentHub ships a Claude ACP wrapper and can also launch compatible external adapters as normal

--- a/userdocs/docs/getting-started/configuration-basics.md
+++ b/userdocs/docs/getting-started/configuration-basics.md
@@ -107,12 +107,17 @@ ACP (Agent Control Protocol) provider settings.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `binary` | string | `"agenthub-codex-acp"` | ACP binary name or path |
+| `binary` | string | `"agenthub-codex-acp"` | Compatibility Codex ACP binary name or path |
 | `default_mode` | string | `"auto"` | Default ACP mode (`auto`, `full`, `suggest`) |
 | `multi_agent_enabled` | boolean | `true` | Force Codex ACP `Feature::Collab` on AgentHub-managed sessions |
 
-The built-in adapter path assumes the repository's current ACP baseline:
+The canonical Codex command for new agents is `agenthub-acp codex`. The
+`codex_acp.binary` setting remains the compatibility override for legacy or
+custom Codex ACP binaries.
 
+The built-in adapter paths assume the repository's current ACP baseline:
+
+- `agenthub-acp codex`
 - `agenthub-codex-acp`
 - official Codex `0.137.x`
 

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -112,8 +112,9 @@ By default, AgentHub serves the UI at `http://localhost:8080`.
 
 ### ACP Provider Baseline
 
-The default Codex ACP adapter binary is `agenthub-codex-acp`. AgentHub also ships
-`agenthub-acp claude` for Claude ACP sessions.
+The canonical AgentHub ACP adapter binary is `agenthub-acp`. Use `agenthub-acp codex` for Codex
+sessions and `agenthub-acp claude` for Claude sessions. AgentHub still installs
+`agenthub-codex-acp` for existing Codex configurations.
 
 - Current repository baseline: official Codex `0.137.x`
 - If you override `codex_acp.binary`, keep the replacement ACP binary protocol-

--- a/web/src/agent_presets.test.ts
+++ b/web/src/agent_presets.test.ts
@@ -38,7 +38,7 @@ describe("agent presets", () => {
     const claude = getAgentPreset("claude");
     const claudeAgent = getAgentPreset("claude_agent");
     const claudeCodeRs = getAgentPreset("claude_code_rs");
-    expect(formatAgentCommand(codex)).toBe("agenthub-codex-acp");
+    expect(formatAgentCommand(codex)).toBe("agenthub-acp codex");
     expect(formatAgentCommand(gemini)).toBe("gemini --acp");
     expect(formatAgentCommand(claude)).toBe("agenthub-acp claude");
     expect(formatAgentCommand(claudeAgent)).toBe("claude-agent-acp");
@@ -50,6 +50,8 @@ describe("agent presets", () => {
     expect(resolveAcpProvider("/usr/local/bin/gemini")).toBe("gemini");
     expect(resolveAcpProvider("kimi")).toBe("kimi");
     expect(resolveAcpProvider("agenthub-acp")).toBe(null);
+    expect(resolveAcpProvider("agenthub-acp codex")).toBe("codex");
+    expect(resolveAcpProvider("/opt/bin/agenthub-acp codex")).toBe("codex");
     expect(resolveAcpProvider("agenthub-acp claude")).toBe("claude");
     expect(resolveAcpProvider("/opt/bin/agenthub-acp claude")).toBe("claude");
     expect(resolveAcpProvider("claude-agent-acp")).toBe("claude");
@@ -62,6 +64,8 @@ describe("agent presets", () => {
 
   it("formats agent model label from args or provider", () => {
     expect(formatAgentModelLabel("agenthub-codex-acp", [])).toBe("Codex");
+    expect(formatAgentModelLabel("agenthub-acp", ["codex"])).toBe("Codex");
+    expect(formatAgentModelLabel("agenthub-acp codex", [])).toBe("Codex");
     expect(formatAgentModelLabel("gemini", ["--model", "gemini-1.5-pro"]))
       .toBe("gemini-1.5-pro");
     expect(formatAgentModelLabel("kimi", ["--model=moonshot-v1"]))

--- a/web/src/agent_presets.ts
+++ b/web/src/agent_presets.ts
@@ -18,8 +18,8 @@ const PRESETS: AgentPreset[] = [
   {
     id: "codex",
     label: "Codex ACP",
-    command: "agenthub-codex-acp",
-    args: [],
+    command: "agenthub-acp",
+    args: ["codex"],
     provider: "codex",
   },
   {
@@ -150,7 +150,8 @@ function resolveAcpProviderFromCommandAndArgs(
 }
 
 function resolveAgenthubAcpProvider(args: string[]): string | null {
-  return args[0]?.trim().toLowerCase() === "claude" ? "claude" : null;
+  const provider = args[0]?.trim().toLowerCase();
+  return provider === "codex" || provider === "claude" ? provider : null;
 }
 
 function extractArgValue(args: string[], flags: string[]): string | null {

--- a/web/src/components/agent_node_detail_shared.test.ts
+++ b/web/src/components/agent_node_detail_shared.test.ts
@@ -39,9 +39,8 @@ describe("deriveDetectedNodeRuntimes", () => {
   it("returns runtime tags in a stable product order", () => {
     const runtimes = deriveDetectedNodeRuntimes(remoteNode, [
       agent({ command: "gemini" }),
-      agent({ id: "agent-2", command: "agenthub codex" }),
+      agent({ id: "agent-2", command: "agenthub-acp", args: ["codex"] }),
       agent({ id: "agent-3", command: "agenthub-acp", args: ["claude"] }),
-      agent({ id: "agent-4", command: "agenthub-acp", args: ["codex"] }),
     ]);
 
     expect(runtimes).toEqual([
@@ -75,6 +74,9 @@ describe("resolveAgentRuntimeLabels", () => {
       resolveAgentRuntimeLabels(agent({ command: "agenthub-acp", args: ["codex"] }))
     ).toEqual([
       { label: "AgentHub Runtime", tone: "outline" },
+      { label: "Codex CLI", tone: "subtle" },
+    ]);
+    expect(resolveAgentRuntimeLabels(agent({ command: "codex-acp" }))).toEqual([
       { label: "Codex CLI", tone: "subtle" },
     ]);
   });

--- a/web/src/components/agent_node_detail_shared.test.ts
+++ b/web/src/components/agent_node_detail_shared.test.ts
@@ -41,6 +41,7 @@ describe("deriveDetectedNodeRuntimes", () => {
       agent({ command: "gemini" }),
       agent({ id: "agent-2", command: "agenthub codex" }),
       agent({ id: "agent-3", command: "agenthub-acp", args: ["claude"] }),
+      agent({ id: "agent-4", command: "agenthub-acp", args: ["codex"] }),
     ]);
 
     expect(runtimes).toEqual([
@@ -67,6 +68,12 @@ describe("deriveDetectedNodeRuntimes", () => {
 describe("resolveAgentRuntimeLabels", () => {
   it("keeps stable runtime badges for agenthub and codex-backed agents", () => {
     expect(resolveAgentRuntimeLabels(agent({ command: "agenthub codex" }))).toEqual([
+      { label: "AgentHub Runtime", tone: "outline" },
+      { label: "Codex CLI", tone: "subtle" },
+    ]);
+    expect(
+      resolveAgentRuntimeLabels(agent({ command: "agenthub-acp", args: ["codex"] }))
+    ).toEqual([
       { label: "AgentHub Runtime", tone: "outline" },
       { label: "Codex CLI", tone: "subtle" },
     ]);

--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -98,6 +98,17 @@ function isClaudeAcpRuntime(agent: AgentRecord): boolean {
   return commandName === "claude-code-acp-rs" && args.includes("--acp");
 }
 
+function isCodexAcpRuntime(agent: AgentRecord): boolean {
+  const commandParts = (agent.command ?? "").trim().toLowerCase().split(/\s+/);
+  const commandName = commandParts[0]?.split(/[\\/]/).pop();
+  const args = [...commandParts.slice(1), ...(agent.args ?? []).map((arg) => arg.toLowerCase())];
+
+  if (commandName === "agenthub-acp") {
+    return args[0] === "codex";
+  }
+  return commandName === "agenthub-codex-acp" || commandName === "codex-acp";
+}
+
 export function resolveAgentRuntimeLabels(
   agent: AgentRecord,
 ): AgentRuntimeLabel[] {
@@ -109,7 +120,7 @@ export function resolveAgentRuntimeLabels(
       tone: "outline",
     });
   }
-  if (command.includes("codex") || agent.code_mode) {
+  if (isCodexAcpRuntime(agent) || command.includes("codex") || agent.code_mode) {
     labels.set("Codex CLI", {
       label: "Codex CLI",
       tone: "subtle",

--- a/web/src/components/agent_node_detail_shared.tsx
+++ b/web/src/components/agent_node_detail_shared.tsx
@@ -84,11 +84,19 @@ type AgentRuntimeLabel = {
   tone: "subtle" | "outline";
 };
 
-function isClaudeAcpRuntime(agent: AgentRecord): boolean {
+function parseAgentCommand(agent: AgentRecord): {
+  commandName: string;
+  args: string[];
+} {
   const commandParts = (agent.command ?? "").trim().toLowerCase().split(/\s+/);
-  const commandName = commandParts[0]?.split(/[\\/]/).pop();
+  const command = commandParts[0] ?? "";
+  const commandName = command.split(/[\\/]/).pop() ?? "";
   const args = [...commandParts.slice(1), ...(agent.args ?? []).map((arg) => arg.toLowerCase())];
+  return { commandName, args };
+}
 
+function isClaudeAcpRuntime(agent: AgentRecord): boolean {
+  const { commandName, args } = parseAgentCommand(agent);
   if (commandName === "agenthub-acp") {
     return args[0] === "claude";
   }
@@ -99,10 +107,7 @@ function isClaudeAcpRuntime(agent: AgentRecord): boolean {
 }
 
 function isCodexAcpRuntime(agent: AgentRecord): boolean {
-  const commandParts = (agent.command ?? "").trim().toLowerCase().split(/\s+/);
-  const commandName = commandParts[0]?.split(/[\\/]/).pop();
-  const args = [...commandParts.slice(1), ...(agent.args ?? []).map((arg) => arg.toLowerCase())];
-
+  const { commandName, args } = parseAgentCommand(agent);
   if (commandName === "agenthub-acp") {
     return args[0] === "codex";
   }
@@ -254,7 +259,7 @@ export function deriveDetectedNodeRuntimes(
   }
   for (const agent of agents) {
     const command = (agent.command ?? "").trim().toLowerCase();
-    if (command.includes("codex") || agent.code_mode) {
+    if (isCodexAcpRuntime(agent) || command.includes("codex") || agent.code_mode) {
       observed.add("Codex CLI");
     }
     if (command.includes("gemini")) {

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -482,7 +482,8 @@ describe("useTeamManagementActions", () => {
       expect(mockedApi.createAgent).toHaveBeenCalledWith(
         "token-1",
         expect.objectContaining({
-          command: "agenthub-codex-acp",
+          command: "agenthub-acp",
+          args: ["codex"],
           codex_acp_default_mode: "full-access",
         })
       );

--- a/web/src/use_app_agents.test.tsx
+++ b/web/src/use_app_agents.test.tsx
@@ -221,7 +221,8 @@ describe("useAppAgents", () => {
       "token-1",
       expect.objectContaining({
         name: "codex-agent",
-        command: "agenthub-codex-acp",
+        command: "agenthub-acp",
+        args: ["codex"],
         codex_acp_default_mode: "full-access",
       })
     );


### PR DESCRIPTION
## Summary

- add `agenthub-acp codex` to the generic ACP adapter entrypoint
- make new Codex presets/docs use `agenthub-acp codex` while keeping `agenthub-codex-acp` compatibility
- keep release packaging for `agenthub-codex-acp` and pass the Codex vendored-OpenSSL release feature through `agenthub-acp` cross builds

## Purpose

Close the follow-up from the Claude ACP adapter rollout: Codex now has a generic provider-selected AgentHub adapter command without breaking existing `agenthub-codex-acp` deployments.

## Related Issues

N/A

## Testing

- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p agenthub-acp-adapter`
- `CARGO_INCREMENTAL=0 cargo check -p agenthub`
- `npm --prefix web run test -- src/agent_presets.test.ts src/components/agent_node_detail_shared.test.ts`
- `npm --prefix web run build`
- `npm --prefix userdocs run build`

Note: `cargo test -p agenthub-acp-adapter` compiled through the adapter graph but local linking failed with `No space left on device` on this machine, even after clearing `target/`. CI should run the full test link on a clean worker.
