### PR TITLE
feat(db): promote queried team_conversation_messages payload fields to columns

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1411,6 +1411,45 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
             );
         }
     }
+    // Promote the payload fields that are queried via SQL to real columns, so the body can later move
+    // into the tiered (compressed) body store without breaking those queries. payload_json keeps the
+    // fields too for now; the body is moved out in a follow-up.
+    if !sqlite_table_has_column(&pool, "team_conversation_messages", "text").await? {
+        add_column_if_missing(
+            &pool,
+            "ALTER TABLE team_conversation_messages ADD COLUMN text TEXT",
+            "team_conversation_messages.text",
+        )
+        .await;
+        add_column_if_missing(
+            &pool,
+            "ALTER TABLE team_conversation_messages ADD COLUMN kind TEXT",
+            "team_conversation_messages.kind",
+        )
+        .await;
+        add_column_if_missing(
+            &pool,
+            "ALTER TABLE team_conversation_messages ADD COLUMN thread_root_message_id INTEGER",
+            "team_conversation_messages.thread_root_message_id",
+        )
+        .await;
+        if let Err(err) = sqlx::query(
+            r#"
+            UPDATE team_conversation_messages
+            SET text = json_extract(payload_json, '$.text'),
+                kind = json_extract(payload_json, '$.kind'),
+                thread_root_message_id = json_extract(payload_json, '$.thread_root_message_id')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        {
+            tracing::warn!(
+                "db init: failed to backfill team_conversation_messages promoted columns: {}",
+                err
+            );
+        }
+    }
     if !sqlite_table_has_column(&pool, "team_channel_message_replicas", "correlation_id").await? {
         add_column_if_missing(
             &pool,

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -969,25 +969,8 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
         );
     }
 
-    if let Err(err) = sqlx::query(
-        r#"
-        CREATE INDEX IF NOT EXISTS idx_team_conversation_messages_task_route_thread_root_id
-        ON team_conversation_messages(
-            task_id,
-            route,
-            json_extract(payload_json, '$.thread_root_message_id'),
-            id
-        );
-        "#,
-    )
-    .execute(&pool)
-    .await
-    {
-        tracing::warn!(
-            "db init: failed to create idx_team_conversation_messages_task_route_thread_root_id: {}",
-            err
-        );
-    }
+    // idx_team_conversation_messages_task_route_thread_root_id is created (on the thread_root_message_id
+    // column) by the column-promotion migration below, once that column exists.
 
     if let Err(err) = sqlx::query(
         r#"
@@ -1413,7 +1396,9 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     }
     // Promote the payload fields that are queried via SQL to real columns, so the body can later move
     // into the tiered (compressed) body store without breaking those queries. payload_json keeps the
-    // fields too for now; the body is moved out in a follow-up.
+    // fields too for now; the body is moved out in a follow-up. Each column is checked independently so
+    // a migration interrupted partway through still completes on the next startup.
+    let mut promoted_any = false;
     if !sqlite_table_has_column(&pool, "team_conversation_messages", "text").await? {
         add_column_if_missing(
             &pool,
@@ -1421,19 +1406,34 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
             "team_conversation_messages.text",
         )
         .await;
+        promoted_any = true;
+    }
+    if !sqlite_table_has_column(&pool, "team_conversation_messages", "kind").await? {
         add_column_if_missing(
             &pool,
             "ALTER TABLE team_conversation_messages ADD COLUMN kind TEXT",
             "team_conversation_messages.kind",
         )
         .await;
+        promoted_any = true;
+    }
+    if !sqlite_table_has_column(
+        &pool,
+        "team_conversation_messages",
+        "thread_root_message_id",
+    )
+    .await?
+    {
         add_column_if_missing(
             &pool,
             "ALTER TABLE team_conversation_messages ADD COLUMN thread_root_message_id INTEGER",
             "team_conversation_messages.thread_root_message_id",
         )
         .await;
-        if let Err(err) = sqlx::query(
+        promoted_any = true;
+    }
+    if promoted_any
+        && let Err(err) = sqlx::query(
             r#"
             UPDATE team_conversation_messages
             SET text = json_extract(payload_json, '$.text'),
@@ -1443,13 +1443,13 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
         )
         .execute(&pool)
         .await
-        {
-            tracing::warn!(
-                "db init: failed to backfill team_conversation_messages promoted columns: {}",
-                err
-            );
-        }
+    {
+        tracing::warn!(
+            "db init: failed to backfill team_conversation_messages promoted columns: {}",
+            err
+        );
     }
+    migrate_team_conversation_messages_thread_root_index(&pool).await?;
     if !sqlite_table_has_column(&pool, "team_channel_message_replicas", "correlation_id").await? {
         add_column_if_missing(
             &pool,
@@ -2665,6 +2665,40 @@ async fn backfill_team_authority_group_ids(pool: &SqlitePool) -> anyhow::Result<
     .execute(pool)
     .await
     .context("backfill team_runs.group_id from team_definitions")?;
+    Ok(())
+}
+
+/// Ensure the thread-reply lookup index is on the `thread_root_message_id` column, not the old
+/// `json_extract(payload_json, ...)` expression (the column query cannot use an expression index).
+/// Idempotent: it only rebuilds the index when it is missing or still expression-based.
+async fn migrate_team_conversation_messages_thread_root_index(
+    pool: &SqlitePool,
+) -> anyhow::Result<()> {
+    let existing: Option<String> = sqlx::query_scalar(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' \
+         AND name = 'idx_team_conversation_messages_task_route_thread_root_id'",
+    )
+    .fetch_optional(pool)
+    .await?;
+    let needs_rebuild = existing
+        .as_deref()
+        .map(|sql| sql.contains("json_extract"))
+        .unwrap_or(true);
+    if needs_rebuild {
+        sqlx::query(
+            "DROP INDEX IF EXISTS idx_team_conversation_messages_task_route_thread_root_id",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_team_conversation_messages_task_route_thread_root_id
+            ON team_conversation_messages(task_id, route, thread_root_message_id, id)
+            "#,
+        )
+        .execute(pool)
+        .await?;
+    }
     Ok(())
 }
 

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -3164,7 +3164,7 @@ async fn query_thread_participant_messages(
         FROM team_conversation_messages
         WHERE task_id = ?1
           AND route = 'team_thread_reply'
-          AND json_extract(payload_json, '$.thread_root_message_id') = ?2
+          AND thread_root_message_id = ?2
         ORDER BY id ASC
         "#,
     )

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -679,6 +679,9 @@ async fn init_test_schema(db: &SqlitePool) {
             payload_json TEXT NOT NULL,
             idempotency_key TEXT,
             created_at INTEGER NOT NULL,
+            text TEXT,
+            kind TEXT,
+            thread_root_message_id INTEGER,
             FOREIGN KEY(conversation_id) REFERENCES team_conversations(id),
             FOREIGN KEY(task_id) REFERENCES team_tasks(id)
         );

--- a/src/team/manager/conversation_insert_common.rs
+++ b/src/team/manager/conversation_insert_common.rs
@@ -39,6 +39,13 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         created_at,
     } = input;
 
+    // Promoted columns mirror the queried payload fields (see init_db); payload_json still carries them.
+    let text = redacted_payload.get("text").and_then(Value::as_str);
+    let kind = redacted_payload.get("kind").and_then(Value::as_str);
+    let thread_root_message_id = redacted_payload
+        .get("thread_root_message_id")
+        .and_then(Value::as_i64);
+
     let (message, created) = if let Some(idempotency_key) = idempotency_key.as_deref() {
         match sqlx::query(
             r#"
@@ -52,9 +59,12 @@ pub(super) async fn insert_task_conversation_message_with_tx(
                 group_id,
                 payload_json,
                 idempotency_key,
-                created_at
+                created_at,
+                text,
+                kind,
+                thread_root_message_id
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
             "#,
         )
         .bind(&conversation.id)
@@ -67,6 +77,9 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(&payload_json)
         .bind(idempotency_key)
         .bind(created_at)
+        .bind(text)
+        .bind(kind)
+        .bind(thread_root_message_id)
         .execute(&mut **tx)
         .await
         {
@@ -116,9 +129,12 @@ pub(super) async fn insert_task_conversation_message_with_tx(
                 correlation_id,
                 group_id,
                 payload_json,
-                created_at
+                created_at,
+                text,
+                kind,
+                thread_root_message_id
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
             "#,
         )
         .bind(&conversation.id)
@@ -130,6 +146,9 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(group_id.as_deref())
         .bind(&payload_json)
         .bind(created_at)
+        .bind(text)
+        .bind(kind)
+        .bind(thread_root_message_id)
         .execute(&mut **tx)
         .await?;
         (

--- a/src/team/manager/task_updates.rs
+++ b/src/team/manager/task_updates.rs
@@ -20,8 +20,8 @@ impl TeamManager {
                 conversation_id,
                 task_id,
                 from_actor_id,
-                json_extract(payload_json, '$.kind') AS kind,
-                json_extract(payload_json, '$.text') AS text,
+                kind,
+                text,
                 created_at
             FROM team_conversation_messages
             WHERE task_id = ?1

--- a/src/team/manager/tests_support.rs
+++ b/src/team/manager/tests_support.rs
@@ -391,6 +391,9 @@ pub(super) async fn setup_test_db() -> SqlitePool {
             payload_json TEXT NOT NULL,
             idempotency_key TEXT,
             created_at INTEGER NOT NULL,
+            text TEXT,
+            kind TEXT,
+            thread_root_message_id INTEGER,
             FOREIGN KEY(conversation_id) REFERENCES team_conversations(id),
             FOREIGN KEY(task_id) REFERENCES team_tasks(id)
         );


### PR DESCRIPTION
## Summary

First step of moving the **chat message body into the tiered RocksDB store**: the `team_conversation_messages` payload fields that are read via SQL `json_extract` must become real columns, so the body can later leave `payload_json` without breaking those queries.

## What's here

- Add `text`, `kind`, `thread_root_message_id` columns to `team_conversation_messages` and **backfill** them from `payload_json` (which still carries the fields for now).
- Populate the columns on insert.
- Switch the two `json_extract` sites to the columns:
  - task-note `kind`/`text` projection (`task_updates`),
  - thread-reply `thread_root_message_id` filter (`api/teams`).
- Add the new columns to the two hand-rolled test schemas.

## Scope / safety

Purely **additive** — `payload_json` is unchanged, so this is backward compatible (old rows are backfilled; new rows populate both). The body actually moving into RocksDB (and leaving `payload_json`) is the follow-up.

## Verified locally

`cargo test -p agenthub` (full lib suite, 677 pass), `cargo test -p agenthub-db`, fmt, clippy. Bazel root + db tests verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)