### PR TITLE
feat(team): thread message body store into TeamManager

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -51,11 +51,12 @@ impl AppState {
         let linker_http = crate::linkers::AppLinkerService::default_http_client();
         let event_dbs = agenthub_db::AgentEventDbRouter::with_default_base_dir();
 
-        let (agents, teams, push, auth, acp_permissions) =
-            Self::initialize_services(&config, db.clone(), event_dbs.clone()).await?;
-        let agent_node_join_bootstrap = Self::build_agent_node_join_bootstrap(&config)?;
-
         let body_store = crate::message_body_store::init_body_store(&config);
+
+        let (agents, teams, push, auth, acp_permissions) =
+            Self::initialize_services(&config, db.clone(), event_dbs.clone(), body_store.clone())
+                .await?;
+        let agent_node_join_bootstrap = Self::build_agent_node_join_bootstrap(&config)?;
 
         Self::run_startup_cleanup(&agents, &teams).await?;
         Self::spawn_startup_workers(&db, &agents, &teams, &body_store).await?;

--- a/src/state/service_factories.rs
+++ b/src/state/service_factories.rs
@@ -62,10 +62,14 @@ pub(super) fn build_team_manager(
     db: &SqlitePool,
     event_dbs: &agenthub_db::AgentEventDbRouter,
     message_archive: Option<agenthub_message_archive::MessageArchiveStoreRef>,
+    body_store: Option<crate::message_body_store::SharedBodyStore>,
 ) -> Arc<TeamManager> {
-    Arc::new(TeamManager::new_with_event_dbs_and_message_archive(
-        db.clone(),
-        event_dbs.clone(),
-        message_archive,
-    ))
+    Arc::new(
+        TeamManager::new_with_event_dbs_and_message_archive(
+            db.clone(),
+            event_dbs.clone(),
+            message_archive,
+        )
+        .with_body_store(body_store),
+    )
 }

--- a/src/state/services.rs
+++ b/src/state/services.rs
@@ -12,6 +12,7 @@ impl AppState {
         config: &agenthub_config::AppConfig,
         db: SqlitePool,
         event_dbs: agenthub_db::AgentEventDbRouter,
+        body_store: Option<crate::message_body_store::SharedBodyStore>,
     ) -> anyhow::Result<(
         Arc<AgentManager>,
         Arc<TeamManager>,
@@ -39,7 +40,12 @@ impl AppState {
             },
         );
 
-        let teams = super::service_factories::build_team_manager(&db, &event_dbs, message_archive);
+        let teams = super::service_factories::build_team_manager(
+            &db,
+            &event_dbs,
+            message_archive,
+            body_store,
+        );
         super::team_wiring::configure_team_services(
             &teams,
             &agents,

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -213,9 +213,13 @@ async fn initialize_services_skips_internal_grpc_material_when_disabled() {
         ..Default::default()
     };
 
-    let services =
-        AppState::initialize_services(&config, db, AgentEventDbRouter::with_default_base_dir())
-            .await;
+    let services = AppState::initialize_services(
+        &config,
+        db,
+        AgentEventDbRouter::with_default_base_dir(),
+        None,
+    )
+    .await;
     assert!(
         services.is_ok(),
         "initialize services should succeed when internal grpc is disabled"
@@ -314,7 +318,7 @@ async fn initialize_services_disables_push_for_node_role() {
     };
 
     let (_, _, push, _, _) =
-        AppState::initialize_services(&config, db, AgentEventDbRouter::new(event_dir))
+        AppState::initialize_services(&config, db, AgentEventDbRouter::new(event_dir), None)
             .await
             .expect("initialize node services");
 
@@ -356,7 +360,7 @@ async fn initialize_services_enables_push_for_main_role() {
     };
 
     let (_, _, push, _, _) =
-        AppState::initialize_services(&config, db, AgentEventDbRouter::new(event_dir))
+        AppState::initialize_services(&config, db, AgentEventDbRouter::new(event_dir), None)
             .await
             .expect("initialize main services");
 

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -181,6 +181,10 @@ pub struct TeamManager {
     db: SqlitePool,
     event_dbs: AgentEventDbRouter,
     message_archive: Option<MessageArchiveStoreRef>,
+    /// Tiered message body store, used by the read path to rehydrate moved-out bodies. Set in
+    /// production via `with_body_store`; the write/read wiring lands in a follow-up.
+    #[allow(dead_code)]
+    body_store: Option<crate::message_body_store::SharedBodyStore>,
     conversation_events: broadcast::Sender<TeamConversationStreamEvent>,
     remote_relay_adapter: Arc<TeamRemoteRelayAdapter>,
     agents_target_node_id_column: Arc<Mutex<Option<bool>>>,

--- a/src/team/manager/manager_core.rs
+++ b/src/team/manager/manager_core.rs
@@ -74,10 +74,21 @@ impl TeamManager {
             db,
             event_dbs,
             message_archive,
+            body_store: None,
             conversation_events,
             remote_relay_adapter,
             agents_target_node_id_column,
         }
+    }
+
+    /// Attach the tiered message body store. The read path uses it to rehydrate bodies that have been
+    /// moved out of `payload_json`; `None` keeps bodies inline.
+    pub fn with_body_store(
+        mut self,
+        body_store: Option<crate::message_body_store::SharedBodyStore>,
+    ) -> Self {
+        self.body_store = body_store;
+        self
     }
 
     pub fn subscribe_conversation_events(


### PR DESCRIPTION
## What

Step 3b-1 of the RocksDB body-store move for `team_conversation_messages`: thread the tiered message body store (`SharedBodyStore = Arc<dyn MessageBodyStore>`) through to `TeamManager` so a follow-up can use it on the read path to rehydrate conversation bodies moved out of `payload_json`.

## Changes

- **`TeamManager`**: add `body_store: Option<SharedBodyStore>` field + `with_body_store(...)` builder. The constructor signature is **unchanged** (defaults the field to `None`) so the ~24 existing test callers stay untouched.
- **Wiring**: thread the store through `build_team_manager` → `initialize_services` → `AppState::init`. `init_body_store(&config)` now runs **before** `initialize_services` so the same `Arc` is shared with both the manager and the outbox drainer.
- Field is `#[allow(dead_code)]` until the write/read wiring lands.

## Behavior

No functional change yet. Production passes the store through; tests pass `None`.

## Verification

- `cargo check -p agenthub` (default features) ✅
- `cargo check -p agenthub --features rocksdb --tests` ✅
- `cargo clippy -p agenthub --features rocksdb --tests` ✅ (clean)
- `cargo fmt` ✅
- `bazelisk build //:agenthub` ✅

## Next

3b-2: write path stages body to outbox (`tcm:{id}`) + slim `payload_json`; read path rehydrates store → outbox → inline fallback. Then migrate/backfill command, then enable the `rocksdb` feature across all 3 release targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)