### PR TITLE
feat(message-store): add RocksDB body-store backend behind a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10097,7 +10097,6 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "lz4-sys",
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,8 +688,10 @@ dependencies = [
 name = "agenthub-message-store"
 version = "0.1.0"
 dependencies = [
+ "rocksdb",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "zstd",
 ]
@@ -10085,6 +10087,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13169,6 +13186,16 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]

--- a/crates/agenthub-message-store/Cargo.toml
+++ b/crates/agenthub-message-store/Cargo.toml
@@ -4,10 +4,19 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 
+[features]
+default = []
+# Opt-in RocksDB body-store backend. Off by default so the standard cargo and
+# Bazel builds do not pull the native librocksdb-sys dependency. The spec keeps
+# this backend isolated behind a flag until CI/prebuild coverage is stable.
+rocksdb = ["dep:rocksdb"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+rocksdb = { version = "0.23", optional = true }
 
 [dev-dependencies]
 zstd = "0.13"
+tempfile = "3"

--- a/crates/agenthub-message-store/Cargo.toml
+++ b/crates/agenthub-message-store/Cargo.toml
@@ -15,7 +15,12 @@ rocksdb = ["dep:rocksdb"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-rocksdb = { version = "0.23", optional = true }
+# Only zstd (what cf_body uses) plus the bindgen runtime are enabled, to keep the
+# native build surface minimal; the default snappy/lz4/bzip2/zlib backends are off.
+rocksdb = { version = "0.23", optional = true, default-features = false, features = [
+    "zstd",
+    "bindgen-runtime",
+] }
 
 [dev-dependencies]
 zstd = "0.13"

--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -15,11 +15,15 @@ pub mod ids;
 pub mod keys;
 pub mod outbox;
 pub mod reference;
+#[cfg(feature = "rocksdb")]
+pub mod rocksdb_store;
 
 pub use body_store::{BodyStoreError, InMemoryBodyStore, MessageBodyStore};
 pub use ids::{AuthorityMessageId, DeliveryMessageId, MessageKind};
 pub use outbox::BodyOutbox;
 pub use reference::MessageRef;
+#[cfg(feature = "rocksdb")]
+pub use rocksdb_store::RocksdbBodyStore;
 
 #[cfg(test)]
 mod tests {

--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -6,9 +6,10 @@
 //! canonical logical-message identity ([`MessageBodyStore`]), and the durability outbox
 //! ([`BodyOutbox`]).
 //!
-//! It intentionally contains no RocksDB dependency. The RocksDB backend (where SST block compression
-//! shrinks bodies at rest) implements [`MessageBodyStore`] in a follow-up, so the native dependency
-//! stays isolated behind this boundary as the spec requires.
+//! The default build has no native dependency. The RocksDB backend (where SST block compression
+//! shrinks bodies at rest) implements [`MessageBodyStore`] in [`rocksdb_store`] behind the optional,
+//! default-off `rocksdb` feature, so the native dependency stays isolated behind this boundary as the
+//! spec requires.
 
 pub mod body_store;
 pub mod ids;

--- a/crates/agenthub-message-store/src/rocksdb_store.rs
+++ b/crates/agenthub-message-store/src/rocksdb_store.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options, WriteBatch};
+use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options};
 
 use crate::body_store::{BodyStoreError, MessageBodyStore};
 use crate::ids::AuthorityMessageId;
@@ -47,9 +47,9 @@ impl RocksdbBodyStore {
         Self::open_with_compression(path, DBCompressionType::Zstd)
     }
 
-    /// Open with an explicit compression type. Exposed mainly so tests can compare on-disk size
-    /// against an uncompressed store.
-    pub fn open_with_compression(
+    /// Open with an explicit compression type. Private: `open` is the public constructor; tests in
+    /// the child module use this to compare on-disk size against an uncompressed store.
+    fn open_with_compression(
         path: impl AsRef<Path>,
         compression: DBCompressionType,
     ) -> Result<Self, BodyStoreError> {
@@ -71,9 +71,10 @@ impl RocksdbBodyStore {
             .ok_or_else(|| BodyStoreError::Backend(format!("missing column family {CF_BODY}")))
     }
 
-    /// Flush memtables and compact `cf_body` so compression is applied to SST files. Used by tests
-    /// that measure on-disk size.
-    pub fn flush_and_compact(&self) -> Result<(), BodyStoreError> {
+    /// Flush memtables and compact `cf_body` so compression is applied to SST files. Test-only:
+    /// it forces a full compaction and is only needed by the on-disk size test.
+    #[cfg(test)]
+    fn flush_and_compact(&self) -> Result<(), BodyStoreError> {
         let cf = self.body_cf()?;
         self.db.flush_cf(cf).map_err(backend_err)?;
         self.db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
@@ -84,10 +85,7 @@ impl RocksdbBodyStore {
 impl MessageBodyStore for RocksdbBodyStore {
     fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
         let cf = self.body_cf()?;
-        // A single logical write uses a WriteBatch so the body put composes with future index puts.
-        let mut batch = WriteBatch::default();
-        batch.put_cf(cf, body_key(id), body);
-        self.db.write(batch).map_err(backend_err)
+        self.db.put_cf(cf, body_key(id), body).map_err(backend_err)
     }
 
     fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
@@ -96,16 +94,30 @@ impl MessageBodyStore for RocksdbBodyStore {
     }
 
     fn contains(&self, id: &AuthorityMessageId) -> bool {
+        // `get_pinned_cf` avoids copying the (potentially large) body just to test existence.
         self.body_cf()
             .ok()
-            .and_then(|cf| self.db.get_cf(cf, body_key(id)).ok().flatten())
+            .and_then(|cf| self.db.get_pinned_cf(cf, body_key(id)).ok().flatten())
             .is_some()
     }
 
     fn len(&self) -> usize {
+        // RocksDB has no O(1) key count; this scans cf_body. Diagnostics/test use only.
         match self.body_cf() {
             Ok(cf) => self.db.iterator_cf(cf, IteratorMode::Start).count(),
             Err(_) => 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        // Avoid the O(N) default (`len() == 0`); checking for the first key is O(1).
+        match self.body_cf() {
+            Ok(cf) => self
+                .db
+                .iterator_cf(cf, IteratorMode::Start)
+                .next()
+                .is_none(),
+            Err(_) => true,
         }
     }
 }
@@ -133,7 +145,10 @@ mod tests {
         out
     }
 
-    fn dir_size(path: &Path) -> u64 {
+    /// Total size of the SST data files (`.sst`/`.ldb`) under `path`. Only these are subject to SST
+    /// block compression, so restricting to them keeps the assertion about compression and ignores
+    /// WAL/LOG/MANIFEST/OPTIONS noise.
+    fn sst_size(path: &Path) -> u64 {
         let mut total = 0;
         let mut stack = vec![path.to_path_buf()];
         while let Some(p) = stack.pop() {
@@ -147,7 +162,13 @@ mod tests {
                 };
                 if meta.is_dir() {
                     stack.push(entry.path());
-                } else {
+                    continue;
+                }
+                let is_sst = entry
+                    .path()
+                    .extension()
+                    .is_some_and(|ext| ext == "sst" || ext == "ldb");
+                if is_sst {
                     total += meta.len();
                 }
             }
@@ -165,7 +186,7 @@ mod tests {
             }
             store.flush_and_compact().expect("compact");
         }
-        dir_size(dir.path())
+        sst_size(dir.path())
     }
 
     #[test]
@@ -201,7 +222,7 @@ mod tests {
         let none_size = write_compact_size(DBCompressionType::None);
         assert!(
             zstd_size < none_size,
-            "zstd on-disk size ({zstd_size}) must be smaller than uncompressed ({none_size})"
+            "zstd SST size ({zstd_size}) must be smaller than uncompressed ({none_size})"
         );
     }
 }

--- a/crates/agenthub-message-store/src/rocksdb_store.rs
+++ b/crates/agenthub-message-store/src/rocksdb_store.rs
@@ -1,0 +1,207 @@
+//! RocksDB-backed [`MessageBodyStore`].
+//!
+//! Message bodies live in a dedicated `cf_body` column family compressed by RocksDB SST block
+//! compression (zstd, with a higher zstd level on the bottommost level). Bodies are keyed by
+//! [`AuthorityMessageId`], so one logical message stores exactly one body regardless of fan-out.
+//!
+//! This module is compiled only with the `rocksdb` feature so the default build does not pull the
+//! native `librocksdb-sys` dependency.
+
+use std::path::Path;
+
+use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options, WriteBatch};
+
+use crate::body_store::{BodyStoreError, MessageBodyStore};
+use crate::ids::AuthorityMessageId;
+use crate::keys::body_key;
+
+/// Column family holding compressed message bodies.
+pub const CF_BODY: &str = "cf_body";
+
+fn backend_err(err: impl ToString) -> BodyStoreError {
+    BodyStoreError::Backend(err.to_string())
+}
+
+/// Build the `cf_body` options: zstd block compression, with a higher zstd level on the bottommost
+/// level for cold data.
+fn body_cf_options(compression: DBCompressionType) -> Options {
+    let mut opts = Options::default();
+    opts.set_compression_type(compression);
+    if matches!(compression, DBCompressionType::Zstd) {
+        opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+        // window_bits=-14 (default), level=19 (high), strategy=0, max_dict_bytes=0, enabled=true.
+        opts.set_bottommost_compression_options(-14, 19, 0, 0, true);
+    }
+    opts
+}
+
+/// A RocksDB body store. Compression is handled by the storage engine; no body is compressed at the
+/// application layer.
+pub struct RocksdbBodyStore {
+    db: DB,
+}
+
+impl RocksdbBodyStore {
+    /// Open (creating if needed) a body store at `path` with zstd compression on `cf_body`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, BodyStoreError> {
+        Self::open_with_compression(path, DBCompressionType::Zstd)
+    }
+
+    /// Open with an explicit compression type. Exposed mainly so tests can compare on-disk size
+    /// against an uncompressed store.
+    pub fn open_with_compression(
+        path: impl AsRef<Path>,
+        compression: DBCompressionType,
+    ) -> Result<Self, BodyStoreError> {
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+
+        let cfs = vec![
+            ColumnFamilyDescriptor::new("default", Options::default()),
+            ColumnFamilyDescriptor::new(CF_BODY, body_cf_options(compression)),
+        ];
+        let db = DB::open_cf_descriptors(&db_opts, path, cfs).map_err(backend_err)?;
+        Ok(Self { db })
+    }
+
+    fn body_cf(&self) -> Result<&rocksdb::ColumnFamily, BodyStoreError> {
+        self.db
+            .cf_handle(CF_BODY)
+            .ok_or_else(|| BodyStoreError::Backend(format!("missing column family {CF_BODY}")))
+    }
+
+    /// Flush memtables and compact `cf_body` so compression is applied to SST files. Used by tests
+    /// that measure on-disk size.
+    pub fn flush_and_compact(&self) -> Result<(), BodyStoreError> {
+        let cf = self.body_cf()?;
+        self.db.flush_cf(cf).map_err(backend_err)?;
+        self.db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
+        Ok(())
+    }
+}
+
+impl MessageBodyStore for RocksdbBodyStore {
+    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+        let cf = self.body_cf()?;
+        // A single logical write uses a WriteBatch so the body put composes with future index puts.
+        let mut batch = WriteBatch::default();
+        batch.put_cf(cf, body_key(id), body);
+        self.db.write(batch).map_err(backend_err)
+    }
+
+    fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
+        let cf = self.body_cf()?;
+        self.db.get_cf(cf, body_key(id)).map_err(backend_err)
+    }
+
+    fn contains(&self, id: &AuthorityMessageId) -> bool {
+        self.body_cf()
+            .ok()
+            .and_then(|cf| self.db.get_cf(cf, body_key(id)).ok().flatten())
+            .is_some()
+    }
+
+    fn len(&self) -> usize {
+        match self.body_cf() {
+            Ok(cf) => self.db.iterator_cf(cf, IteratorMode::Start).count(),
+            Err(_) => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus(repeat: usize) -> Vec<(AuthorityMessageId, String)> {
+        let speakers = ["alice", "bob", "agent-claude", "agent-codex"];
+        let phrases = [
+            "Can you take a look at the failing test in the storage module?",
+            "Sure, I'll check the dual-write path and report back.",
+            "The transcript looks good, shipping the change now.",
+            "Please rebase onto main and re-run the bazel crate tests.",
+            "Done. CI is green and the PR is ready for review.",
+        ];
+        let mut out = Vec::new();
+        for i in 0..repeat {
+            let speaker = speakers[i % speakers.len()];
+            let phrase = phrases[i % phrases.len()];
+            let body = format!("{{\"speaker\":\"{speaker}\",\"seq\":{i},\"text\":\"{phrase}\"}}");
+            out.push((AuthorityMessageId::new(format!("auth-{i}")), body));
+        }
+        out
+    }
+
+    fn dir_size(path: &Path) -> u64 {
+        let mut total = 0;
+        let mut stack = vec![path.to_path_buf()];
+        while let Some(p) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&p) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let meta = match entry.metadata() {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if meta.is_dir() {
+                    stack.push(entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+        }
+        total
+    }
+
+    fn write_compact_size(compression: DBCompressionType) -> u64 {
+        let dir = tempfile::tempdir().expect("tempdir");
+        {
+            let mut store =
+                RocksdbBodyStore::open_with_compression(dir.path(), compression).expect("open");
+            for (id, body) in corpus(4000) {
+                store.put_body(&id, body.as_bytes()).expect("put");
+            }
+            store.flush_and_compact().expect("compact");
+        }
+        dir_size(dir.path())
+    }
+
+    #[test]
+    fn body_round_trips_through_cf_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let id = AuthorityMessageId::new("auth-1");
+        let body = b"a meeting summary body";
+        store.put_body(&id, body).unwrap();
+        assert_eq!(store.get_body(&id).unwrap().as_deref(), Some(&body[..]));
+        assert!(store.contains(&id));
+        let missing = AuthorityMessageId::new("auth-missing");
+        assert_eq!(store.get_body(&missing).unwrap(), None);
+        assert!(!store.contains(&missing));
+    }
+
+    #[test]
+    fn fan_out_stores_one_body_per_authority_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let id = AuthorityMessageId::new("auth-fanout");
+        for _delivery in 0..5 {
+            store.put_body(&id, b"shared body").unwrap();
+        }
+        assert_eq!(store.len(), 1, "fan-out must not duplicate the body");
+    }
+
+    #[test]
+    fn zstd_compression_reduces_on_disk_size() {
+        // The same chat data must take less disk with zstd than with no compression, proving SST
+        // block compression is active and helps on real chat-like bodies.
+        let zstd_size = write_compact_size(DBCompressionType::Zstd);
+        let none_size = write_compact_size(DBCompressionType::None);
+        assert!(
+            zstd_size < none_size,
+            "zstd on-disk size ({zstd_size}) must be smaller than uncompressed ({none_size})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The compression payoff of the storage-tiering design: a RocksDB implementation of `MessageBodyStore`. Message bodies live in a dedicated `cf_body` column family compressed by **SST block compression (zstd, with a higher zstd level on the bottommost level)**, keyed by `AuthorityMessageId` so fan-out stores exactly one body.

Gated behind a **default-off `rocksdb` cargo feature**, so the standard cargo and Bazel builds do **not** pull native `librocksdb-sys`. (`cargo tree` confirms the default build has no rocksdb; only `--features rocksdb` pulls `rocksdb` + `librocksdb-sys`.) The spec keeps this backend isolated behind a flag until CI coverage is stable.

## Tests (`cargo test -p agenthub-message-store --features rocksdb`, fmt + clippy clean)

- `body_round_trips_through_cf_body` — put/get/contains and absent-key handling.
- `fan_out_stores_one_body_per_authority_message` — 5 deliveries of one logical message → one `cf_body` entry.
- `zstd_compression_reduces_on_disk_size` — writes a 4k-message chat corpus, flushes + compacts, and asserts the **zstd-configured store is smaller on disk than an uncompressed one** (real SST compression, not an estimate).

## Heads-up for reviewers

This adds `librocksdb-sys` to `Cargo.lock`. The default build doesn't compile it, but please confirm the Bazel `crate_index` (`crate.from_cargo`) is happy with the new lock entries — if it needs a `crate.annotation` for `librocksdb-sys`, I'll add it (I can't run Bazel locally, so I'm watching CI). The pure-Rust `fjall` LSM is the fallback if the native Bazel wiring proves intractable.

## Scope

Backend only. No SQLite write-path changes / migration yet; that's the next step (dual-body write path + `message_body_outbox` wiring into the real persistence layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)