### PR TITLE
chore(release): align package versions for 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agent-client-protocol",
  "agenthub-acp",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-acp"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agent-client-protocol",
  "agenthub-acp-core",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-acp-adapter"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-codex-acp",
  "anyhow",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-acp-core"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agent-client-protocol",
  "serde",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-agent-domain"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "serde",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-agent-event-codec"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-agent-domain",
  "agenthub-db",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-auth-domain"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "argon2",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-auth-passkeys"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-auth-store"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-auth-domain",
  "anyhow",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-config"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "serde",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-db"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-config",
  "agenthub-message-store",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-diagnostics"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-agent-domain",
  "agenthub-agent-event-codec",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-doctor-cli"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-diagnostics",
  "agenthub-managed-skills",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-internal-p2p"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-team-actor",
  "anyhow",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-internal-tls"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-linkers"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-db",
  "anyhow",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-logging"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -667,14 +667,14 @@ dependencies = [
 
 [[package]]
 name = "agenthub-managed-skills"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "agenthub-message-archive"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-message-store"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "rocksdb",
  "serde",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-push"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "agenthub-config",
  "anyhow",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-pyroscope"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "pyroscope",
  "tracing",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-team-actor"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "async-trait",
  "serde",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "agenthub-team-domain"
-version = "0.1.0"
+version = "0.0.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -748,11 +748,11 @@ dependencies = [
 
 [[package]]
 name = "agenthub-team-prompts"
-version = "0.1.0"
+version = "0.0.10"
 
 [[package]]
 name = "agenthub-text"
-version = "0.1.0"
+version = "0.0.10"
 
 [[package]]
 name = "ahash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev 
 
 [package]
 name = "agenthub"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/cmd/agenthub/Cargo.toml
+++ b/cmd/agenthub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-cmd"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-acp-adapter"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 authors = ["AgentHub <dev@agenthub.local>"]
 license = "Apache-2.0"

--- a/crates/agenthub-acp-core/Cargo.toml
+++ b/crates/agenthub-acp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-acp-core"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-acp"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-agent-domain/Cargo.toml
+++ b/crates/agenthub-agent-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-agent-domain"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-agent-event-codec/Cargo.toml
+++ b/crates/agenthub-agent-event-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-agent-event-codec"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-auth-domain/Cargo.toml
+++ b/crates/agenthub-auth-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-auth-domain"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-auth-passkeys/Cargo.toml
+++ b/crates/agenthub-auth-passkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-auth-passkeys"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-auth-store/Cargo.toml
+++ b/crates/agenthub-auth-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-auth-store"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-config/Cargo.toml
+++ b/crates/agenthub-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-config"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-db/Cargo.toml
+++ b/crates/agenthub-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-db"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-diagnostics/Cargo.toml
+++ b/crates/agenthub-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-diagnostics"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-doctor-cli/Cargo.toml
+++ b/crates/agenthub-doctor-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-doctor-cli"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-internal-p2p/Cargo.toml
+++ b/crates/agenthub-internal-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-internal-p2p"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-internal-tls/Cargo.toml
+++ b/crates/agenthub-internal-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-internal-tls"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-linkers/Cargo.toml
+++ b/crates/agenthub-linkers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-linkers"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-logging/Cargo.toml
+++ b/crates/agenthub-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-logging"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-managed-skills/Cargo.toml
+++ b/crates/agenthub-managed-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-managed-skills"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-message-archive/Cargo.toml
+++ b/crates/agenthub-message-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-message-archive"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-message-store/Cargo.toml
+++ b/crates/agenthub-message-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-message-store"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-push/Cargo.toml
+++ b/crates/agenthub-push/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-push"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-pyroscope/Cargo.toml
+++ b/crates/agenthub-pyroscope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-pyroscope"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-team-actor/Cargo.toml
+++ b/crates/agenthub-team-actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-team-actor"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-team-domain/Cargo.toml
+++ b/crates/agenthub-team-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-team-domain"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-team-prompts/Cargo.toml
+++ b/crates/agenthub-team-prompts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-team-prompts"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/agenthub-text/Cargo.toml
+++ b/crates/agenthub-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenthub-text"
-version = "0.1.0"
+version = "0.0.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/userdocs/package-lock.json
+++ b/userdocs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthub-userdocs",
-  "version": "0.1.0",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthub-userdocs",
-      "version": "0.1.0",
+      "version": "0.0.10",
       "dependencies": {
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/preset-classic": "^3.10.1",

--- a/userdocs/package.json
+++ b/userdocs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agenthub-userdocs",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.10",
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthub-web",
-  "version": "0.1.0",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthub-web",
-      "version": "0.1.0",
+      "version": "0.0.10",
       "dependencies": {
         "@chenglou/pretext": "^0.0.7",
         "@mantine/core": "9.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agenthub-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Align first-party Cargo package versions from 0.1.0 to 0.0.10 for the requested v0.0.10 release.
- Align web and userdocs package/package-lock versions to 0.0.10.
- Keep Cargo.lock changes scoped to first-party agenthub package entries only.

## Testing

- `cargo check --locked -p agenthub --bin agenthub`
- `cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name|startswith("agenthub")) | [.name,.version] | @tsv' | sort`
- `node -p "require('./package.json').version + ' ' + require('./package-lock.json').version + ' ' + require('./package-lock.json').packages[''].version"` in `web`
- `node -p "require('./package.json').version + ' ' + require('./package-lock.json').version + ' ' + require('./package-lock.json').packages[''].version"` in `userdocs`
- `git diff --check`
