### PR TITLE
feat(message-store): add body-store lifecycle and background outbox drainer

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -27,6 +27,7 @@ pub struct AppConfig {
     pub codex_acp: Option<CodexAcpConfig>,
     pub history: Option<HistoryConfig>,
     pub message_archive: Option<MessageArchiveConfig>,
+    pub message_body_store: Option<MessageBodyStoreConfig>,
     pub push: Option<PushConfig>,
     pub internal_grpc: Option<InternalGrpcConfig>,
     pub safe_paths: Option<Vec<String>>,
@@ -103,6 +104,14 @@ pub struct MessageArchiveConfig {
     pub backend: Option<String>,
     pub uri: Option<String>,
     pub message_table: Option<String>,
+}
+
+/// Tiered message body store (compresses message bodies into RocksDB). Default-on when the binary is
+/// built with the `rocksdb` feature; `enabled = false` turns it off.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageBodyStoreConfig {
+    pub enabled: Option<bool>,
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -334,6 +343,28 @@ impl AppConfig {
             .filter(|value| !value.is_empty())
             .unwrap_or("messages")
             .to_string()
+    }
+
+    /// Whether the tiered message body store is enabled. Default-on (a default capability); only an
+    /// explicit `enabled = false` turns it off. The build must also include the `rocksdb` feature for
+    /// the store to actually be constructed.
+    pub fn message_body_store_enabled(&self) -> bool {
+        self.message_body_store
+            .as_ref()
+            .and_then(|config| config.enabled)
+            .unwrap_or(true)
+    }
+
+    /// Filesystem path for the message body store. Defaults next to the other agenthub data.
+    pub fn message_body_store_path(&self) -> String {
+        let path = self
+            .message_body_store
+            .as_ref()
+            .and_then(|config| config.path.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("~/.agenthub/message-bodies");
+        expand_tilde(path)
     }
 
     pub fn history_event_retention_days(&self) -> Option<u32> {

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1747,6 +1747,7 @@ mod tests {
             acp_permissions: permissions,
             agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
             default_worktree_root: config.default_worktree_root(),
+            body_store: None,
         }
     }
 

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -292,6 +292,7 @@ async fn build_test_state_with_db_source_and_archive(
         acp_permissions: permissions,
         agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
         default_worktree_root: config.default_worktree_root(),
+        body_store: None,
     };
     if seed_default_agents {
         seed_default_team_member_agents(&state).await;

--- a/src/message_body_store.rs
+++ b/src/message_body_store.rs
@@ -2,16 +2,47 @@
 //!
 //! The durable SQLite outbox lives in `agenthub-db` (`message_body_outbox`). The RocksDB-backed body
 //! store that staged bodies drain into is only compiled when the binary is built with the `rocksdb`
-//! feature, which is enabled per release target (x86_64) so the native `librocksdb-sys` build does not
-//! affect the default, Bazel, or aarch64 builds. The background drainer and the body/metadata split on
-//! the write path are added in a follow-up.
+//! feature, which is enabled per release target so the native `librocksdb-sys` build does not affect
+//! the default or Bazel builds. The write-path body/metadata split is added in a follow-up.
 
-pub use agenthub_message_store::AuthorityMessageId;
+use std::sync::Arc;
 
-/// Open the RocksDB-backed message body store at `path`.
-#[cfg(feature = "rocksdb")]
-pub fn open_rocksdb_body_store(
-    path: impl AsRef<std::path::Path>,
-) -> Result<agenthub_message_store::RocksdbBodyStore, agenthub_message_store::BodyStoreError> {
-    agenthub_message_store::RocksdbBodyStore::open(path)
+pub use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+
+/// A shared handle to the message body store, when one is active.
+pub type SharedBodyStore = Arc<dyn MessageBodyStore>;
+
+/// Construct the message body store from config, if it is enabled and compiled in.
+///
+/// The store is a default capability: it is on unless `message_body_store.enabled = false`. It can
+/// only actually be constructed when the binary is built with the `rocksdb` feature; otherwise this
+/// logs and returns `None` so the binary still runs (without compression).
+pub fn init_body_store(config: &agenthub_config::AppConfig) -> Option<SharedBodyStore> {
+    if !config.message_body_store_enabled() {
+        tracing::info!("message body store disabled by config");
+        return None;
+    }
+
+    #[cfg(feature = "rocksdb")]
+    {
+        let path = config.message_body_store_path();
+        match agenthub_message_store::RocksdbBodyStore::open(&path) {
+            Ok(store) => {
+                tracing::info!(path = %path, "message body store (rocksdb) enabled");
+                Some(Arc::new(store) as SharedBodyStore)
+            }
+            Err(error) => {
+                tracing::error!(error = %error, path = %path, "failed to open message body store; running without it");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "rocksdb"))]
+    {
+        tracing::info!(
+            "message body store is enabled in config but this binary was built without the `rocksdb` feature; running without it"
+        );
+        None
+    }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1288,6 +1288,7 @@ mod tests {
             acp_permissions: permissions,
             agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
             default_worktree_root: config.default_worktree_root(),
+            body_store: None,
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -33,6 +33,10 @@ pub struct AppState {
     pub acp_permissions: Arc<AcpPermissionService>,
     pub agent_node_join_bootstrap: AgentNodeJoinBootstrapInfo,
     pub default_worktree_root: String,
+    /// Tiered message body store, when enabled and compiled in. Held here so the read path can fetch
+    /// bodies from it; the write/read wiring lands in a follow-up.
+    #[allow(dead_code)]
+    pub body_store: Option<crate::message_body_store::SharedBodyStore>,
 }
 
 impl AppState {
@@ -51,8 +55,10 @@ impl AppState {
             Self::initialize_services(&config, db.clone(), event_dbs.clone()).await?;
         let agent_node_join_bootstrap = Self::build_agent_node_join_bootstrap(&config)?;
 
+        let body_store = crate::message_body_store::init_body_store(&config);
+
         Self::run_startup_cleanup(&agents, &teams).await?;
-        Self::spawn_startup_workers(&db, &agents, &teams).await?;
+        Self::spawn_startup_workers(&db, &agents, &teams, &body_store).await?;
 
         let default_worktree_root = config.default_worktree_root();
         Ok(Self {
@@ -65,6 +71,7 @@ impl AppState {
             acp_permissions,
             agent_node_join_bootstrap,
             default_worktree_root,
+            body_store,
         })
     }
 

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -47,15 +47,31 @@ impl AppState {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
-                match agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), DRAIN_BATCH)
+                // Keep draining while batches come back full so a backlog (e.g. on startup) isn't
+                // paced at one batch per interval; wait for the next tick once it is (nearly) empty.
+                loop {
+                    match agenthub_db::message_body_outbox::drain_into(
+                        &db,
+                        store.as_ref(),
+                        DRAIN_BATCH,
+                    )
                     .await
-                {
-                    Ok(drained) if drained > 0 => {
-                        tracing::debug!(drained, "message body outbox drained into body store");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        tracing::warn!(error = %error, "message body outbox drain failed");
+                    {
+                        Ok(drained) => {
+                            if drained > 0 {
+                                tracing::debug!(
+                                    drained,
+                                    "message body outbox drained into body store"
+                                );
+                            }
+                            if drained < DRAIN_BATCH {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(error = %error, "message body outbox drain failed");
+                            break;
+                        }
                     }
                 }
             }

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -14,7 +14,11 @@ impl AppState {
         db: &SqlitePool,
         agents: &Arc<AgentManager>,
         teams: &Arc<TeamManager>,
+        body_store: &Option<crate::message_body_store::SharedBodyStore>,
     ) -> anyhow::Result<()> {
+        if let Some(store) = body_store {
+            Self::spawn_message_body_outbox_drainer(db.clone(), store.clone());
+        }
         let _mailbox_hint_handle = TeamMailboxUnreadHintWorker::new(teams.clone(), agents.clone())
             .spawn(TeamMailboxUnreadHintWorkerSettings::default());
         let trigger_manager = Arc::new(AgentTimeTriggerManager::new(db.clone()));
@@ -28,5 +32,33 @@ impl AppState {
         let _agent_trigger_handle = AgentTimeTriggerWorker::new(trigger_manager, agents.clone())
             .spawn(AgentTimeTriggerWorkerSettings::default());
         Ok(())
+    }
+
+    /// Periodically drains the SQLite message-body outbox into the body store, so staged bodies are
+    /// moved into the tiered (compressed) store shortly after they are written.
+    fn spawn_message_body_outbox_drainer(
+        db: SqlitePool,
+        store: crate::message_body_store::SharedBodyStore,
+    ) {
+        const DRAIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+        const DRAIN_BATCH: usize = 256;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(DRAIN_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                match agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), DRAIN_BATCH)
+                    .await
+                {
+                    Ok(drained) if drained > 0 => {
+                        tracing::debug!(drained, "message body outbox drained into body store");
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(error = %error, "message body outbox drain failed");
+                    }
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary

Wires the tiered message body store into the running server. No message-format change yet — the write-path body/metadata split and read-path rehydration land in the next step; here the store is constructed and a background drainer runs.

## What's here

- **Config** `MessageBodyStoreConfig { enabled, path }`:
  - `message_body_store_enabled()` defaults to **true** — a default capability; only `enabled = false` turns it off.
  - `message_body_store_path()` defaults to `~/.agenthub/message-bodies`.
- **`init_body_store()`** opens a RocksDB-backed store when the binary is built with the `rocksdb` feature **and** the store is enabled; otherwise returns `None` and logs (so non-rocksdb / aarch64 / Bazel builds still run, just without compression). `SharedBodyStore = Arc<dyn MessageBodyStore>`.
- **`AppState`** holds the optional body store.
- **Startup drainer**: a background task that moves staged bodies from the SQLite `message_body_outbox` into the body store every couple of seconds. It's a no-op until the write path stages bodies (next step).

## Verified locally

`cargo check -p agenthub` (default + `--features rocksdb`), `cargo clippy` (both), `cargo fmt --check`, and `bazelisk build //:agenthub` (rocksdb-free) all pass.

## Next

PR-6 step 3: stage bulky non-`json_extract`'d body fields into the outbox on write (deduped by `authority_message_id`), rehydrate on read, and add the `migrate` backfill command — then enable the `rocksdb` feature across the release targets (verified via CI on a branch first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)