### PR TITLE
test(body-store): concurrent write/drain/read race test

### DIFF
--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -37,6 +37,13 @@ pub(super) fn conversation_payload_was_moved(payload_json: &str) -> bool {
 
 /// Load a moved conversation body, preferring the drained body store and falling back to the durable
 /// outbox (for bodies staged but not yet drained). Returns `None` only if the body is in neither.
+///
+/// The lookup order is store → outbox → store. The second store check is what makes this race-free
+/// against a concurrent drainer: the drainer writes the body into the store and only *then* deletes its
+/// outbox row, so if the body is missing from the store on the first check and also missing from the
+/// outbox, the drainer must have moved it between the two checks — and an absent outbox row means the
+/// store write already completed. Without the re-check, a read interleaved with a drain could see the
+/// body in neither place and spuriously fail.
 async fn load_moved_conversation_body<'a, E>(
     body_store: Option<&dyn MessageBodyStore>,
     outbox_executor: E,
@@ -45,19 +52,41 @@ async fn load_moved_conversation_body<'a, E>(
 where
     E: sqlx::Executor<'a, Database = Sqlite>,
 {
-    if let Some(store) = body_store
-        && let Some(body) = store
+    let get_from_store = |store: &dyn MessageBodyStore| {
+        store
             .get_body(key)
-            .map_err(|err| anyhow::anyhow!(err.to_string()))?
+            .map_err(|err| anyhow::anyhow!(err.to_string()))
+    };
+
+    // Steady state: the body has been drained into the store. Check it first so a read does not pay for
+    // an outbox query once the body has settled.
+    if let Some(store) = body_store
+        && let Some(body) = get_from_store(store)?
     {
         return Ok(Some(body));
     }
-    let body: Option<Vec<u8>> =
-        sqlx::query_scalar("SELECT body FROM message_body_outbox WHERE authority_message_id = ?1")
-            .bind(key.as_str())
-            .fetch_optional(outbox_executor)
-            .await?;
-    Ok(body)
+
+    // Not (yet) in the store: it should still be staged in the durable outbox.
+    if let Some(body) = sqlx::query_scalar::<_, Vec<u8>>(
+        "SELECT body FROM message_body_outbox WHERE authority_message_id = ?1",
+    )
+    .bind(key.as_str())
+    .fetch_optional(outbox_executor)
+    .await?
+    {
+        return Ok(Some(body));
+    }
+
+    // Missing from both the first store check and the outbox: a concurrent drainer may have moved the
+    // body into the store after that first check and before the outbox check. Re-check the store to
+    // close that window (the drainer writes the store before deleting the outbox row).
+    if let Some(store) = body_store
+        && let Some(body) = get_from_store(store)?
+    {
+        return Ok(Some(body));
+    }
+
+    Ok(None)
 }
 
 /// Rehydrate a moved conversation body in place, using `tx` for the outbox fallback. For the insert

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -1016,10 +1016,25 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
     use agenthub_message_store::{InMemoryBodyStore, MessageBodyStore};
     use std::collections::HashSet;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     // A real file-backed WAL pool so the write path, the outbox drainer, and the read path actually
     // interleave (the shared :memory: pool serializes everything).
     let (db, dir) = setup_concurrent_conversation_db().await;
+
+    // Remove the temp database directory even if the test panics. Cleanup is spawned so the blocking
+    // filesystem work stays off the async drop path.
+    struct CleanupGuard(std::path::PathBuf);
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            let path = std::mem::take(&mut self.0);
+            tokio::spawn(async move {
+                let _ = tokio::fs::remove_dir_all(path).await;
+            });
+        }
+    }
+    let _cleanup = CleanupGuard(dir);
+
     let store = Arc::new(InMemoryBodyStore::new());
     let manager = Arc::new(TeamManager::new(db.clone()).with_body_store(Some(
         store.clone() as crate::message_body_store::SharedBodyStore
@@ -1048,6 +1063,10 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
 
     const MESSAGE_COUNT: usize = 40;
 
+    // The drainer and readers run for the whole duration of the appends (driven by this flag) rather
+    // than a fixed iteration count that might finish before the writes do.
+    let appenders_done = Arc::new(AtomicBool::new(false));
+
     // Appenders write concurrently: each stages its body to the outbox and slims the row to the sentinel.
     let mut appenders = Vec::new();
     for i in 0..MESSAGE_COUNT {
@@ -1067,12 +1086,14 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
         }));
     }
 
-    // A drainer moves staged bodies into the store concurrently with the writes.
+    // A drainer moves staged bodies into the store concurrently with the writes, exercising the
+    // store↔outbox handoff the read path must tolerate.
     let drainer = {
         let db = db.clone();
         let store = store.clone();
+        let appenders_done = appenders_done.clone();
         tokio::spawn(async move {
-            for _ in 0..400 {
+            while !appenders_done.load(Ordering::Relaxed) {
                 agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 8)
                     .await
                     .expect("drain");
@@ -1084,13 +1105,14 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
     // Readers continuously list while writes/drains race. The invariant: a moved row must ALWAYS
     // rehydrate to its real object payload — never the null/sentinel placeholder and never an error —
     // because the body is staged atomically with the sentinel and only leaves the outbox after the
-    // store write succeeds, so it is always in the store or the outbox.
+    // store write succeeds (the read path re-checks the store to stay race-free against the drainer).
     let mut readers = Vec::new();
     for _ in 0..3 {
         let manager = manager.clone();
         let task_id = task_id.clone();
+        let appenders_done = appenders_done.clone();
         readers.push(tokio::spawn(async move {
-            for _ in 0..80 {
+            while !appenders_done.load(Ordering::Relaxed) {
                 let messages = manager
                     .list_task_conversation_messages(&task_id, 100, None)
                     .await
@@ -1114,6 +1136,7 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
     for appender in appenders {
         appender.await.expect("appender task");
     }
+    appenders_done.store(true, Ordering::Relaxed);
     drainer.await.expect("drainer task");
     for reader in readers {
         reader.await.expect("reader task");
@@ -1153,6 +1176,4 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
         0
     );
     assert_eq!(store.len(), MESSAGE_COUNT);
-
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -1010,3 +1010,149 @@ async fn read_surfaces_corrupt_body_instead_of_a_garbage_payload() {
         "a corrupt stored body must fail rehydration, got {result:?}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
+    use agenthub_message_store::{InMemoryBodyStore, MessageBodyStore};
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    // A real file-backed WAL pool so the write path, the outbox drainer, and the read path actually
+    // interleave (the shared :memory: pool serializes everything).
+    let (db, dir) = setup_concurrent_conversation_db().await;
+    let store = Arc::new(InMemoryBodyStore::new());
+    let manager = Arc::new(TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    )));
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "race-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"coordinator","members":[{"member_id":"coordinator"}]}),
+        })
+        .await
+        .expect("create team");
+    let (task, _conversation) = manager
+        .create_task(
+            &team.id,
+            "all",
+            "user",
+            json!({"bootstrap_kind":"shared_thread"}),
+            "group_chat",
+            Some("all"),
+        )
+        .await
+        .expect("create task");
+    let task_id = task.id;
+
+    const MESSAGE_COUNT: usize = 40;
+
+    // Appenders write concurrently: each stages its body to the outbox and slims the row to the sentinel.
+    let mut appenders = Vec::new();
+    for i in 0..MESSAGE_COUNT {
+        let manager = manager.clone();
+        let task_id = task_id.clone();
+        appenders.push(tokio::spawn(async move {
+            manager
+                .append_task_conversation_message(
+                    &task_id,
+                    "user",
+                    None,
+                    "group_chat",
+                    json!({"type":"chat_message","seq":i,"text":format!("message {i}")}),
+                )
+                .await
+                .expect("append");
+        }));
+    }
+
+    // A drainer moves staged bodies into the store concurrently with the writes.
+    let drainer = {
+        let db = db.clone();
+        let store = store.clone();
+        tokio::spawn(async move {
+            for _ in 0..400 {
+                agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 8)
+                    .await
+                    .expect("drain");
+                tokio::task::yield_now().await;
+            }
+        })
+    };
+
+    // Readers continuously list while writes/drains race. The invariant: a moved row must ALWAYS
+    // rehydrate to its real object payload — never the null/sentinel placeholder and never an error —
+    // because the body is staged atomically with the sentinel and only leaves the outbox after the
+    // store write succeeds, so it is always in the store or the outbox.
+    let mut readers = Vec::new();
+    for _ in 0..3 {
+        let manager = manager.clone();
+        let task_id = task_id.clone();
+        readers.push(tokio::spawn(async move {
+            for _ in 0..80 {
+                let messages = manager
+                    .list_task_conversation_messages(&task_id, 100, None)
+                    .await
+                    .expect("list must not error mid-race");
+                for message in &messages {
+                    assert!(
+                        message
+                            .payload
+                            .get("seq")
+                            .and_then(serde_json::Value::as_u64)
+                            .is_some(),
+                        "a moved body must rehydrate to its real payload, got {:?}",
+                        message.payload
+                    );
+                }
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
+
+    for appender in appenders {
+        appender.await.expect("appender task");
+    }
+    drainer.await.expect("drainer task");
+    for reader in readers {
+        reader.await.expect("reader task");
+    }
+
+    // Drain whatever is left, then assert the final state is fully consistent: every message is present
+    // exactly once with its real body, the outbox is empty, and the store holds one body per message.
+    loop {
+        let drained = agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
+            .await
+            .expect("final drain");
+        if drained == 0 {
+            break;
+        }
+    }
+
+    let messages = manager
+        .list_task_conversation_messages(&task_id, 200, None)
+        .await
+        .expect("final list");
+    assert_eq!(messages.len(), MESSAGE_COUNT);
+    let mut seqs = HashSet::new();
+    for message in &messages {
+        let seq = message
+            .payload
+            .get("seq")
+            .and_then(serde_json::Value::as_u64)
+            .expect("rehydrated payload keeps seq");
+        assert_eq!(message.payload["text"], json!(format!("message {seq}")));
+        seqs.insert(seq);
+    }
+    assert_eq!(seqs.len(), MESSAGE_COUNT, "every distinct message survived");
+    assert_eq!(
+        agenthub_db::message_body_outbox::pending_count(&db)
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(store.len(), MESSAGE_COUNT);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/team/manager/tests_support.rs
+++ b/src/team/manager/tests_support.rs
@@ -662,6 +662,118 @@ pub(super) async fn setup_test_db() -> SqlitePool {
     pool
 }
 
+/// A file-backed, WAL-mode, multi-connection SQLite pool for concurrency/race tests. The shared
+/// `:memory:` pool used elsewhere is single-connection and serializes everything, which cannot exercise
+/// real interleavings between the write path, the outbox drainer, and the read path. This applies only
+/// the tables the conversation body paths touch (create team/task, append, list, drain, migrate).
+///
+/// Returns the pool and the temp directory holding the database; the caller removes the directory when
+/// the test finishes.
+pub(super) async fn setup_concurrent_conversation_db() -> (SqlitePool, std::path::PathBuf) {
+    let dir = std::env::temp_dir().join(format!("agenthub-race-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let options = SqliteConnectOptions::new()
+        .filename(dir.join("race.db"))
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(20));
+    let pool = SqlitePoolOptions::new()
+        .max_connections(8)
+        .connect_with(options)
+        .await
+        .expect("connect sqlite");
+
+    for (stmt, label) in [
+        (
+            r#"CREATE TABLE team_definitions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                spec_json TEXT NOT NULL,
+                owner_user_id TEXT,
+                group_id TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );"#,
+            "team_definitions",
+        ),
+        (
+            r#"CREATE TABLE team_tasks (
+                id TEXT PRIMARY KEY,
+                team_id TEXT NOT NULL,
+                group_id TEXT,
+                title TEXT NOT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL DEFAULT 'medium',
+                created_by_actor_id TEXT NOT NULL,
+                assigned_member_id TEXT,
+                context_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY(team_id) REFERENCES team_definitions(id)
+            );"#,
+            "team_tasks",
+        ),
+        (
+            r#"CREATE TABLE team_conversations (
+                id TEXT PRIMARY KEY,
+                team_id TEXT NOT NULL,
+                task_id TEXT NOT NULL UNIQUE,
+                mode TEXT NOT NULL,
+                topic TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY(team_id) REFERENCES team_definitions(id),
+                FOREIGN KEY(task_id) REFERENCES team_tasks(id)
+            );"#,
+            "team_conversations",
+        ),
+        (
+            r#"CREATE TABLE team_conversation_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                conversation_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                from_actor_id TEXT NOT NULL,
+                to_actor_id TEXT,
+                route TEXT NOT NULL,
+                correlation_id TEXT NOT NULL DEFAULT '',
+                group_id TEXT,
+                payload_json TEXT NOT NULL,
+                idempotency_key TEXT,
+                created_at INTEGER NOT NULL,
+                text TEXT,
+                kind TEXT,
+                thread_root_message_id INTEGER,
+                FOREIGN KEY(conversation_id) REFERENCES team_conversations(id),
+                FOREIGN KEY(task_id) REFERENCES team_tasks(id)
+            );"#,
+            "team_conversation_messages",
+        ),
+        (
+            r#"CREATE UNIQUE INDEX idx_team_conversation_messages_idempotency
+                ON team_conversation_messages(conversation_id, from_actor_id, idempotency_key)
+                WHERE idempotency_key IS NOT NULL;"#,
+            "team_conversation_messages idempotency index",
+        ),
+        (
+            r#"CREATE TABLE message_body_outbox (
+                authority_message_id TEXT PRIMARY KEY,
+                body BLOB NOT NULL,
+                staged_at INTEGER NOT NULL
+            );"#,
+            "message_body_outbox",
+        ),
+    ] {
+        sqlx::query(stmt)
+            .execute(&pool)
+            .await
+            .unwrap_or_else(|err| panic!("create {label}: {err}"));
+    }
+
+    (pool, dir)
+}
+
 pub(super) fn task_attempt_number(task: &crate::team::TeamTaskRecord) -> Option<i64> {
     task.context
         .get("execution")


### PR DESCRIPTION
## What

Item 2 (part 1) of the body-store test hardening: a **real-concurrency race test** for the tiered conversation-body paths, built on the fault-injection harness from #776.

The shared `:memory:` test pool is single-connection and serializes everything, so it cannot exercise interleavings between the write path, the outbox drainer, and the read path. This adds:

- **`setup_concurrent_conversation_db`** — a file-backed, **WAL-mode, multi-connection** (8) pool with `busy_timeout`, applying just the tables the conversation paths touch.
- **`concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body`** (`#[tokio::test(flavor = "multi_thread")]`):
  - 40 appenders write concurrently (each stages its body to the outbox + slims the row to the moved sentinel),
  - a drainer moves staged bodies into the store concurrently,
  - 3 readers continuously list/rehydrate while the above races.

## The invariant it locks in

A moved row must **always** rehydrate to its real object payload — never the null/sentinel placeholder, never an error — because the body is staged atomically with the sentinel and only leaves the outbox after the store write succeeds, so it's always in the store **or** the outbox (the read path checks store → outbox). The readers assert this on every message on every pass.

The final pass asserts the end state is fully consistent: every message present exactly once with its real body, outbox empty, store holds one body per message.

## Verification

- `cargo test … conversation_cases::` ✅ 17 passed (incl. the new race test); ran the race test 3× — stable.
- `cargo clippy --tests` ✅ clean · `cargo fmt` ✅
- Lives in `conversation_cases`, so the dedicated **Body Store Tests (Bazel)** workflow reruns it 25× under stress.

## Next (item 2, part 2)

Track down and fix the **latent flaky test** in the full suite that surfaced under repeated runs in #776 CI (separate from the body-store tests) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)