### PR TITLE
chore(acp): upgrade agent-client-protocol 0.14.0 → 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,17 +282,16 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
+checksum = "eb5232c1162bcff4eafe378cc88a1ccaee2d49cedd9fe3d2517c5742bb748ced"
 dependencies = [
  "agent-client-protocol-derive",
- "agent-client-protocol-schema 0.13.6",
+ "agent-client-protocol-schema 0.14.0",
  "async-process",
  "blocking",
  "futures",
  "futures-concurrency",
- "jsonrpcmsg",
  "rustc-hash 2.1.2",
  "schemars 1.2.1",
  "serde",
@@ -300,13 +299,14 @@ dependencies = [
  "shell-words",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
+checksum = "7cb3131da850c922c348b36a9b96684d69779c3a776e83a948ba0b10e77766bb"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+checksum = "b4e7eb6f1e554741f621ae4abb046d4fbb3cb88541bc599693ae7f9aa30b72eb"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ agenthub-config = { path = "crates/agenthub-config" }
 agenthub-db = { path = "crates/agenthub-db" }
 agenthub-message-store = { path = "crates/agenthub-message-store" }
 agenthub-pyroscope = { path = "crates/agenthub-pyroscope" }
-agent-client-protocol = { version = "0.14.0", features = ["unstable"] }
+agent-client-protocol = { version = "0.15.1", features = ["unstable"] }
 prost = "0.14"
 tonic-prost = "0.14"
 tonic = { version = "0.14", features = ["transport", "tls-native-roots"] }

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 release-vendored-openssl = ["dep:openssl"]
 
 [dependencies]
-agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
+agent-client-protocol = { version = "=0.15.1", features = ["unstable"] }
 agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agent_client_protocol::Error;
-use agent_client_protocol::schema::SessionId;
+use agent_client_protocol::schema::v1::SessionId;
 use codex_app_server_client::{
     DEFAULT_IN_PROCESS_CHANNEL_CAPACITY, InProcessAppServerClient, InProcessAppServerRequestHandle,
     InProcessClientStartArgs, InProcessServerEvent, TypedRequestError,

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -6,9 +6,9 @@ use agent_client_protocol::schema::v1::{
     InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
     LoadSessionResponse, McpCapabilities, McpServer, McpServerHttp, McpServerStdio,
     NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse,
-    SessionCapabilities, SessionCloseCapabilities, SessionId, SessionInfo,
-    SessionListCapabilities, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
-    SetSessionModeRequest, SetSessionModeResponse,
+    SessionCapabilities, SessionCloseCapabilities, SessionId, SessionInfo, SessionListCapabilities,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse,
 };
 // `ProtocolVersion` is version-agnostic in 0.15 (schema root, not `schema::v1`).
 use agent_client_protocol::schema::ProtocolVersion;

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -1,15 +1,17 @@
 use agent_client_protocol::Error;
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     AgentCapabilities, AuthEnvVar, AuthMethod, AuthMethodAgent, AuthMethodEnvVar, AuthMethodId,
     AuthenticateRequest, AuthenticateResponse, CancelNotification, ClientCapabilities,
     CloseSessionRequest, CloseSessionResponse, Implementation, InitializeRequest,
     InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
     LoadSessionResponse, McpCapabilities, McpServer, McpServerHttp, McpServerStdio,
     NewSessionRequest, NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse,
-    ProtocolVersion, SessionCapabilities, SessionCloseCapabilities, SessionId, SessionInfo,
+    SessionCapabilities, SessionCloseCapabilities, SessionId, SessionInfo,
     SessionListCapabilities, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
     SetSessionModeRequest, SetSessionModeResponse,
 };
+// `ProtocolVersion` is version-agnostic in 0.15 (schema root, not `schema::v1`).
+use agent_client_protocol::schema::ProtocolVersion;
 use codex_config::DEFAULT_MCP_SERVER_ENVIRONMENT_ID;
 use codex_config::types::{AuthKeyringBackendKind, McpServerConfig, McpServerTransportConfig};
 use codex_core::{
@@ -971,7 +973,7 @@ mod tests {
         HistoryRepairStats, codex_mcp_server_config, persist_repaired_initial_history,
         repair_initial_history, repair_response_item_history,
     };
-    use agent_client_protocol::schema::{
+    use agent_client_protocol::schema::v1::{
         EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio,
     };
     use codex_config::types::McpServerTransportConfig;

--- a/agenthub-codex-acp/src/lib.rs
+++ b/agenthub-codex-acp/src/lib.rs
@@ -7,7 +7,7 @@
 // for a dependency bump; allow the lint crate-wide for this wrapper.
 #![allow(clippy::result_large_err)]
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     AuthenticateRequest, CancelNotification, CloseSessionRequest, InitializeRequest,
     ListSessionsRequest, LoadSessionRequest, NewSessionRequest, PromptRequest,
     SetSessionConfigOptionRequest, SetSessionModeRequest,

--- a/agenthub-codex-acp/src/local_spawner.rs
+++ b/agenthub-codex-acp/src/local_spawner.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use agent_client_protocol::ConnectionTo;
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     ClientCapabilities, ReadTextFileRequest, SessionId, WriteTextFileRequest,
 };
 use agent_client_protocol::Client;

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, ClientCapabilities,
     ConfigOptionUpdate, Content, ContentBlock, ContentChunk, Diff, EmbeddedResource,
     EmbeddedResourceResource, LoadSessionResponse, Meta, PermissionOption, PermissionOptionKind,
@@ -4644,7 +4644,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use agent_client_protocol::schema::{
+    use agent_client_protocol::schema::v1::{
         RequestPermissionResponse, SessionConfigKind, SessionConfigSelectOptions, TextContent,
     };
     use agenthub_managed_skills::{

--- a/crates/agenthub-acp-core/Cargo.toml
+++ b/crates/agenthub-acp-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-agent-client-protocol = { version = "0.14.0", features = ["unstable"] }
+agent-client-protocol = { version = "0.15.1", features = ["unstable"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/agenthub-acp-core/src/lib.rs
+++ b/crates/agenthub-acp-core/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     ContentBlock, EnvVariable, HttpHeader, McpCapabilities, McpServer, McpServerHttp,
     McpServerStdio, TextContent,
 };

--- a/crates/agenthub-acp/Cargo.toml
+++ b/crates/agenthub-acp/Cargo.toml
@@ -10,7 +10,7 @@ agenthub-config = { path = "../agenthub-config" }
 agenthub-managed-skills = { path = "../agenthub-managed-skills" }
 agenthub-team-domain = { path = "../agenthub-team-domain" }
 agenthub-text = { path = "../agenthub-text" }
-agent-client-protocol = { version = "0.14.0", features = ["unstable"] }
+agent-client-protocol = { version = "0.15.1", features = ["unstable"] }
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["clock"] }

--- a/crates/agenthub-acp/src/actor_runtime_skill.rs
+++ b/crates/agenthub-acp/src/actor_runtime_skill.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use agent_client_protocol::schema::{ContentBlock, TextContent};
+use agent_client_protocol::schema::v1::{ContentBlock, TextContent};
 use agenthub_acp_core::{AcpSkill, build_skill};
 use agenthub_managed_skills::{ManagedSkillKind, managed_skill_doc};
 use agenthub_team_domain::{
@@ -121,7 +121,7 @@ mod tests {
         AcpActorSkillContext, build_actor_runtime_context_block, build_required_managed_skill,
     };
     use crate::test_utils::TempManagedSkillsHome;
-    use agent_client_protocol::schema::ContentBlock;
+    use agent_client_protocol::schema::v1::ContentBlock;
 
     #[test]
     fn actor_runtime_skill_uses_static_name() {

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -14,14 +14,17 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption,
-    PermissionOptionKind, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    PermissionOptionKind, PromptRequest, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
     TextContent, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
 };
+// `ProtocolVersion` is version-agnostic in 0.15 — it lives at the schema root, not
+// under the versioned `schema::v1` module.
+use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{Agent, ConnectionTo, Error as AcpError, ErrorCode as AcpErrorCode};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -2653,7 +2656,7 @@ mod tests {
         load_workdir_skills, permission_outcome_allows, permission_review_failure_outcome,
         remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
     };
-    use agent_client_protocol::schema::{
+    use agent_client_protocol::schema::v1::{
         ContentBlock, McpServer, PermissionOption, PermissionOptionKind, RequestPermissionOutcome,
         SelectedPermissionOutcome,
     };

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -17,10 +17,10 @@ use std::time::Duration;
 use agent_client_protocol::schema::v1::{
     CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption,
-    PermissionOptionKind, PromptRequest, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
-    TextContent, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+    PermissionOptionKind, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, SelectedPermissionOutcome, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, TextContent, ToolCall, ToolCallStatus,
+    ToolCallUpdate, ToolCallUpdateFields,
 };
 // `ProtocolVersion` is version-agnostic in 0.15 — it lives at the schema root, not
 // under the versioned `schema::v1` module.

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -22,7 +22,7 @@ use crate::acp::{
 };
 use crate::agent::event_message_codec::persist_agent_event;
 use crate::agent::{AgentStatus, OutputStream};
-use agent_client_protocol::schema::Implementation;
+use agent_client_protocol::schema::v1::Implementation;
 
 const RESUMED_ACP_SESSION_GRACE_PERIOD: Duration = Duration::from_secs(2);
 const RESUMED_ACP_SESSION_POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -789,13 +789,13 @@ async fn respond_permission(
         ));
     }
     let outcome = if let Some(option_id) = payload.option_id.as_ref() {
-        agent_client_protocol::schema::RequestPermissionOutcome::Selected(
-            agent_client_protocol::schema::SelectedPermissionOutcome::new(option_id.clone()),
+        agent_client_protocol::schema::v1::RequestPermissionOutcome::Selected(
+            agent_client_protocol::schema::v1::SelectedPermissionOutcome::new(option_id.clone()),
         )
     } else {
         match payload.outcome.as_deref() {
             Some("cancelled") | None => {
-                agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
+                agent_client_protocol::schema::v1::RequestPermissionOutcome::Cancelled
             }
             Some(_other) => {
                 return Err(ApiError::bad_request(

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -1081,15 +1081,15 @@ impl TeamInternalControl for TeamInternalControlService {
             ));
         }
         let outcome = if let Some(selected_option_id) = option_id.as_ref() {
-            agent_client_protocol::schema::RequestPermissionOutcome::Selected(
-                agent_client_protocol::schema::SelectedPermissionOutcome::new(
+            agent_client_protocol::schema::v1::RequestPermissionOutcome::Selected(
+                agent_client_protocol::schema::v1::SelectedPermissionOutcome::new(
                     selected_option_id.clone(),
                 ),
             )
         } else {
             match requested_outcome {
                 Some("cancelled") | None => {
-                    agent_client_protocol::schema::RequestPermissionOutcome::Cancelled
+                    agent_client_protocol::schema::v1::RequestPermissionOutcome::Cancelled
                 }
                 Some(other) => {
                     return Err(Status::invalid_argument(format!(

--- a/src/team/permission_review/tests_support.rs
+++ b/src/team/permission_review/tests_support.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::state::AppState;
 use crate::team::mailbox_hint::{RunningActorRuntime, TeamMailboxHintAgentNudger};
 use crate::team::{TeamDefinitionConfig, TeamDefinitionRecord};
-use agent_client_protocol::schema::PermissionOptionKind;
+use agent_client_protocol::schema::v1::PermissionOptionKind;
 use agenthub_acp::{AcpPermissionOption, AcpPermissionReviewRequest, AcpPermissionRoutingMetadata};
 use serde_json::{Value, json};
 use tokio::sync::Mutex;


### PR DESCRIPTION
Upgrades `agent-client-protocol` `0.14.0` → `0.15.1`. **Supersedes dependabot #816**, which bumped only `Cargo.lock` — the `Cargo.toml` version constraints + a small schema-path migration are required to compile.

## What 0.15 changed (small, mechanical)
0.15 **versioned the schema module**: the flat `agent_client_protocol::schema::X` types moved to `schema::v1::X` (and a `v2` exists). The types are **identical in shape** (e.g. `McpServer` is still an enum with `Http(McpServerHttp)` / `Stdio(McpServerStdio)`), so `v1` is just the 0.14 schema, namespaced. The migration is therefore a path rename:
- `agent_client_protocol::schema::` → `agent_client_protocol::schema::v1::` across 12 files.
- **`ProtocolVersion`** is version-agnostic in 0.15 — it lives at the schema **root**, not under `v1` — so it's imported separately as `agent_client_protocol::schema::ProtocolVersion` (in `agenthub-acp` and `agenthub-codex-acp`).

No API-shape changes were needed (unlike the codex 0.142 migration). `codex-*` deps are untouched.

## Dependency resolution
`agent-client-protocol` 0.14.0→0.15.1, `-derive` 0.14.0→0.15.1, `-schema` 0.13.6→0.14.0. **No conflict** with `claude-code-acp-rs 0.1.22` / `sacp 10.1.0` — they keep their separate `agent-client-protocol-schema 0.10.8` (already coexisting).

## Verification
- `cargo check --workspace`: **clean**
- `cargo clippy` (acp crates): **clean**
- `cargo test`: **172 pass** (agenthub-acp 47 / agenthub-acp-core 3 / agenthub-codex-acp 122), 0 failed
- `cargo fmt --check`: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)