### PR TITLE
feat(agent): apply runtime profile to Codex ACP sessions (phase 2a)

### DIFF
--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -55,6 +55,27 @@ impl AcpProviderSpec {
             AcpDefaultModeBehavior::ApplyWhenConfigured
         )
     }
+
+    /// Whether this provider applies the agent runtime profile (model + thinking level) at runtime via
+    /// ACP session config options (`set_model` / `set_config("reasoning_effort", ...)`). Only Codex
+    /// exposes these runtime config handlers today; Claude takes the profile as spawn env instead, and
+    /// Gemini/Kimi do not support per-agent runtime profiles.
+    pub(super) fn applies_runtime_profile_via_session_config(self) -> bool {
+        self.id == ACP_PROVIDER_CODEX
+    }
+}
+
+/// Map the provider-neutral thinking level to the Codex `reasoning_effort` config value. Codex tops out
+/// at `high`, so `max` maps to `high`; an unrecognized level yields `None` (caller skips the option and
+/// the provider default applies).
+pub(super) fn codex_reasoning_effort_for_thinking_level(level: &str) -> Option<&'static str> {
+    match level.trim().to_ascii_lowercase().as_str() {
+        "low" => Some("low"),
+        "medium" => Some("medium"),
+        "high" => Some("high"),
+        "max" => Some("high"),
+        _ => None,
+    }
 }
 
 impl AgentManager {
@@ -217,14 +238,58 @@ mod tests {
 
     use super::{
         ACP_PROVIDER_CODEX, AGENTHUB_CODEX_ACP_MULTI_AGENT_ENABLED_ENV, AcpProviderSpec,
-        acp_provider_spec_for_agent_with_binary, default_env_for_acp_provider,
-        should_use_configured_codex_binary,
+        acp_provider_spec_for_agent_with_binary, codex_reasoning_effort_for_thinking_level,
+        default_env_for_acp_provider, should_use_configured_codex_binary,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn lock_env() -> MutexGuard<'static, ()> {
         ENV_LOCK.lock().expect("lock env")
+    }
+
+    #[test]
+    fn only_codex_applies_runtime_profile_via_session_config() {
+        assert!(AcpProviderSpec::CODEX.applies_runtime_profile_via_session_config());
+        for spec in [
+            AcpProviderSpec::CLAUDE,
+            AcpProviderSpec::GEMINI,
+            AcpProviderSpec::KIMI,
+        ] {
+            assert!(
+                !spec.applies_runtime_profile_via_session_config(),
+                "provider {} must not use session-config runtime profile",
+                spec.id
+            );
+        }
+    }
+
+    #[test]
+    fn codex_reasoning_effort_maps_thinking_levels() {
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("low"),
+            Some("low")
+        );
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("medium"),
+            Some("medium")
+        );
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("high"),
+            Some("high")
+        );
+        // Codex tops out at high, so max maps to high.
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("max"),
+            Some("high")
+        );
+        // Case-insensitive + trimmed.
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level(" MAX "),
+            Some("high")
+        );
+        // Unknown levels are skipped (provider default applies).
+        assert_eq!(codex_reasoning_effort_for_thinking_level("turbo"), None);
     }
 
     #[test]

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -7,7 +7,8 @@ use tokio::sync::{Mutex, broadcast};
 use uuid::Uuid;
 
 use super::acp_provider::{
-    ACP_PROVIDER_CODEX, AcpDefaultModeBehavior, AcpProviderSpec, default_env_for_acp_provider,
+    ACP_PROVIDER_CODEX, AcpDefaultModeBehavior, AcpProviderSpec,
+    codex_reasoning_effort_for_thinking_level, default_env_for_acp_provider,
 };
 use super::executor::LocalExecutionRequest;
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
@@ -836,6 +837,35 @@ impl AgentManager {
                     provider.id,
                     agent.id
                 );
+            }
+            // Apply the agent runtime profile (model + thinking level) for providers that accept it as
+            // ACP session config — currently Codex. Unset fields are skipped so the provider default
+            // stays authoritative; failures are logged but never abort the launch. Claude takes the
+            // profile as spawn env instead (handled where the launch environment is built).
+            if provider.applies_runtime_profile_via_session_config() {
+                if let Some(model) = agent.runtime_model.as_deref()
+                    && let Err(err) = handle.set_model(model.to_string()).await
+                {
+                    tracing::warn!(
+                        "set acp runtime model failed: agent_id={}, model={}, error={}",
+                        agent.id,
+                        model,
+                        err
+                    );
+                }
+                if let Some(level) = agent.thinking_level.as_deref()
+                    && let Some(effort) = codex_reasoning_effort_for_thinking_level(level)
+                    && let Err(err) = handle
+                        .set_config("reasoning_effort".to_string(), effort.to_string())
+                        .await
+                {
+                    tracing::warn!(
+                        "set acp reasoning effort failed: agent_id={}, level={}, error={}",
+                        agent.id,
+                        level,
+                        err
+                    );
+                }
             }
             if let Some(config) = normalize_agent_loop_config(
                 agent.agent_loop_enabled,

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -853,18 +853,31 @@ impl AgentManager {
                         err
                     );
                 }
-                if let Some(level) = agent.thinking_level.as_deref()
-                    && let Some(effort) = codex_reasoning_effort_for_thinking_level(level)
-                    && let Err(err) = handle
-                        .set_config("reasoning_effort".to_string(), effort.to_string())
-                        .await
-                {
-                    tracing::warn!(
-                        "set acp reasoning effort failed: agent_id={}, level={}, error={}",
-                        agent.id,
-                        level,
-                        err
-                    );
+                if let Some(level) = agent.thinking_level.as_deref() {
+                    match codex_reasoning_effort_for_thinking_level(level) {
+                        Some(effort) => {
+                            if let Err(err) = handle
+                                .set_config("reasoning_effort".to_string(), effort.to_string())
+                                .await
+                            {
+                                tracing::warn!(
+                                    "set acp reasoning effort failed: agent_id={}, level={}, error={}",
+                                    agent.id,
+                                    level,
+                                    err
+                                );
+                            }
+                        }
+                        None => {
+                            // Phase 1 only persists low|medium|high|max, so an unmapped level means
+                            // manual or stale data; surface it rather than silently using the default.
+                            tracing::warn!(
+                                "unmapped thinking level for codex reasoning effort, leaving provider default: agent_id={}, level={}",
+                                agent.id,
+                                level
+                            );
+                        }
+                    }
                 }
             }
             if let Some(config) = normalize_agent_loop_config(


### PR DESCRIPTION
## What

**Phase 2a** of Agent Runtime Profiles: translate the persisted profile (from #782) into **Codex** ACP session config at launch. Per @agenthub's Claude spike, Codex is the provider that exposes runtime config handlers; Claude uses spawn env instead (Phase 2b).

After the existing `set_mode` step in `session.rs`, for providers where `applies_runtime_profile_via_session_config()` is true (Codex only):
- `handle.set_model(runtime_model)` when a model override is set;
- `handle.set_config("reasoning_effort", mapped)` when a thinking level is set.

`thinking_level` → Codex `reasoning_effort` via `codex_reasoning_effort_for_thinking_level`: `low`/`medium`/`high` pass through, Codex tops out at high so `max` → `high`, unknown → skip. **Unset fields are skipped** so the provider default stays authoritative, and failures are logged without aborting the launch.

## Changes

- `acp_provider.rs`: `AcpProviderSpec::applies_runtime_profile_via_session_config` (Codex only) + `codex_reasoning_effort_for_thinking_level` mapper.
- `session.rs`: inject `set_model` / `set_config("reasoning_effort")` after the `set_mode` block, gated by the capability.
- Tests: the capability gate (Codex yes; Claude/Gemini/Kimi no) and the level mapping (incl. `max`→`high`, case-insensitive, unknown→`None`).

## Verification

- `cargo test … acp_provider::` ✅; `agent::manager` ✅ 74 passed.
- `cargo clippy --tests` clean; `cargo fmt` clean.

## Next

- **Phase 2b** (Claude): inject `ANTHROPIC_MODEL` + `MAX_THINKING_TOKENS` (low=4096/medium=8000/high=16000/max=20000) as spawn env via the launch-environment builder; startup-only, with a diagnostic on runtime change. 
- Then Phase 3 (create/update API + provider gating), 4 (web), 5 (per-team-member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)