### PR TITLE
chore(acp): upgrade codex to rust v0.141.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,22 +803,22 @@ dependencies = [
 
 [[package]]
 name = "allocative"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
 dependencies = [
  "allocative_derive",
  "bumpalo",
  "ctor",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "num-bigint",
 ]
 
 [[package]]
 name = "allocative_derive"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -946,6 +946,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "arrow"
@@ -1169,7 +1172,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1177,15 +1180,6 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -1456,6 +1450,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -2052,18 +2061,18 @@ checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.6.3",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -2132,16 +2141,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.4.2",
- "cpufeatures 0.3.0",
+ "constant_time_eq 0.3.1",
+ "digest 0.10.7",
+ "rayon-core",
 ]
 
 [[package]]
@@ -2159,7 +2169,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.12",
 ]
 
 [[package]]
@@ -2298,6 +2308,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -2614,6 +2638,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clatter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fed49fa357a85c377c0f920e86100f5326111b09ad69f6de684e324e3ad8097"
+dependencies = [
+ "aes-gcm",
+ "arrayvec",
+ "displaydoc",
+ "getrandom 0.3.4",
+ "ml-kem",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "thiserror-no-std",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "claude-code-acp-rs"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,9 +2770,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codex-agent-identity"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2748,8 +2799,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2757,6 +2808,7 @@ dependencies = [
  "codex-model-provider",
  "codex-plugin",
  "codex-protocol",
+ "codex-state",
  "os_info",
  "serde",
  "serde_json",
@@ -2767,11 +2819,10 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "async-channel",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -2797,11 +2848,10 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
- "async-trait",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -2827,10 +2877,12 @@ dependencies = [
  "codex-git-utils",
  "codex-goal-extension",
  "codex-guardian",
+ "codex-home",
  "codex-hooks",
  "codex-image-generation-extension",
  "codex-login",
  "codex-mcp",
+ "codex-mcp-extension",
  "codex-memories-extension",
  "codex-memories-write",
  "codex-model-provider",
@@ -2842,12 +2894,14 @@ dependencies = [
  "codex-rollout",
  "codex-sandboxing",
  "codex-shell-command",
+ "codex-skills-extension",
  "codex-state",
  "codex-thread-store",
  "codex-tools",
  "codex-utils-absolute-path",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
+ "codex-utils-path-uri",
  "codex-utils-pty",
  "codex-web-search-extension",
  "codex-windows-sandbox",
@@ -2868,8 +2922,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2894,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2903,6 +2957,7 @@ dependencies = [
  "codex-protocol",
  "codex-shell-command",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "inventory",
  "rmcp 1.7.0",
  "schemars 0.8.22",
@@ -2918,8 +2973,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "axum",
@@ -2954,12 +3009,13 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-exec-server",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "similar",
  "thiserror 2.0.18",
  "tokio",
@@ -2969,8 +3025,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2981,6 +3037,7 @@ dependencies = [
  "codex-shell-escalation",
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
+ "codex-windows-sandbox",
  "dotenvy",
  "tempfile",
  "tokio",
@@ -2988,18 +3045,17 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3012,8 +3068,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3029,8 +3085,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3039,15 +3095,14 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "clap",
  "codex-app-server-protocol",
  "codex-connectors",
  "codex-core",
- "codex-core-plugins",
  "codex-git-utils",
  "codex-login",
  "codex-model-provider",
@@ -3059,10 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "bytes",
  "codex-utils-rustls-provider",
  "eventsource-stream",
@@ -3085,8 +3139,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3107,12 +3161,12 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
+ "codex-code-mode-protocol",
  "codex-protocol",
  "deno_core_icudata",
- "serde",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -3121,17 +3175,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-code-mode-protocol"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+dependencies = [
+ "codex-protocol",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 
 [[package]]
 name = "codex-config"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "codex-app-server-protocol",
  "codex-execpolicy",
@@ -3143,6 +3208,7 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-path",
+ "codex-utils-path-uri",
  "core-foundation 0.9.4",
  "dns-lookup",
  "dunce",
@@ -3172,11 +3238,12 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
+ "codex-config",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3186,8 +3253,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3195,13 +3262,12 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-channel",
- "async-trait",
  "base64 0.22.1",
  "bm25",
  "chrono",
@@ -3222,6 +3288,7 @@ dependencies = [
  "codex-extension-api",
  "codex-features",
  "codex-feedback",
+ "codex-file-system",
  "codex-git-utils",
  "codex-hooks",
  "codex-install-context",
@@ -3253,6 +3320,7 @@ dependencies = [
  "codex-utils-image",
  "codex-utils-output-truncation",
  "codex-utils-path",
+ "codex-utils-path-uri",
  "codex-utils-plugins",
  "codex-utils-pty",
  "codex-utils-stream-parser",
@@ -3295,8 +3363,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3308,11 +3376,13 @@ dependencies = [
  "codex-git-utils",
  "codex-hooks",
  "codex-login",
+ "codex-mcp",
  "codex-model-provider",
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "codex-utils-plugins",
  "dirs",
  "flate2",
@@ -3333,8 +3403,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3346,9 +3416,11 @@ dependencies = [
  "codex-model-provider",
  "codex-otel",
  "codex-protocol",
+ "codex-shell-command",
  "codex-skills",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
+ "codex-utils-path-uri",
  "codex-utils-plugins",
  "dirs",
  "dunce",
@@ -3364,14 +3436,14 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "arc-swap",
- "async-trait",
  "axum",
  "base64 0.22.1",
  "bytes",
+ "clatter",
  "codex-api",
  "codex-app-server-protocol",
  "codex-client",
@@ -3380,6 +3452,7 @@ dependencies = [
  "codex-sandboxing",
  "codex-shell-command",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "codex-utils-pty",
  "codex-utils-rustls-provider",
  "futures",
@@ -3398,8 +3471,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "clap",
@@ -3414,8 +3487,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3424,19 +3497,20 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
+ "codex-config",
  "codex-context-fragments",
  "codex-protocol",
  "codex-tools",
+ "codex-utils-absolute-path",
 ]
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3446,8 +3520,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3459,8 +3533,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3472,8 +3546,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3485,8 +3559,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "clap",
@@ -3500,19 +3574,19 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "serde",
 ]
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "notify",
  "tokio",
@@ -3521,14 +3595,15 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "chrono",
  "codex-file-system",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "futures",
  "gix",
  "once_cell",
@@ -3545,10 +3620,10 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
+ "codex-analytics",
  "codex-core",
  "codex-extension-api",
  "codex-otel",
@@ -3564,19 +3639,28 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-core",
  "codex-extension-api",
  "codex-protocol",
 ]
 
 [[package]]
+name = "codex-home"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+dependencies = [
+ "codex-extension-api",
+ "codex-utils-absolute-path",
+ "tokio",
+]
+
+[[package]]
 name = "codex-hooks"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3597,10 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-api",
  "codex-core",
  "codex-extension-api",
@@ -3610,6 +3693,8 @@ dependencies = [
  "codex-protocol",
  "codex-tools",
  "codex-utils-absolute-path",
+ "codex-utils-image",
+ "codex-utils-path-uri",
  "http 1.4.0",
  "schemars 0.8.22",
  "serde",
@@ -3618,8 +3703,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3627,8 +3712,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "keyring",
  "tracing",
@@ -3636,8 +3721,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3657,10 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "codex-agent-identity",
@@ -3671,6 +3755,7 @@ dependencies = [
  "codex-model-provider-info",
  "codex-otel",
  "codex-protocol",
+ "codex-secrets",
  "codex-terminal-detection",
  "codex-utils-template",
  "once_cell",
@@ -3691,10 +3776,11 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-channel",
  "codex-api",
  "codex-async-utils",
@@ -3721,9 +3807,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-mcp-extension"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+dependencies = [
+ "codex-config",
+ "codex-core",
+ "codex-core-plugins",
+ "codex-exec-server",
+ "codex-extension-api",
+ "codex-features",
+ "codex-mcp",
+ "codex-plugin",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-path-uri",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-mcp-server"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3731,6 +3839,7 @@ dependencies = [
  "codex-core",
  "codex-exec-server",
  "codex-extension-api",
+ "codex-home",
  "codex-login",
  "codex-protocol",
  "codex-utils-cli",
@@ -3747,10 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-core",
  "codex-extension-api",
  "codex-features",
@@ -3768,8 +3876,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3778,8 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3789,6 +3897,7 @@ dependencies = [
  "codex-features",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
  "codex-otel",
  "codex-protocol",
  "codex-rollout",
@@ -3809,10 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-agent-identity",
  "codex-api",
  "codex-aws-auth",
@@ -3831,8 +3939,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3844,10 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "chrono",
  "codex-app-server-protocol",
  "codex-collaboration-mode-templates",
@@ -3864,11 +3971,10 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -3897,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3929,10 +4035,11 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-config",
+ "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-plugins",
  "thiserror 2.0.18",
@@ -3940,16 +4047,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3962,8 +4069,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3972,6 +4079,7 @@ dependencies = [
  "codex-network-proxy",
  "codex-utils-absolute-path",
  "codex-utils-image",
+ "codex-utils-path-uri",
  "codex-utils-string",
  "encoding_rs",
  "globset",
@@ -3999,8 +4107,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4010,8 +4118,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "axum",
@@ -4023,7 +4131,9 @@ dependencies = [
  "codex-exec-server",
  "codex-keyring-store",
  "codex-protocol",
+ "codex-secrets",
  "codex-utils-home-dir",
+ "codex-utils-path-uri",
  "codex-utils-pty",
  "futures",
  "keyring",
@@ -4046,11 +4156,10 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "codex-file-search",
  "codex-git-utils",
@@ -4072,8 +4181,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4087,12 +4196,13 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "dunce",
  "libc",
  "regex-lite",
@@ -4104,8 +4214,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "age",
  "anyhow",
@@ -4123,8 +4233,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4143,11 +4253,10 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "codex-protocol",
  "codex-utils-absolute-path",
@@ -4163,8 +4272,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4172,15 +4281,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-skills-extension"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+dependencies = [
+ "codex-core-skills",
+ "codex-exec-server",
+ "codex-extension-api",
+ "codex-mcp",
+ "codex-protocol",
+ "codex-tools",
+ "codex-utils-absolute-path",
+ "codex-utils-path-uri",
+ "codex-utils-string",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "codex-state"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "codex-protocol",
  "dirs",
+ "libsqlite3-sys",
  "log",
  "owo-colors",
  "serde",
@@ -4195,18 +4327,17 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "chrono",
  "codex-git-utils",
  "codex-install-context",
@@ -4223,13 +4354,13 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-app-server-protocol",
  "codex-code-mode",
  "codex-features",
+ "codex-file-system",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
@@ -4246,8 +4377,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "async-io",
  "tokio",
@@ -4257,8 +4388,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "dirs",
  "dunce",
@@ -4269,16 +4400,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4287,8 +4418,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4299,8 +4430,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4308,8 +4439,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4321,8 +4452,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4330,8 +4461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4339,8 +4470,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4348,21 +4479,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-utils-path-uri"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+dependencies = [
+ "base64 0.22.1",
+ "codex-utils-absolute-path",
+ "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.18",
+ "ts-rs",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
 name = "codex-utils-plugins"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "codex-exec-server",
  "codex-login",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4377,21 +4524,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4400,15 +4547,14 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
- "async-trait",
  "codex-api",
  "codex-core",
  "codex-extension-api",
@@ -4425,8 +4571,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.138.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.138.0#c18e9f478bc940ef1ef8e1c426364c0fe3d86b73"
+version = "0.141.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4824,7 +4970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.2",
- "hybrid-array",
+ "hybrid-array 0.4.12",
  "rand_core 0.10.1",
 ]
 
@@ -4887,12 +5033,12 @@ checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 dependencies = [
- "quote",
- "syn 1.0.109",
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -5530,7 +5676,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5552,7 +5698,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "paste",
- "petgraph 0.8.3",
+ "petgraph",
  "tokio",
 ]
 
@@ -5956,12 +6102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6252,13 +6392,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.4"
+name = "embedded-io"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
-]
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -6330,6 +6473,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6362,6 +6525,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -6435,6 +6609,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6456,7 +6641,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "serde",
 ]
 
@@ -6606,12 +6791,6 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -6679,6 +6858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6830,7 +7018,7 @@ version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "futures-core",
  "futures-lite",
  "pin-project",
@@ -7916,7 +8104,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7972,6 +8160,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -7990,10 +8187,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -8058,11 +8251,25 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -8288,6 +8495,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -8848,7 +9064,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.12",
 ]
 
 [[package]]
@@ -8982,15 +9198,6 @@ dependencies = [
  "tracing-futures",
  "url",
  "waker-fn",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -9276,12 +9483,31 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -9344,37 +9570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "static_assertions",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "diff",
- "ena",
- "is-terminal",
- "itertools 0.10.5",
- "lalrpop-util",
- "petgraph 0.6.5",
- "regex",
- "regex-syntax 0.6.29",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -10129,9 +10324,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -10205,6 +10400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10254,6 +10461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic",
+ "parking_lot",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10261,25 +10478,36 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logos"
-version = "0.12.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
-name = "logos-derive"
-version = "0.12.1"
+name = "logos-codegen"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
 dependencies = [
  "beef",
  "fnv",
+ "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.6.29",
- "syn 1.0.109",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -10315,15 +10543,15 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -10480,15 +10708,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -10549,11 +10768,24 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
- "hybrid-array",
+ "hybrid-array 0.4.12",
  "module-lattice",
  "pkcs8 0.11.0",
- "sha3",
+ "sha3 0.11.0",
  "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3 0.10.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -10563,7 +10795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
  "ctutils",
- "hybrid-array",
+ "hybrid-array 0.4.12",
  "num-traits",
 ]
 
@@ -10665,12 +10897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10712,7 +10938,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -10862,6 +11088,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -11460,6 +11687,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "pagable"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3658968938a4d1eaa1987e69dcd84b01fb067c5b3416dccc8d71373b6ded6821"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "bytemuck",
+ "dashmap",
+ "dupe",
+ "either",
+ "erased-serde 0.4.10",
+ "fancy-regex",
+ "indexmap 2.14.0",
+ "inventory",
+ "num-bigint",
+ "once_cell",
+ "pagable_derive",
+ "parking_lot",
+ "postcard",
+ "regex",
+ "sequence_trie",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sorted_vector_map",
+ "static_assertions",
+ "static_interner",
+ "strong_hash",
+ "take_mut",
+ "triomphe",
+]
+
+[[package]]
+name = "pagable_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838d17166587914f4e99353766c29160462b681511f08679545a0d07a0dc9415"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11623,21 +11897,11 @@ checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.14.0",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "serde",
@@ -11680,15 +11944,6 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -11882,6 +12137,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "crc",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11906,12 +12175,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -12006,7 +12269,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "unarray",
 ]
 
@@ -12030,7 +12293,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -12242,6 +12505,17 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -12899,7 +13173,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -12910,7 +13184,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -12918,12 +13192,6 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -13915,6 +14183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
+name = "sequence_trie"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14176,12 +14450,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -14399,6 +14683,16 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sorted_vector_map"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bf565ee1681b4473aa5a9d71d807347c28021bd1d8947cb626b02f42a0141f"
+dependencies = [
+ "itertools 0.14.0",
+ "quickcheck",
 ]
 
 [[package]]
@@ -14666,29 +14960,33 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starlark"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f53849859f05d9db705b221bd92eede93877fd426c1b4a3c3061403a5912a8f"
+checksum = "9062e866918dc4c9701c98ac99f7f4fa9e4b3b4edce306e147393bc75458c4fc"
 dependencies = [
  "allocative",
  "anyhow",
+ "blake3",
  "bumpalo",
  "cmp_any",
+ "dashmap",
  "debugserver-types",
  "derivative",
  "derive_more 1.0.0",
  "display_container",
  "dupe",
  "either",
- "erased-serde",
- "hashbrown 0.14.5",
+ "erased-serde 0.3.31",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "inventory",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "maplit",
- "memoffset 0.6.5",
+ "memoffset",
  "num-bigint",
  "num-traits",
  "once_cell",
+ "pagable",
  "paste",
  "ref-cast",
  "regex",
@@ -14699,16 +14997,17 @@ dependencies = [
  "starlark_map",
  "starlark_syntax",
  "static_assertions",
+ "strong_hash",
  "strsim 0.10.0",
  "textwrap",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "starlark_derive"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe58bc6c8b7980a1fe4c9f8f48200c3212db42ebfe21ae6a0336385ab53f082a"
+checksum = "797e235eb70936bfa14fabf490bf7453e6f0caaf6b9c56fe4c9aff02aee7e66d"
 dependencies = [
  "dupe",
  "proc-macro2",
@@ -14718,23 +15017,25 @@ dependencies = [
 
 [[package]]
 name = "starlark_map"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92659970f120df0cc1c0bb220b33587b7a9a90e80d4eecc5c5af5debb950173d"
+checksum = "234877898fd216af93b2f5798b08cbbdc1a2e8f16a622a258b1db23a61a1c4ba"
 dependencies = [
  "allocative",
  "dupe",
  "equivalent",
  "fxhash",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "pagable",
  "serde",
+ "strong_hash",
 ]
 
 [[package]]
 name = "starlark_syntax"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe53b3690d776aafd7cb6b9fed62d94f83280e3b87d88e3719cc0024638461b3"
+checksum = "7492c571c531e68099c911cfd909d32659f1cc0910cf3adee9fce66e39d21f14"
 dependencies = [
  "allocative",
  "annotate-snippets",
@@ -14742,16 +15043,15 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "dupe",
- "lalrpop",
- "lalrpop-util",
  "logos",
  "lsp-types",
  "memchr",
  "num-bigint",
  "num-traits",
  "once_cell",
+ "pagable",
  "starlark_map",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -14759,6 +15059,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_interner"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a72d2480db611b8ee9287b4a2e0adc63c4d7fdd647d2a1a65d529fc234fd16"
+dependencies = [
+ "equivalent",
+ "lock_free_hashtable",
+]
 
 [[package]]
 name = "std_prelude"
@@ -14797,18 +15107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
-]
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14817,6 +15115,26 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
+]
+
+[[package]]
+name = "strong_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0831334aea34390b6b6ec7af0a27f9ee6324ad3a69463e6b240d83d6b7bce9c9"
+dependencies = [
+ "ref-cast",
+ "strong_hash_derive",
+]
+
+[[package]]
+name = "strong_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6b48b7c4383a39bd3b966cca41bc999003aab9f690a2f355525c924296928"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15124,17 +15442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15200,6 +15507,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -15820,7 +16147,7 @@ checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -15841,6 +16168,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "try-lock"
@@ -15947,6 +16284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15958,7 +16301,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -16187,9 +16530,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "147.4.0"
+version = "149.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
+checksum = "46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb"
 dependencies = [
  "bindgen",
  "bitflags 2.11.1",

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -972,7 +972,11 @@ impl AppServerCodexThread {
                                     .map(codex_app_server_protocol::NetworkPolicyAmendment::into_core)
                                     .collect()
                             }),
-                        additional_permissions: params.additional_permissions.map(Into::into),
+                        additional_permissions: params
+                            .additional_permissions
+                            .map(codex_protocol::models::AdditionalPermissionProfile::try_from)
+                            .transpose()
+                            .map_err(|err| CodexErr::Fatal(err.to_string()))?,
                         available_decisions: params.available_decisions.map(|items| {
                             items
                                 .into_iter()
@@ -1017,7 +1021,7 @@ impl AppServerCodexThread {
                     id: submission_id,
                     msg: EventMsg::RequestPermissions(permissions_request_event_from_params(
                         params,
-                    )),
+                    )?),
                 }))
             }
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
@@ -1102,6 +1106,7 @@ impl AppServerCodexThread {
         match notification {
             ServerNotification::ThreadNameUpdated(_)
             | ServerNotification::ThreadSettingsUpdated(_)
+            | ServerNotification::ThreadDeleted(_)
             | ServerNotification::TurnModerationMetadata(_) => Ok(None),
             ServerNotification::FileChangePatchUpdated(payload) => {
                 let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
@@ -1846,7 +1851,9 @@ impl CodexThreadImpl for AppServerCodexThread {
             Op::Shutdown => self.shutdown_thread().await,
             Op::ThreadSettings { thread_settings } => {
                 self.override_turn_context(OverrideTurnContextArgs {
-                    cwd: thread_settings.cwd.map(|cwd| cwd.to_path_buf()),
+                    cwd: thread_settings
+                        .environments
+                        .map(|environments| environments.legacy_fallback_cwd.to_path_buf()),
                     workspace_roots: thread_settings.workspace_roots,
                     profile_workspace_roots: thread_settings.profile_workspace_roots,
                     approval_policy: thread_settings.approval_policy,
@@ -2020,6 +2027,7 @@ fn app_server_request_user_input_to_core(
             .into_iter()
             .map(app_server_request_user_input_question_to_core)
             .collect(),
+        auto_resolution_ms: params.auto_resolution_ms,
     }
 }
 
@@ -2812,19 +2820,17 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
 
 fn permissions_request_event_from_params(
     params: codex_app_server_protocol::PermissionsRequestApprovalParams,
-) -> RequestPermissionsEvent {
-    RequestPermissionsEvent {
+) -> Result<RequestPermissionsEvent, CodexErr> {
+    Ok(RequestPermissionsEvent {
         call_id: params.item_id,
         turn_id: params.turn_id,
         environment_id: params.environment_id,
         started_at_ms: params.started_at_ms,
         reason: params.reason,
-        permissions: RequestPermissionProfile {
-            network: params.permissions.network.map(Into::into),
-            file_system: params.permissions.file_system.map(Into::into),
-        },
+        permissions: RequestPermissionProfile::try_from(params.permissions)
+            .map_err(|err| CodexErr::Fatal(err.to_string()))?,
         cwd: Some(params.cwd),
-    }
+    })
 }
 
 fn file_change_patch_updated_to_core(
@@ -3225,6 +3231,7 @@ mod tests {
                 thread_id: "thread-1".to_string(),
                 turn_id: "turn-1".to_string(),
                 item_id: "item-1".to_string(),
+                auto_resolution_ms: None,
                 questions: vec![codex_app_server_protocol::ToolRequestUserInputQuestion {
                     id: "question-1".to_string(),
                     header: "Clarify".to_string(),
@@ -3292,7 +3299,8 @@ mod tests {
                     file_system: None,
                 },
             },
-        );
+        )
+        .expect("valid permissions request event");
 
         assert_eq!(event.call_id, "call-1");
         assert_eq!(event.turn_id, "turn-1");
@@ -3480,6 +3488,7 @@ mod tests {
             call_id: "call-1".to_string(),
             name: "apply_patch".to_string(),
             input: "*** Begin Patch".to_string(),
+            metadata: None,
         };
         record_raw_response_item(&mut state, "turn-1", &call);
 
@@ -3489,6 +3498,7 @@ mod tests {
             call_id: "call-1".to_string(),
             name: Some("apply_patch".to_string()),
             output: codex_protocol::models::FunctionCallOutputPayload::from_text("ok".to_string()),
+            metadata: None,
         };
         record_raw_response_item(&mut state, "turn-1", &output);
 
@@ -3504,6 +3514,7 @@ mod tests {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "function-call-1".to_string(),
+            metadata: None,
         };
 
         record_raw_response_item(&mut state, "turn-1", &item);
@@ -3551,7 +3562,6 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: Default::default(),
             },
         )
@@ -3625,7 +3635,6 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: Default::default(),
             },
         )
@@ -3648,7 +3657,6 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: Default::default(),
             },
         )

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -11,12 +11,15 @@ use agent_client_protocol::schema::{
     SetSessionModeRequest, SetSessionModeResponse,
 };
 use codex_config::DEFAULT_MCP_SERVER_ENVIRONMENT_ID;
-use codex_config::types::{McpServerConfig, McpServerTransportConfig};
+use codex_config::types::{AuthKeyringBackendKind, McpServerConfig, McpServerTransportConfig};
 use codex_core::{
     RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
     find_thread_path_by_id_str, parse_cursor, thread_store_from_config,
 };
-use codex_extension_api::empty_extension_registry;
+use codex_extension_api::{
+    LoadUserInstructionsFuture, LoadedUserInstructions, UserInstructionsProvider,
+    empty_extension_registry,
+};
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -64,6 +67,14 @@ const SESSION_LIST_PAGE_SIZE: usize = 25;
 const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
 const REPAIRED_ROLLOUT_TIMESTAMP: &str = "1970-01-01T00:00:00.000Z";
 
+struct EmptyUserInstructionsProvider;
+
+impl UserInstructionsProvider for EmptyUserInstructionsProvider {
+    fn load_user_instructions(&self) -> LoadUserInstructionsFuture<'_> {
+        Box::pin(std::future::ready(LoadedUserInstructions::default()))
+    }
+}
+
 impl CodexAgent {
     /// Create a new `CodexAgent` with the given configuration
     pub async fn new(config: Config) -> Result<Self, Error> {
@@ -72,6 +83,7 @@ impl CodexAgent {
             false,
             config.cli_auth_credentials_store_mode,
             Some(config.chatgpt_base_url.clone()),
+            AuthKeyringBackendKind::default(),
         )
         .await;
 
@@ -84,6 +96,7 @@ impl CodexAgent {
             SessionSource::Unknown,
             build_environment_manager(&config).await?,
             empty_extension_registry(),
+            Arc::new(EmptyUserInstructionsProvider),
             None,
             thread_store_from_config(&config, None),
             None,
@@ -322,6 +335,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                     ResponseItem::FunctionCallOutput {
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
+                        metadata: None,
                     },
                 ));
             }
@@ -335,6 +349,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                         call_id: call_id.clone(),
                         name: None,
                         output: aborted_call_output(),
+                        metadata: None,
                     },
                 ));
             }
@@ -348,6 +363,7 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                     ResponseItem::FunctionCallOutput {
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
+                        metadata: None,
                     },
                 ));
             }
@@ -395,10 +411,18 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput { call_id, output }) => {
+            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
+                call_id,
+                output,
+                metadata,
+            }) => {
                 if function_call_ids.contains(&call_id) || local_shell_call_ids.contains(&call_id) {
                     retained.push(RolloutItem::ResponseItem(
-                        ResponseItem::FunctionCallOutput { call_id, output },
+                        ResponseItem::FunctionCallOutput {
+                            call_id,
+                            output,
+                            metadata,
+                        },
                     ));
                 } else {
                     repaired.dropped_orphan_function_call_outputs += 1;
@@ -407,6 +431,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
             RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
                 call_id,
                 output,
+                metadata,
                 ..
             }) => {
                 if custom_tool_call_ids.contains(&call_id) {
@@ -415,6 +440,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                             call_id,
                             name: None,
                             output,
+                            metadata,
                         },
                     ));
                 } else {
@@ -462,6 +488,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
+                        metadata: None,
                     }),
                 ));
             }
@@ -475,6 +502,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                         call_id: call_id.clone(),
                         name: None,
                         output: aborted_call_output(),
+                        metadata: None,
                     }),
                 ));
             }
@@ -488,6 +516,7 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
+                        metadata: None,
                     }),
                 ));
             }
@@ -636,6 +665,7 @@ impl CodexAgent {
                     CLIENT_ID.to_string(),
                     None,
                     self.config.cli_auth_credentials_store_mode,
+                    AuthKeyringBackendKind::default(),
                 );
 
                 let server =
@@ -654,6 +684,7 @@ impl CodexAgent {
                     &self.config.codex_home,
                     &api_key,
                     self.config.cli_auth_credentials_store_mode,
+                    AuthKeyringBackendKind::default(),
                 )
                 .map_err(Error::into_internal_error)?;
             }
@@ -665,6 +696,7 @@ impl CodexAgent {
                     &self.config.codex_home,
                     &api_key,
                     self.config.cli_auth_credentials_store_mode,
+                    AuthKeyringBackendKind::default(),
                 )
                 .map_err(Error::into_internal_error)?;
             }
@@ -1048,6 +1080,7 @@ mod tests {
                 call_id: "call-1".to_string(),
                 name: "actor_send".to_string(),
                 input: "{}".to_string(),
+                metadata: None,
             })],
             rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
         });
@@ -1095,6 +1128,7 @@ mod tests {
                     call_id: "call-persist".to_string(),
                     name: "actor_send".to_string(),
                     input: "{}".to_string(),
+                    metadata: None,
                 }),
             ],
             rollout_path: Some(rollout_path.clone()),
@@ -1141,6 +1175,7 @@ mod tests {
                 call_id: "missing".to_string(),
                 name: None,
                 output: FunctionCallOutputPayload::from_text("ok".to_string()),
+                metadata: None,
             },
             ResponseItem::CustomToolCall {
                 id: None,
@@ -1148,6 +1183,7 @@ mod tests {
                 call_id: "call-2".to_string(),
                 name: "actor_ack".to_string(),
                 input: "{}".to_string(),
+                metadata: None,
             },
         ];
 
@@ -1176,6 +1212,7 @@ mod tests {
                 id: None,
                 call_id: Some("shell-1".to_string()),
                 status: LocalShellStatus::Completed,
+                metadata: None,
                 action: LocalShellAction::Exec(LocalShellExecAction {
                     command: vec!["echo".to_string(), "hi".to_string()],
                     timeout_ms: None,
@@ -1184,6 +1221,7 @@ mod tests {
                     user: None,
                 }),
             }]),
+            window_id: None,
         })]);
 
         let (repaired, repaired_stats) = repair_initial_history(history);
@@ -1204,7 +1242,9 @@ mod tests {
             .expect("replacement history");
         assert!(matches!(
             &replacement_history[1],
-            ResponseItem::FunctionCallOutput { call_id, output }
+            ResponseItem::FunctionCallOutput {
+                call_id, output, ..
+            }
                 if call_id == "shell-1" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
         ));
     }

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -1,5 +1,11 @@
 //! Codex ACP - An Agent Client Protocol implementation for Codex.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
+// `CodexErr` (upstream `codex_protocol::error::CodexErr`) grew past clippy's
+// default large-error threshold (128 bytes) as of codex `rust-v0.141`, and it is
+// the `Err` type of ~26 `Result<_, CodexErr>` functions across this Codex wrapper
+// crate. We can't shrink an upstream type, and boxing every site is out of scope
+// for a dependency bump; allow the lint crate-wide for this wrapper.
+#![allow(clippy::result_large_err)]
 
 use agent_client_protocol::schema::{
     AuthenticateRequest, CancelNotification, CloseSessionRequest, InitializeRequest,

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1310,6 +1310,7 @@ impl PromptState {
             | EventMsg::CollabResumeEnd(..)
             | EventMsg::CollabCloseBegin(..)
             | EventMsg::CollabCloseEnd(..)
+            | EventMsg::SubAgentActivity(..)
             | EventMsg::PlanDelta(..) => {}
             EventMsg::GuardianAssessment(..) => {}
         }
@@ -2241,6 +2242,7 @@ impl PromptState {
             call_id,
             turn_id,
             questions,
+            auto_resolution_ms: _,
         } = event;
         let tool_call_id = ToolCallId::new(format!("request-user-input:{call_id}"));
         let raw_input = serde_json::to_value(&questions)
@@ -3422,7 +3424,6 @@ impl<A: Auth> ThreadActor<A> {
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
                         additional_context: Default::default(),
-                        environments: None,
                         thread_settings: ThreadSettingsOverrides::default(),
                     }
                 }
@@ -3476,7 +3477,6 @@ impl<A: Auth> ThreadActor<A> {
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
                         additional_context: Default::default(),
-                        environments: None,
                         thread_settings: ThreadSettingsOverrides::default(),
                     }
                 }
@@ -3487,7 +3487,6 @@ impl<A: Auth> ThreadActor<A> {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: ThreadSettingsOverrides::default(),
             }
         }
@@ -3849,7 +3848,9 @@ impl<A: Auth> ThreadActor<A> {
                     )
                     .await;
             }
-            ResponseItem::FunctionCallOutput { call_id, output } => {
+            ResponseItem::FunctionCallOutput {
+                call_id, output, ..
+            } => {
                 self.client
                     .send_tool_call_completed(call_id.clone(), serde_json::to_value(output).ok())
                     .await;
@@ -4908,7 +4909,6 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: ThreadSettingsOverrides::default(),
             }],
             "ops don't match {ops:?}"
@@ -5186,7 +5186,6 @@ mod tests {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
                 additional_context: Default::default(),
-                environments: None,
                 thread_settings: ThreadSettingsOverrides::default(),
             }],
             "ops don't match {ops:?}"
@@ -5563,6 +5562,7 @@ mod tests {
                         is_secret: false,
                         options: None,
                     }],
+                    auto_resolution_ms: None,
                 }));
                 tokio::task::yield_now().await;
 

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.138.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]


### PR DESCRIPTION
## Summary

- Upgrade AgentHub's Codex Rust git dependencies from `rust-v0.138.0` to `rust-v0.141.0`.
- Update the direct `codex-utils-cli` dependency used by `agenthub-acp-adapter` to the same Codex tag.
- Refresh `Cargo.lock`, including the resolver-required `blake3` and `libsqlite3-sys` adjustments.
- Adapt the Codex ACP adapter to upstream API changes for auth keyring backend selection, user-instruction providers, permission profile conversion, thread settings, request-user-input auto resolution, and response item metadata.

## Purpose

Keep AgentHub's Codex ACP integration aligned with the current Codex Rust release while preserving existing adapter behavior.

## Related Issues

None.

## Testing

- `cargo fmt --all`
- `cargo check -p agenthub-codex-acp`
- `cargo check -p agenthub-acp-adapter`
- `cargo test -p agenthub-codex-acp`
- `cargo test -p agenthub-acp-adapter`
