### PR TITLE
chore(codex): upgrade codex rust-v0.141.0 → rust-v0.142.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,8 +2780,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2799,8 +2799,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2819,8 +2819,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2848,8 +2848,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "axum",
@@ -2922,8 +2922,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2948,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "clap",
@@ -2973,8 +2973,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "axum",
@@ -3009,8 +3009,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3025,8 +3025,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3045,8 +3045,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3054,8 +3054,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3068,8 +3068,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3085,8 +3085,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "serde",
  "serde_json",
@@ -3095,8 +3095,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "clap",
@@ -3114,8 +3114,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -3139,8 +3139,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3161,8 +3161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -3176,8 +3176,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-protocol",
  "serde",
@@ -3188,13 +3188,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 
 [[package]]
 name = "codex-config"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3238,8 +3238,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -3253,8 +3253,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3262,8 +3262,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3363,8 +3363,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3381,6 +3381,7 @@ dependencies = [
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
+ "codex-tools",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "codex-utils-plugins",
@@ -3403,8 +3404,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3424,6 +3425,7 @@ dependencies = [
  "codex-utils-plugins",
  "dirs",
  "dunce",
+ "futures",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3436,8 +3438,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3456,6 +3458,8 @@ dependencies = [
  "codex-utils-pty",
  "codex-utils-rustls-provider",
  "futures",
+ "http 1.4.0",
+ "libc",
  "prost",
  "reqwest 0.12.28",
  "serde",
@@ -3467,12 +3471,13 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "clap",
@@ -3487,8 +3492,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3497,8 +3502,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3509,8 +3514,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3520,8 +3525,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3533,8 +3538,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3546,8 +3551,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3559,8 +3564,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "clap",
@@ -3574,19 +3579,21 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
+ "bytes",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
+ "futures",
  "serde",
 ]
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "notify",
  "tokio",
@@ -3595,8 +3602,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3620,8 +3627,8 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-analytics",
  "codex-core",
@@ -3639,8 +3646,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3649,8 +3656,8 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3659,8 +3666,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3681,8 +3688,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -3703,8 +3710,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3712,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "keyring",
  "tracing",
@@ -3721,8 +3728,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3742,8 +3749,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3776,8 +3783,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3792,6 +3799,7 @@ dependencies = [
  "codex-plugin",
  "codex-protocol",
  "codex-rmcp-client",
+ "codex-utils-path-uri",
  "codex-utils-plugins",
  "futures",
  "regex-lite",
@@ -3808,8 +3816,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-config",
  "codex-core",
@@ -3830,8 +3838,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3856,8 +3864,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3876,8 +3884,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3886,8 +3894,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3918,8 +3926,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -3939,8 +3947,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -3952,8 +3960,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3971,8 +3979,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3991,6 +3999,8 @@ dependencies = [
  "rama-tls-rustls",
  "rama-unix",
  "rustls-native-certs",
+ "schannel",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4003,8 +4013,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4035,8 +4045,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4047,16 +4057,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4069,8 +4079,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4107,8 +4117,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4118,8 +4128,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "axum",
@@ -4156,8 +4166,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4181,8 +4191,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4196,13 +4206,15 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-home-dir",
  "codex-utils-path-uri",
+ "codex-windows-sandbox",
  "dunce",
  "libc",
  "regex-lite",
@@ -4214,8 +4226,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "age",
  "anyhow",
@@ -4233,8 +4245,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4253,8 +4265,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "clap",
@@ -4272,8 +4284,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4282,8 +4294,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4304,8 +4316,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4327,16 +4339,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4354,8 +4366,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
@@ -4377,8 +4389,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "async-io",
  "tokio",
@@ -4388,8 +4400,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "dirs",
  "dunce",
@@ -4400,16 +4412,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4418,8 +4430,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4430,8 +4442,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4439,8 +4451,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4452,8 +4464,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4461,8 +4473,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4470,8 +4482,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4480,8 +4492,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4495,11 +4507,10 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-exec-server",
- "codex-login",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "serde",
@@ -4508,8 +4519,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4524,21 +4535,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4547,13 +4558,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4571,8 +4582,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.141.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.141.0#3fb81667d30d9d24297216ea61fbfcc4351b2aa9"
+version = "0.142.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.0#3a76f3ac68c8949d1cac6ea769b6ec7b8953a415"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,8 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 git_repository(
     name = "codex_src",
-    commit = "c18e9f478bc940ef1ef8e1c426364c0fe3d86b73",
+    # rust-v0.142.0 tag commit (matches what Cargo resolves the codex-* tags to).
+    commit = "3a76f3ac68c8949d1cac6ea769b6ec7b8953a415",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
 heck = "0.5.0"
 itertools = "0.14.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -954,9 +954,15 @@ impl AppServerCodexThread {
                         call_id: params.item_id,
                         approval_id: params.approval_id,
                         turn_id: params.turn_id,
+                        environment_id: params.environment_id,
                         started_at_ms: params.started_at_ms,
                         command: command_vec.clone(),
-                        cwd: params.cwd.unwrap_or_else(|| state.config.cwd.clone()),
+                        cwd: params
+                            .cwd
+                            .and_then(|cwd| {
+                                codex_utils_absolute_path::AbsolutePathBuf::try_from(cwd).ok()
+                            })
+                            .unwrap_or_else(|| state.config.cwd.clone()),
                         reason: params.reason,
                         network_approval_context: params
                             .network_approval_context
@@ -1043,6 +1049,15 @@ impl AppServerCodexThread {
                         requested_schema: serde_json::to_value(requested_schema)
                             .map_err(|err| CodexErr::Fatal(err.to_string()))?,
                     },
+                    codex_app_server_protocol::McpServerElicitationRequest::OpenAiForm {
+                        meta,
+                        message,
+                        requested_schema,
+                    } => ElicitationRequest::OpenAiForm {
+                        meta,
+                        message,
+                        requested_schema,
+                    },
                     codex_app_server_protocol::McpServerElicitationRequest::Url {
                         meta,
                         message,
@@ -1095,7 +1110,10 @@ impl AppServerCodexThread {
             }
             ServerRequest::ChatgptAuthTokensRefresh { .. }
             | ServerRequest::ApplyPatchApproval { .. }
-            | ServerRequest::ExecCommandApproval { .. } => Ok(None),
+            | ServerRequest::ExecCommandApproval { .. }
+            // The ACP adapter does not provide an external current-time source,
+            // so there is no core event to translate this request into.
+            | ServerRequest::CurrentTimeRead { .. } => Ok(None),
         }
     }
 
@@ -1331,6 +1349,11 @@ impl AppServerCodexThread {
                         },
                     ) => {
                         let command_vec = shell_command_vec(&command);
+                        // The app-server reports cwd as a `LegacyAppPathString`, but the
+                        // core exec events now require a `PathUri`. Fall back to the
+                        // agent's configured cwd if the legacy string cannot be parsed.
+                        let fallback_cwd = self.state.lock().await.config.cwd.clone();
+                        let cwd = cwd.try_into().unwrap_or_else(|_| fallback_cwd.into());
                         Some(Event {
                             id,
                             msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
@@ -1365,7 +1388,9 @@ impl AppServerCodexThread {
                                 tool,
                                 arguments: Some(arguments),
                             },
+                            connector_id: None,
                             mcp_app_resource_uri,
+                            link_id: None,
                             plugin_id: None,
                         }),
                     }),
@@ -1509,6 +1534,11 @@ impl AppServerCodexThread {
                         },
                     ) => {
                         let command_vec = shell_command_vec(&command);
+                        // The app-server reports cwd as a `LegacyAppPathString`, but the
+                        // core exec events now require a `PathUri`. Fall back to the
+                        // agent's configured cwd if the legacy string cannot be parsed.
+                        let fallback_cwd = self.state.lock().await.config.cwd.clone();
+                        let cwd = cwd.try_into().unwrap_or_else(|_| fallback_cwd.into());
                         Some(Event {
                             id,
                             msg: EventMsg::ExecCommandEnd(ExecCommandEndEvent {
@@ -1597,7 +1627,9 @@ impl AppServerCodexThread {
                                     tool,
                                     arguments: Some(arguments),
                                 },
+                                connector_id: None,
                                 mcp_app_resource_uri,
+                                link_id: None,
                                 plugin_id: None,
                                 duration: duration_ms
                                     .and_then(|ms| u64::try_from(ms).ok())
@@ -1808,6 +1840,8 @@ impl AppServerCodexThread {
             | ServerNotification::AccountRateLimitsUpdated(_)
             | ServerNotification::AppListUpdated(_)
             | ServerNotification::ExternalAgentConfigImportCompleted(_)
+            | ServerNotification::ExternalAgentConfigImportProgress(_)
+            | ServerNotification::ModelSafetyBufferingUpdated(_)
             | ServerNotification::ThreadGoalUpdated(_)
             | ServerNotification::ThreadGoalCleared(_)
             | ServerNotification::RemoteControlStatusChanged(_)
@@ -2299,6 +2333,7 @@ fn prepare_submission_start(
                     collaboration_mode: None,
                     environments: None,
                     permissions: None,
+                    multi_agent_mode: None,
                 }),
             }))
         }
@@ -2811,6 +2846,9 @@ async fn start_client(config: &Config) -> Result<InProcessAppServerClient, Error
         client_name: ACP_CLIENT_NAME.to_string(),
         client_version: env!("CARGO_PKG_VERSION").to_string(),
         experimental_api: true,
+        // We do not handle `openai/form` elicitation requests in the ACP
+        // adapter, so do not advertise support for them.
+        mcp_server_openai_form_elicitation: false,
         opt_out_notification_methods: Vec::new(),
         channel_capacity: DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
     })
@@ -3488,17 +3526,18 @@ mod tests {
             call_id: "call-1".to_string(),
             name: "apply_patch".to_string(),
             input: "*** Begin Patch".to_string(),
-            metadata: None,
+            internal_chat_message_metadata_passthrough: None,
         };
         record_raw_response_item(&mut state, "turn-1", &call);
 
         assert!(state.pending_custom_tool_calls.contains("call-1"));
 
         let output = ResponseItem::CustomToolCallOutput {
+            id: None,
             call_id: "call-1".to_string(),
             name: Some("apply_patch".to_string()),
             output: codex_protocol::models::FunctionCallOutputPayload::from_text("ok".to_string()),
-            metadata: None,
+            internal_chat_message_metadata_passthrough: None,
         };
         record_raw_response_item(&mut state, "turn-1", &output);
 
@@ -3514,7 +3553,7 @@ mod tests {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "function-call-1".to_string(),
-            metadata: None,
+            internal_chat_message_metadata_passthrough: None,
         };
 
         record_raw_response_item(&mut state, "turn-1", &item);

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -960,7 +960,16 @@ impl AppServerCodexThread {
                         cwd: params
                             .cwd
                             .and_then(|cwd| {
-                                codex_utils_absolute_path::AbsolutePathBuf::try_from(cwd).ok()
+                                match codex_utils_absolute_path::AbsolutePathBuf::try_from(cwd) {
+                                    Ok(path) => Some(path),
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            ?err,
+                                            "exec-approval cwd is not an absolute path; falling back to configured cwd"
+                                        );
+                                        None
+                                    }
+                                }
                             })
                             .unwrap_or_else(|| state.config.cwd.clone()),
                         reason: params.reason,
@@ -1353,7 +1362,13 @@ impl AppServerCodexThread {
                         // core exec events now require a `PathUri`. Fall back to the
                         // agent's configured cwd if the legacy string cannot be parsed.
                         let fallback_cwd = self.state.lock().await.config.cwd.clone();
-                        let cwd = cwd.try_into().unwrap_or_else(|_| fallback_cwd.into());
+                        let cwd = cwd.try_into().unwrap_or_else(|err| {
+                            tracing::warn!(
+                                ?err,
+                                "legacy exec cwd is not a parseable path; falling back to configured cwd"
+                            );
+                            fallback_cwd.into()
+                        });
                         Some(Event {
                             id,
                             msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
@@ -1538,7 +1553,13 @@ impl AppServerCodexThread {
                         // core exec events now require a `PathUri`. Fall back to the
                         // agent's configured cwd if the legacy string cannot be parsed.
                         let fallback_cwd = self.state.lock().await.config.cwd.clone();
-                        let cwd = cwd.try_into().unwrap_or_else(|_| fallback_cwd.into());
+                        let cwd = cwd.try_into().unwrap_or_else(|err| {
+                            tracing::warn!(
+                                ?err,
+                                "legacy exec cwd is not a parseable path; falling back to configured cwd"
+                            );
+                            fallback_cwd.into()
+                        });
                         Some(Event {
                             id,
                             msg: EventMsg::ExecCommandEnd(ExecCommandEndEvent {

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -82,8 +82,10 @@ impl CodexAgent {
             config.codex_home.to_path_buf(),
             false,
             config.cli_auth_credentials_store_mode,
+            config.forced_chatgpt_workspace_id.clone(),
             Some(config.chatgpt_base_url.clone()),
             AuthKeyringBackendKind::default(),
+            config.auth_route_config(),
         )
         .await;
 
@@ -101,6 +103,7 @@ impl CodexAgent {
             thread_store_from_config(&config, None),
             None,
             "agenthub-codex-acp".to_string(),
+            None,
             None,
         );
         Ok(Self {
@@ -333,9 +336,10 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     },
                 ));
             }
@@ -346,10 +350,11 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::CustomToolCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         name: None,
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     },
                 ));
             }
@@ -361,9 +366,10 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 synthetic_outputs.push((
                     idx,
                     ResponseItem::FunctionCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     },
                 ));
             }
@@ -412,16 +418,18 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     for item in std::mem::take(items) {
         match item {
             RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
+                id,
                 call_id,
                 output,
-                metadata,
+                internal_chat_message_metadata_passthrough,
             }) => {
                 if function_call_ids.contains(&call_id) || local_shell_call_ids.contains(&call_id) {
                     retained.push(RolloutItem::ResponseItem(
                         ResponseItem::FunctionCallOutput {
+                            id,
                             call_id,
                             output,
-                            metadata,
+                            internal_chat_message_metadata_passthrough,
                         },
                     ));
                 } else {
@@ -429,18 +437,20 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                 }
             }
             RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
+                id,
                 call_id,
+                name,
                 output,
-                metadata,
-                ..
+                internal_chat_message_metadata_passthrough,
             }) => {
                 if custom_tool_call_ids.contains(&call_id) {
                     retained.push(RolloutItem::ResponseItem(
                         ResponseItem::CustomToolCallOutput {
+                            id,
                             call_id,
-                            name: None,
+                            name,
                             output,
-                            metadata,
+                            internal_chat_message_metadata_passthrough,
                         },
                     ));
                 } else {
@@ -486,9 +496,10 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     }),
                 ));
             }
@@ -499,10 +510,11 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         name: None,
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     }),
                 ));
             }
@@ -514,9 +526,10 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                 synthetic_outputs.push((
                     idx,
                     RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
+                        id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
-                        metadata: None,
+                        internal_chat_message_metadata_passthrough: None,
                     }),
                 ));
             }
@@ -666,6 +679,7 @@ impl CodexAgent {
                     None,
                     self.config.cli_auth_credentials_store_mode,
                     AuthKeyringBackendKind::default(),
+                    self.config.auth_route_config(),
                 );
 
                 let server =
@@ -1080,7 +1094,7 @@ mod tests {
                 call_id: "call-1".to_string(),
                 name: "actor_send".to_string(),
                 input: "{}".to_string(),
-                metadata: None,
+                internal_chat_message_metadata_passthrough: None,
             })],
             rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
         });
@@ -1128,7 +1142,7 @@ mod tests {
                     call_id: "call-persist".to_string(),
                     name: "actor_send".to_string(),
                     input: "{}".to_string(),
-                    metadata: None,
+                    internal_chat_message_metadata_passthrough: None,
                 }),
             ],
             rollout_path: Some(rollout_path.clone()),
@@ -1172,10 +1186,11 @@ mod tests {
     fn repair_response_item_history_drops_orphan_outputs() {
         let mut history = vec![
             ResponseItem::CustomToolCallOutput {
+                id: None,
                 call_id: "missing".to_string(),
                 name: None,
                 output: FunctionCallOutputPayload::from_text("ok".to_string()),
-                metadata: None,
+                internal_chat_message_metadata_passthrough: None,
             },
             ResponseItem::CustomToolCall {
                 id: None,
@@ -1183,7 +1198,7 @@ mod tests {
                 call_id: "call-2".to_string(),
                 name: "actor_ack".to_string(),
                 input: "{}".to_string(),
-                metadata: None,
+                internal_chat_message_metadata_passthrough: None,
             },
         ];
 
@@ -1212,7 +1227,7 @@ mod tests {
                 id: None,
                 call_id: Some("shell-1".to_string()),
                 status: LocalShellStatus::Completed,
-                metadata: None,
+                internal_chat_message_metadata_passthrough: None,
                 action: LocalShellAction::Exec(LocalShellExecAction {
                     command: vec!["echo".to_string(), "hi".to_string()],
                     timeout_ms: None,
@@ -1221,6 +1236,9 @@ mod tests {
                     user: None,
                 }),
             }]),
+            window_number: None,
+            first_window_id: None,
+            previous_window_id: None,
             window_id: None,
         })]);
 

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -1284,6 +1284,9 @@ impl PromptState {
 
             // Ignore these events
             EventMsg::TurnModerationMetadata(..)
+            // Informational: backend is waiting on a safety review before
+            // streaming more output. No user-facing action in the ACP adapter.
+            | EventMsg::SafetyBuffering(..)
             |
             EventMsg::ImageGenerationBegin(..)
             | EventMsg::ImageGenerationEnd(..)
@@ -1329,6 +1332,7 @@ impl PromptState {
         } = event;
         let request_kind = match &request {
             ElicitationRequest::Form { .. } => "form",
+            ElicitationRequest::OpenAiForm { .. } => "openai/form",
             ElicitationRequest::Url { .. } => "url",
         };
 
@@ -1655,6 +1659,7 @@ impl PromptState {
             call_id,
             command,
             turn_id,
+            environment_id: _,
             started_at_ms: _,
             cwd,
             reason,
@@ -1813,7 +1818,7 @@ impl PromptState {
             locations,
             terminal_output,
             kind,
-        } = parse_command_tool_call(parsed_cmd, &cwd);
+        } = parse_command_tool_call(parsed_cmd, &cwd.to_path_buf());
 
         let active_command = ActiveCommand {
             tool_call_id: tool_call_id.clone(),
@@ -5787,7 +5792,7 @@ mod tests {
                             process_id: None,
                             turn_id: turn_id.clone(),
                             command: vec!["echo".into(), "a".into()],
-                            cwd: cwd.clone(),
+                            cwd: cwd.clone().into(),
                             parsed_cmd: vec![ParsedCommand::Unknown {
                                 cmd: "echo a".into(),
                             }],
@@ -5800,7 +5805,7 @@ mod tests {
                             process_id: None,
                             turn_id: turn_id.clone(),
                             command: vec!["echo".into(), "b".into()],
-                            cwd: cwd.clone(),
+                            cwd: cwd.clone().into(),
                             parsed_cmd: vec![ParsedCommand::Unknown {
                                 cmd: "echo b".into(),
                             }],
@@ -5813,7 +5818,7 @@ mod tests {
                             process_id: None,
                             turn_id: turn_id.clone(),
                             command: vec!["echo".into(), "a".into()],
-                            cwd: cwd.clone(),
+                            cwd: cwd.clone().into(),
                             parsed_cmd: vec![],
                             source: Default::default(),
                             interaction_input: None,
@@ -5831,7 +5836,7 @@ mod tests {
                             process_id: None,
                             turn_id: turn_id.clone(),
                             command: vec!["echo".into(), "b".into()],
-                            cwd: cwd.clone(),
+                            cwd: cwd.clone().into(),
                             parsed_cmd: vec![],
                             source: Default::default(),
                             interaction_input: None,
@@ -5860,7 +5865,7 @@ mod tests {
                                     process_id: None,
                                     turn_id: id.to_string(),
                                     command: vec!["sleep".into(), "999".into()],
-                                    cwd: current_dir_abs().unwrap(),
+                                    cwd: current_dir_abs().unwrap().into(),
                                     parsed_cmd: vec![ParsedCommand::Unknown {
                                         cmd: "sleep 999".into(),
                                     }],
@@ -5877,6 +5882,7 @@ mod tests {
                                 msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
                                     call_id: "call-id".to_string(),
                                     approval_id: Some("approval-id".to_string()),
+                                    environment_id: None,
                                     turn_id: id.to_string(),
                                     started_at_ms: 0,
                                     command: vec!["echo".to_string(), "hi".to_string()],
@@ -6302,6 +6308,7 @@ mod tests {
                         ExecApprovalRequestEvent {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
+                            environment_id: None,
                             turn_id: "turn-id".to_string(),
                             started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
@@ -6389,6 +6396,7 @@ mod tests {
                         ExecApprovalRequestEvent {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
+                            environment_id: None,
                             turn_id: "turn-id".to_string(),
                             started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
@@ -6716,6 +6724,7 @@ mod tests {
                         ExecApprovalRequestEvent {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
+                            environment_id: None,
                             turn_id: "turn-id".to_string(),
                             started_at_ms: 0,
                             command: vec![
@@ -6797,6 +6806,7 @@ mod tests {
                         ExecApprovalRequestEvent {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
+                            environment_id: None,
                             turn_id: "turn-id".to_string(),
                             started_at_ms: 0,
                             command: vec![
@@ -7058,6 +7068,7 @@ mod tests {
                         EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
                             call_id: "call-id".to_string(),
                             approval_id: Some("approval-id".to_string()),
+                            environment_id: None,
                             turn_id: "turn-id".to_string(),
                             started_at_ms: 0,
                             command: vec!["echo".to_string(), "hi".to_string()],
@@ -7290,7 +7301,9 @@ mod tests {
                         EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
                             call_id: "call-1".to_string(),
                             invocation: invocation.clone(),
+                            connector_id: None,
                             mcp_app_resource_uri: Some(resource_uri.clone()),
+                            link_id: None,
                             plugin_id: None,
                         }),
                     )
@@ -7302,7 +7315,9 @@ mod tests {
                         EventMsg::McpToolCallEnd(McpToolCallEndEvent {
                             call_id: "call-1".to_string(),
                             invocation,
+                            connector_id: None,
                             mcp_app_resource_uri: Some(resource_uri.clone()),
+                            link_id: None,
                             plugin_id: None,
                             duration: Duration::from_millis(5),
                             result: Ok(CallToolResult {
@@ -7526,7 +7541,8 @@ mod tests {
                             command: vec!["cargo".to_string(), "test".to_string()],
                             cwd: AbsolutePathBuf::from_absolute_path(
                                 std::env::current_dir()?.join("."),
-                            )?,
+                            )?
+                            .into(),
                             parsed_cmd: vec![],
                             source: Default::default(),
                             interaction_input: None,
@@ -7632,7 +7648,8 @@ mod tests {
                             command: vec!["cargo".to_string(), "test".to_string()],
                             cwd: AbsolutePathBuf::from_absolute_path(
                                 std::env::current_dir()?.join("."),
-                            )?,
+                            )?
+                            .into(),
                             parsed_cmd: vec![],
                             source: Default::default(),
                             interaction_input: None,

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.141.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.142.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]


### PR DESCRIPTION
Bumps all `codex-*` crates `rust-v0.141.0` → `rust-v0.142.0`. **Supersedes the dependabot piecemeal single-crate bumps #808/#809/#810** — the codex crates are version-locked (same monorepo tag) and must move together; bumping one at a time doesn't compile.

This is a **real migration**, not a version-only bump — 0.142 changed several APIs. All changes are in `agenthub-codex-acp/src/{codex_agent,app_server_thread,thread}.rs`.

## API changes handled
- **`ResponseItem::{FunctionCallOutput,CustomToolCallOutput}`**: `metadata` field removed → `id` + `internal_chat_message_metadata_passthrough`. History-repair reconstruction now preserves the real `id`/passthrough (and the custom-tool `name`, which was previously hard-nulled).
- **New required struct fields**: `ExecApprovalRequestEvent.environment_id` (threaded from the app-server params), `McpToolCall{Begin,End}Event.{connector_id,link_id}` = `None`, `TurnStartParams.multi_agent_mode` = `None`, `InProcessClientStartArgs.mcp_server_openai_form_elicitation` = `false` (adapter doesn't implement form elicitation).
- **Path types**: app-server `LegacyAppPathString` → `AbsolutePathBuf` / `PathUri` for the core exec events, via fallible conversion with fallback to the configured cwd.
- **New fn args**: `AuthManager::shared` (+`forced_chatgpt_workspace_id`, +`auth_route_config`), `ThreadManager::new` (+`external_time_provider`=`None`), `ServerOptions::new` (+`auth_route_config`).
- **New enum variants** given deliberate arms (not blind `_ =>`): `EventMsg::SafetyBuffering` (ignored — informational, mirrors `TurnModerationMetadata`), `ElicitationRequest::OpenAiForm` (auto-declined like `Form`/`Url` — no UI to satisfy it), `ServerRequest::CurrentTimeRead` (`Ok(None)` — no external time source), `ServerNotification::{ExternalAgentConfigImportProgress,ModelSafetyBufferingUpdated}` (ignored).

`agent-client-protocol` stays pinned at `=0.14.0` (the 0.15 bump #806 is a separate breaking migration, deferred).

## Semantic decisions worth a glance
1. `SafetyBuffering` / new notifications → no-op ignore (informational; no ACP-adapter surface). If you want a user-visible "waiting on safety review" hint, that's where it'd go.
2. `OpenAiForm` elicitation → auto-decline + advertise no support (`mcp_server_openai_form_elicitation: false`).
3. `environment_id` forwarded from params (more faithful than `None`); ignored on the reverse path the adapter doesn't consume.
4. `cwd` legacy→PathUri/AbsolutePathBuf conversions fall back to the configured cwd if the legacy string isn't a parseable absolute path (app-server emits absolute, so rarely triggered).
5. `CustomToolCallOutput.name` now preserved in history repair (was hard-nulled in 0.141 — strictly more faithful, but a behavior change worth noting).

## Verification (all independently re-run, not just trusted)
- `cargo check -p agenthub-codex-acp -p agenthub-acp-adapter`: **0 errors**
- `cargo clippy` (same): **clean**
- `cargo test -p agenthub-codex-acp`: **122 passed, 0 failed**
- `cargo fmt --check`: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)