### PR TITLE
feat(cli): add `agenthub migrate` to backfill conversation bodies into the store

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -290,6 +290,9 @@ pub async fn run() -> anyhow::Result<()> {
         Ok(crate::cli::RootCliCommand::Actor { args }) => {
             return crate::actor_cli::run_from_args(&args).await;
         }
+        Ok(crate::cli::RootCliCommand::Migrate { args }) => {
+            return crate::migrate_cli::run_from_args(&args).await;
+        }
         Ok(crate::cli::RootCliCommand::LegacyActorMcp) => {
             return Err(anyhow::anyhow!(
                 "`agenthub actor-mcp` has been removed. Use `agenthub actor ...` instead."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ pub(crate) enum RootCliCommand {
     Init { args: Vec<String> },
     Doctor { args: Vec<String> },
     Actor { args: Vec<String> },
+    Migrate { args: Vec<String> },
     LegacyActorMcp,
 }
 
@@ -23,6 +24,7 @@ enum AgentHubSubcommand {
     Init(PassthroughArgs),
     Doctor(PassthroughArgs),
     Actor(PassthroughArgs),
+    Migrate(PassthroughArgs),
     #[command(name = "actor-mcp", hide = true)]
     ActorMcp(PassthroughArgs),
 }
@@ -49,6 +51,7 @@ where
         Some(AgentHubSubcommand::Init(args)) => RootCliCommand::Init { args: args.args },
         Some(AgentHubSubcommand::Doctor(args)) => RootCliCommand::Doctor { args: args.args },
         Some(AgentHubSubcommand::Actor(args)) => RootCliCommand::Actor { args: args.args },
+        Some(AgentHubSubcommand::Migrate(args)) => RootCliCommand::Migrate { args: args.args },
         Some(AgentHubSubcommand::ActorMcp(_)) => RootCliCommand::LegacyActorMcp,
     })
 }
@@ -110,6 +113,18 @@ mod tests {
                     "inbox".to_string(),
                     "--help".to_string()
                 ]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_root_preserves_migrate_passthrough_args() {
+        let parsed =
+            parse_root_cli_from(["agenthub", "migrate", "--dry-run"]).expect("parse migrate");
+        assert_eq!(
+            parsed,
+            RootCliCommand::Migrate {
+                args: vec!["--dry-run".to_string()]
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use agenthub_db as db;
 mod internal;
 mod linkers;
 pub mod message_body_store;
+mod migrate_cli;
 pub use agenthub_config::path_utils;
 mod push;
 mod sse;

--- a/src/migrate_cli.rs
+++ b/src/migrate_cli.rs
@@ -1,0 +1,86 @@
+//! `agenthub migrate` — one-shot maintenance commands.
+//!
+//! Currently this backfills existing `team_conversation_messages` bodies into the tiered message body
+//! store: rows written before the store was enabled keep their body inline in SQLite, and this command
+//! moves them into the store (staging through the durable outbox, exactly like the write path) so the
+//! larger chat bodies live in the compressed store. It is safe to re-run: already-moved rows are
+//! skipped.
+
+use clap::{CommandFactory, Parser, error::ErrorKind};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "migrate",
+    bin_name = "agenthub migrate",
+    about = "Backfill existing conversation message bodies into the tiered body store.",
+    disable_help_subcommand = true
+)]
+struct MigrateCli {
+    /// Number of rows to move per transaction.
+    #[arg(long, value_name = "N", default_value_t = 500)]
+    batch_size: usize,
+    /// Report how many rows would be moved without changing anything.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+fn render_help() -> anyhow::Result<()> {
+    let mut command = MigrateCli::command();
+    command.print_long_help()?;
+    Ok(())
+}
+
+pub(crate) async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
+    if matches!(args, [arg] if arg.trim().eq_ignore_ascii_case("help")) {
+        return render_help();
+    }
+
+    let argv = std::iter::once("migrate".to_string()).chain(args.iter().cloned());
+    let cli = match MigrateCli::try_parse_from(argv) {
+        Ok(cli) => cli,
+        Err(err) if err.kind() == ErrorKind::DisplayHelp => {
+            err.print()?;
+            return Ok(());
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let (config, _info) = agenthub_config::AppConfig::load_with_info()?;
+    let pool = agenthub_db::init_db().await?;
+
+    let remaining = crate::team::count_inline_conversation_bodies(&pool).await?;
+    if cli.dry_run {
+        println!(
+            "[dry-run] {remaining} conversation message body/bodies would be moved into the body store"
+        );
+        return Ok(());
+    }
+
+    if remaining == 0 {
+        println!("no inline conversation message bodies to migrate");
+        return Ok(());
+    }
+
+    let Some(store) = crate::message_body_store::init_body_store(&config) else {
+        anyhow::bail!(
+            "the message body store is not available, so there is nowhere to migrate bodies to. \
+             Build with the `rocksdb` feature and keep `message_body_store` enabled in config, then \
+             re-run `agenthub migrate`. Nothing was changed."
+        );
+    };
+
+    let staged_at = chrono::Utc::now().timestamp();
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &pool,
+        store.as_ref(),
+        cli.batch_size,
+        staged_at,
+    )
+    .await?;
+
+    println!(
+        "migrated {} conversation message body/bodies into the body store ({} confirmed in the store)",
+        report.migrated, report.drained
+    );
+    Ok(())
+}

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -160,6 +160,9 @@ use self::codec_status::{
     team_run_status_to_str, team_step_status_to_str, team_task_priority_to_str,
     team_task_status_to_str,
 };
+pub(crate) use self::conversation_body::{
+    count_inline_conversation_bodies, migrate_conversation_bodies_into_store,
+};
 #[cfg(test)]
 pub(super) use self::conversation_idempotency::task_conversation_payload_correlation_id;
 use self::remote_relay_types::TeamRemoteRelayAdapter;

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -11,7 +11,7 @@
 //! keep their full inline `payload_json` and are never treated as moved, so both shapes coexist.
 
 use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
-use sqlx::Sqlite;
+use sqlx::{Sqlite, SqlitePool};
 
 use super::TeamManager;
 use crate::team::TeamConversationMessageRecord;
@@ -99,6 +99,107 @@ impl TeamManager {
         record.payload = serde_json::from_slice(&body)?;
         Ok(())
     }
+}
+
+/// Outcome of [`migrate_conversation_bodies_into_store`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConversationBodyMigrationReport {
+    /// Rows whose inline body was moved out of SQLite and staged into the outbox.
+    pub(crate) migrated: u64,
+    /// Bodies durably confirmed in the body store (drained from the outbox).
+    pub(crate) drained: u64,
+}
+
+/// Number of conversation rows whose body is still stored inline (i.e. not yet moved into the store).
+pub(crate) async fn count_inline_conversation_bodies(pool: &SqlitePool) -> anyhow::Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM team_conversation_messages WHERE payload_json != ?1",
+    )
+    .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
+/// Backfill existing inline conversation bodies into the body store.
+///
+/// Each batch moves rows out of SQLite (staging the body into the durable outbox and replacing the
+/// row's `payload_json` with the moved sentinel, atomically per transaction) and then drains that
+/// batch into the body store. A final drain pass clears any bodies left staged by an earlier
+/// interrupted run. The pass is resumable and idempotent: already-moved rows are skipped, so re-running
+/// after an interruption only processes what remains.
+pub(crate) async fn migrate_conversation_bodies_into_store(
+    pool: &SqlitePool,
+    store: &dyn MessageBodyStore,
+    batch_size: usize,
+    staged_at: i64,
+) -> anyhow::Result<ConversationBodyMigrationReport> {
+    use sqlx::Row as _;
+
+    let batch_size = batch_size.max(1) as i64;
+    // Only touch rows that already exist; rows written concurrently are handled by the write path.
+    let max_id: Option<i64> = sqlx::query_scalar("SELECT MAX(id) FROM team_conversation_messages")
+        .fetch_one(pool)
+        .await?;
+    let Some(max_id) = max_id else {
+        return Ok(ConversationBodyMigrationReport::default());
+    };
+
+    let mut report = ConversationBodyMigrationReport::default();
+    let mut cursor = 0_i64;
+    loop {
+        let rows = sqlx::query(
+            "SELECT id, payload_json FROM team_conversation_messages \
+             WHERE id > ?1 AND id <= ?2 AND payload_json != ?3 \
+             ORDER BY id ASC LIMIT ?4",
+        )
+        .bind(cursor)
+        .bind(max_id)
+        .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+        .bind(batch_size)
+        .fetch_all(pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+
+        let mut tx = pool.begin().await?;
+        for row in &rows {
+            let id: i64 = row.get("id");
+            let payload_json: String = row.get("payload_json");
+            agenthub_db::message_body_outbox::stage_body(
+                &mut tx,
+                &conversation_body_key(id),
+                payload_json.as_bytes(),
+                staged_at,
+            )
+            .await?;
+            sqlx::query("UPDATE team_conversation_messages SET payload_json = ?1 WHERE id = ?2")
+                .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+            cursor = id;
+            report.migrated += 1;
+        }
+        tx.commit().await?;
+
+        // Drain this batch so the outbox (which holds a duplicate of each body) stays bounded.
+        report.drained +=
+            agenthub_db::message_body_outbox::drain_into(pool, store, rows.len()).await? as u64;
+    }
+
+    // Clear anything left staged by an earlier interrupted run.
+    loop {
+        let drained =
+            agenthub_db::message_body_outbox::drain_into(pool, store, batch_size as usize).await?;
+        report.drained += drained as u64;
+        if (drained as i64) < batch_size {
+            break;
+        }
+    }
+
+    Ok(report)
 }
 
 #[cfg(test)]

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -137,6 +137,11 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
     use sqlx::Row as _;
 
     let batch_size = batch_size.max(1) as i64;
+    // The drain window is deliberately decoupled from the SQLite-tx batch size: `batch_size` bounds how
+    // many rows we rewrite per transaction, but draining must always look at a window wide enough to
+    // step over a sparse body that persistently fails to write. Otherwise, with a tiny batch size, the
+    // oldest stuck body would sit at the head of every drain and block everything behind it.
+    let drain_batch = batch_size.max(256) as usize;
     // Only touch rows that already exist; rows written concurrently are handled by the write path.
     let max_id: Option<i64> = sqlx::query_scalar("SELECT MAX(id) FROM team_conversation_messages")
         .fetch_one(pool)
@@ -184,17 +189,25 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
         }
         tx.commit().await?;
 
-        // Drain this batch so the outbox (which holds a duplicate of each body) stays bounded.
+        // Keep the outbox (which holds a duplicate of each body) bounded as we go.
         report.drained +=
-            agenthub_db::message_body_outbox::drain_into(pool, store, rows.len()).await? as u64;
+            agenthub_db::message_body_outbox::drain_into(pool, store, drain_batch).await? as u64;
     }
 
-    // Clear anything left staged by an earlier interrupted run.
+    // Clear anything left staged (e.g. by an earlier interrupted run). Drive the loop off the outbox
+    // count rather than the per-pass drained count: if a body persistently fails to write, a full pass
+    // returns fewer than the window size, which must not stop the loop while other bodies are still
+    // pending (head-of-line blocking). Stop when the outbox is empty, or when a whole pass makes no
+    // progress at all — only genuinely stuck bodies remain, which a later retry / the drainer can pick
+    // up.
     loop {
+        if agenthub_db::message_body_outbox::pending_count(pool).await? == 0 {
+            break;
+        }
         let drained =
-            agenthub_db::message_body_outbox::drain_into(pool, store, batch_size as usize).await?;
+            agenthub_db::message_body_outbox::drain_into(pool, store, drain_batch).await?;
         report.drained += drained as u64;
-        if (drained as i64) < batch_size {
+        if drained == 0 {
             break;
         }
     }

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -727,3 +727,81 @@ async fn conversation_body_stays_inline_without_body_store() {
         .expect("list");
     assert_eq!(messages[0].payload, payload);
 }
+
+#[tokio::test]
+async fn migrate_backfills_inline_conversation_bodies_into_store() {
+    use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+
+    let db = setup_test_db().await;
+    // Write rows without a store, so the bodies are stored inline (the pre-migration shape).
+    let writer = TeamManager::new(db.clone());
+    let task = body_store_team_and_task(&writer).await;
+
+    let p1 = json!({"type":"chat_message","text":"first inline body"});
+    let p2 = json!({"type":"chat_message","text":"second inline body"});
+    let m1 = writer
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", p1.clone())
+        .await
+        .expect("append 1");
+    let m2 = writer
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", p2.clone())
+        .await
+        .expect("append 2");
+
+    assert_eq!(
+        crate::team::count_inline_conversation_bodies(&db)
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        0
+    );
+
+    // Migrate into a fresh store with batch_size 1 to exercise the batching loop.
+    let store = body_store();
+    let report =
+        crate::team::migrate_conversation_bodies_into_store(&db, store.as_ref(), 1, 1_700_000_000)
+            .await
+            .expect("migrate");
+    assert_eq!(report.migrated, 2);
+    assert_eq!(report.drained, 2);
+
+    // Rows now carry the sentinel, the bodies live in the store, and the outbox is empty.
+    assert_eq!(
+        crate::team::count_inline_conversation_bodies(&db)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        0
+    );
+    assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", m1.message_id))));
+    assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", m2.message_id))));
+
+    // A reader with the store rehydrates the original payloads.
+    let reader = TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    ));
+    let messages = reader
+        .list_task_conversation_messages(&task.id, 50, None)
+        .await
+        .expect("list after migrate");
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].payload, p1);
+    assert_eq!(messages[1].payload, p2);
+
+    // Re-running the migration is a no-op.
+    let report_again =
+        crate::team::migrate_conversation_bodies_into_store(&db, store.as_ref(), 16, 1_700_000_000)
+            .await
+            .expect("migrate again");
+    assert_eq!(report_again.migrated, 0);
+}

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -805,3 +805,81 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
             .expect("migrate again");
     assert_eq!(report_again.migrated, 0);
 }
+
+#[tokio::test]
+async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
+    use agenthub_message_store::{
+        AuthorityMessageId, BodyStoreError, InMemoryBodyStore, MessageBodyStore,
+    };
+
+    let db = setup_test_db().await;
+    let writer = TeamManager::new(db.clone());
+    let task = body_store_team_and_task(&writer).await;
+
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        let message = writer
+            .append_task_conversation_message(
+                &task.id,
+                "user",
+                None,
+                "group_chat",
+                json!({"type":"chat_message","text":format!("body {i}")}),
+            )
+            .await
+            .expect("append");
+        ids.push(message.message_id);
+    }
+
+    // A store that always rejects the middle row's body, so it stays stuck in the outbox.
+    struct RejectOneStore {
+        inner: InMemoryBodyStore,
+        reject_key: String,
+    }
+    impl MessageBodyStore for RejectOneStore {
+        fn put_body(&self, id: &AuthorityMessageId, body: &[u8]) -> Result<(), BodyStoreError> {
+            if id.as_str() == self.reject_key {
+                return Err(BodyStoreError::Backend("rejected".into()));
+            }
+            self.inner.put_body(id, body)
+        }
+        fn get_body(&self, id: &AuthorityMessageId) -> Result<Option<Vec<u8>>, BodyStoreError> {
+            self.inner.get_body(id)
+        }
+        fn contains(&self, id: &AuthorityMessageId) -> bool {
+            self.inner.contains(id)
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+    }
+    let store = RejectOneStore {
+        inner: InMemoryBodyStore::new(),
+        reject_key: format!("tcm:{}", ids[1]),
+    };
+
+    // batch_size 1: a naive drain keyed off the row batch would let the stuck oldest body block the
+    // rest. The migration must still move every other body into the store and only leave the stuck one.
+    let report = crate::team::migrate_conversation_bodies_into_store(&db, &store, 1, 1_700_000_000)
+        .await
+        .expect("migrate");
+    assert_eq!(report.migrated, 3);
+    assert_eq!(report.drained, 2);
+
+    assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[0]))));
+    assert!(!store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[1]))));
+    assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[2]))));
+    // Only the rejected body is still pending; every row left SQLite (all moved to the sentinel).
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        crate::team::count_inline_conversation_bodies(&db)
+            .await
+            .unwrap(),
+        0
+    );
+}

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -41,6 +41,9 @@ pub use manager::{
     TeamTaskContextPatch, TeamTaskCreateInput, TeamTaskListQuery, TeamTaskNoteCreateInput,
     TeamTaskUpdateWithNoteInput,
 };
+pub(crate) use manager::{
+    count_inline_conversation_bodies, migrate_conversation_bodies_into_store,
+};
 pub(crate) use permission_review::resolve_team_permission_review_target;
 pub use permission_review::{
     TeamPermissionReviewDispatcher, TeamPermissionReviewDispatcherSettings,


### PR DESCRIPTION
## What

Step 3b-3 of the RocksDB body-store move for `team_conversation_messages`: the **migration capability**. Adds a one-shot `agenthub migrate` subcommand that moves existing *inline* conversation bodies into the tiered body store, for databases that predate the store being enabled (#771 only moves bodies written *after* the store is active).

Built on #771.

## How it works

Mirrors the write path so the on-disk result is identical to a freshly-written moved row:
- Scans `team_conversation_messages` for rows still storing their body inline (cursor by id, up to the start-of-run `MAX(id)`).
- Each batch, in one transaction, stages each body into the durable `message_body_outbox` and replaces the row's `payload_json` with the moved sentinel — atomic per row.
- After each batch commits, drains it into the body store, so the outbox (which holds a duplicate of each body) stays bounded. A final drain pass clears anything left staged by an earlier interrupted run.

**Resumable & idempotent:** already-moved rows are skipped via the sentinel filter, so re-running after an interruption only processes what remains; re-running a completed migration is a no-op.

## CLI

```
agenthub migrate [--batch-size N] [--dry-run]
```
- `--dry-run` — report how many rows would move, change nothing.
- `--batch-size N` — rows per transaction (default 500).
- If the body store is unavailable (binary built without the `rocksdb` feature, or disabled in config), the command **refuses with a clear message and changes nothing**, rather than silently no-op'ing.

## Layout

- Core: `team::manager::conversation_body::{migrate_conversation_bodies_into_store, count_inline_conversation_bodies}` (reuses the existing sentinel + outbox `stage_body`/`drain_into`).
- CLI: new `migrate_cli` module; `RootCliCommand::Migrate` + dispatch in `app.rs`, mirroring `init`/`doctor`/`actor`.

## Tests

- Migrate round-trip: write inline rows (no store) → migrate into a store with `batch_size=1` → assert sentinel in SQLite, both bodies in the store, outbox empty, a reader rehydrates the original payloads, and a second run reports `migrated=0`.
- `parse_root_preserves_migrate_passthrough_args` for the CLI wiring.

## Verification

- `cargo test -p agenthub --lib` ✅ 685 passed
- `cargo clippy` default **and** `--features rocksdb --tests` ✅ clean
- `cargo fmt` ✅
- `bazelisk build //:agenthub` + `bazelisk test //:agenthub_unit_tests` ✅; `agenthub migrate --help` renders.

## Next

3b-4 (final): enable the `rocksdb` feature across all 3 release targets (linux x86_64 / linux aarch64 / darwin aarch64), verifying the aarch64 cross build via branch CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)