### PR TITLE
docs(acp): close completed ACP todo matrix

### DIFF
--- a/docs/journal/2026-06-11-acp-todo-closeout.md
+++ b/docs/journal/2026-06-11-acp-todo-closeout.md
@@ -1,0 +1,45 @@
+# ACP TODO Closeout
+
+## Summary
+
+Closed the remaining ACP-specific active TODO matrix after the generic Codex adapter rollout landed
+on `main`. The active backlog now focuses on release packaging, Team workspace follow-ups, Team
+runtime verification, message storage, and docs compaction.
+
+## Background
+
+The ACP backlog had accumulated verification tails for long-session browser behavior,
+provider-driven selectors, and Codex native input polish. After PR #750 completed the generic
+`agenthub-acp codex` rollout and the operator confirmed the ACP TODO line is complete, keeping the
+ACP matrix in `docs/todo.md` would make the active backlog stale.
+
+## Scope
+
+- Remove the ACP Long-Session Matrix section from `docs/todo.md`.
+- Keep the stable ACP contracts in `docs/features/` unchanged.
+- Do not change ACP runtime behavior, provider detection, or web UI code in this closeout.
+
+## Key Decisions
+
+- Treat this as backlog cleanup rather than a new ACP implementation slice.
+- Preserve ACP stable contracts in feature specs so future provider work can still reference them.
+- Leave any new ACP provider or UX work to future explicit TODO entries instead of carrying broad
+  historical verification text forward.
+
+## Validation
+
+Evidence checked before the closeout:
+
+```bash
+gh pr view 750 --json url,state,mergedAt,mergeCommit,title
+gh pr checks 750 | cat
+```
+
+Observed PR #750 merged on 2026-06-11 with merge commit
+`998525c412b2599623eafb20170bc08c19ae4a7c`. Bazel, Rust, Web, Web E2E, Web E2E Mobile, User Docs,
+Distributed P2P Pipeline, and project coverage checks reported passing after the merge.
+
+## Follow-Ups
+
+None for the removed ACP TODO matrix. New ACP work should be added as a narrower active item only
+when there is a fresh implementation or verification target.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -32,20 +32,6 @@ Matrix to keep current on `agenthub.hawkingrei.com` and in PR browser evidence:
 - [ ] `P1` Evaluate explicit Team adoption extensions after the copy-first rollout: design stopped-only `move existing agent to Team`, opt-in workspace-content copy, and opt-in memory/context seeding as separate reviewable modes with runtime, ownership, and history guardrails. Stable contract: [features/team-agent-adoption.md](features/team-agent-adoption.md).
 - [ ] `P2` Frontend performance hardening for Team and ACP-heavy pages: reduce avoidable rerenders, keep long lists and live surfaces responsive, and evaluate virtualization/stick-to-bottom behavior for extremely long histories. Stable contracts: [features/frontend-design.md](features/frontend-design.md) and [features/acp-runtime.md](features/acp-runtime.md).
 
-## ACP Long-Session Matrix
-
-Stable contracts:
-
-- [features/acp-runtime.md](features/acp-runtime.md)
-- [features/runtime-diagnostics.md](features/runtime-diagnostics.md)
-- [features/team-conversation-event-bus.md](features/team-conversation-event-bus.md)
-
-Matrix to keep current across real long-running Codex and non-Codex sessions:
-
-- [ ] `P1` Verify deployed ACP long-session browser behavior under real long output histories: the shipped stick-to-bottom, permission-history jump/copy, stale-session `send input` recovery, debug/runtime-metrics surfaces, and provider session switching should stay stable during real Codex and non-Codex sessions.
-- [ ] `P2` Provider-driven config selectors: verify real Gemini and Kimi ACP sessions end to end so upstream `config_options` render `mode`/`model` controls, `Set Model` / `Set Mode` works without manual ID entry, and selected values remain stable across reconnects.
-- [ ] `P2` Polish ACP-native Codex `request_user_input` UX after the inline card rollout: cover richer note-entry flows in browser-level fixtures and decide whether pending questions should bypass prompt-text serialization entirely.
-
 ## Team Runtime And Task Model
 
 Stable contracts:


### PR DESCRIPTION
## Summary

- remove the completed ACP Long-Session Matrix from `docs/todo.md`
- add a closeout journal entry recording the PR #750 merge evidence and backlog decision
- keep ACP feature specs unchanged; this is a docs/backlog cleanup only

## Purpose

The ACP TODO line was confirmed complete after PR #750 landed. Keeping the broad ACP matrix in the
active backlog would make `docs/todo.md` stale, so this PR moves the closeout evidence into a dated
journal and leaves future ACP work to narrower explicit TODO entries.

## Related Issues

- None

## Testing

- `git diff --check`
- `rg -n "ACP Long-Session Matrix|Provider-driven config selectors|Polish ACP-native Codex|Verify deployed ACP long-session" docs/todo.md docs/journal/2026-06-11-acp-todo-closeout.md`
