### PR TITLE
feat(message-store): wire the rocksdb feature into the binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ rust_library(
         "//crates/agenthub-push:agenthub_push",
         "//crates/agenthub-logging:agenthub_logging",
         "//crates/agenthub-message-archive:agenthub_message_archive",
+        "//crates/agenthub-message-store:agenthub_message_store",
         "//crates/agenthub-pyroscope:agenthub_pyroscope",
         "//crates/agenthub-config:agenthub_config",
         "//crates/agenthub-db:agenthub_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "agenthub-logging",
  "agenthub-managed-skills",
  "agenthub-message-archive",
+ "agenthub-message-store",
  "agenthub-push",
  "agenthub-pyroscope",
  "agenthub-team-actor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ license = "Apache-2.0"
 default = []
 release-vendored-openssl = ["dep:openssl"]
 release-lance-fp16 = ["agenthub-message-archive/release-lance-fp16"]
+# Compile the native RocksDB-backed message body store into the binary. Off by
+# default and enabled per release target (x86_64) so the native librocksdb-sys
+# build does not affect default/Bazel/aarch64 builds.
+rocksdb = ["agenthub-message-store/rocksdb"]
 
 [[bin]]
 name = "agenthub"
@@ -113,6 +117,7 @@ agenthub-logging = { path = "crates/agenthub-logging" }
 agenthub-message-archive = { path = "crates/agenthub-message-archive" }
 agenthub-config = { path = "crates/agenthub-config" }
 agenthub-db = { path = "crates/agenthub-db" }
+agenthub-message-store = { path = "crates/agenthub-message-store" }
 agenthub-pyroscope = { path = "crates/agenthub-pyroscope" }
 agent-client-protocol = { version = "0.14.0", features = ["unstable"] }
 prost = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use agenthub_config as config;
 pub use agenthub_db as db;
 mod internal;
 mod linkers;
+pub mod message_body_store;
 pub use agenthub_config::path_utils;
 mod push;
 mod sse;

--- a/src/message_body_store.rs
+++ b/src/message_body_store.rs
@@ -1,0 +1,17 @@
+//! Wiring for the tiered message body store (see `docs/features/message-storage-tiering.md`).
+//!
+//! The durable SQLite outbox lives in `agenthub-db` (`message_body_outbox`). The RocksDB-backed body
+//! store that staged bodies drain into is only compiled when the binary is built with the `rocksdb`
+//! feature, which is enabled per release target (x86_64) so the native `librocksdb-sys` build does not
+//! affect the default, Bazel, or aarch64 builds. The background drainer and the body/metadata split on
+//! the write path are added in a follow-up.
+
+pub use agenthub_message_store::AuthorityMessageId;
+
+/// Open the RocksDB-backed message body store at `path`.
+#[cfg(feature = "rocksdb")]
+pub fn open_rocksdb_body_store(
+    path: impl AsRef<std::path::Path>,
+) -> Result<agenthub_message_store::RocksdbBodyStore, agenthub_message_store::BodyStoreError> {
+    agenthub_message_store::RocksdbBodyStore::open(path)
+}


### PR DESCRIPTION
## Summary

Plumbs the non-default `rocksdb` feature through the `agenthub` binary so the native RocksDB body store can be compiled in **per release target** (x86_64) without affecting the default, Bazel, or aarch64 builds. This is the safe wiring step; the drainer and the write-path body/metadata split land in the follow-up.

## What's here

- A non-default `rocksdb` feature: `rocksdb = ["agenthub-message-store/rocksdb"]`.
- `agenthub-message-store` as a binary dependency (Cargo.toml + the Bazel `agenthub_lib` dep).
- `src/message_body_store.rs`: re-exports `AuthorityMessageId` and, under `#[cfg(feature = "rocksdb")]`, an `open_rocksdb_body_store` constructor.

## Verified locally

- `cargo check -p agenthub` (default features) — passes.
- `cargo check -p agenthub --features rocksdb` — passes (compiles `librocksdb-sys`).
- `bazelisk build //:agenthub` (no feature) — passes (confirms the Bazel dep wiring; the shipped/Bazel build stays rocksdb-free).
- fmt + clippy clean.

## Scope / next (PR-6)

No behavior change yet, no message-format change, no release-matrix change — so nothing shipped/cross-compiled is affected. PR-6 adds the background drainer (`message_body_outbox` → `RocksdbBodyStore`), the write-path body/metadata separation (moving bulky non-`json_extract`'d fields like `result` out of `payload_json`), and enables the `rocksdb` feature for the x86_64 release target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)