### PR TITLE
ci(bazel): guard toolcache cleanup against unset AGENT_TOOLSDIRECTORY

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -65,7 +65,8 @@ jobs:
         run: |
           echo "Disk before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
-            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+            /usr/local/lib/android /usr/local/share/boost || true
+          if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then sudo rm -rf "${AGENT_TOOLSDIRECTORY}" || true; fi
           sudo docker image prune --all --force || true
           echo "Disk after:"; df -h /
       - name: Install system deps
@@ -97,7 +98,8 @@ jobs:
         run: |
           echo "Disk before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
-            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+            /usr/local/lib/android /usr/local/share/boost || true
+          if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then sudo rm -rf "${AGENT_TOOLSDIRECTORY}" || true; fi
           sudo docker image prune --all --force || true
           echo "Disk after:"; df -h /
       - name: Install system deps
@@ -131,7 +133,8 @@ jobs:
         run: |
           echo "Disk before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
-            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+            /usr/local/lib/android /usr/local/share/boost || true
+          if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then sudo rm -rf "${AGENT_TOOLSDIRECTORY}" || true; fi
           sudo docker image prune --all --force || true
           echo "Disk after:"; df -h /
       - name: Install system deps
@@ -163,7 +166,8 @@ jobs:
         run: |
           echo "Disk before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
-            /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+            /usr/local/lib/android /usr/local/share/boost || true
+          if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then sudo rm -rf "${AGENT_TOOLSDIRECTORY}" || true; fi
           sudo docker image prune --all --force || true
           echo "Disk after:"; df -h /
       - name: Install system deps


### PR DESCRIPTION
## Summary

Follow-up to #751. The Copilot review on #751 flagged that `rm -rf ... "${AGENT_TOOLSDIRECTORY:-}"` can expand to an empty argument (noisy `rm: cannot remove ''`) — but #751 was merged before the fix landed, so this re-applies it in a fresh PR.

Each "Free disk space" step now removes the tool cache only when `AGENT_TOOLSDIRECTORY` is set:

```bash
if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then sudo rm -rf "${AGENT_TOOLSDIRECTORY}" || true; fi
```

No functional change otherwise — the dotnet/ghc/android/boost cleanup and docker prune are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)