### PR TITLE
feat(web): add codex runtime model selector

### DIFF
--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -96,6 +96,21 @@ export const CODEX_RUNTIME_MODEL_OPTIONS = [
   { value: "gpt-5.4-mini", label: "GPT-5.4-Mini" },
   { value: "gpt-5.2", label: "GPT-5.2" },
 ];
+
+export function listCodexRuntimeModelOptions(runtimeModel: string) {
+  const customModel = runtimeModel.trim();
+  if (
+    !customModel ||
+    CODEX_RUNTIME_MODEL_OPTIONS.some((option) => option.value === customModel)
+  ) {
+    return CODEX_RUNTIME_MODEL_OPTIONS;
+  }
+
+  return [
+    ...CODEX_RUNTIME_MODEL_OPTIONS,
+    { value: customModel, label: customModel },
+  ];
+}
 const TEAM_AGENT_MODAL_ACCENT_BUTTON_CLASS =
   "!border !border-ui-border-emphasis !bg-brand-primary !text-white !shadow-sm transition hover:!border-ui-border-strong hover:!bg-brand-primary-hover";
 const TEAM_AGENT_MODAL_MUTED_BUTTON_CLASS =
@@ -293,7 +308,7 @@ export function CreateAgentModal({
                   description="Optional. Leave blank to use the provider default."
                   placeholder="Provider default"
                   value={runtimeModel || null}
-                  data={CODEX_RUNTIME_MODEL_OPTIONS}
+                  data={listCodexRuntimeModelOptions(runtimeModel)}
                   searchable
                   clearable
                   onChange={(value) => setRuntimeModel?.(value ?? "")}

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -87,6 +87,15 @@ export const THINKING_LEVEL_OPTIONS = [
   { value: "high", label: "High" },
   { value: "max", label: "Max" },
 ];
+export const CODEX_RUNTIME_MODEL_OPTIONS = [
+  { value: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
+  { value: "gpt-5.6-terra", label: "GPT-5.6-Terra" },
+  { value: "gpt-5.6-luna", label: "GPT-5.6-Luna" },
+  { value: "gpt-5.5", label: "GPT-5.5" },
+  { value: "gpt-5.4", label: "GPT-5.4" },
+  { value: "gpt-5.4-mini", label: "GPT-5.4-Mini" },
+  { value: "gpt-5.2", label: "GPT-5.2" },
+];
 const TEAM_AGENT_MODAL_ACCENT_BUTTON_CLASS =
   "!border !border-ui-border-emphasis !bg-brand-primary !text-white !shadow-sm transition hover:!border-ui-border-strong hover:!bg-brand-primary-hover";
 const TEAM_AGENT_MODAL_MUTED_BUTTON_CLASS =
@@ -278,13 +287,26 @@ export function CreateAgentModal({
           ) : null}
           {supportsRuntimeProfile ? (
             <>
-              <TextInput
-                label="Runtime model"
-                description="Optional. Leave blank to use the provider default."
-                placeholder={isCodexPreset ? "gpt-5" : "claude-sonnet"}
-                value={runtimeModel}
-                onChange={(event) => setRuntimeModel?.(event.currentTarget.value)}
-              />
+              {isCodexPreset ? (
+                <Select
+                  label="Runtime model"
+                  description="Optional. Leave blank to use the provider default."
+                  placeholder="Provider default"
+                  value={runtimeModel || null}
+                  data={CODEX_RUNTIME_MODEL_OPTIONS}
+                  searchable
+                  clearable
+                  onChange={(value) => setRuntimeModel?.(value ?? "")}
+                />
+              ) : (
+                <TextInput
+                  label="Runtime model"
+                  description="Optional. Leave blank to use the provider default."
+                  placeholder="claude-sonnet"
+                  value={runtimeModel}
+                  onChange={(event) => setRuntimeModel?.(event.currentTarget.value)}
+                />
+              )}
               <Select
                 label="Thinking level"
                 description="Applied when the next session starts."

--- a/web/src/create_agent_modal.interaction.test.tsx
+++ b/web/src/create_agent_modal.interaction.test.tsx
@@ -12,6 +12,8 @@ type ModalHarnessProps = {
   worktreeMode: "use_existing" | "create_worktree" | "reuse_worktree";
   worktreeError: string | null;
   agentName?: string;
+  runtimeModel?: string;
+  setRuntimeModel?: (value: string) => void;
 };
 
 function renderHarness(root: Root, props: ModalHarnessProps) {
@@ -25,6 +27,8 @@ function renderHarness(root: Root, props: ModalHarnessProps) {
           setAgentWorkdir={() => {}}
           agentPresetId="codex"
           setAgentPresetId={() => {}}
+          runtimeModel={props.runtimeModel}
+          setRuntimeModel={props.setRuntimeModel}
           worktreeMode={props.worktreeMode}
           setWorktreeMode={() => {}}
           worktreeRepo=""
@@ -125,5 +129,34 @@ describe("CreateAgentModal interactions", () => {
     });
     expect(container.textContent).toContain("Show Advanced workspace options");
     expect(container.textContent).not.toContain("Repository path");
+  });
+
+  it("updates the Codex runtime model selection", () => {
+    const setRuntimeModel = vi.fn();
+    renderHarness(root, {
+      worktreeMode: "use_existing",
+      worktreeError: null,
+      setRuntimeModel,
+    });
+
+    const runtimeModelLabel = Array.from(container.querySelectorAll("label")).find(
+      (label) => label.textContent === "Runtime model"
+    );
+    const runtimeModel = document.getElementById(
+      runtimeModelLabel?.htmlFor ?? ""
+    ) as HTMLInputElement | null;
+    expect(runtimeModel).not.toBeNull();
+
+    act(() => {
+      runtimeModel?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const modelOption = Array.from(document.querySelectorAll('[role="option"]')).find(
+      (node) => node.textContent === "GPT-5.5"
+    );
+    expect(modelOption).toBeDefined();
+    act(() => {
+      modelOption?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(setRuntimeModel).toHaveBeenLastCalledWith("gpt-5.5");
   });
 });

--- a/web/src/create_agent_modal.test.tsx
+++ b/web/src/create_agent_modal.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import {
   CreateAgentModal,
+  CODEX_RUNTIME_MODEL_OPTIONS,
   type CreateAgentModalProps,
   resolveCreateAgentPresetId,
   resolveCreateAgentWorktreeMode,
@@ -99,6 +100,22 @@ describe("CreateAgentModal", () => {
     expect(renderModal()).toContain("Thinking level");
     expect(renderModal({ agentPresetId: "claude" })).toContain("Runtime model");
     expect(renderModal({ agentPresetId: "gemini" })).not.toContain("Runtime model");
+  });
+
+  it("renders the Codex runtime model selector with bundled model presets", () => {
+    const html = renderModal();
+
+    expect(html).toContain("Runtime model");
+    expect(html).toContain("Provider default");
+    expect(CODEX_RUNTIME_MODEL_OPTIONS).toEqual([
+      { value: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
+      { value: "gpt-5.6-terra", label: "GPT-5.6-Terra" },
+      { value: "gpt-5.6-luna", label: "GPT-5.6-Luna" },
+      { value: "gpt-5.5", label: "GPT-5.5" },
+      { value: "gpt-5.4", label: "GPT-5.4" },
+      { value: "gpt-5.4-mini", label: "GPT-5.4-Mini" },
+      { value: "gpt-5.2", label: "GPT-5.2" },
+    ]);
   });
 
   it("can hide the command summary strip", () => {

--- a/web/src/create_agent_modal.test.tsx
+++ b/web/src/create_agent_modal.test.tsx
@@ -4,6 +4,7 @@ import { MantineProvider } from "@mantine/core";
 import {
   CreateAgentModal,
   CODEX_RUNTIME_MODEL_OPTIONS,
+  listCodexRuntimeModelOptions,
   type CreateAgentModalProps,
   resolveCreateAgentPresetId,
   resolveCreateAgentWorktreeMode,
@@ -115,6 +116,16 @@ describe("CreateAgentModal", () => {
       { value: "gpt-5.4", label: "GPT-5.4" },
       { value: "gpt-5.4-mini", label: "GPT-5.4-Mini" },
       { value: "gpt-5.2", label: "GPT-5.2" },
+    ]);
+  });
+
+  it("preserves a custom Codex runtime model in the selector", () => {
+    expect(listCodexRuntimeModelOptions("gpt-5.5")).toEqual(
+      CODEX_RUNTIME_MODEL_OPTIONS
+    );
+    expect(listCodexRuntimeModelOptions("custom-codex-model")).toEqual([
+      ...CODEX_RUNTIME_MODEL_OPTIONS,
+      { value: "custom-codex-model", label: "custom-codex-model" },
     ]);
   });
 

--- a/web/tests/e2e/app.e2e.ts
+++ b/web/tests/e2e/app.e2e.ts
@@ -39,7 +39,8 @@ test("creates a Codex agent with an explicit runtime profile", async ({ page }) 
   await expect(dialog.getByLabel("Thinking level")).toBeVisible();
   await dialog.getByPlaceholder("e.g. Alice").fill("Runtime Profile Agent");
   await dialog.getByLabel("Workspace path").fill("/workspace/runtime-profile-agent");
-  await dialog.getByLabel("Runtime model").fill("gpt-5");
+  await dialog.getByLabel("Runtime model").click();
+  await page.getByRole("option", { name: "GPT-5.5", exact: true }).click();
   await dialog.getByLabel("Thinking level").click();
   await page.getByRole("option", { name: "High", exact: true }).click();
   await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
@@ -47,7 +48,7 @@ test("creates a Codex agent with an explicit runtime profile", async ({ page }) 
   await expect(dialog).toBeHidden();
   expect(fixture.agents.at(-1)).toMatchObject({
     name: "Runtime Profile Agent",
-    runtime_model: "gpt-5",
+    runtime_model: "gpt-5.5",
     thinking_level: "high",
   });
 });

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -233,7 +233,9 @@ export async function createTeamMemberFromModal(
     if (options.model === "codex") {
       await runtimeModel.click();
       await runtimeModel.fill(options.runtimeModel);
-      await runtimeModel.press("Enter");
+      await page
+        .getByRole("option", { name: new RegExp(options.runtimeModel, "i") })
+        .click();
     } else {
       await runtimeModel.fill(options.runtimeModel);
     }

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -229,7 +229,14 @@ export async function createTeamMemberFromModal(
     await dialog.getByLabel(TEAM_MEMBER_RUNTIME_LABEL_PATTERN).selectOption(options.model);
   }
   if (options.runtimeModel) {
-    await dialog.getByLabel("Runtime model").fill(options.runtimeModel);
+    const runtimeModel = dialog.getByLabel("Runtime model");
+    if (options.model === "codex") {
+      await runtimeModel.click();
+      await runtimeModel.fill(options.runtimeModel);
+      await runtimeModel.press("Enter");
+    } else {
+      await runtimeModel.fill(options.runtimeModel);
+    }
   }
   if (options.thinkingLevel) {
     await dialog.getByLabel("Thinking level").click();

--- a/web/tests/e2e/team_page_setup.e2e.ts
+++ b/web/tests/e2e/team_page_setup.e2e.ts
@@ -97,7 +97,7 @@ test("team member setup adds the first agent and appends more agents through spe
     teamName,
     workdir: "/workspace/member-setup-coordinator",
     model: "codex",
-    runtimeModel: "gpt-5",
+    runtimeModel: "gpt-5.5",
     thinkingLevel: "high",
     identity: "Principal planner and reviewer",
   });
@@ -122,7 +122,7 @@ test("team member setup adds the first agent and appends more agents through spe
   const [coordinatorMember, workerMember] = updates[1]?.payload.spec.members ?? [];
   expect(coordinatorMember?.model).toBe("codex");
   expect(coordinatorMember?.runtime).toMatchObject({
-    runtime_model: "gpt-5",
+    runtime_model: "gpt-5.5",
     thinking_level: "high",
   });
   expect(coordinatorMember?.skills).toBeUndefined();


### PR DESCRIPTION
## Summary

- Replace the Codex Create Agent runtime-model free-text field with a searchable model selector.
- Populate the selector from the bundled Codex `rust-v0.144.1` model presets and retain the provider-default clear state.
- Keep the Claude runtime-model field unchanged.

## Purpose

Make common Codex runtime model selection faster and less error-prone without changing provider-default behavior.

## Related issue

None.

## Validation

- `cd web && npm run test -- src/create_agent_modal.test.tsx`
- `cd web && npm run lint`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run build`
