### PR TITLE
feat(team): create tasks from channel messages

### DIFF
--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -40,9 +40,10 @@ use crate::team::{
     TeamConversationMessageRecord, TeamConversationRecord, TeamDefinitionConfig,
     TeamDefinitionRecord, TeamMemoryFlushRequest, TeamReplyObligationRecord, TeamRunEventRecord,
     TeamRunRecord, TeamRunStatus, TeamRuntimeRecord, TeamStepRecord, TeamStepStatus,
-    TeamTaskExecutionPlan, TeamTaskNoteRecord, TeamTaskPriority, TeamTaskRecord,
-    TeamTaskStepExecutionSpec, TeamThreadReplyRecord, dispatch_actor_mailbox_immediate_hint,
-    effective_team_member_skills, ensure_team_runtime_started, force_team_member_new_session,
+    TeamTaskCreateInput, TeamTaskExecutionPlan, TeamTaskNoteRecord, TeamTaskPriority,
+    TeamTaskRecord, TeamTaskStepExecutionSpec, TeamThreadReplyRecord,
+    dispatch_actor_mailbox_immediate_hint, effective_team_member_skills,
+    ensure_team_runtime_started, force_team_member_new_session,
     normalize_optional_idempotency_key_input, parse_task_execution_plan,
     plan_actor_mailbox_immediate_hint, stop_team_runtime,
 };
@@ -169,6 +170,15 @@ pub struct CreateTeamTaskRequest {
     pub context: Option<Value>,
     pub conversation_mode: Option<String>,
     pub topic: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateTeamTaskFromChannelMessageRequest {
+    pub title: Option<String>,
+    pub priority: Option<String>,
+    pub assigned_member_id: Option<String>,
+    pub created_by_actor_id: Option<String>,
+    pub context: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -516,6 +526,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/{id}/channels/{channel_id}/threads/{root_message_id}/replies",
             post(reply_team_thread),
+        )
+        .route(
+            "/{id}/channels/{channel_id}/messages/{message_id}/tasks",
+            post(create_team_task_from_channel_message),
         )
         .route(
             "/{id}/channels",
@@ -903,6 +917,103 @@ async fn list_team_tasks(
         .await
         .map_err(map_team_internal_error)?;
     Ok(Json(tasks))
+}
+
+async fn create_team_task_from_channel_message(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((team_id, channel_id, message_id)): Path<(String, String, i64)>,
+    Json(payload): Json<CreateTeamTaskFromChannelMessageRequest>,
+) -> Result<Json<TeamTaskDetailResponse>, ApiError> {
+    if message_id <= 0 {
+        return Err(ApiError::bad_request("message_id must be positive"));
+    }
+    let user = require_user(&headers, &state).await?;
+    load_team_for_user(&state, &team_id, &user).await?;
+    let channel_id = channel_id.trim().to_lowercase();
+    if channel_id.is_empty() {
+        return Err(ApiError::bad_request("channel_id is required"));
+    }
+    let source_message = state
+        .teams
+        .get_channel_conversation_message(&team_id, &channel_id, message_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "channel message not found"))?;
+    if source_message.route == "team_thread_reply" {
+        return Err(ApiError::bad_request(
+            "thread replies cannot be converted into tasks directly; convert the root channel message",
+        ));
+    }
+
+    let source_excerpt = summarize_task_source_message(&source_message.payload);
+    let title = payload
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| source_excerpt.clone());
+    if title.trim().is_empty() {
+        return Err(ApiError::bad_request(
+            "title is required when the source message has no readable text",
+        ));
+    }
+    let priority = normalize_task_priority(payload.priority.as_deref())?;
+    let assigned_member_id = payload
+        .assigned_member_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let created_by_actor_id =
+        normalize_task_created_by_actor_id(payload.created_by_actor_id.as_deref(), &user)?;
+    let mut context = match payload.context {
+        Some(Value::Object(map)) => map,
+        Some(_) => {
+            return Err(ApiError::bad_request(
+                "context must be a JSON object when provided",
+            ));
+        }
+        None => Map::new(),
+    };
+    context.insert(
+        "bootstrap_kind".to_string(),
+        Value::String("channel_message_task".to_string()),
+    );
+    context.insert(
+        "source".to_string(),
+        serde_json::json!({
+            "kind": "team_channel_message",
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "conversation_id": source_message.conversation_id,
+            "task_id": source_message.task_id,
+            "message_id": source_message.message_id,
+            "from_actor_id": source_message.from_actor_id,
+            "created_at": source_message.created_at,
+            "excerpt": source_excerpt,
+        }),
+    );
+
+    let (task, conversation) = state
+        .teams
+        .create_task_with_metadata(TeamTaskCreateInput {
+            team_id: &team_id,
+            title: title.trim(),
+            created_by_actor_id: &created_by_actor_id,
+            priority,
+            assigned_member_id,
+            context: Value::Object(context),
+            conversation_mode: "group_chat",
+            topic: Some(&channel_id),
+        })
+        .await
+        .map_err(map_team_internal_error)?;
+    Ok(Json(TeamTaskDetailResponse {
+        task,
+        conversation,
+        latest_run: None,
+        notes: Vec::new(),
+    }))
 }
 
 async fn list_team_channels(
@@ -2701,7 +2812,6 @@ fn normalize_task_actor_id(
     Ok(trimmed.to_string())
 }
 
-#[cfg(test)]
 fn normalize_task_created_by_actor_id(
     value: Option<&str>,
     user: &UserRecord,
@@ -2710,6 +2820,41 @@ fn normalize_task_created_by_actor_id(
         return Ok(canonical_user_actor_id(user));
     };
     normalize_task_actor_id(raw, "created_by_actor_id", user)
+}
+
+fn normalize_task_priority(value: Option<&str>) -> Result<TeamTaskPriority, ApiError> {
+    let Some(raw) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(TeamTaskPriority::default());
+    };
+    raw.parse::<TeamTaskPriority>().map_err(|_| {
+        ApiError::bad_request("invalid task priority; expected one of: critical, high, medium, low")
+    })
+}
+
+fn summarize_task_source_message(payload: &Value) -> String {
+    let raw = payload
+        .get("text")
+        .and_then(Value::as_str)
+        .or_else(|| payload.as_str())
+        .unwrap_or("")
+        .trim();
+    if raw.is_empty() {
+        return String::new();
+    }
+    summarize_text(raw, TEAM_MESSAGE_SUMMARY_MAX_CHARS)
+}
+
+fn summarize_text(raw: &str, max_chars: usize) -> String {
+    let normalized = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+    let mut summary = normalized
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    summary.push_str("...");
+    summary
 }
 
 struct TaskMessageCorrelationSeed<'a> {

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -968,12 +968,12 @@ async fn create_team_task_from_channel_message(
         normalize_task_created_by_actor_id(payload.created_by_actor_id.as_deref(), &user)?;
     let mut context = match payload.context {
         Some(Value::Object(map)) => map,
+        None | Some(Value::Null) => Map::new(),
         Some(_) => {
             return Err(ApiError::bad_request(
                 "context must be a JSON object when provided",
             ));
         }
-        None => Map::new(),
     };
     context.insert(
         "bootstrap_kind".to_string(),

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -411,6 +411,37 @@ async fn teams_router_http_contract() {
         created_from_message["task"]["context"]["token"],
         Value::from("[redacted]")
     );
+    let create_from_message_null_context_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            &format!("/{team_id}/channels/review/messages/{source_message_id}/tasks"),
+            Some(&token),
+            Some(json!({
+                "title": "task from null context",
+                "context": null
+            })),
+        ))
+        .await
+        .expect("create task from channel message with null context via router");
+    assert_eq!(
+        create_from_message_null_context_resp.status(),
+        StatusCode::OK
+    );
+    let created_from_message_null_context =
+        decode_json_body(create_from_message_null_context_resp).await;
+    assert_eq!(
+        created_from_message_null_context["task"]["title"],
+        Value::from("task from null context")
+    );
+    assert_eq!(
+        created_from_message_null_context["task"]["context"]["bootstrap_kind"],
+        Value::from("channel_message_task")
+    );
+    assert_eq!(
+        created_from_message_null_context["task"]["context"]["source"]["message_id"],
+        Value::from(source_message_id)
+    );
 
     let send_task_message_resp = app
         .clone()

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -338,6 +338,80 @@ async fn teams_router_http_contract() {
             .unwrap_or(false)
     );
 
+    let create_channel_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            &format!("/{team_id}/channels"),
+            Some(&token),
+            Some(json!({
+                "channel_id": "review",
+                "description": "Review lane"
+            })),
+        ))
+        .await
+        .expect("create channel via router");
+    assert_eq!(create_channel_resp.status(), StatusCode::OK);
+    let channel = decode_json_body(create_channel_resp).await;
+    let channel_task_id = channel["task_id"]
+        .as_str()
+        .expect("channel task id")
+        .to_string();
+    let source_message_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            &format!("/{team_id}/tasks/{channel_task_id}/messages"),
+            Some(&token),
+            Some(json!({
+                "route": "group_chat",
+                "payload": {"type":"chat_message","text":"Turn this channel message into a tracked task"}
+            })),
+        ))
+        .await
+        .expect("send channel message via router");
+    assert_eq!(source_message_resp.status(), StatusCode::OK);
+    let source_message = decode_json_body(source_message_resp).await;
+    let source_message_id = source_message["message_id"]
+        .as_i64()
+        .expect("source message id");
+    let create_from_message_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            &format!("/{team_id}/channels/review/messages/{source_message_id}/tasks"),
+            Some(&token),
+            Some(json!({
+                "priority": "high",
+                "context": {"token":"should-redact"}
+            })),
+        ))
+        .await
+        .expect("create task from channel message via router");
+    assert_eq!(create_from_message_resp.status(), StatusCode::OK);
+    let created_from_message = decode_json_body(create_from_message_resp).await;
+    assert_eq!(
+        created_from_message["task"]["title"],
+        Value::from("Turn this channel message into a tracked task")
+    );
+    assert_eq!(created_from_message["task"]["priority"], Value::from("high"));
+    assert_eq!(
+        created_from_message["task"]["context"]["bootstrap_kind"],
+        Value::from("channel_message_task")
+    );
+    assert_eq!(
+        created_from_message["task"]["context"]["source"]["channel_id"],
+        Value::from("review")
+    );
+    assert_eq!(
+        created_from_message["task"]["context"]["source"]["message_id"],
+        Value::from(source_message_id)
+    );
+    assert_eq!(
+        created_from_message["task"]["context"]["token"],
+        Value::from("[redacted]")
+    );
+
     let send_task_message_resp = app
         .clone()
         .oneshot(build_json_request(

--- a/src/team/manager/conversation.rs
+++ b/src/team/manager/conversation.rs
@@ -1,5 +1,6 @@
 use sqlx::{QueryBuilder, Sqlite};
 
+use super::TEAM_CHANNEL_BOOTSTRAP_KIND;
 use super::TeamManager;
 use super::codec_rows::{parse_team_conversation_message_row, parse_team_conversation_row};
 use crate::team::{TeamConversationMessageRecord, TeamConversationRecord};
@@ -71,5 +72,45 @@ impl TeamManager {
         }
         messages.reverse();
         Ok(messages)
+    }
+
+    pub async fn get_channel_conversation_message(
+        &self,
+        team_id: &str,
+        channel_id: &str,
+        message_id: i64,
+    ) -> anyhow::Result<TeamConversationMessageRecord> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                m.id,
+                m.conversation_id,
+                m.task_id,
+                m.group_id,
+                m.from_actor_id,
+                m.to_actor_id,
+                m.route,
+                m.payload_json,
+                m.created_at
+            FROM team_conversation_messages AS m
+            INNER JOIN team_tasks AS t ON t.id = m.task_id
+            WHERE m.id = ?1
+              AND t.team_id = ?2
+              AND lower(trim(COALESCE(json_extract(t.context_json, '$.bootstrap_kind'), ''))) = ?3
+              AND lower(trim(COALESCE(json_extract(t.context_json, '$.channel_id'), ''))) = ?4
+            "#,
+        )
+        .bind(message_id)
+        .bind(team_id)
+        .bind(TEAM_CHANNEL_BOOTSTRAP_KIND)
+        .bind(channel_id.trim().to_lowercase())
+        .fetch_one(&self.db)
+        .await?;
+        let (mut message, body_moved) = parse_team_conversation_message_row(&row)?;
+        if body_moved {
+            self.rehydrate_moved_conversation_payload(&mut message)
+                .await?;
+        }
+        Ok(message)
     }
 }

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -211,6 +211,37 @@ describe("api request headers", () => {
     expect(url).toContain("priority=critical");
   });
 
+  it("creates a task from a channel message through the narrow channel route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ task: { id: "task-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.createTeamTaskFromChannelMessage(
+      "token-1",
+      "team/1",
+      "review lane",
+      42,
+      {
+        priority: "high",
+        context: { source: "test" },
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "/api/teams/team%2F1/channels/review%20lane/messages/42/tasks"
+    );
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(
+      JSON.stringify({ priority: "high", context: { source: "test" } })
+    );
+  });
+
   it("builds the team run-context SSE URL with encoded dynamic segments", () => {
     expect(
       buildTeamRunContextSseUrl(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -352,6 +352,14 @@ export type TeamTaskRecord = {
   updated_at: number;
 };
 
+export type CreateTeamTaskFromChannelMessagePayload = {
+  title?: string | null;
+  priority?: TeamTaskPriority | null;
+  assigned_member_id?: string | null;
+  created_by_actor_id?: string | null;
+  context?: unknown;
+};
+
 export type TeamConversationRecord = {
   id: string;
   team_id: string;
@@ -1012,6 +1020,21 @@ export const api = {
       token
     );
   },
+  createTeamTaskFromChannelMessage: (
+    token: string,
+    teamId: string,
+    channelId: string,
+    messageId: number,
+    payload: CreateTeamTaskFromChannelMessagePayload
+  ) =>
+    apiFetch<TeamTaskDetailResponse>(
+      `/api/teams/${encodePathSegment(teamId)}/channels/${encodePathSegment(channelId)}/messages/${messageId}/tasks`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }
+    ),
   getTeamTask: (token: string, teamId: string, taskId: string) =>
     apiFetch<TeamTaskDetailResponse>(
       `/api/teams/${encodePathSegment(teamId)}/tasks/${encodePathSegment(taskId)}`,


### PR DESCRIPTION
## Summary

- add a narrow Team API route that converts an existing channel message into a canonical task
- validate that the source message belongs to the requested team channel and preserve source metadata in task context
- add backend router coverage plus a web API wrapper test

## Purpose

Channel messages can now become tracked Team tasks without opening the generic human task mutation surface. The existing `POST /tasks` contract stays closed, while this scoped route records where the task came from.

## Related Issues

None.

## Testing

- `cargo test -p agenthub teams_router_http_contract`
- `npm --prefix web test -- --run src/api.test.ts`
