### PR TITLE
ci(release): enable rocksdb across all release targets

### DIFF
--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -2,7 +2,7 @@ name: Release Prebuild
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "feat/release-rocksdb-targets"]
 
 permissions:
   contents: read
@@ -23,17 +23,17 @@ jobs:
             os: ubuntu-22.04
             arch: amd64
             cross: true
-            agenthub_features: release-vendored-openssl,release-lance-fp16
+            agenthub_features: release-vendored-openssl,release-lance-fp16,rocksdb
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             arch: arm64
             cross: true
-            agenthub_features: release-vendored-openssl
+            agenthub_features: release-vendored-openssl,rocksdb
           - target: aarch64-apple-darwin
             os: macos-14
             arch: arm64
             cross: false
-            agenthub_features: ""
+            agenthub_features: rocksdb
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -2,7 +2,7 @@ name: Release Prebuild
 
 on:
   push:
-    branches: ["main", "feat/release-rocksdb-targets"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,21 +35,21 @@ jobs:
             os: ubuntu-22.04
             arch: amd64
             cross: true
-            agenthub_features: release-vendored-openssl,release-lance-fp16
-          
+            agenthub_features: release-vendored-openssl,release-lance-fp16,rocksdb
+
           # Linux ARM64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             arch: arm64
             cross: true
-            agenthub_features: release-vendored-openssl
-          
+            agenthub_features: release-vendored-openssl,rocksdb
+
           # macOS ARM64 (Apple Silicon)
           - target: aarch64-apple-darwin
             os: macos-14
             arch: arm64
             cross: false
-            agenthub_features: ""
+            agenthub_features: rocksdb
 
     steps:
       - name: Checkout

--- a/Cross.toml
+++ b/Cross.toml
@@ -11,13 +11,16 @@ pre-build = [
 
 env.passthrough = ["OPENSSL_STATIC=1"]
 
+# The default cross image for this target is Ubuntu Xenial, whose distro libclang (3.8) is far too old
+# for librocksdb-sys' bindgen (clang-sys needs clang_getTranslationUnitTargetInfo). Use the Focal-based
+# :edge image (same family as the x86_64 target) and install a modern libclang from apt.llvm.org. The
+# C/C++ for the aarch64 target is still compiled by the image's aarch64 g++; libclang is host-only, for
+# bindgen, which runs on the build host.
 [target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    # `clang` + `libclang-dev` are host (build-arch) packages: bindgen-runtime runs on the build host to
-    # generate librocksdb-sys' RocksDB bindings, while the bundled RocksDB/zstd C/C++ are compiled for
-    # the target by the cross image's aarch64 g++.
-    "apt-get update && apt-get install --assume-yes pkg-config curl unzip clang libclang-dev zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates gnupg pkg-config curl unzip zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && mkdir -p /etc/apt/keyrings && curl --fail --location 'https://apt.llvm.org/llvm-snapshot.gpg.key' | gpg --dearmor --yes --output /etc/apt/keyrings/llvm.gpg && echo 'deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/focal/ llvm-toolchain-focal-15 main' > /etc/apt/sources.list.d/llvm.list && apt-get update && apt-get install --assume-yes --no-install-recommends clang-15 libclang-15-dev && apt-get clean && rm -rf /var/lib/apt/lists/*",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]
 env.passthrough = ["OPENSSL_STATIC=1"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,9 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
-    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates gnupg pkg-config curl unzip zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && mkdir -p /etc/apt/keyrings && curl --fail --location 'https://apt.llvm.org/llvm-snapshot.gpg.key' | gpg --dearmor --yes --output /etc/apt/keyrings/llvm.gpg && echo 'deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/focal/ llvm-toolchain-focal-15 main' > /etc/apt/sources.list.d/llvm.list && apt-get update && apt-get install --assume-yes --no-install-recommends clang-15 lld-15 && apt-get clean && rm -rf /var/lib/apt/lists/*",
+    # clang-15 is the C/C++ compiler (Lance fp16 kernels need Clang 15+); libclang-15-dev provides the
+    # shared library that librocksdb-sys' bindgen-runtime loads to generate the RocksDB bindings.
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates gnupg pkg-config curl unzip zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH && mkdir -p /etc/apt/keyrings && curl --fail --location 'https://apt.llvm.org/llvm-snapshot.gpg.key' | gpg --dearmor --yes --output /etc/apt/keyrings/llvm.gpg && echo 'deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/focal/ llvm-toolchain-focal-15 main' > /etc/apt/sources.list.d/llvm.list && apt-get update && apt-get install --assume-yes --no-install-recommends clang-15 lld-15 libclang-15-dev && apt-get clean && rm -rf /var/lib/apt/lists/*",
     "update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-15 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-15 100 && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 100 && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 100 && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-15 100 && cc --version",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]
@@ -12,7 +14,10 @@ env.passthrough = ["OPENSSL_STATIC=1"]
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get install --assume-yes pkg-config curl unzip zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH",
+    # `clang` + `libclang-dev` are host (build-arch) packages: bindgen-runtime runs on the build host to
+    # generate librocksdb-sys' RocksDB bindings, while the bundled RocksDB/zstd C/C++ are compiled for
+    # the target by the cross image's aarch64 g++.
+    "apt-get update && apt-get install --assume-yes pkg-config curl unzip clang libclang-dev zlib1g-dev:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libcap-dev:$CROSS_DEB_ARCH",
     "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip && rm -rf /opt/protoc-27.1 && mkdir -p /opt/protoc-27.1 && unzip -q /tmp/protoc.zip -d /opt/protoc-27.1 && ln -sf /opt/protoc-27.1/bin/protoc /usr/local/bin/protoc && protoc --version",
 ]
 env.passthrough = ["OPENSSL_STATIC=1"]


### PR DESCRIPTION
## What

Final step (3b-4) of the message-body compression effort: ship the compressed RocksDB body store in release binaries by enabling the `rocksdb` feature on **all three release targets** — linux x86_64, linux aarch64, darwin aarch64.

## Changes

- **release.yml + release-prebuild.yml**: add `rocksdb` to `agenthub_features` for each target (x86_64 → `release-vendored-openssl,release-lance-fp16,rocksdb`; aarch64-linux → `release-vendored-openssl,rocksdb`; darwin → `rocksdb`).
- **Cross.toml** — give `librocksdb-sys`' bindgen the libclang it needs (zstd is vendored by librocksdb-sys, so no system compression libs):
  - **x86_64**: already installs clang-15 as the compiler; add `libclang-15-dev`.
  - **aarch64**: the default cross image is Ubuntu Xenial, whose distro libclang is **3.8** — too old for bindgen (`clang-sys` panics: *"clang_getTranslationUnitTargetInfo not supported, loaded instance = 3.8.x"*). Pin this target to the Focal-based `:edge` image (same family as x86_64) and install `clang-15` + `libclang-15-dev` from apt.llvm.org. The aarch64 RocksDB/zstd C/C++ is still compiled by the image's aarch64 g++; libclang is host-only, for bindgen.

## Verification

The aarch64 cross build of bundled RocksDB can't be verified locally, so the prebuild matrix was run on this branch (via a temporary trigger, since removed). **All three targets built green** with `rocksdb` enabled:

- ✅ Prebuild x86_64-unknown-linux-gnu
- ✅ Prebuild aarch64-unknown-linux-gnu
- ✅ Prebuild aarch64-apple-darwin

(run `27474206393`). The final commit removes the temporary branch trigger, restoring prebuild to main-only; the matrix/Cross.toml content is identical to the verified commit.

## Result

With this merged, release binaries on all three platforms include the compressed body store, so the conversation-body compression (write/read move #771, manual migrate #772, auto-migrate #774) actually ships to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)