### PR TITLE
feat(team): move conversation message bodies into the tiered body store

### DIFF
--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -12,6 +12,7 @@ mod context_artifact_support;
 mod context_artifacts;
 mod conversation;
 mod conversation_append;
+mod conversation_body;
 mod conversation_idempotency;
 mod conversation_insert_common;
 mod conversation_side_effects;
@@ -181,9 +182,8 @@ pub struct TeamManager {
     db: SqlitePool,
     event_dbs: AgentEventDbRouter,
     message_archive: Option<MessageArchiveStoreRef>,
-    /// Tiered message body store, used by the read path to rehydrate moved-out bodies. Set in
-    /// production via `with_body_store`; the write/read wiring lands in a follow-up.
-    #[allow(dead_code)]
+    /// Tiered message body store. When set, conversation message bodies are moved out of SQLite into
+    /// the store (staged via the outbox) on write and rehydrated on read; `None` keeps bodies inline.
     body_store: Option<crate::message_body_store::SharedBodyStore>,
     conversation_events: broadcast::Sender<TeamConversationStreamEvent>,
     remote_relay_adapter: Arc<TeamRemoteRelayAdapter>,

--- a/src/team/manager/codec_rows.rs
+++ b/src/team/manager/codec_rows.rs
@@ -84,22 +84,34 @@ pub(super) fn parse_team_conversation_row(
     })
 }
 
+/// Parse a `team_conversation_messages` row, returning the record alongside whether its body was moved
+/// into the tiered body store. For a moved row the `payload` is a [`Value::Null`] placeholder that the
+/// caller must rehydrate (see `conversation_body`); moved-ness is decided purely by the stored sentinel
+/// string, so a real payload can never be mistaken for a moved body.
 pub(super) fn parse_team_conversation_message_row(
     row: &sqlx::sqlite::SqliteRow,
-) -> anyhow::Result<TeamConversationMessageRecord> {
+) -> anyhow::Result<(TeamConversationMessageRecord, bool)> {
     let payload_json: String = row.get("payload_json");
-    let payload: Value = serde_json::from_str(&payload_json)?;
-    Ok(TeamConversationMessageRecord {
-        message_id: row.get("id"),
-        conversation_id: row.get("conversation_id"),
-        task_id: row.get("task_id"),
-        group_id: row.try_get("group_id").ok().flatten(),
-        from_actor_id: row.get("from_actor_id"),
-        to_actor_id: row.try_get("to_actor_id")?,
-        route: row.get("route"),
-        payload,
-        created_at: row.get("created_at"),
-    })
+    let body_moved = super::conversation_body::conversation_payload_was_moved(&payload_json);
+    let payload: Value = if body_moved {
+        Value::Null
+    } else {
+        serde_json::from_str(&payload_json)?
+    };
+    Ok((
+        TeamConversationMessageRecord {
+            message_id: row.get("id"),
+            conversation_id: row.get("conversation_id"),
+            task_id: row.get("task_id"),
+            group_id: row.try_get("group_id").ok().flatten(),
+            from_actor_id: row.get("from_actor_id"),
+            to_actor_id: row.try_get("to_actor_id")?,
+            route: row.get("route"),
+            payload,
+            created_at: row.get("created_at"),
+        },
+        body_moved,
+    ))
 }
 
 pub(super) fn parse_team_task_note_row(

--- a/src/team/manager/conversation.rs
+++ b/src/team/manager/conversation.rs
@@ -62,7 +62,12 @@ impl TeamManager {
         let rows = builder.build().fetch_all(&self.db).await?;
         let mut messages = Vec::with_capacity(rows.len());
         for row in rows {
-            messages.push(parse_team_conversation_message_row(&row)?);
+            let (mut message, body_moved) = parse_team_conversation_message_row(&row)?;
+            if body_moved {
+                self.rehydrate_moved_conversation_payload(&mut message)
+                    .await?;
+            }
+            messages.push(message);
         }
         messages.reverse();
         Ok(messages)

--- a/src/team/manager/conversation_append.rs
+++ b/src/team/manager/conversation_append.rs
@@ -72,6 +72,7 @@ impl TeamManager {
                 idempotency_key,
                 created_at: now,
             },
+            self.body_store.as_deref(),
         )
         .await?;
         tx.commit().await?;

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -21,8 +21,9 @@ use crate::team::TeamConversationMessageRecord;
 /// It is intentionally not valid JSON, so it can never collide with a real serialized payload (which
 /// is always valid JSON). Moved-ness is therefore decided by an exact string comparison against this
 /// constant, not by inspecting the parsed payload value, which keeps user-supplied payloads from ever
-/// being mistaken for a moved body.
-pub(super) const CONVERSATION_BODY_MOVED_SENTINEL: &str = "\u{0}agenthub:tcm-body-moved\u{1}";
+/// being mistaken for a moved body. It is kept ASCII (no control characters) so it stays legible in
+/// SQLite browsers / CLIs, which can silently truncate strings containing a NUL byte.
+pub(super) const CONVERSATION_BODY_MOVED_SENTINEL: &str = "::agenthub:tcm-body-moved::";
 
 /// Body-store key for a conversation message's moved body. One copy per logical message (row id).
 pub(super) fn conversation_body_key(message_id: i64) -> AuthorityMessageId {
@@ -122,7 +123,7 @@ mod tests {
         assert!(!conversation_payload_was_moved("{\"text\":\"hi\"}"));
         // A payload that merely mentions the sentinel as data is not treated as moved.
         assert!(!conversation_payload_was_moved(
-            "{\"text\":\"\\u0000agenthub:tcm-body-moved\\u0001\"}"
+            "{\"text\":\"::agenthub:tcm-body-moved::\"}"
         ));
     }
 

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -1,0 +1,133 @@
+//! Tiered-body support for `team_conversation_messages`.
+//!
+//! When the message body store is active, a conversation message's `payload_json` is moved out of the
+//! SQLite row into the body store (keyed by the row's authority id) so the larger chat body lives in
+//! the compressed RocksDB store rather than inline in SQLite. The SQLite row keeps the queried
+//! metadata columns (see `init_db`) and stores [`CONVERSATION_BODY_MOVED_SENTINEL`] in place of the
+//! body. The read path rehydrates the real payload from the body store, falling back to the durable
+//! outbox for bodies that have been staged but not yet drained.
+//!
+//! Rows written without an active store (older rows, or platforms built without the `rocksdb` feature)
+//! keep their full inline `payload_json` and are never treated as moved, so both shapes coexist.
+
+use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+use sqlx::Sqlite;
+
+use super::TeamManager;
+use crate::team::TeamConversationMessageRecord;
+
+/// Sentinel stored in `payload_json` when a conversation body has been moved into the body store.
+///
+/// It is intentionally not valid JSON, so it can never collide with a real serialized payload (which
+/// is always valid JSON). Moved-ness is therefore decided by an exact string comparison against this
+/// constant, not by inspecting the parsed payload value, which keeps user-supplied payloads from ever
+/// being mistaken for a moved body.
+pub(super) const CONVERSATION_BODY_MOVED_SENTINEL: &str = "\u{0}agenthub:tcm-body-moved\u{1}";
+
+/// Body-store key for a conversation message's moved body. One copy per logical message (row id).
+pub(super) fn conversation_body_key(message_id: i64) -> AuthorityMessageId {
+    AuthorityMessageId::new(format!("tcm:{message_id}"))
+}
+
+/// Whether a stored `payload_json` indicates the body was moved into the body store.
+pub(super) fn conversation_payload_was_moved(payload_json: &str) -> bool {
+    payload_json == CONVERSATION_BODY_MOVED_SENTINEL
+}
+
+/// Load a moved conversation body, preferring the drained body store and falling back to the durable
+/// outbox (for bodies staged but not yet drained). Returns `None` only if the body is in neither.
+async fn load_moved_conversation_body<'a, E>(
+    body_store: Option<&dyn MessageBodyStore>,
+    outbox_executor: E,
+    key: &AuthorityMessageId,
+) -> anyhow::Result<Option<Vec<u8>>>
+where
+    E: sqlx::Executor<'a, Database = Sqlite>,
+{
+    if let Some(store) = body_store
+        && let Some(body) = store
+            .get_body(key)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))?
+    {
+        return Ok(Some(body));
+    }
+    let body: Option<Vec<u8>> =
+        sqlx::query_scalar("SELECT body FROM message_body_outbox WHERE authority_message_id = ?1")
+            .bind(key.as_str())
+            .fetch_optional(outbox_executor)
+            .await?;
+    Ok(body)
+}
+
+/// Rehydrate a moved conversation body in place, using `tx` for the outbox fallback. For the insert
+/// idempotency-conflict path, where the existing row may have been staged within an in-flight write.
+pub(super) async fn rehydrate_conversation_body_in_tx(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    body_store: Option<&dyn MessageBodyStore>,
+    record: &mut TeamConversationMessageRecord,
+) -> anyhow::Result<()> {
+    let key = conversation_body_key(record.message_id);
+    let body = load_moved_conversation_body(body_store, &mut **tx, &key)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "conversation message {} is marked moved but its body is missing from the store and outbox",
+                record.message_id
+            )
+        })?;
+    record.payload = serde_json::from_slice(&body)?;
+    Ok(())
+}
+
+impl TeamManager {
+    /// Rehydrate a moved conversation body in place from the body store (falling back to the outbox).
+    /// Callers must only invoke this for rows whose `payload_json` was the moved sentinel.
+    pub(super) async fn rehydrate_moved_conversation_payload(
+        &self,
+        record: &mut TeamConversationMessageRecord,
+    ) -> anyhow::Result<()> {
+        let key = conversation_body_key(record.message_id);
+        let body = load_moved_conversation_body(self.body_store.as_deref(), &self.db, &key)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "conversation message {} is marked moved but its body is missing from the store and outbox",
+                    record.message_id
+                )
+            })?;
+        record.payload = serde_json::from_slice(&body)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CONVERSATION_BODY_MOVED_SENTINEL, conversation_body_key, conversation_payload_was_moved,
+    };
+
+    #[test]
+    fn sentinel_is_not_valid_json() {
+        // The moved sentinel must never collide with a real serialized payload (always valid JSON).
+        assert!(
+            serde_json::from_str::<serde_json::Value>(CONVERSATION_BODY_MOVED_SENTINEL).is_err()
+        );
+    }
+
+    #[test]
+    fn moved_detection_matches_only_sentinel() {
+        assert!(conversation_payload_was_moved(
+            CONVERSATION_BODY_MOVED_SENTINEL
+        ));
+        assert!(!conversation_payload_was_moved("{\"text\":\"hi\"}"));
+        // A payload that merely mentions the sentinel as data is not treated as moved.
+        assert!(!conversation_payload_was_moved(
+            "{\"text\":\"\\u0000agenthub:tcm-body-moved\\u0001\"}"
+        ));
+    }
+
+    #[test]
+    fn body_key_is_namespaced_by_row_id() {
+        assert_eq!(conversation_body_key(42).as_str(), "tcm:42");
+    }
+}

--- a/src/team/manager/conversation_idempotency.rs
+++ b/src/team/manager/conversation_idempotency.rs
@@ -41,12 +41,14 @@ fn task_conversation_message_fingerprint(
     super::hex_encode(&hasher.finalize())
 }
 
+/// Returns the matching message and whether its body was moved into the body store (so the caller can
+/// rehydrate before comparing payloads).
 pub(super) async fn fetch_task_conversation_message_by_idempotency(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     conversation_id: &str,
     from_actor_id: &str,
     idempotency_key: &str,
-) -> Result<TeamConversationMessageRecord, sqlx::Error> {
+) -> Result<(TeamConversationMessageRecord, bool), sqlx::Error> {
     let row = sqlx::query(
         r#"
         SELECT

--- a/src/team/manager/conversation_insert_common.rs
+++ b/src/team/manager/conversation_insert_common.rs
@@ -1,6 +1,10 @@
+use agenthub_message_store::MessageBodyStore;
 use serde_json::Value;
 use sqlx::Sqlite;
 
+use super::conversation_body::{
+    CONVERSATION_BODY_MOVED_SENTINEL, conversation_body_key, rehydrate_conversation_body_in_tx,
+};
 use super::conversation_idempotency::{
     ensure_task_conversation_message_idempotency_compatible,
     fetch_task_conversation_message_by_idempotency,
@@ -25,6 +29,7 @@ pub(super) async fn insert_task_conversation_message_with_tx(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     conversation: &TeamConversationRecord,
     input: TaskConversationInsertInput<'_>,
+    body_store: Option<&dyn MessageBodyStore>,
 ) -> anyhow::Result<(TeamConversationMessageRecord, bool)> {
     let TaskConversationInsertInput {
         task_id,
@@ -45,6 +50,16 @@ pub(super) async fn insert_task_conversation_message_with_tx(
     let thread_root_message_id = redacted_payload
         .get("thread_root_message_id")
         .and_then(Value::as_i64);
+
+    // When a body store is active, the body moves out of SQLite into the store: the row stores the
+    // moved sentinel and the real `payload_json` is staged to the outbox below (keyed by the new row
+    // id). Without a store the body stays inline, exactly as before.
+    let move_body = body_store.is_some();
+    let stored_payload_json: &str = if move_body {
+        CONVERSATION_BODY_MOVED_SENTINEL
+    } else {
+        payload_json.as_str()
+    };
 
     let (message, created) = if let Some(idempotency_key) = idempotency_key.as_deref() {
         match sqlx::query(
@@ -74,7 +89,7 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(route)
         .bind(&correlation_id)
         .bind(group_id.as_deref())
-        .bind(&payload_json)
+        .bind(stored_payload_json)
         .bind(idempotency_key)
         .bind(created_at)
         .bind(text)
@@ -98,13 +113,17 @@ pub(super) async fn insert_task_conversation_message_with_tx(
                 true,
             ),
             Err(err) if is_task_conversation_message_idempotency_unique_violation(&err) => {
-                let existing = fetch_task_conversation_message_by_idempotency(
-                    tx,
-                    &conversation.id,
-                    from_actor_id,
-                    idempotency_key,
-                )
-                .await?;
+                let (mut existing, existing_moved) =
+                    fetch_task_conversation_message_by_idempotency(
+                        tx,
+                        &conversation.id,
+                        from_actor_id,
+                        idempotency_key,
+                    )
+                    .await?;
+                if existing_moved {
+                    rehydrate_conversation_body_in_tx(tx, body_store, &mut existing).await?;
+                }
                 ensure_task_conversation_message_idempotency_compatible(
                     task_id,
                     from_actor_id,
@@ -144,7 +163,7 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(route)
         .bind(&correlation_id)
         .bind(group_id.as_deref())
-        .bind(&payload_json)
+        .bind(stored_payload_json)
         .bind(created_at)
         .bind(text)
         .bind(kind)
@@ -166,6 +185,20 @@ pub(super) async fn insert_task_conversation_message_with_tx(
             true,
         )
     };
+
+    // Stage the moved body into the durable outbox inside this same transaction, so the body is
+    // committed atomically with the row that points at it. The background drainer later moves it into
+    // the body store. Only a freshly inserted row owns a new body; an idempotency hit reuses the
+    // existing row (and its already-staged body).
+    if created && move_body {
+        agenthub_db::message_body_outbox::stage_body(
+            tx,
+            &conversation_body_key(message.message_id),
+            payload_json.as_bytes(),
+            created_at,
+        )
+        .await?;
+    }
 
     Ok((message, created))
 }

--- a/src/team/manager/conversation_tx_insert.rs
+++ b/src/team/manager/conversation_tx_insert.rs
@@ -67,6 +67,7 @@ impl TeamManager {
                 idempotency_key,
                 created_at: now,
             },
+            self.body_store.as_deref(),
         )
         .await?;
 

--- a/src/team/manager/mailbox_channels.rs
+++ b/src/team/manager/mailbox_channels.rs
@@ -213,7 +213,7 @@ impl TeamManager {
             WHERE conversation_id = ?1
               AND from_actor_id = ?2
               AND route = 'group_chat'
-              AND trim(COALESCE(json_extract(payload_json, '$.correlation_id'), '')) = ?3
+              AND trim(COALESCE(correlation_id, '')) = ?3
             ORDER BY id DESC
             LIMIT 1
             "#,
@@ -223,10 +223,15 @@ impl TeamManager {
         .bind(correlation_id)
         .fetch_optional(&self.db)
         .await?;
-        row.map(|row| {
-            super::codec_rows::parse_team_conversation_message_row(&row)
-                .map_err(|err| anyhow::anyhow!(err.to_string()))
-        })
-        .transpose()
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let (mut message, body_moved) =
+            super::codec_rows::parse_team_conversation_message_row(&row)?;
+        if body_moved {
+            self.rehydrate_moved_conversation_payload(&mut message)
+                .await?;
+        }
+        Ok(Some(message))
     }
 }

--- a/src/team/manager/message_archive_batches.rs
+++ b/src/team/manager/message_archive_batches.rs
@@ -63,7 +63,11 @@ impl TeamManager {
                     created_at: 0,
                     updated_at: 0,
                 };
-                let message = parse_team_conversation_message_row(&row)?;
+                let (mut message, body_moved) = parse_team_conversation_message_row(&row)?;
+                if body_moved {
+                    self.rehydrate_moved_conversation_payload(&mut message)
+                        .await?;
+                }
                 documents.push(team_conversation_message_archive_document(
                     &conversation,
                     &message,

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -541,3 +541,189 @@ async fn append_task_conversation_message_propagates_non_idempotency_insert_fail
         "expected non-idempotency error, got: {err:?}"
     );
 }
+
+fn body_store() -> std::sync::Arc<agenthub_message_store::InMemoryBodyStore> {
+    std::sync::Arc::new(agenthub_message_store::InMemoryBodyStore::new())
+}
+
+async fn body_store_team_and_task(manager: &TeamManager) -> crate::team::TeamTaskRecord {
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "body-store-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"coordinator","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, _conversation) = manager
+        .create_task(
+            &team.id,
+            "all",
+            "user",
+            json!({"bootstrap_kind":"shared_thread"}),
+            "group_chat",
+            Some("all"),
+        )
+        .await
+        .expect("create task");
+    task
+}
+
+#[tokio::test]
+async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
+    use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+
+    let db = setup_test_db().await;
+    let store = body_store();
+    let manager = TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    ));
+    let task = body_store_team_and_task(&manager).await;
+
+    let payload =
+        json!({"type":"chat_message","text":"a fairly chatty message body","extra":{"k":"v"}});
+    let message = manager
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", payload.clone())
+        .await
+        .expect("append message");
+    // The returned in-memory record keeps the full payload.
+    assert_eq!(message.payload, payload);
+
+    // SQLite stores the moved sentinel in place of the body.
+    let stored: String =
+        sqlx::query_scalar("SELECT payload_json FROM team_conversation_messages WHERE id = ?1")
+            .bind(message.message_id)
+            .fetch_one(&db)
+            .await
+            .expect("read stored payload");
+    assert_eq!(stored, "\u{0}agenthub:tcm-body-moved\u{1}");
+
+    // Promoted columns stay populated so queries keep working without the body.
+    let text_col: Option<String> =
+        sqlx::query_scalar("SELECT text FROM team_conversation_messages WHERE id = ?1")
+            .bind(message.message_id)
+            .fetch_one(&db)
+            .await
+            .expect("read text column");
+    assert_eq!(text_col.as_deref(), Some("a fairly chatty message body"));
+
+    // The real body is staged in the durable outbox, not yet in the store.
+    let key = AuthorityMessageId::new(format!("tcm:{}", message.message_id));
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(!store.contains(&key));
+
+    // Read path rehydrates from the outbox while the body is still staged.
+    let messages = manager
+        .list_task_conversation_messages(&task.id, 50, None)
+        .await
+        .expect("list before drain");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].payload, payload);
+
+    // Draining moves the body into the store and clears the outbox.
+    let drained = agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
+        .await
+        .unwrap();
+    assert_eq!(drained, 1);
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        0
+    );
+    assert!(store.contains(&key));
+
+    // Read path now rehydrates from the body store.
+    let messages = manager
+        .list_task_conversation_messages(&task.id, 50, None)
+        .await
+        .expect("list after drain");
+    assert_eq!(messages[0].payload, payload);
+}
+
+#[tokio::test]
+async fn conversation_idempotency_replay_with_moved_body_is_not_a_false_conflict() {
+    let db = setup_test_db().await;
+    let store = body_store();
+    let manager = TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    ));
+    let task = body_store_team_and_task(&manager).await;
+
+    let payload = json!({"type":"chat_message","text":"idempotent body"});
+    let (first, first_created) = manager
+        .append_task_conversation_message_with_created(
+            &task.id,
+            "user",
+            None,
+            "group_chat",
+            payload.clone(),
+            Some("idem-key-1"),
+        )
+        .await
+        .expect("first append");
+    assert!(first_created);
+
+    // Drain so the existing body lives only in the store: the conflict path must rehydrate from the
+    // store (outbox is empty) before comparing payload fingerprints.
+    agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
+        .await
+        .unwrap();
+
+    let (second, second_created) = manager
+        .append_task_conversation_message_with_created(
+            &task.id,
+            "user",
+            None,
+            "group_chat",
+            payload.clone(),
+            Some("idem-key-1"),
+        )
+        .await
+        .expect("idempotent replay should not error");
+    assert!(!second_created);
+    assert_eq!(second.message_id, first.message_id);
+}
+
+#[tokio::test]
+async fn conversation_body_stays_inline_without_body_store() {
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+    let task = body_store_team_and_task(&manager).await;
+
+    let payload = json!({"type":"chat_message","text":"inline body"});
+    let message = manager
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", payload.clone())
+        .await
+        .expect("append message");
+
+    let stored: String =
+        sqlx::query_scalar("SELECT payload_json FROM team_conversation_messages WHERE id = ?1")
+            .bind(message.message_id)
+            .fetch_one(&db)
+            .await
+            .expect("read stored payload");
+    // Body stays inline; the moved sentinel is never written.
+    assert_ne!(stored, "\u{0}agenthub:tcm-body-moved\u{1}");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stored).expect("inline payload is valid json"),
+        payload
+    );
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        0
+    );
+
+    let messages = manager
+        .list_task_conversation_messages(&task.id, 50, None)
+        .await
+        .expect("list");
+    assert_eq!(messages[0].payload, payload);
+}

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -596,7 +596,7 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
             .fetch_one(&db)
             .await
             .expect("read stored payload");
-    assert_eq!(stored, "\u{0}agenthub:tcm-body-moved\u{1}");
+    assert_eq!(stored, "::agenthub:tcm-body-moved::");
 
     // Promoted columns stay populated so queries keep working without the body.
     let text_col: Option<String> =
@@ -709,7 +709,7 @@ async fn conversation_body_stays_inline_without_body_store() {
             .await
             .expect("read stored payload");
     // Body stays inline; the moved sentinel is never written.
-    assert_ne!(stored, "\u{0}agenthub:tcm-body-moved\u{1}");
+    assert_ne!(stored, "::agenthub:tcm-body-moved::");
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&stored).expect("inline payload is valid json"),
         payload

--- a/src/team/manager/tests_support.rs
+++ b/src/team/manager/tests_support.rs
@@ -416,6 +416,19 @@ pub(super) async fn setup_test_db() -> SqlitePool {
 
     sqlx::query(
         r#"
+        CREATE TABLE message_body_outbox (
+            authority_message_id TEXT PRIMARY KEY,
+            body BLOB NOT NULL,
+            staged_at INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create message_body_outbox");
+
+    sqlx::query(
+        r#"
         CREATE TABLE team_actor_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id TEXT NOT NULL,


### PR DESCRIPTION
## What

Step 3b-2 of the RocksDB body-store move for `team_conversation_messages`: the **write/read** half. When a message body store is active, a conversation row's body moves out of SQLite into the (RocksDB-backed, SST-compressed) body store instead of living inline in `payload_json`. This is where the actual storage saving / compression comes from. Migrate/backfill command and per-target release wiring follow in later PRs.

Built on #770 (`TeamManager` already carries the body store).

## Write path (`insert_task_conversation_message_with_tx`)

- **Store present:** `payload_json` stores a moved sentinel; the real body is staged into the durable `message_body_outbox` **inside the same transaction** (keyed `tcm:{rowid}`), so the body commits atomically with the row that points at it. The existing background drainer later moves it into the body store.
- **No store** (older rows, or a binary built without the `rocksdb` feature): body stays inline, exactly as before — both shapes coexist.
- The returned in-memory record keeps the **full** payload, so the realtime archive dual-write and the conversation stream event are unaffected.

## Read path — 3-tier rehydrate (store → outbox → inline)

- `parse_team_conversation_message_row` now also reports whether the body was moved. The four readers rehydrate the payload from the body store, falling back to the not-yet-drained outbox:
  1. `list_task_conversation_messages`
  2. `find_channel_message_by_correlation_id`
  3. idempotency-conflict compare (rehydrates the existing row before fingerprinting)
  4. archive-migration batch
- Moved-ness is decided by an **exact sentinel string compare** — the sentinel is intentionally *not* valid JSON, so a real serialized payload can never collide with it and a user payload can never be mistaken for a moved body.
- `find_channel_message_by_correlation_id` now matches on the `correlation_id` **column** instead of `json_extract(payload_json, '$.correlation_id')` (which no longer sees the body). The column is already backfilled in `init_db`, so this is behavior-preserving.

The promoted `text` / `kind` / `thread_root_message_id` columns (step 3a) keep all queries working without the body. All other `json_extract(payload_json, …)` usages are on `team_actor_messages` (the deferred mailbox), untouched this round.

## Tests

New round-trip tests in `conversation_cases.rs`:
- body moves to store, SQLite holds the sentinel, promoted columns stay populated, read rehydrates from the **outbox** (pre-drain) and then from the **store** (post-drain);
- idempotency replay with a drained (store-only) body is **not** a false conflict;
- without a store the body stays inline and no sentinel/outbox row is written.

Plus `conversation_body` unit tests (sentinel is non-JSON, detection matches only the sentinel, key namespacing) and the `message_body_outbox` table added to the team test schema.

## Verification

- `cargo test -p agenthub --lib` ✅ 683 passed (incl. new round-trip + api::teams 94)
- `cargo check`/`clippy` default **and** `--features rocksdb --tests` ✅ clean
- `cargo fmt` ✅
- `bazelisk build //:agenthub` + `bazelisk test //:agenthub_unit_tests` ✅

## Next

3b-3: `migrate` command to backfill existing rows' bodies into the store. 3b-4: enable the `rocksdb` feature across all 3 release targets (verify aarch64 cross via branch CI first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)