### PR TITLE
fix(acp): default codex binary to adapter

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -293,7 +293,7 @@ impl AppConfig {
         self.codex_acp
             .as_ref()
             .and_then(|c| c.binary.clone())
-            .unwrap_or_else(|| "agenthub-codex-acp".to_string())
+            .unwrap_or_else(|| "agenthub-acp".to_string())
     }
 
     pub fn codex_acp_default_mode(&self) -> Option<String> {
@@ -749,6 +749,25 @@ mod tests {
             config.codex_acp_default_mode().as_deref(),
             Some("full-access")
         );
+    }
+
+    #[test]
+    fn codex_acp_binary_defaults_to_canonical_adapter() {
+        let config = AppConfig::default();
+        assert_eq!(config.codex_acp_binary(), "agenthub-acp");
+    }
+
+    #[test]
+    fn codex_acp_binary_preserves_configured_legacy_adapter() {
+        let config = AppConfig {
+            codex_acp: Some(CodexAcpConfig {
+                binary: Some("agenthub-codex-acp".to_string()),
+                default_mode: None,
+                multi_agent_enabled: None,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(config.codex_acp_binary(), "agenthub-codex-acp");
     }
 
     #[test]

--- a/userdocs/docs/getting-started/configuration-basics.md
+++ b/userdocs/docs/getting-started/configuration-basics.md
@@ -107,13 +107,14 @@ ACP (Agent Control Protocol) provider settings.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `binary` | string | `"agenthub-codex-acp"` | Legacy/custom Codex ACP binary name or path |
+| `binary` | string | `"agenthub-acp"` | Canonical AgentHub ACP adapter binary name or path |
 | `default_mode` | string | `"auto"` | Default ACP mode (`auto`, `full`, `suggest`) |
 | `multi_agent_enabled` | boolean | `true` | Force Codex ACP `Feature::Collab` on AgentHub-managed sessions |
 
 The canonical Codex command for new agents is `agenthub-acp codex`. The
-`codex_acp.binary` setting remains a legacy/custom override and should point to
-a single executable path, not a command string with arguments.
+`codex_acp.binary` setting points to the adapter executable only and should not
+include the `codex` subcommand argument. Existing deployments can still set it
+to `agenthub-codex-acp` or another compatible Codex ACP executable.
 
 The built-in adapter paths assume the repository's current ACP baseline:
 


### PR DESCRIPTION
## Summary

- Change the default `codex_acp.binary` value from the removed legacy `agenthub-codex-acp` release binary to the canonical `agenthub-acp` adapter binary.
- Keep legacy `agenthub-codex-acp` supported as an explicit configured override.
- Update the user docs table and explanation to match the runtime default.

## Purpose

Follow-up for the final review comment on #762. Since release packages no longer include `agenthub-codex-acp`, the default configuration should not point to that binary.

## Related Issues

Follow-up to #762.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo test -p agenthub-config`
