### PR TITLE
feat(db): add message_body_outbox durable staging for the tiered body store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ name = "agenthub-db"
 version = "0.1.0"
 dependencies = [
  "agenthub-config",
+ "agenthub-message-store",
  "anyhow",
  "chrono",
  "serde",

--- a/crates/agenthub-db/BUILD.bazel
+++ b/crates/agenthub-db/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(normal = True) + [
         "//crates/agenthub-config:agenthub_config",
+        "//crates/agenthub-message-store:agenthub_message_store",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
 )

--- a/crates/agenthub-db/Cargo.toml
+++ b/crates/agenthub-db/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 agenthub-config = { path = "../agenthub-config" }
+agenthub-message-store = { path = "../agenthub-message-store" }

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -17,6 +17,8 @@ use anyhow::Context;
 
 use agenthub_config::path_utils::expand_tilde;
 
+pub mod message_body_outbox;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AgentEventCleanupResult {
     pub cutoff_ts: i64,
@@ -1549,6 +1551,22 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
             err
         );
     }
+
+    // Durable staging for message bodies that are being moved into the tiered body store. A body is
+    // staged here inside the authority transaction and removed only after the body store durably
+    // acknowledges it, so a body store write failure or a crash never loses a body. See
+    // docs/features/message-storage-tiering.md and crate agenthub-message-store (BodyOutbox).
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS message_body_outbox (
+            authority_message_id TEXT PRIMARY KEY,
+            body BLOB NOT NULL,
+            staged_at INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
 
     Ok(pool)
 }

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1567,6 +1567,16 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     )
     .execute(&pool)
     .await?;
+    // The drainer scans oldest-first; index staged_at so ORDER BY ... LIMIT stays an index scan even
+    // if the outbox backs up during a prolonged body-store outage.
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_message_body_outbox_staged_at
+        ON message_body_outbox (staged_at);
+        "#,
+    )
+    .execute(&pool)
+    .await?;
 
     Ok(pool)
 }

--- a/crates/agenthub-db/src/message_body_outbox.rs
+++ b/crates/agenthub-db/src/message_body_outbox.rs
@@ -56,7 +56,9 @@ pub async fn drain_into<S: MessageBodyStore>(
     .fetch_all(pool)
     .await?;
 
-    let mut confirmed = 0;
+    // Do the (potentially slow) store writes without holding a SQLite transaction, collecting the
+    // ids that were durably accepted. A failed write leaves its row for a later retry.
+    let mut confirmed_ids = Vec::new();
     for row in rows {
         let id: String = row.get("authority_message_id");
         let body: Vec<u8> = row.get("body");
@@ -64,14 +66,23 @@ pub async fn drain_into<S: MessageBodyStore>(
             .put_body(&AuthorityMessageId::new(id.clone()), &body)
             .is_ok()
         {
-            sqlx::query("DELETE FROM message_body_outbox WHERE authority_message_id = ?")
-                .bind(id)
-                .execute(pool)
-                .await?;
-            confirmed += 1;
+            confirmed_ids.push(id);
         }
     }
-    Ok(confirmed)
+
+    // Clear all confirmed rows in one transaction, so the batch costs a single fsync rather than one
+    // fsync per row.
+    if !confirmed_ids.is_empty() {
+        let mut tx = pool.begin().await?;
+        for id in &confirmed_ids {
+            sqlx::query("DELETE FROM message_body_outbox WHERE authority_message_id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+    }
+    Ok(confirmed_ids.len())
 }
 
 #[cfg(test)]

--- a/crates/agenthub-db/src/message_body_outbox.rs
+++ b/crates/agenthub-db/src/message_body_outbox.rs
@@ -1,0 +1,176 @@
+//! SQLite-backed durable outbox for message bodies being moved into the tiered body store.
+//!
+//! A body is staged into `message_body_outbox` inside the authority transaction (so it is committed
+//! atomically with the authority metadata) and is removed only after the body store durably
+//! acknowledges it. A body store write failure or a crash between commit and ack therefore never loses
+//! a body: it survives in the outbox until a later drain succeeds. This is the persistent counterpart
+//! of `agenthub_message_store::BodyOutbox`. See `docs/features/message-storage-tiering.md`.
+
+use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+/// Stage a body for `id` inside an authority transaction. Idempotent per logical message: re-staging
+/// the same `authority_message_id` replaces the row rather than creating a second copy.
+pub async fn stage_body(
+    tx: &mut Transaction<'_, Sqlite>,
+    id: &AuthorityMessageId,
+    body: &[u8],
+    staged_at: i64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT OR REPLACE INTO message_body_outbox (authority_message_id, body, staged_at) \
+         VALUES (?, ?, ?)",
+    )
+    .bind(id.as_str())
+    .bind(body)
+    .bind(staged_at)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Number of bodies awaiting confirmation in the body store.
+pub async fn pending_count(pool: &SqlitePool) -> anyhow::Result<i64> {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM message_body_outbox")
+        .fetch_one(pool)
+        .await?;
+    Ok(count)
+}
+
+/// Drain up to `batch` staged bodies into `store`, oldest first.
+///
+/// Each body is written to the store and its outbox row is deleted only after the store write
+/// succeeds, so a failed write leaves the row for a later retry and no body is lost. The store write
+/// is idempotent per logical message, so a crash between the store write and the row delete is safe:
+/// the next drain simply re-writes and deletes. Returns the number of bodies confirmed in this drain.
+pub async fn drain_into<S: MessageBodyStore>(
+    pool: &SqlitePool,
+    store: &mut S,
+    batch: usize,
+) -> anyhow::Result<usize> {
+    let rows = sqlx::query(
+        "SELECT authority_message_id, body FROM message_body_outbox ORDER BY staged_at, \
+         authority_message_id LIMIT ?",
+    )
+    .bind(batch as i64)
+    .fetch_all(pool)
+    .await?;
+
+    let mut confirmed = 0;
+    for row in rows {
+        let id: String = row.get("authority_message_id");
+        let body: Vec<u8> = row.get("body");
+        if store
+            .put_body(&AuthorityMessageId::new(id.clone()), &body)
+            .is_ok()
+        {
+            sqlx::query("DELETE FROM message_body_outbox WHERE authority_message_id = ?")
+                .bind(id)
+                .execute(pool)
+                .await?;
+            confirmed += 1;
+        }
+    }
+    Ok(confirmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agenthub_message_store::{BodyStoreError, InMemoryBodyStore};
+    use uuid::Uuid;
+
+    /// Body store that fails the first `fail_next` writes, to exercise the retry path.
+    struct FlakyStore {
+        inner: InMemoryBodyStore,
+        fail_next: usize,
+    }
+
+    impl MessageBodyStore for FlakyStore {
+        fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+            if self.fail_next > 0 {
+                self.fail_next -= 1;
+                return Err(BodyStoreError::Backend("injected".into()));
+            }
+            self.inner.put_body(id, body)
+        }
+        fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
+            self.inner.get_body(id)
+        }
+        fn contains(&self, id: &AuthorityMessageId) -> bool {
+            self.inner.contains(id)
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+    }
+
+    async fn test_pool() -> SqlitePool {
+        let dir = std::env::temp_dir().join(format!("agenthub-outbox-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        crate::init_db_at_path(&dir.join("agenthub.db"))
+            .await
+            .expect("init db")
+    }
+
+    #[tokio::test]
+    async fn stage_then_drain_moves_body_to_store_and_clears_outbox() {
+        let pool = test_pool().await;
+        let id = AuthorityMessageId::new("auth-1");
+
+        let mut tx = pool.begin().await.unwrap();
+        stage_body(&mut tx, &id, b"hello body", 100).await.unwrap();
+        tx.commit().await.unwrap();
+        assert_eq!(pending_count(&pool).await.unwrap(), 1);
+
+        let mut store = InMemoryBodyStore::new();
+        let confirmed = drain_into(&pool, &mut store, 64).await.unwrap();
+        assert_eq!(confirmed, 1);
+        assert_eq!(pending_count(&pool).await.unwrap(), 0);
+        assert_eq!(
+            store.get_body(&id).unwrap().as_deref(),
+            Some(&b"hello body"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn restaging_same_message_keeps_one_row() {
+        let pool = test_pool().await;
+        let id = AuthorityMessageId::new("auth-dup");
+
+        let mut tx = pool.begin().await.unwrap();
+        stage_body(&mut tx, &id, b"v1", 100).await.unwrap();
+        stage_body(&mut tx, &id, b"v1", 101).await.unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(pending_count(&pool).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn body_survives_store_failure_and_is_recovered_by_replay() {
+        let pool = test_pool().await;
+        let id = AuthorityMessageId::new("auth-replay");
+
+        let mut tx = pool.begin().await.unwrap();
+        stage_body(&mut tx, &id, b"must not be lost", 100)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let mut store = FlakyStore {
+            inner: InMemoryBodyStore::new(),
+            fail_next: 1,
+        };
+        // First drain hits the injected failure: nothing confirmed, body stays staged.
+        assert_eq!(drain_into(&pool, &mut store, 64).await.unwrap(), 0);
+        assert_eq!(pending_count(&pool).await.unwrap(), 1);
+
+        // Retry (e.g. background drainer after a crash) succeeds and clears the outbox.
+        assert_eq!(drain_into(&pool, &mut store, 64).await.unwrap(), 1);
+        assert_eq!(pending_count(&pool).await.unwrap(), 0);
+        assert_eq!(
+            store.get_body(&id).unwrap().as_deref(),
+            Some(&b"must not be lost"[..])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase-1 substrate for the storage-tiering design (`docs/features/message-storage-tiering.md`): the durable **body outbox** that guarantees a message body is never lost between the authority commit and the body store's durable ack. This is pure-Rust/SQLite — no RocksDB here — and is the persistent counterpart of `agenthub_message_store::BodyOutbox`.

## What's here

- New SQLite table **`message_body_outbox`** (`authority_message_id` PK, `body` BLOB, `staged_at`) created in `init_db_at_path`.
- New module **`agenthub-db::message_body_outbox`**:
  - `stage_body(tx, ...)` — stage a body **inside the authority transaction** (idempotent per logical message via `INSERT OR REPLACE`), so it commits atomically with the authority metadata.
  - `pending_count` — bodies awaiting confirmation.
  - `drain_into<S: MessageBodyStore>` — write staged bodies to the body store, deleting each outbox row **only after** a durable store ack; a failed write leaves the body for a later retry, so a crash never loses it.
- `agenthub-db` now depends on `agenthub-message-store` (Cargo.toml + BUILD.bazel first-party dep).

## Tests (cargo + Bazel, fmt + clippy clean)

Verified locally with both `cargo test -p agenthub-db` and `bazelisk test //crates/agenthub-db:agenthub_db_tests`:
- stage → drain clears the outbox and lands the body in the store;
- re-staging the same message keeps exactly one row;
- a body **survives an injected store-write failure and is recovered by replay** (no body lost).

## Scope / next

This wires the substrate, not the live path yet. Next PR: enable the `rocksdb` feature on the binary (with the Bazel `librocksdb-sys` annotation), wire a background drainer (`outbox → RocksdbBodyStore`), and stage bodies in the real conversation-insert transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)