### PR TITLE
feat(state): auto-backfill conversation bodies into the store on startup

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -112,6 +112,10 @@ pub struct MessageArchiveConfig {
 pub struct MessageBodyStoreConfig {
     pub enabled: Option<bool>,
     pub path: Option<String>,
+    /// Whether to backfill existing inline conversation bodies into the store on startup. Default-on;
+    /// set `auto_migrate = false` to only move bodies written from now on (e.g. to run `agenthub
+    /// migrate` manually instead).
+    pub auto_migrate: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -367,6 +371,15 @@ impl AppConfig {
         expand_tilde(path)
     }
 
+    /// Whether to backfill existing inline conversation bodies into the store on startup. Default-on;
+    /// only an explicit `auto_migrate = false` disables it.
+    pub fn message_body_store_auto_migrate(&self) -> bool {
+        self.message_body_store
+            .as_ref()
+            .and_then(|config| config.auto_migrate)
+            .unwrap_or(true)
+    }
+
     pub fn history_event_retention_days(&self) -> Option<u32> {
         let days = self
             .history
@@ -571,9 +584,36 @@ fn detect_env_overrides() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig, ServerConfig, ServerRole,
-        WorktreeConfig,
+        AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig, MessageBodyStoreConfig,
+        ServerConfig, ServerRole, WorktreeConfig,
     };
+
+    #[test]
+    fn message_body_store_auto_migrate_defaults_on() {
+        assert!(AppConfig::default().message_body_store_auto_migrate());
+        let config = AppConfig {
+            message_body_store: Some(MessageBodyStoreConfig {
+                enabled: Some(true),
+                path: None,
+                auto_migrate: None,
+            }),
+            ..Default::default()
+        };
+        assert!(config.message_body_store_auto_migrate());
+    }
+
+    #[test]
+    fn message_body_store_auto_migrate_can_be_disabled() {
+        let config = AppConfig {
+            message_body_store: Some(MessageBodyStoreConfig {
+                enabled: Some(true),
+                path: None,
+                auto_migrate: Some(false),
+            }),
+            ..Default::default()
+        };
+        assert!(!config.message_body_store_auto_migrate());
+    }
 
     #[test]
     fn server_role_defaults_to_main() {

--- a/src/migrate_cli.rs
+++ b/src/migrate_cli.rs
@@ -70,11 +70,13 @@ pub(crate) async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
     };
 
     let staged_at = chrono::Utc::now().timestamp();
+    // Foreground maintenance command: run flat-out, no inter-batch throttle.
     let report = crate::team::migrate_conversation_bodies_into_store(
         &pool,
         store.as_ref(),
         cli.batch_size,
         staged_at,
+        std::time::Duration::ZERO,
     )
     .await?;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -59,7 +59,14 @@ impl AppState {
         let agent_node_join_bootstrap = Self::build_agent_node_join_bootstrap(&config)?;
 
         Self::run_startup_cleanup(&agents, &teams).await?;
-        Self::spawn_startup_workers(&db, &agents, &teams, &body_store).await?;
+        Self::spawn_startup_workers(
+            &db,
+            &agents,
+            &teams,
+            &body_store,
+            config.message_body_store_auto_migrate(),
+        )
+        .await?;
 
         let default_worktree_root = config.default_worktree_root();
         Ok(Self {

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -48,6 +48,10 @@ impl AppState {
         store: crate::message_body_store::SharedBodyStore,
     ) {
         const BACKFILL_BATCH: usize = 256;
+        // Pace the background backfill so it yields the single SQLite writer between batches and does
+        // not starve concurrent writes (incoming messages, agent triggers) on startup.
+        const BACKFILL_INTER_BATCH_DELAY: std::time::Duration =
+            std::time::Duration::from_millis(25);
         tokio::spawn(async move {
             match crate::team::count_inline_conversation_bodies(&db).await {
                 Ok(0) => return,
@@ -68,6 +72,7 @@ impl AppState {
                 store.as_ref(),
                 BACKFILL_BATCH,
                 staged_at,
+                BACKFILL_INTER_BATCH_DELAY,
             )
             .await
             {

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -15,9 +15,13 @@ impl AppState {
         agents: &Arc<AgentManager>,
         teams: &Arc<TeamManager>,
         body_store: &Option<crate::message_body_store::SharedBodyStore>,
+        auto_migrate_conversation_bodies: bool,
     ) -> anyhow::Result<()> {
         if let Some(store) = body_store {
             Self::spawn_message_body_outbox_drainer(db.clone(), store.clone());
+            if auto_migrate_conversation_bodies {
+                Self::spawn_conversation_body_backfill(db.clone(), store.clone());
+            }
         }
         let _mailbox_hint_handle = TeamMailboxUnreadHintWorker::new(teams.clone(), agents.clone())
             .spawn(TeamMailboxUnreadHintWorkerSettings::default());
@@ -32,6 +36,53 @@ impl AppState {
         let _agent_trigger_handle = AgentTimeTriggerWorker::new(trigger_manager, agents.clone())
             .spawn(AgentTimeTriggerWorkerSettings::default());
         Ok(())
+    }
+
+    /// Backfills existing inline conversation bodies into the body store once, in the background, so a
+    /// database that predates the store being enabled is migrated automatically after an upgrade and
+    /// restart. It is safe to run on every startup: it is idempotent and resumable (already-moved rows
+    /// are skipped), and the read path serves both inline and moved rows, so online traffic during the
+    /// backfill is unaffected. Once the database is fully migrated each startup only pays a quick count.
+    fn spawn_conversation_body_backfill(
+        db: SqlitePool,
+        store: crate::message_body_store::SharedBodyStore,
+    ) {
+        const BACKFILL_BATCH: usize = 256;
+        tokio::spawn(async move {
+            match crate::team::count_inline_conversation_bodies(&db).await {
+                Ok(0) => return,
+                Ok(remaining) => {
+                    tracing::info!(
+                        remaining,
+                        "backfilling inline conversation bodies into the body store"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "conversation body backfill: failed to count inline bodies; skipping this startup");
+                    return;
+                }
+            }
+            let staged_at = chrono::Utc::now().timestamp();
+            match crate::team::migrate_conversation_bodies_into_store(
+                &db,
+                store.as_ref(),
+                BACKFILL_BATCH,
+                staged_at,
+            )
+            .await
+            {
+                Ok(report) => {
+                    tracing::info!(
+                        migrated = report.migrated,
+                        confirmed = report.drained,
+                        "conversation body backfill complete"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "conversation body backfill failed; will retry on next startup");
+                }
+            }
+        });
     }
 
     /// Periodically drains the SQLite message-body outbox into the body store, so staged bodies are

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -128,11 +128,17 @@ pub(crate) async fn count_inline_conversation_bodies(pool: &SqlitePool) -> anyho
 /// batch into the body store. A final drain pass clears any bodies left staged by an earlier
 /// interrupted run. The pass is resumable and idempotent: already-moved rows are skipped, so re-running
 /// after an interruption only processes what remains.
+///
+/// `inter_batch_delay` paces the loop by sleeping between batches. SQLite allows only one writer, so a
+/// tight loop of write transactions can starve concurrent writers; a non-zero delay yields the write
+/// lock so online traffic makes progress. Pass `Duration::ZERO` for the foreground `agenthub migrate`
+/// command (run it flat-out), and a small delay for the background startup backfill.
 pub(crate) async fn migrate_conversation_bodies_into_store(
     pool: &SqlitePool,
     store: &dyn MessageBodyStore,
     batch_size: usize,
     staged_at: i64,
+    inter_batch_delay: std::time::Duration,
 ) -> anyhow::Result<ConversationBodyMigrationReport> {
     use sqlx::Row as _;
 
@@ -192,6 +198,11 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
         // Keep the outbox (which holds a duplicate of each body) bounded as we go.
         report.drained +=
             agenthub_db::message_body_outbox::drain_into(pool, store, drain_batch).await? as u64;
+
+        // Yield the single SQLite writer between batches so concurrent writes are not starved.
+        if !inter_batch_delay.is_zero() {
+            tokio::time::sleep(inter_batch_delay).await;
+        }
     }
 
     // Clear anything left staged (e.g. by an earlier interrupted run). Drive the loop off the outbox
@@ -209,6 +220,9 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
         report.drained += drained as u64;
         if drained == 0 {
             break;
+        }
+        if !inter_batch_delay.is_zero() {
+            tokio::time::sleep(inter_batch_delay).await;
         }
     }
 

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -763,10 +763,15 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
 
     // Migrate into a fresh store with batch_size 1 to exercise the batching loop.
     let store = body_store();
-    let report =
-        crate::team::migrate_conversation_bodies_into_store(&db, store.as_ref(), 1, 1_700_000_000)
-            .await
-            .expect("migrate");
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        1,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("migrate");
     assert_eq!(report.migrated, 2);
     assert_eq!(report.drained, 2);
 
@@ -799,10 +804,15 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
     assert_eq!(messages[1].payload, p2);
 
     // Re-running the migration is a no-op.
-    let report_again =
-        crate::team::migrate_conversation_bodies_into_store(&db, store.as_ref(), 16, 1_700_000_000)
-            .await
-            .expect("migrate again");
+    let report_again = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        16,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("migrate again");
     assert_eq!(report_again.migrated, 0);
 }
 
@@ -860,9 +870,15 @@ async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
 
     // batch_size 1: a naive drain keyed off the row batch would let the stuck oldest body block the
     // rest. The migration must still move every other body into the store and only leave the stuck one.
-    let report = crate::team::migrate_conversation_bodies_into_store(&db, &store, 1, 1_700_000_000)
-        .await
-        .expect("migrate");
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        &store,
+        1,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("migrate");
     assert_eq!(report.migrated, 3);
     assert_eq!(report.drained, 2);
 


### PR DESCRIPTION
## What

Answers "升级重启后能自动迁移吗?" — yes. After an upgrade-and-restart, a database that predates the body store being enabled still has its conversation bodies inline in SQLite. This runs the backfill (the same logic as `agenthub migrate`, #772) **automatically as a background task on startup** when the store is active, so operators don't have to run the CLI by hand.

Built on #772.

## Why it's safe to run every boot

- **Idempotent & resumable** — already-moved rows are skipped (sentinel filter), so a completed migration is a no-op and an interrupted one resumes.
- **Read path serves both shapes** — inline and moved rows both rehydrate correctly, so online traffic during the backfill is unaffected.
- **Background** — runs in a spawned task, so it never delays serving. Failures are logged and retried on the next startup.
- Once the database is fully migrated, each startup only pays a quick `count_inline_conversation_bodies` check and returns immediately.

## Config

Gated by `message_body_store.auto_migrate` (**default on**). Set it to `false` to only move bodies written from now on and run `agenthub migrate` manually instead.

## Changes

- `MessageBodyStoreConfig.auto_migrate: Option<bool>` + `AppConfig::message_body_store_auto_migrate()` (default-on).
- `AppState::spawn_conversation_body_backfill` in `startup.rs`, spawned alongside the existing outbox drainer when the store is present and the flag is on; the flag is threaded through `spawn_startup_workers` from `AppState::init`.

## Tests

- Config accessor: default-on and explicit-`false` (`agenthub-config`).
- The backfill body reuses `migrate_conversation_bodies_into_store`, already covered by #772's round-trip and head-of-line-blocking tests.

## Verification

- `cargo test -p agenthub --lib` ✅ 686 · `-p agenthub-config` ✅ 31
- `cargo clippy --features rocksdb --tests` ✅ clean · `cargo fmt` ✅
- `bazelisk build //:agenthub` + `bazelisk test //:agenthub_unit_tests //crates/agenthub-config:agenthub_config_tests` ✅

## Next

3b-4 (final): enable the `rocksdb` feature across the 3 release targets (linux x86_64 / linux aarch64 / darwin aarch64), verifying the aarch64 cross build via branch CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)