### PR TITLE
ci(body-store): scope the stress workflow with --test_arg, not --test_filter

### DIFF
--- a/.github/workflows/body-store-tests.yml
+++ b/.github/workflows/body-store-tests.yml
@@ -77,12 +77,16 @@ jobs:
         run: |
           bazel test --test_output=errors --nocache_test_results \
             --runs_per_test="${BODY_STORE_RUNS_PER_TEST}" \
-            --test_filter='team::manager::tests::conversation_cases::' \
+            --test_arg='team::manager::tests::conversation_cases::' \
             //:agenthub_unit_tests
       - name: Body store unit tests (stress)
-        # The store abstraction + durable outbox stage/drain/replay layer.
+        # The store abstraction + durable outbox stage/drain/replay layer. Each test binary takes its
+        # own filter, so the db target is scoped to the outbox tests separately.
         run: |
           bazel test --test_output=errors --nocache_test_results \
             --runs_per_test="${BODY_STORE_RUNS_PER_TEST}" \
-            //crates/agenthub-message-store:agenthub_message_store_tests \
+            //crates/agenthub-message-store:agenthub_message_store_tests
+          bazel test --test_output=errors --nocache_test_results \
+            --runs_per_test="${BODY_STORE_RUNS_PER_TEST}" \
+            --test_arg='message_body_outbox' \
             //crates/agenthub-db:agenthub_db_tests


### PR DESCRIPTION
## Problem

The body-store stress workflow added in #776 used Bazel's `--test_filter` to scope the run to the `conversation_cases` suite. But **`rules_rust`'s `rust_test` ignores `--test_filter`**, so the job actually reran the **entire ~689-test `agenthub_unit_tests` binary 25×** — slow, and it pulled in an unrelated **flaky** test from the full suite. That's exactly why the first run on #776 failed (`FAIL: //:agenthub_unit_tests (run 1 of 25)`, with the log showing `actor_cli::…`/`api::…` tests running); the review-fix commit only passed by luck.

## Fix

Pass the libtest filter as **`--test_arg`** instead, which the test binary honors as a positional filter, and scope the db target to its outbox tests the same way (each test binary takes its own filter, so the two-target command is split).

Verified locally:
- `//:agenthub_unit_tests --test_arg='team::manager::tests::conversation_cases::'` → **running 16 tests** (673 filtered out)
- `//crates/agenthub-db:agenthub_db_tests --test_arg='message_body_outbox'` → **running 3 tests** (32 filtered out)
- `--runs_per_test=2` reruns pass.

Now the stress job exercises only the body-store tests, so unrelated suite flakiness can't fail it (and it's far faster).

## Follow-up (separate)

The full suite does have a latent flaky test that surfaces under repeated runs — out of scope here, but worth tracking down separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)