### PR TITLE
refactor(message-store): make MessageBodyStore methods take &self

### DIFF
--- a/crates/agenthub-db/src/message_body_outbox.rs
+++ b/crates/agenthub-db/src/message_body_outbox.rs
@@ -43,9 +43,9 @@ pub async fn pending_count(pool: &SqlitePool) -> anyhow::Result<i64> {
 /// succeeds, so a failed write leaves the row for a later retry and no body is lost. The store write
 /// is idempotent per logical message, so a crash between the store write and the row delete is safe:
 /// the next drain simply re-writes and deletes. Returns the number of bodies confirmed in this drain.
-pub async fn drain_into<S: MessageBodyStore>(
+pub async fn drain_into<S: MessageBodyStore + ?Sized>(
     pool: &SqlitePool,
-    store: &mut S,
+    store: &S,
     batch: usize,
 ) -> anyhow::Result<usize> {
     let rows = sqlx::query(
@@ -94,13 +94,14 @@ mod tests {
     /// Body store that fails the first `fail_next` writes, to exercise the retry path.
     struct FlakyStore {
         inner: InMemoryBodyStore,
-        fail_next: usize,
+        fail_next: std::sync::atomic::AtomicUsize,
     }
 
     impl MessageBodyStore for FlakyStore {
-        fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
-            if self.fail_next > 0 {
-                self.fail_next -= 1;
+        fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+            use std::sync::atomic::Ordering;
+            if self.fail_next.load(Ordering::SeqCst) > 0 {
+                self.fail_next.fetch_sub(1, Ordering::SeqCst);
                 return Err(BodyStoreError::Backend("injected".into()));
             }
             self.inner.put_body(id, body)
@@ -134,8 +135,8 @@ mod tests {
         tx.commit().await.unwrap();
         assert_eq!(pending_count(&pool).await.unwrap(), 1);
 
-        let mut store = InMemoryBodyStore::new();
-        let confirmed = drain_into(&pool, &mut store, 64).await.unwrap();
+        let store = InMemoryBodyStore::new();
+        let confirmed = drain_into(&pool, &store, 64).await.unwrap();
         assert_eq!(confirmed, 1);
         assert_eq!(pending_count(&pool).await.unwrap(), 0);
         assert_eq!(
@@ -168,16 +169,16 @@ mod tests {
             .unwrap();
         tx.commit().await.unwrap();
 
-        let mut store = FlakyStore {
+        let store = FlakyStore {
             inner: InMemoryBodyStore::new(),
-            fail_next: 1,
+            fail_next: std::sync::atomic::AtomicUsize::new(1),
         };
         // First drain hits the injected failure: nothing confirmed, body stays staged.
-        assert_eq!(drain_into(&pool, &mut store, 64).await.unwrap(), 0);
+        assert_eq!(drain_into(&pool, &store, 64).await.unwrap(), 0);
         assert_eq!(pending_count(&pool).await.unwrap(), 1);
 
         // Retry (e.g. background drainer after a crash) succeeds and clears the outbox.
-        assert_eq!(drain_into(&pool, &mut store, 64).await.unwrap(), 1);
+        assert_eq!(drain_into(&pool, &store, 64).await.unwrap(), 1);
         assert_eq!(pending_count(&pool).await.unwrap(), 0);
         assert_eq!(
             store.get_body(&id).unwrap().as_deref(),

--- a/crates/agenthub-db/src/message_body_outbox.rs
+++ b/crates/agenthub-db/src/message_body_outbox.rs
@@ -100,8 +100,14 @@ mod tests {
     impl MessageBodyStore for FlakyStore {
         fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
             use std::sync::atomic::Ordering;
-            if self.fail_next.load(Ordering::SeqCst) > 0 {
-                self.fail_next.fetch_sub(1, Ordering::SeqCst);
+            // Atomically check-and-decrement so concurrent callers can't underflow the counter.
+            if self
+                .fail_next
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                    (v > 0).then(|| v - 1)
+                })
+                .is_ok()
+            {
                 return Err(BodyStoreError::Backend("injected".into()));
             }
             self.inner.put_body(id, body)

--- a/crates/agenthub-message-store/src/body_store.rs
+++ b/crates/agenthub-message-store/src/body_store.rs
@@ -107,8 +107,14 @@ impl FailingBodyStore {
 impl MessageBodyStore for FailingBodyStore {
     fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
         use std::sync::atomic::Ordering;
-        if self.fail_next.load(Ordering::SeqCst) > 0 {
-            self.fail_next.fetch_sub(1, Ordering::SeqCst);
+        // Atomically check-and-decrement so concurrent callers can't underflow the counter.
+        if self
+            .fail_next
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                (v > 0).then(|| v - 1)
+            })
+            .is_ok()
+        {
             return Err(BodyStoreError::Backend("injected failure".to_string()));
         }
         self.inner.put_body(id, body)

--- a/crates/agenthub-message-store/src/body_store.rs
+++ b/crates/agenthub-message-store/src/body_store.rs
@@ -4,8 +4,12 @@
 //! even when it fans out to many actors/channels. This is the backend-agnostic boundary the
 //! storage-tiering spec requires: the production backend is RocksDB (compression handled by SST block
 //! compression), but the trait keeps callers and tests independent of it.
+//!
+//! Methods take `&self` so one store can be shared (e.g. behind an `Arc`) between the background
+//! drainer that writes bodies and the read path that fetches them; backends use interior mutability.
 
 use std::collections::BTreeMap;
+use std::sync::Mutex;
 
 use thiserror::Error;
 
@@ -18,11 +22,11 @@ pub enum BodyStoreError {
 }
 
 /// Stores and retrieves message bodies keyed by the canonical logical-message identity.
-pub trait MessageBodyStore {
+pub trait MessageBodyStore: Send + Sync {
     /// Store the body for `id`. Idempotent for a given logical message: a logical message has one
     /// immutable body, so re-putting the same id is a no-op-equivalent overwrite and never creates a
     /// second copy.
-    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError>;
+    fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError>;
 
     /// Fetch the body for `id`, or `None` if absent.
     fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError>;
@@ -42,7 +46,7 @@ pub trait MessageBodyStore {
 /// In-memory reference implementation used by tests and as the abstraction's executable contract.
 #[derive(Debug, Default)]
 pub struct InMemoryBodyStore {
-    bodies: BTreeMap<AuthorityMessageId, Vec<u8>>,
+    bodies: Mutex<BTreeMap<AuthorityMessageId, Vec<u8>>>,
 }
 
 impl InMemoryBodyStore {
@@ -52,21 +56,32 @@ impl InMemoryBodyStore {
 }
 
 impl MessageBodyStore for InMemoryBodyStore {
-    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
-        self.bodies.insert(id.clone(), body.to_vec());
+    fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+        self.bodies
+            .lock()
+            .expect("body store mutex poisoned")
+            .insert(id.clone(), body.to_vec());
         Ok(())
     }
 
     fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
-        Ok(self.bodies.get(id).cloned())
+        Ok(self
+            .bodies
+            .lock()
+            .expect("body store mutex poisoned")
+            .get(id)
+            .cloned())
     }
 
     fn contains(&self, id: &AuthorityMessageId) -> bool {
-        self.bodies.contains_key(id)
+        self.bodies
+            .lock()
+            .expect("body store mutex poisoned")
+            .contains_key(id)
     }
 
     fn len(&self) -> usize {
-        self.bodies.len()
+        self.bodies.lock().expect("body store mutex poisoned").len()
     }
 }
 
@@ -75,7 +90,7 @@ impl MessageBodyStore for InMemoryBodyStore {
 #[derive(Debug)]
 pub struct FailingBodyStore {
     inner: InMemoryBodyStore,
-    fail_next: usize,
+    fail_next: std::sync::atomic::AtomicUsize,
 }
 
 #[cfg(test)]
@@ -83,16 +98,17 @@ impl FailingBodyStore {
     pub fn new(fail_next: usize) -> Self {
         Self {
             inner: InMemoryBodyStore::new(),
-            fail_next,
+            fail_next: std::sync::atomic::AtomicUsize::new(fail_next),
         }
     }
 }
 
 #[cfg(test)]
 impl MessageBodyStore for FailingBodyStore {
-    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
-        if self.fail_next > 0 {
-            self.fail_next -= 1;
+    fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+        use std::sync::atomic::Ordering;
+        if self.fail_next.load(Ordering::SeqCst) > 0 {
+            self.fail_next.fetch_sub(1, Ordering::SeqCst);
             return Err(BodyStoreError::Backend("injected failure".to_string()));
         }
         self.inner.put_body(id, body)

--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -132,7 +132,7 @@ mod tests {
         // One logical message delivered to three actors -> three index rows, one body.
         let authority = AuthorityMessageId::new("auth-fanout");
         let body = b"shared meeting summary body";
-        let mut store = InMemoryBodyStore::new();
+        let store = InMemoryBodyStore::new();
 
         for actor in ["actor-a", "actor-b", "actor-c"] {
             // Each delivery row references the same authority id.
@@ -156,13 +156,13 @@ mod tests {
         let id = AuthorityMessageId::new("auth-drain");
         let body = b"durable body";
         let mut outbox = BodyOutbox::new();
-        let mut store = InMemoryBodyStore::new();
+        let store = InMemoryBodyStore::new();
 
         outbox.stage(&id, body);
         assert_eq!(outbox.pending_len(), 1);
         assert!(!store.contains(&id));
 
-        let confirmed = outbox.drain_into(&mut store);
+        let confirmed = outbox.drain_into(&store);
         assert_eq!(confirmed, 1);
         assert!(outbox.is_empty(), "confirmed bodies leave the outbox");
         assert_eq!(store.get_body(&id).unwrap().as_deref(), Some(&body[..]));
@@ -175,10 +175,10 @@ mod tests {
         let id = AuthorityMessageId::new("auth-replay");
         let body = b"body that must not be lost";
         let mut outbox = BodyOutbox::new();
-        let mut store = FailingBodyStore::new(1); // first write fails
+        let store = FailingBodyStore::new(1); // first write fails
 
         outbox.stage(&id, body);
-        let confirmed = outbox.drain_into(&mut store);
+        let confirmed = outbox.drain_into(&store);
         assert_eq!(confirmed, 0, "the failing write confirms nothing");
         assert!(
             outbox.contains(&id),
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(store.len(), 0);
 
         // Retry (e.g. background drainer after a crash) succeeds.
-        let confirmed = outbox.drain_into(&mut store);
+        let confirmed = outbox.drain_into(&store);
         assert_eq!(confirmed, 1);
         assert!(outbox.is_empty());
         assert_eq!(store.get_body(&id).unwrap().as_deref(), Some(&body[..]));

--- a/crates/agenthub-message-store/src/outbox.rs
+++ b/crates/agenthub-message-store/src/outbox.rs
@@ -47,7 +47,7 @@ impl BodyOutbox {
     /// Drain pending bodies into `store`. Each body is written to the store; an outbox row is removed
     /// only when its write succeeds (durable ack). A failed write leaves the row pending for a later
     /// retry, so no body is lost. Returns the number of bodies confirmed in this drain.
-    pub fn drain_into<S: MessageBodyStore>(&mut self, store: &mut S) -> usize {
+    pub fn drain_into<S: MessageBodyStore + ?Sized>(&mut self, store: &S) -> usize {
         let mut confirmed = Vec::new();
         for (id, body) in &self.pending {
             if store.put_body(id, body).is_ok() {

--- a/crates/agenthub-message-store/src/rocksdb_store.rs
+++ b/crates/agenthub-message-store/src/rocksdb_store.rs
@@ -83,7 +83,7 @@ impl RocksdbBodyStore {
 }
 
 impl MessageBodyStore for RocksdbBodyStore {
-    fn put_body(&mut self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+    fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
         let cf = self.body_cf()?;
         self.db.put_cf(cf, body_key(id), body).map_err(backend_err)
     }
@@ -179,7 +179,7 @@ mod tests {
     fn write_compact_size(compression: DBCompressionType) -> u64 {
         let dir = tempfile::tempdir().expect("tempdir");
         {
-            let mut store =
+            let store =
                 RocksdbBodyStore::open_with_compression(dir.path(), compression).expect("open");
             for (id, body) in corpus(4000) {
                 store.put_body(&id, body.as_bytes()).expect("put");
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn body_round_trips_through_cf_body() {
         let dir = tempfile::tempdir().unwrap();
-        let mut store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let store = RocksdbBodyStore::open(dir.path()).unwrap();
         let id = AuthorityMessageId::new("auth-1");
         let body = b"a meeting summary body";
         store.put_body(&id, body).unwrap();
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn fan_out_stores_one_body_per_authority_message() {
         let dir = tempfile::tempdir().unwrap();
-        let mut store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let store = RocksdbBodyStore::open(dir.path()).unwrap();
         let id = AuthorityMessageId::new("auth-fanout");
         for _delivery in 0..5 {
             store.put_body(&id, b"shared body").unwrap();


### PR DESCRIPTION
## Summary

Prep for wiring the body store into shared `AppState`: the `MessageBodyStore` trait now takes `&self` (with a `Send + Sync` supertrait), so **one store can be shared behind an `Arc`** between the background drainer that writes bodies and the read path that fetches them. Backends use interior mutability.

## Changes

- `MessageBodyStore::put_body(&self, ...)`; supertrait `Send + Sync`.
- `InMemoryBodyStore` wraps its map in a `Mutex`.
- `RocksdbBodyStore::put_body` becomes `&self` (rocksdb `put_cf` already takes `&self`).
- `BodyOutbox::drain_into` and `agenthub-db::message_body_outbox::drain_into` take `&S` with `S: ?Sized`, so a `dyn MessageBodyStore` can be drained.

## Verified locally

- `cargo test -p agenthub-message-store` (default + `--features rocksdb`, all 13) and `cargo test -p agenthub-db` outbox tests.
- `bazelisk test //crates/agenthub-message-store:... //crates/agenthub-db:...`.
- fmt + clippy clean.

No behavior change — purely an API shape change to enable sharing. Next: the body-store lifecycle in `AppState` + the background drainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)