### PR TITLE
ci(rust): build and test the message-store RocksDB backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,30 @@ jobs:
       - name: Cargo check (workspace)
         run: cargo check --workspace --locked
 
+  rust-message-store-rocksdb:
+    name: Rust (Message Store RocksDB)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install system deps
+        # clang provides the bindgen resource headers (stdbool.h) and libzstd-dev
+        # provides zstd.h, both needed to build the native librocksdb-sys backend.
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev libcap-dev protobuf-compiler clang libzstd-dev
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          profile: minimal
+          components: clippy, rustfmt
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Cargo fmt (rocksdb feature)
+        run: cargo fmt -p agenthub-message-store -- --check
+      - name: Cargo clippy (rocksdb feature)
+        run: cargo clippy -p agenthub-message-store --features rocksdb --all-targets --locked
+      - name: Cargo test (rocksdb feature)
+        run: cargo test -p agenthub-message-store --features rocksdb --locked
+
   rust-proto-check:
     name: Rust (Proto Check)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

First, zero-risk step of the RocksDB native integration: a dedicated CI job that **builds and tests `agenthub-message-store` with the `rocksdb` feature**, so the native body-store backend (added in #752 but not previously exercised in CI) is covered.

The job installs the two system packages the native `librocksdb-sys` build needs — `clang` (provides the bindgen resource headers, i.e. `stdbool.h`) and `libzstd-dev` (provides `zstd.h`) — then runs `fmt --check`, `clippy`, and the test suite under `--features rocksdb`.

**Verified locally** that both `bazelisk build` (with these packages) and `cargo test -p agenthub-message-store --features rocksdb` compile `librocksdb-sys` and pass — **no `crate.annotation` needed**.

## Why this shape

- The default cargo and Bazel builds are unaffected — `rocksdb` stays an off-by-default feature, so nothing else compiles `librocksdb-sys`.
- It doesn't touch any release/cross-compile build, so it can't break the aarch64 release path.

## Next (PR-5)

Add a non-default `rocksdb` feature on the binary, wire the outbox drainer to `RocksdbBodyStore`, separate the message body from the queryable `payload_json` metadata, and enable the feature for the **x86_64** release target (with `clang`/`libzstd-dev` in the cross image). aarch64 stays compression-free for this first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)