### PR TITLE
ci(bazel): free runner disk space before heavy bazel jobs

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -58,6 +58,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Free disk space
+        # The GitHub-hosted runner ships ~14 GB free, which the instrumented Bazel
+        # build plus the repository-contents cache can exhaust ("No space left on
+        # device"). Drop large preinstalled toolchains we do not use to reclaim ~20 GB.
+        run: |
+          echo "Disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after:"; df -h /
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
@@ -80,6 +90,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Free disk space
+        # The GitHub-hosted runner ships ~14 GB free, which the instrumented Bazel
+        # build plus the repository-contents cache can exhaust ("No space left on
+        # device"). Drop large preinstalled toolchains we do not use to reclaim ~20 GB.
+        run: |
+          echo "Disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after:"; df -h /
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
@@ -104,6 +124,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Free disk space
+        # The GitHub-hosted runner ships ~14 GB free, which the instrumented Bazel
+        # build plus the repository-contents cache can exhaust ("No space left on
+        # device"). Drop large preinstalled toolchains we do not use to reclaim ~20 GB.
+        run: |
+          echo "Disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after:"; df -h /
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust
@@ -126,6 +156,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Free disk space
+        # The GitHub-hosted runner ships ~14 GB free, which the instrumented Bazel
+        # build plus the repository-contents cache can exhaust ("No space left on
+        # device"). Drop large preinstalled toolchains we do not use to reclaim ~20 GB.
+        run: |
+          echo "Disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after:"; df -h /
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev lld protobuf-compiler
       - name: Setup Rust


### PR DESCRIPTION
## Summary

Root-causes the intermittent **`No space left on device`** failures on the Bazel jobs (hit both #747 and #749). The GitHub-hosted runner ships ~14 GB free, which the instrumented Bazel build plus the repository-contents cache can exhaust.

Adds a **Free disk space** step to each heavy Bazel job (`Bazel Build`, `Bazel Test (Root)`, `Bazel Test (Crates)`, `Bazel Coverage`) that drops large preinstalled toolchains we don't use (dotnet, ghc, android SDK, boost, the tool cache) and prunes docker images — reclaiming ~20 GB before the build runs.

No new third-party action; it's a self-contained `rm`/`docker prune` step, tolerant of missing paths (`|| true`), and prints `df -h` before/after for visibility.

## Why now

This flake forces manual job re-runs. PR-2 (the RocksDB backend) will add a native C++ build that stresses runner disk further, so stabilizing this first keeps that work unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)