### PR TITLE
fix(team): retain SQLite message bodies during phase one

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -106,15 +106,14 @@ pub struct MessageArchiveConfig {
     pub message_table: Option<String>,
 }
 
-/// Tiered message body store (compresses message bodies into RocksDB). Default-on when the binary is
-/// built with the `rocksdb` feature; `enabled = false` turns it off.
+/// Tiered message body store (compresses message bodies into RocksDB). It is opt-in: set
+/// `enabled = true` after building with the `rocksdb` feature.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MessageBodyStoreConfig {
     pub enabled: Option<bool>,
     pub path: Option<String>,
-    /// Whether to backfill existing inline conversation bodies into the store on startup. Default-on;
-    /// set `auto_migrate = false` to only move bodies written from now on (e.g. to run `agenthub
-    /// migrate` manually instead).
+    /// Whether to backfill existing SQLite compatibility bodies into the store on startup. Default-on
+    /// once the store itself is enabled; set `auto_migrate = false` to use `agenthub migrate`.
     pub auto_migrate: Option<bool>,
 }
 
@@ -349,14 +348,13 @@ impl AppConfig {
             .to_string()
     }
 
-    /// Whether the tiered message body store is enabled. Default-on (a default capability); only an
-    /// explicit `enabled = false` turns it off. The build must also include the `rocksdb` feature for
-    /// the store to actually be constructed.
+    /// Whether the tiered message body store is enabled. It is opt-in, and the build must include the
+    /// `rocksdb` feature for the store to actually be constructed.
     pub fn message_body_store_enabled(&self) -> bool {
         self.message_body_store
             .as_ref()
             .and_then(|config| config.enabled)
-            .unwrap_or(true)
+            .unwrap_or(false)
     }
 
     /// Filesystem path for the message body store. Defaults next to the other agenthub data.
@@ -371,8 +369,8 @@ impl AppConfig {
         expand_tilde(path)
     }
 
-    /// Whether to backfill existing inline conversation bodies into the store on startup. Default-on;
-    /// only an explicit `auto_migrate = false` disables it.
+    /// Whether to backfill existing SQLite compatibility bodies into the store on startup. Default-on
+    /// once the store is enabled; only an explicit `auto_migrate = false` disables it.
     pub fn message_body_store_auto_migrate(&self) -> bool {
         self.message_body_store
             .as_ref()
@@ -617,6 +615,20 @@ mod tests {
         AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig, MessageBodyStoreConfig,
         ServerConfig, ServerRole, WorktreeConfig,
     };
+
+    #[test]
+    fn message_body_store_is_opt_in() {
+        assert!(!AppConfig::default().message_body_store_enabled());
+        let config = AppConfig {
+            message_body_store: Some(MessageBodyStoreConfig {
+                enabled: Some(true),
+                path: None,
+                auto_migrate: None,
+            }),
+            ..Default::default()
+        };
+        assert!(config.message_body_store_enabled());
+    }
 
     #[test]
     fn message_body_store_auto_migrate_defaults_on() {

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -1631,6 +1631,20 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     .execute(&pool)
     .await?;
 
+    // The Phase 1 dual-write backfill advances this durable prefix only after the matching outbox
+    // rows have been committed. It lets a restart resume historical staging without replacing the
+    // SQLite compatibility body with a sentinel.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS message_body_backfill_checkpoint (
+            scope TEXT PRIMARY KEY,
+            last_message_id INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
     Ok(pool)
 }
 

--- a/docs/features/message-storage-tiering.md
+++ b/docs/features/message-storage-tiering.md
@@ -207,7 +207,8 @@ Failure handling:
   process crashes between the authority commit and the `cf_body` ack.
 
 During Phase 1 the legacy SQLite body column also still holds the body, so the outbox is effectively
-redundant; from Phase 2 onward the outbox is the only non-RocksDB durable home for an unconfirmed body.
+redundant; normal conversation reads use that SQLite compatibility copy rather than `cf_body`. From
+Phase 2 onward the outbox is the only non-RocksDB durable home for an unconfirmed body.
 
 For flows where LanceDB append happens asynchronously, the index may store a pending
 `archive_document_id` state, but it must preserve enough authority metadata for a later repair job to
@@ -230,8 +231,8 @@ Search APIs continue to use LanceDB. Search results may optionally hydrate deliv
 index when the UI needs unread/ack/cursor hints, but search ranking and body matching stay in the
 archive layer.
 
-SQLite remains the fallback path for both index and body until the RocksDB backend has been built and
-validated and the SQLite body column has been dropped.
+SQLite remains the body read path throughout Phase 1. RocksDB ordered-index reads and body hydration
+remain future work until the backend has been validated and the SQLite body column can be dropped.
 
 ### 7) Rebuild And Repair
 
@@ -345,13 +346,16 @@ it must not authorize or redefine message authority.
 
 - Migration is staged and non-destructive:
   - Phase 1 (canonical write becomes dual-body): new writes put the body into both SQLite (compat) and
-    `cf_body`, with the SQLite body outbox staged in the authority transaction; reads can be switched
-    to RocksDB behind the flag; historical bodies are backfilled into `cf_body` by idempotent,
-    resumable, prefix-scoped jobs.
+    `cf_body`, with the SQLite body outbox staged in the authority transaction; normal reads remain on
+    SQLite; historical bodies are backfilled into `cf_body` by idempotent, resumable, prefix-scoped
+    jobs.
   - Phase 2 (canonical): once `cf_body` is validated and included in backups, the SQLite body column is
     dropped; SQLite becomes metadata-only and the `message_body_outbox` becomes the only non-RocksDB
     durable home for a not-yet-confirmed body.
 - Historical SQLite rows remain readable during Phase 1.
+- The first implementation is opt-in with `message_body_store.enabled = true`. A durable SQLite
+  checkpoint records the staged `team_conversation_messages` prefix. Earlier sentinel rows are repaired
+  only after their body is found in `cf_body` or the outbox, so enabling Phase 1 never discards a body.
 - Backfill must be idempotent, resumable by prefix scope, and must never overwrite a newer live write.
 - Rebuild must be safe to interrupt.
 - Rollback before Phase 2 is disabling the RocksDB backend and reading the body from SQLite; no data is

--- a/docs/features/message-storage-tiering.md
+++ b/docs/features/message-storage-tiering.md
@@ -356,6 +356,8 @@ it must not authorize or redefine message authority.
 - The first implementation is opt-in with `message_body_store.enabled = true`. A durable SQLite
   checkpoint records the staged `team_conversation_messages` prefix. Earlier sentinel rows are repaired
   only after their body is found in `cf_body` or the outbox, so enabling Phase 1 never discards a body.
+  A completed backfill does not re-stage later dual-written rows, while a later SQLite-only write makes
+  the next enabled run resume from that exact message boundary.
 - Backfill must be idempotent, resumable by prefix scope, and must never overwrite a newer live write.
 - Rebuild must be safe to interrupt.
 - Rollback before Phase 2 is disabling the RocksDB backend and reading the body from SQLite; no data is

--- a/docs/journal/2026-07-13-message-body-store-phase1-dual-write.md
+++ b/docs/journal/2026-07-13-message-body-store-phase1-dual-write.md
@@ -1,0 +1,32 @@
+# Message Body Store Phase 1 Dual Write
+
+**Date:** 2026-07-13
+
+## Summary
+
+Completed the opt-in Phase 1 conversation-message body rollout. New messages retain their complete
+`payload_json` in SQLite and stage the same serialized body to `message_body_outbox` in the authority
+transaction. The asynchronous drainer writes the staged copy to RocksDB `cf_body` and deletes the
+outbox row only after acknowledgement.
+
+## Compatibility And Migration
+
+- Added `message_body_backfill_checkpoint` to record the historical message-id prefix staged to the
+  outbox. Backfill is resumable and never replaces a SQLite body with a sentinel.
+- Restored support for rows produced by the earlier sentinel implementation: migration reads the body
+  from `cf_body` or the outbox before restoring `payload_json`; missing bodies leave the sentinel row
+  unchanged and fail the pass for a later retry.
+- Made the body store opt-in through `message_body_store.enabled = true`. Disabling it keeps the
+  SQLite-only path intact.
+
+## Validation
+
+- Focused conversation tests cover dual writes, outbox retry, checkpointed idempotent backfill,
+  legacy-sentinel restoration, store outage/corruption isolation for Phase 1 reads, and concurrent
+  append/drain/read behavior.
+- `cargo fmt --check` was run after the changes.
+
+## Follow-Up
+
+The remaining P1 storage task is the body-free `cf_index` delivery projection, its repair path, and
+operational backup validation. SQLite bodies remain in place until a separately reviewed Phase 2.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -134,6 +134,17 @@ Start with:
 - `2026-06-10-message-store-foundation-crate.md`
 - `2026-06-13-debian-systemd-release-package.md`
 
+### 2026-07
+
+Main shape:
+
+- Phase 1 message-body storage now keeps SQLite compatibility bodies while asynchronously staging
+  compressed RocksDB copies through a durable outbox and checkpointed backfill.
+
+Start with:
+
+- `2026-07-13-message-body-store-phase1-dual-write.md`
+
 ## Compaction Rules
 
 - Keep original dated journals when they contain validation evidence, PR context, or detailed

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -39,13 +39,12 @@ Stable contracts:
 - [features/team-execution-vocabulary.md](features/team-execution-vocabulary.md)
 - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
 
-- [ ] `P1` Implement per-agent runtime profiles for ACP-backed agents: persist provider/model/thinking-level settings per agent, expose them in create/edit and Team member flows, and map the first supported profiles to Codex and Claude Code adapters without taking over provider credentials or live model catalogs. Stable contract: [features/agent-runtime-profiles.md](features/agent-runtime-profiles.md).
 - [ ] `P1` Verify remote Team direct-mailbox routing on real multi-node teams: after the local API regression and routing fix in [journal/2026-05-26-team-remote-direct-mailbox-routing.md](journal/2026-05-26-team-remote-direct-mailbox-routing.md), confirm direct single-member delivery still preserves mention metadata plus summary/`detail_ref` payloads when the recipient agent is remote and transport falls back to p2p relay in a real multi-node rollout. Existing notes: [journal/2026-03-26-team-direct-mailbox-summary-first.md](journal/2026-03-26-team-direct-mailbox-summary-first.md).
 - [ ] `P2` Verify Team agent self-maintenance and deferred follow-up flows: `profile_patch_proposal`, `agent_time_trigger_*`, and operator-controlled `agent_loop` should behave consistently without blocking normal task progress.
 
 ## Message Storage
 
-- [ ] `P1` Implement message-body compression via RocksDB, per [features/message-storage-tiering.md](features/message-storage-tiering.md). Move message bodies out of SQLite authority rows into a RocksDB `cf_body` column family compressed by SST block compression (plain zstd + bottommost zstd; trained dictionary deferred), keep a body-free RocksDB delivery index, and stage migration as dual-body write + backfill (Phase 1) then drop the SQLite body column (Phase 2). Goal is shrinking at-rest chat/message storage; SQLite stays metadata authority, LanceDB stays the (eventually-consistent) search layer. First PR boundary: opt-in RocksDB backend behind a feature flag with `cf_body` round-trip + compression-ratio tests on a real chat corpus, before any SQLite body drop.
+- [ ] `P1` Implement the RocksDB `cf_index` delivery projection and its authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill is complete; keep normal reads on SQLite until ordered index reads, integrity checks, and backup validation are in place. Do not drop SQLite bodies before the Phase 2 rollout decision.
 
 ## Observability, CI, And Docs
 

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -693,6 +693,18 @@ async fn init_test_schema(db: &SqlitePool) {
 
     sqlx::query(
         r#"
+        CREATE TABLE message_body_backfill_checkpoint (
+            scope TEXT PRIMARY KEY,
+            last_message_id INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create message_body_backfill_checkpoint");
+
+    sqlx::query(
+        r#"
         CREATE UNIQUE INDEX idx_team_conversation_messages_idempotency
         ON team_conversation_messages(conversation_id, from_actor_id, idempotency_key)
         WHERE idempotency_key IS NOT NULL;

--- a/src/message_body_store.rs
+++ b/src/message_body_store.rs
@@ -3,7 +3,8 @@
 //! The durable SQLite outbox lives in `agenthub-db` (`message_body_outbox`). The RocksDB-backed body
 //! store that staged bodies drain into is only compiled when the binary is built with the `rocksdb`
 //! feature, which is enabled per release target so the native `librocksdb-sys` build does not affect
-//! the default or Bazel builds. The write-path body/metadata split is added in a follow-up.
+//! the default or Bazel builds. Phase 1 keeps SQLite as the compatibility copy and dual-writes bodies
+//! through the durable outbox.
 
 use std::sync::Arc;
 
@@ -14,9 +15,9 @@ pub type SharedBodyStore = Arc<dyn MessageBodyStore>;
 
 /// Construct the message body store from config, if it is enabled and compiled in.
 ///
-/// The store is a default capability: it is on unless `message_body_store.enabled = false`. It can
-/// only actually be constructed when the binary is built with the `rocksdb` feature; otherwise this
-/// logs and returns `None` so the binary still runs (without compression).
+/// The store is opt-in through `message_body_store.enabled = true`. It can only actually be
+/// constructed when the binary is built with the `rocksdb` feature; otherwise this logs and returns
+/// `None` so the binary still runs (without compression).
 pub fn init_body_store(config: &agenthub_config::AppConfig) -> Option<SharedBodyStore> {
     if !config.message_body_store_enabled() {
         tracing::info!("message body store disabled by config");

--- a/src/migrate_cli.rs
+++ b/src/migrate_cli.rs
@@ -1,10 +1,8 @@
 //! `agenthub migrate` — one-shot maintenance commands.
 //!
-//! Currently this backfills existing `team_conversation_messages` bodies into the tiered message body
-//! store: rows written before the store was enabled keep their body inline in SQLite, and this command
-//! moves them into the store (staging through the durable outbox, exactly like the write path) so the
-//! larger chat bodies live in the compressed store. It is safe to re-run: already-moved rows are
-//! skipped.
+//! Currently this stages existing `team_conversation_messages` bodies into the tiered message body
+//! store while retaining the SQLite compatibility copy. It also restores any legacy sentinel rows
+//! written by the earlier move-out implementation. It is safe to re-run from its durable checkpoint.
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
 
@@ -16,10 +14,10 @@ use clap::{CommandFactory, Parser, error::ErrorKind};
     disable_help_subcommand = true
 )]
 struct MigrateCli {
-    /// Number of rows to move per transaction.
+    /// Number of rows to stage per transaction.
     #[arg(long, value_name = "N", default_value_t = 500)]
     batch_size: usize,
-    /// Report how many rows would be moved without changing anything.
+    /// Report how many rows need restoration or staging without changing anything.
     #[arg(long)]
     dry_run: bool,
 }
@@ -48,16 +46,16 @@ pub(crate) async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
     let (config, _info) = agenthub_config::AppConfig::load_with_info()?;
     let pool = agenthub_db::init_db().await?;
 
-    let remaining = crate::team::count_inline_conversation_bodies(&pool).await?;
+    let remaining = crate::team::count_pending_conversation_body_migration(&pool).await?;
     if cli.dry_run {
         println!(
-            "[dry-run] {remaining} conversation message body/bodies would be moved into the body store"
+            "[dry-run] {remaining} conversation message body/bodies would be restored or staged"
         );
         return Ok(());
     }
 
     if remaining == 0 {
-        println!("no inline conversation message bodies to migrate");
+        println!("no conversation message bodies need restoration or staging");
         return Ok(());
     }
 
@@ -81,8 +79,8 @@ pub(crate) async fn run_from_args(args: &[String]) -> anyhow::Result<()> {
     .await?;
 
     println!(
-        "migrated {} conversation message body/bodies into the body store ({} confirmed in the store)",
-        report.migrated, report.drained
+        "restored {} and staged {} conversation message body/bodies ({} confirmed in the body store)",
+        report.restored, report.staged, report.drained
     );
     Ok(())
 }

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -38,11 +38,9 @@ impl AppState {
         Ok(())
     }
 
-    /// Backfills existing inline conversation bodies into the body store once, in the background, so a
-    /// database that predates the store being enabled is migrated automatically after an upgrade and
-    /// restart. It is safe to run on every startup: it is idempotent and resumable (already-moved rows
-    /// are skipped), and the read path serves both inline and moved rows, so online traffic during the
-    /// backfill is unaffected. Once the database is fully migrated each startup only pays a quick count.
+    /// Stages existing SQLite compatibility bodies into the body store in the background. The durable
+    /// checkpoint makes this resumable, while SQLite remains readable throughout Phase 1. It also
+    /// repairs any sentinel rows left by the earlier move-out implementation before proceeding.
     fn spawn_conversation_body_backfill(
         db: SqlitePool,
         store: crate::message_body_store::SharedBodyStore,
@@ -53,16 +51,16 @@ impl AppState {
         const BACKFILL_INTER_BATCH_DELAY: std::time::Duration =
             std::time::Duration::from_millis(25);
         tokio::spawn(async move {
-            match crate::team::count_inline_conversation_bodies(&db).await {
+            match crate::team::count_pending_conversation_body_migration(&db).await {
                 Ok(0) => return,
                 Ok(remaining) => {
                     tracing::info!(
                         remaining,
-                        "backfilling inline conversation bodies into the body store"
+                        "staging SQLite conversation bodies into the body store"
                     );
                 }
                 Err(error) => {
-                    tracing::warn!(error = %error, "conversation body backfill: failed to count inline bodies; skipping this startup");
+                    tracing::warn!(error = %error, "conversation body backfill: failed to count pending rows; skipping this startup");
                     return;
                 }
             }
@@ -78,7 +76,8 @@ impl AppState {
             {
                 Ok(report) => {
                     tracing::info!(
-                        migrated = report.migrated,
+                        restored = report.restored,
+                        staged = report.staged,
                         confirmed = report.drained,
                         "conversation body backfill complete"
                     );

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -161,7 +161,7 @@ use self::codec_status::{
     team_task_status_to_str,
 };
 pub(crate) use self::conversation_body::{
-    count_inline_conversation_bodies, migrate_conversation_bodies_into_store,
+    count_pending_conversation_body_migration, migrate_conversation_bodies_into_store,
 };
 #[cfg(test)]
 pub(super) use self::conversation_idempotency::task_conversation_payload_correlation_id;
@@ -185,8 +185,9 @@ pub struct TeamManager {
     db: SqlitePool,
     event_dbs: AgentEventDbRouter,
     message_archive: Option<MessageArchiveStoreRef>,
-    /// Tiered message body store. When set, conversation message bodies are moved out of SQLite into
-    /// the store (staged via the outbox) on write and rehydrated on read; `None` keeps bodies inline.
+    /// Tiered message body store. When set, conversation bodies are dual-written through the durable
+    /// outbox while SQLite remains the Phase 1 compatibility source of truth. Legacy sentinel rows
+    /// are still rehydrated until the migration restores them.
     body_store: Option<crate::message_body_store::SharedBodyStore>,
     conversation_events: broadcast::Sender<TeamConversationStreamEvent>,
     remote_relay_adapter: Arc<TeamRemoteRelayAdapter>,

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -1,14 +1,8 @@
 //! Tiered-body support for `team_conversation_messages`.
 //!
-//! When the message body store is active, a conversation message's `payload_json` is moved out of the
-//! SQLite row into the body store (keyed by the row's authority id) so the larger chat body lives in
-//! the compressed RocksDB store rather than inline in SQLite. The SQLite row keeps the queried
-//! metadata columns (see `init_db`) and stores [`CONVERSATION_BODY_MOVED_SENTINEL`] in place of the
-//! body. The read path rehydrates the real payload from the body store, falling back to the durable
-//! outbox for bodies that have been staged but not yet drained.
-//!
-//! Rows written without an active store (older rows, or platforms built without the `rocksdb` feature)
-//! keep their full inline `payload_json` and are never treated as moved, so both shapes coexist.
+//! Phase 1 keeps every new `payload_json` in SQLite and stages a duplicate into the durable outbox for
+//! compressed RocksDB storage. The sentinel and rehydration path remain only to repair rows written by
+//! the earlier move-out implementation; new writes must never create a sentinel row.
 
 use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
 use sqlx::{Sqlite, SqlitePool};
@@ -16,7 +10,7 @@ use sqlx::{Sqlite, SqlitePool};
 use super::TeamManager;
 use crate::team::TeamConversationMessageRecord;
 
-/// Sentinel stored in `payload_json` when a conversation body has been moved into the body store.
+/// Legacy sentinel stored by the pre-Phase-1 move-out implementation.
 ///
 /// It is intentionally not valid JSON, so it can never collide with a real serialized payload (which
 /// is always valid JSON). Moved-ness is therefore decided by an exact string comparison against this
@@ -25,12 +19,12 @@ use crate::team::TeamConversationMessageRecord;
 /// SQLite browsers / CLIs, which can silently truncate strings containing a NUL byte.
 pub(super) const CONVERSATION_BODY_MOVED_SENTINEL: &str = "::agenthub:tcm-body-moved::";
 
-/// Body-store key for a conversation message's moved body. One copy per logical message (row id).
+/// Body-store key for a conversation message body. One copy per logical message (row id).
 pub(super) fn conversation_body_key(message_id: i64) -> AuthorityMessageId {
     AuthorityMessageId::new(format!("tcm:{message_id}"))
 }
 
-/// Whether a stored `payload_json` indicates the body was moved into the body store.
+/// Whether a stored `payload_json` is a legacy moved-body marker.
 pub(super) fn conversation_payload_was_moved(payload_json: &str) -> bool {
     payload_json == CONVERSATION_BODY_MOVED_SENTINEL
 }
@@ -133,30 +127,39 @@ impl TeamManager {
 /// Outcome of [`migrate_conversation_bodies_into_store`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ConversationBodyMigrationReport {
-    /// Rows whose inline body was moved out of SQLite and staged into the outbox.
-    pub(crate) migrated: u64,
+    /// Legacy sentinel rows restored to their inline SQLite compatibility body.
+    pub(crate) restored: u64,
+    /// SQLite compatibility bodies staged to the outbox for the compressed store.
+    pub(crate) staged: u64,
     /// Bodies durably confirmed in the body store (drained from the outbox).
     pub(crate) drained: u64,
 }
 
-/// Number of conversation rows whose body is still stored inline (i.e. not yet moved into the store).
-pub(crate) async fn count_inline_conversation_bodies(pool: &SqlitePool) -> anyhow::Result<i64> {
+const CONVERSATION_BODY_BACKFILL_SCOPE: &str = "team_conversation_messages";
+
+/// Number of rows that still need either legacy restoration or Phase 1 outbox staging.
+pub(crate) async fn count_pending_conversation_body_migration(
+    pool: &SqlitePool,
+) -> anyhow::Result<i64> {
     let count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM team_conversation_messages WHERE payload_json != ?1",
+        "SELECT COUNT(*) FROM team_conversation_messages \
+         WHERE payload_json = ?1 OR id > COALESCE((\
+             SELECT last_message_id FROM message_body_backfill_checkpoint WHERE scope = ?2\
+         ), 0)",
     )
     .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+    .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
     .fetch_one(pool)
     .await?;
     Ok(count)
 }
 
-/// Backfill existing inline conversation bodies into the body store.
+/// Restore historical sentinel rows, then backfill SQLite compatibility bodies into the body store.
 ///
-/// Each batch moves rows out of SQLite (staging the body into the durable outbox and replacing the
-/// row's `payload_json` with the moved sentinel, atomically per transaction) and then drains that
-/// batch into the body store. A final drain pass clears any bodies left staged by an earlier
-/// interrupted run. The pass is resumable and idempotent: already-moved rows are skipped, so re-running
-/// after an interruption only processes what remains.
+/// Each historical row is staged to the durable outbox in the same transaction as the checkpoint
+/// advance, while its SQLite body remains unchanged. A final drain pass clears any bodies left staged
+/// by an earlier interrupted run. The pass is resumable and idempotent: restarting continues from the
+/// committed prefix, and legacy sentinel rows are restored only after their original body is available.
 ///
 /// `inter_batch_delay` paces the loop by sleeping between batches. SQLite allows only one writer, so a
 /// tight loop of write transactions can starve concurrent writers; a non-zero delay yields the write
@@ -186,16 +189,55 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
     };
 
     let mut report = ConversationBodyMigrationReport::default();
-    let mut cursor = 0_i64;
+    loop {
+        let ids = sqlx::query_scalar::<_, i64>(
+            "SELECT id FROM team_conversation_messages WHERE payload_json = ?1 ORDER BY id ASC LIMIT ?2",
+        )
+        .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+        .bind(batch_size)
+        .fetch_all(pool)
+        .await?;
+        if ids.is_empty() {
+            break;
+        }
+
+        for id in ids {
+            let key = conversation_body_key(id);
+            let body = load_moved_conversation_body(Some(store), pool, &key)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!(
+                    "conversation message {id} is marked moved but its body is missing from the store and outbox"
+                ))?;
+            let payload_json = String::from_utf8(body).map_err(|error| {
+                anyhow::anyhow!("conversation message {id} has a non-UTF-8 legacy body: {error}")
+            })?;
+            let restored = sqlx::query(
+                "UPDATE team_conversation_messages SET payload_json = ?1 WHERE id = ?2 AND payload_json = ?3",
+            )
+            .bind(payload_json)
+            .bind(id)
+            .bind(CONVERSATION_BODY_MOVED_SENTINEL)
+            .execute(pool)
+            .await?
+            .rows_affected();
+            report.restored += restored;
+        }
+    }
+
+    let mut cursor: i64 = sqlx::query_scalar(
+        "SELECT COALESCE((SELECT last_message_id FROM message_body_backfill_checkpoint WHERE scope = ?1), 0)",
+    )
+    .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
+    .fetch_one(pool)
+    .await?;
     loop {
         let rows = sqlx::query(
             "SELECT id, payload_json FROM team_conversation_messages \
-             WHERE id > ?1 AND id <= ?2 AND payload_json != ?3 \
-             ORDER BY id ASC LIMIT ?4",
+             WHERE id > ?1 AND id <= ?2 \
+             ORDER BY id ASC LIMIT ?3",
         )
         .bind(cursor)
         .bind(max_id)
-        .bind(CONVERSATION_BODY_MOVED_SENTINEL)
         .bind(batch_size)
         .fetch_all(pool)
         .await?;
@@ -214,14 +256,17 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
                 staged_at,
             )
             .await?;
-            sqlx::query("UPDATE team_conversation_messages SET payload_json = ?1 WHERE id = ?2")
-                .bind(CONVERSATION_BODY_MOVED_SENTINEL)
-                .bind(id)
-                .execute(&mut *tx)
-                .await?;
             cursor = id;
-            report.migrated += 1;
+            report.staged += 1;
         }
+        sqlx::query(
+            "INSERT INTO message_body_backfill_checkpoint (scope, last_message_id) VALUES (?1, ?2) \
+             ON CONFLICT(scope) DO UPDATE SET last_message_id = excluded.last_message_id",
+        )
+        .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
+        .bind(cursor)
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
 
         // Keep the outbox (which holds a duplicate of each body) bounded as we go.

--- a/src/team/manager/conversation_body.rs
+++ b/src/team/manager/conversation_body.rs
@@ -136,6 +136,33 @@ pub(crate) struct ConversationBodyMigrationReport {
 }
 
 const CONVERSATION_BODY_BACKFILL_SCOPE: &str = "team_conversation_messages";
+const CONVERSATION_BODY_BACKFILL_COMPLETE: i64 = i64::MAX;
+
+/// Record the first write after a completed historical backfill.
+///
+/// A dual-written message is already present in the outbox, so its id becomes the new safe prefix.
+/// A SQLite-only message needs later backfill, so its id is intentionally excluded from that prefix.
+pub(super) async fn record_conversation_body_write(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    message_id: i64,
+    body_store_active: bool,
+) -> anyhow::Result<()> {
+    let safe_prefix = if body_store_active {
+        message_id
+    } else {
+        message_id.saturating_sub(1)
+    };
+    sqlx::query(
+        "UPDATE message_body_backfill_checkpoint SET last_message_id = ?1 \
+         WHERE scope = ?2 AND last_message_id = ?3",
+    )
+    .bind(safe_prefix)
+    .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
+    .bind(CONVERSATION_BODY_BACKFILL_COMPLETE)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
 
 /// Number of rows that still need either legacy restoration or Phase 1 outbox staging.
 pub(crate) async fn count_pending_conversation_body_migration(
@@ -184,10 +211,6 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
     let max_id: Option<i64> = sqlx::query_scalar("SELECT MAX(id) FROM team_conversation_messages")
         .fetch_one(pool)
         .await?;
-    let Some(max_id) = max_id else {
-        return Ok(ConversationBodyMigrationReport::default());
-    };
-
     let mut report = ConversationBodyMigrationReport::default();
     loop {
         let ids = sqlx::query_scalar::<_, i64>(
@@ -230,54 +253,65 @@ pub(crate) async fn migrate_conversation_bodies_into_store(
     .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
     .fetch_one(pool)
     .await?;
-    loop {
-        let rows = sqlx::query(
-            "SELECT id, payload_json FROM team_conversation_messages \
+    if let Some(max_id) = max_id {
+        loop {
+            let rows = sqlx::query(
+                "SELECT id, payload_json FROM team_conversation_messages \
              WHERE id > ?1 AND id <= ?2 \
              ORDER BY id ASC LIMIT ?3",
-        )
-        .bind(cursor)
-        .bind(max_id)
-        .bind(batch_size)
-        .fetch_all(pool)
-        .await?;
-        if rows.is_empty() {
-            break;
-        }
-
-        let mut tx = pool.begin().await?;
-        for row in &rows {
-            let id: i64 = row.get("id");
-            let payload_json: String = row.get("payload_json");
-            agenthub_db::message_body_outbox::stage_body(
-                &mut tx,
-                &conversation_body_key(id),
-                payload_json.as_bytes(),
-                staged_at,
             )
+            .bind(cursor)
+            .bind(max_id)
+            .bind(batch_size)
+            .fetch_all(pool)
             .await?;
-            cursor = id;
-            report.staged += 1;
-        }
-        sqlx::query(
-            "INSERT INTO message_body_backfill_checkpoint (scope, last_message_id) VALUES (?1, ?2) \
-             ON CONFLICT(scope) DO UPDATE SET last_message_id = excluded.last_message_id",
-        )
-        .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
-        .bind(cursor)
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
+            if rows.is_empty() {
+                break;
+            }
 
-        // Keep the outbox (which holds a duplicate of each body) bounded as we go.
-        report.drained +=
-            agenthub_db::message_body_outbox::drain_into(pool, store, drain_batch).await? as u64;
+            let mut tx = pool.begin().await?;
+            for row in &rows {
+                let id: i64 = row.get("id");
+                let payload_json: String = row.get("payload_json");
+                agenthub_db::message_body_outbox::stage_body(
+                    &mut tx,
+                    &conversation_body_key(id),
+                    payload_json.as_bytes(),
+                    staged_at,
+                )
+                .await?;
+                cursor = id;
+                report.staged += 1;
+            }
+            sqlx::query(
+                "INSERT INTO message_body_backfill_checkpoint (scope, last_message_id) VALUES (?1, ?2) \
+                 ON CONFLICT(scope) DO UPDATE SET last_message_id = excluded.last_message_id",
+            )
+            .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
+            .bind(cursor)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
 
-        // Yield the single SQLite writer between batches so concurrent writes are not starved.
-        if !inter_batch_delay.is_zero() {
-            tokio::time::sleep(inter_batch_delay).await;
+            // Keep the outbox (which holds a duplicate of each body) bounded as we go.
+            report.drained += agenthub_db::message_body_outbox::drain_into(pool, store, drain_batch)
+                .await? as u64;
+
+            // Yield the single SQLite writer between batches so concurrent writes are not starved.
+            if !inter_batch_delay.is_zero() {
+                tokio::time::sleep(inter_batch_delay).await;
+            }
         }
     }
+
+    sqlx::query(
+        "INSERT INTO message_body_backfill_checkpoint (scope, last_message_id) VALUES (?1, ?2) \
+         ON CONFLICT(scope) DO UPDATE SET last_message_id = excluded.last_message_id",
+    )
+    .bind(CONVERSATION_BODY_BACKFILL_SCOPE)
+    .bind(CONVERSATION_BODY_BACKFILL_COMPLETE)
+    .execute(pool)
+    .await?;
 
     // Clear anything left staged (e.g. by an earlier interrupted run). Drive the loop off the outbox
     // count rather than the per-pass drained count: if a body persistently fails to write, a full pass

--- a/src/team/manager/conversation_insert_common.rs
+++ b/src/team/manager/conversation_insert_common.rs
@@ -2,9 +2,7 @@ use agenthub_message_store::MessageBodyStore;
 use serde_json::Value;
 use sqlx::Sqlite;
 
-use super::conversation_body::{
-    CONVERSATION_BODY_MOVED_SENTINEL, conversation_body_key, rehydrate_conversation_body_in_tx,
-};
+use super::conversation_body::{conversation_body_key, rehydrate_conversation_body_in_tx};
 use super::conversation_idempotency::{
     ensure_task_conversation_message_idempotency_compatible,
     fetch_task_conversation_message_by_idempotency,
@@ -51,15 +49,9 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .get("thread_root_message_id")
         .and_then(Value::as_i64);
 
-    // When a body store is active, the body moves out of SQLite into the store: the row stores the
-    // moved sentinel and the real `payload_json` is staged to the outbox below (keyed by the new row
-    // id). Without a store the body stays inline, exactly as before.
-    let move_body = body_store.is_some();
-    let stored_payload_json: &str = if move_body {
-        CONVERSATION_BODY_MOVED_SENTINEL
-    } else {
-        payload_json.as_str()
-    };
+    // Phase 1 keeps SQLite as the authoritative compatibility copy. When a body store is active,
+    // the same body is additionally staged to the durable outbox below for asynchronous compression.
+    let stage_body = body_store.is_some();
 
     let (message, created) = if let Some(idempotency_key) = idempotency_key.as_deref() {
         match sqlx::query(
@@ -89,7 +81,7 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(route)
         .bind(&correlation_id)
         .bind(group_id.as_deref())
-        .bind(stored_payload_json)
+        .bind(&payload_json)
         .bind(idempotency_key)
         .bind(created_at)
         .bind(text)
@@ -163,7 +155,7 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         .bind(route)
         .bind(&correlation_id)
         .bind(group_id.as_deref())
-        .bind(stored_payload_json)
+        .bind(&payload_json)
         .bind(created_at)
         .bind(text)
         .bind(kind)
@@ -186,11 +178,9 @@ pub(super) async fn insert_task_conversation_message_with_tx(
         )
     };
 
-    // Stage the moved body into the durable outbox inside this same transaction, so the body is
-    // committed atomically with the row that points at it. The background drainer later moves it into
-    // the body store. Only a freshly inserted row owns a new body; an idempotency hit reuses the
-    // existing row (and its already-staged body).
-    if created && move_body {
+    // Stage the compatibility copy into the durable outbox in the same transaction. The drainer
+    // later writes it into the compressed body store; idempotency replays reuse the existing body.
+    if created && stage_body {
         agenthub_db::message_body_outbox::stage_body(
             tx,
             &conversation_body_key(message.message_id),

--- a/src/team/manager/conversation_insert_common.rs
+++ b/src/team/manager/conversation_insert_common.rs
@@ -2,7 +2,9 @@ use agenthub_message_store::MessageBodyStore;
 use serde_json::Value;
 use sqlx::Sqlite;
 
-use super::conversation_body::{conversation_body_key, rehydrate_conversation_body_in_tx};
+use super::conversation_body::{
+    conversation_body_key, record_conversation_body_write, rehydrate_conversation_body_in_tx,
+};
 use super::conversation_idempotency::{
     ensure_task_conversation_message_idempotency_compatible,
     fetch_task_conversation_message_by_idempotency,
@@ -188,6 +190,9 @@ pub(super) async fn insert_task_conversation_message_with_tx(
             created_at,
         )
         .await?;
+    }
+    if created {
+        record_conversation_body_write(tx, message.message_id, stage_body).await?;
     }
 
     Ok((message, created))

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -570,7 +570,7 @@ async fn body_store_team_and_task(manager: &TeamManager) -> crate::team::TeamTas
 }
 
 #[tokio::test]
-async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
+async fn conversation_body_dual_writes_to_store_while_retaining_sqlite_payload() {
     use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
 
     let db = setup_test_db().await;
@@ -589,14 +589,17 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
     // The returned in-memory record keeps the full payload.
     assert_eq!(message.payload, payload);
 
-    // SQLite stores the moved sentinel in place of the body.
+    // Phase 1 retains the full authoritative compatibility body in SQLite.
     let stored: String =
         sqlx::query_scalar("SELECT payload_json FROM team_conversation_messages WHERE id = ?1")
             .bind(message.message_id)
             .fetch_one(&db)
             .await
             .expect("read stored payload");
-    assert_eq!(stored, "::agenthub:tcm-body-moved::");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stored).expect("stored payload is valid json"),
+        payload
+    );
 
     // Promoted columns stay populated so queries keep working without the body.
     let text_col: Option<String> =
@@ -617,7 +620,7 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
     );
     assert!(!store.contains(&key));
 
-    // Read path rehydrates from the outbox while the body is still staged.
+    // Reads remain available from SQLite while the body is staged.
     let messages = manager
         .list_task_conversation_messages(&task.id, 50, None)
         .await
@@ -625,7 +628,7 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].payload, payload);
 
-    // Draining moves the body into the store and clears the outbox.
+    // Draining writes the duplicate body into the store and clears the outbox.
     let drained = agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
         .await
         .unwrap();
@@ -638,7 +641,7 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
     );
     assert!(store.contains(&key));
 
-    // Read path now rehydrates from the body store.
+    // The SQLite read remains unchanged after asynchronous compression.
     let messages = manager
         .list_task_conversation_messages(&task.id, 50, None)
         .await
@@ -647,7 +650,7 @@ async fn conversation_body_moves_to_body_store_and_rehydrates_on_read() {
 }
 
 #[tokio::test]
-async fn conversation_idempotency_replay_with_moved_body_is_not_a_false_conflict() {
+async fn conversation_idempotency_replay_with_dual_written_body_is_not_a_false_conflict() {
     let db = setup_test_db().await;
     let store = body_store();
     let manager = TeamManager::new(db.clone()).with_body_store(Some(
@@ -669,8 +672,7 @@ async fn conversation_idempotency_replay_with_moved_body_is_not_a_false_conflict
         .expect("first append");
     assert!(first_created);
 
-    // Drain so the existing body lives only in the store: the conflict path must rehydrate from the
-    // store (outbox is empty) before comparing payload fingerprints.
+    // Drain the duplicate body before replaying the idempotent write.
     agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
         .await
         .unwrap();
@@ -708,7 +710,7 @@ async fn conversation_body_stays_inline_without_body_store() {
             .fetch_one(&db)
             .await
             .expect("read stored payload");
-    // Body stays inline; the moved sentinel is never written.
+    // Body stays inline; the legacy sentinel is never written.
     assert_ne!(stored, "::agenthub:tcm-body-moved::");
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&stored).expect("inline payload is valid json"),
@@ -749,7 +751,7 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
         .expect("append 2");
 
     assert_eq!(
-        crate::team::count_inline_conversation_bodies(&db)
+        crate::team::count_pending_conversation_body_migration(&db)
             .await
             .unwrap(),
         2
@@ -772,12 +774,13 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
     )
     .await
     .expect("migrate");
-    assert_eq!(report.migrated, 2);
+    assert_eq!(report.restored, 0);
+    assert_eq!(report.staged, 2);
     assert_eq!(report.drained, 2);
 
-    // Rows now carry the sentinel, the bodies live in the store, and the outbox is empty.
+    // SQLite retains the bodies, the compressed copies live in the store, and the outbox is empty.
     assert_eq!(
-        crate::team::count_inline_conversation_bodies(&db)
+        crate::team::count_pending_conversation_body_migration(&db)
             .await
             .unwrap(),
         0
@@ -791,7 +794,7 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
     assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", m1.message_id))));
     assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", m2.message_id))));
 
-    // A reader with the store rehydrates the original payloads.
+    // A reader with the store sees the original SQLite payloads.
     let reader = TeamManager::new(db.clone()).with_body_store(Some(
         store.clone() as crate::message_body_store::SharedBodyStore
     ));
@@ -813,7 +816,8 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
     )
     .await
     .expect("migrate again");
-    assert_eq!(report_again.migrated, 0);
+    assert_eq!(report_again.restored, 0);
+    assert_eq!(report_again.staged, 0);
 }
 
 #[tokio::test]
@@ -844,7 +848,7 @@ async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
     store.reject_put_key(format!("tcm:{}", ids[1]));
 
     // batch_size 1: a naive drain keyed off the row batch would let the stuck oldest body block the
-    // rest. The migration must still move every other body into the store and only leave the stuck one.
+    // rest. The migration must still stage every other body into the store and only leave the stuck one.
     let report = crate::team::migrate_conversation_bodies_into_store(
         &db,
         &store,
@@ -854,13 +858,13 @@ async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
     )
     .await
     .expect("migrate");
-    assert_eq!(report.migrated, 3);
+    assert_eq!(report.staged, 3);
     assert_eq!(report.drained, 2);
 
     assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[0]))));
     assert!(!store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[1]))));
     assert!(store.contains(&AuthorityMessageId::new(format!("tcm:{}", ids[2]))));
-    // Only the rejected body is still pending; every row left SQLite (all moved to the sentinel).
+    // Only the rejected body is still pending; every compatibility body remains in SQLite.
     assert_eq!(
         agenthub_db::message_body_outbox::pending_count(&db)
             .await
@@ -868,7 +872,7 @@ async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
         1
     );
     assert_eq!(
-        crate::team::count_inline_conversation_bodies(&db)
+        crate::team::count_pending_conversation_body_migration(&db)
             .await
             .unwrap(),
         0
@@ -905,7 +909,7 @@ async fn drain_retries_after_transient_put_failure_without_losing_body() {
         1
     );
 
-    // The read path still rehydrates from the durable outbox while the store does not have the body.
+    // The Phase 1 read path remains available from SQLite while the store does not have the body.
     let messages = manager
         .list_task_conversation_messages(&task.id, 50, None)
         .await
@@ -935,7 +939,7 @@ async fn drain_retries_after_transient_put_failure_without_losing_body() {
 }
 
 #[tokio::test]
-async fn read_surfaces_body_store_get_failure_instead_of_an_empty_payload() {
+async fn phase_one_reads_do_not_depend_on_body_store_gets() {
     use std::sync::Arc;
 
     let db = setup_test_db().await;
@@ -945,38 +949,34 @@ async fn read_surfaces_body_store_get_failure_instead_of_an_empty_payload() {
     ));
     let task = body_store_team_and_task(&manager).await;
 
+    let payload = json!({"type":"chat_message","text":"body behind a flaky store"});
     manager
-        .append_task_conversation_message(
-            &task.id,
-            "user",
-            None,
-            "group_chat",
-            json!({"type":"chat_message","text":"body behind a flaky store"}),
-        )
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", payload.clone())
         .await
         .expect("append");
-    // Drain so the body lives only in the store (no outbox fallback left).
+    // Drain the duplicate body, then make a future store read fail.
     agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
         .await
         .unwrap();
 
-    // A failing get must surface as an error, never as a silent empty/placeholder payload.
+    // SQLite remains the Phase 1 source of truth, so a body-store outage cannot affect a read.
     store.fail_next_gets(1);
     let result = manager
         .list_task_conversation_messages(&task.id, 50, None)
         .await;
-    assert!(
-        result.is_err(),
-        "a body-store read failure must propagate, got {result:?}"
+    assert_eq!(
+        result.expect("SQLite compatibility read")[0].payload,
+        payload
     );
-    assert!(
-        store.get_calls() >= 1,
-        "the read path must have queried the store"
+    assert_eq!(
+        store.get_calls(),
+        0,
+        "normal Phase 1 reads do not query the store"
     );
 }
 
 #[tokio::test]
-async fn read_surfaces_corrupt_body_instead_of_a_garbage_payload() {
+async fn phase_one_reads_ignore_a_corrupt_compressed_copy() {
     use std::sync::Arc;
 
     let db = setup_test_db().await;
@@ -1000,19 +1000,71 @@ async fn read_surfaces_corrupt_body_instead_of_a_garbage_payload() {
         .await
         .unwrap();
 
-    // The store returns non-JSON bytes: rehydration must fail loudly rather than hand back a bad value.
+    // A corrupt compressed copy cannot affect the retained SQLite compatibility body.
     store.corrupt_get_key(format!("tcm:{}", message.message_id));
     let result = manager
         .list_task_conversation_messages(&task.id, 50, None)
         .await;
     assert!(
-        result.is_err(),
-        "a corrupt stored body must fail rehydration, got {result:?}"
+        result.is_ok(),
+        "SQLite compatibility read must succeed: {result:?}"
     );
 }
 
+#[tokio::test]
+async fn migrate_restores_legacy_sentinel_before_dual_write_backfill() {
+    use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+
+    let db = setup_test_db().await;
+    let store = body_store();
+    let manager = TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    ));
+    let task = body_store_team_and_task(&manager).await;
+    let payload = json!({"type":"chat_message","text":"legacy sentinel body"});
+    let message = manager
+        .append_task_conversation_message(&task.id, "user", None, "group_chat", payload.clone())
+        .await
+        .expect("append");
+    agenthub_db::message_body_outbox::drain_into(&db, store.as_ref(), 64)
+        .await
+        .expect("drain");
+    sqlx::query("UPDATE team_conversation_messages SET payload_json = ?1 WHERE id = ?2")
+        .bind("::agenthub:tcm-body-moved::")
+        .bind(message.message_id)
+        .execute(&db)
+        .await
+        .expect("simulate legacy row");
+
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        16,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("restore and backfill");
+    assert_eq!(report.restored, 1);
+    assert_eq!(report.staged, 1);
+    let stored: String =
+        sqlx::query_scalar("SELECT payload_json FROM team_conversation_messages WHERE id = ?1")
+            .bind(message.message_id)
+            .fetch_one(&db)
+            .await
+            .expect("read restored payload");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stored).unwrap(),
+        payload
+    );
+    assert!(store.contains(&AuthorityMessageId::new(format!(
+        "tcm:{}",
+        message.message_id
+    ))));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
+async fn concurrent_append_drain_and_read_keep_sqlite_compatibility_bodies() {
     use agenthub_message_store::{InMemoryBodyStore, MessageBodyStore};
     use std::collections::HashSet;
     use std::sync::Arc;
@@ -1067,7 +1119,7 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
     // than a fixed iteration count that might finish before the writes do.
     let appenders_done = Arc::new(AtomicBool::new(false));
 
-    // Appenders write concurrently: each stages its body to the outbox and slims the row to the sentinel.
+    // Appenders write concurrently: each retains its SQLite body and stages a compressed copy.
     let mut appenders = Vec::new();
     for i in 0..MESSAGE_COUNT {
         let manager = manager.clone();
@@ -1102,10 +1154,8 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
         })
     };
 
-    // Readers continuously list while writes/drains race. The invariant: a moved row must ALWAYS
-    // rehydrate to its real object payload — never the null/sentinel placeholder and never an error —
-    // because the body is staged atomically with the sentinel and only leaves the outbox after the
-    // store write succeeds (the read path re-checks the store to stay race-free against the drainer).
+    // Readers continuously list while writes/drains race. The retained SQLite body must always be a
+    // real object payload; asynchronous store writes must never surface a placeholder or read error.
     let mut readers = Vec::new();
     for _ in 0..3 {
         let manager = manager.clone();
@@ -1124,7 +1174,7 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
                             .get("seq")
                             .and_then(serde_json::Value::as_u64)
                             .is_some(),
-                        "a moved body must rehydrate to its real payload, got {:?}",
+                        "a SQLite compatibility body must retain its real payload, got {:?}",
                         message.payload
                     );
                 }
@@ -1164,7 +1214,7 @@ async fn concurrent_append_drain_and_read_never_lose_or_expose_a_moved_body() {
             .payload
             .get("seq")
             .and_then(serde_json::Value::as_u64)
-            .expect("rehydrated payload keeps seq");
+            .expect("SQLite compatibility payload keeps seq");
         assert_eq!(message.payload["text"], json!(format!("message {seq}")));
         seqs.insert(seq);
     }

--- a/src/team/manager/tests/conversation_cases.rs
+++ b/src/team/manager/tests/conversation_cases.rs
@@ -821,6 +821,98 @@ async fn migrate_backfills_inline_conversation_bodies_into_store() {
 }
 
 #[tokio::test]
+async fn completed_backfill_skips_dual_writes_and_recovers_later_sqlite_only_writes() {
+    use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
+
+    let db = setup_test_db().await;
+    let sqlite_writer = TeamManager::new(db.clone());
+    let task = body_store_team_and_task(&sqlite_writer).await;
+    sqlite_writer
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            None,
+            "group_chat",
+            json!({"type":"chat_message","text":"historical body"}),
+        )
+        .await
+        .expect("append historical body");
+
+    let store = body_store();
+    crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        16,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("complete historical backfill");
+
+    let dual_writer = TeamManager::new(db.clone()).with_body_store(Some(
+        store.clone() as crate::message_body_store::SharedBodyStore
+    ));
+    dual_writer
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            None,
+            "group_chat",
+            json!({"type":"chat_message","text":"already dual-written"}),
+        )
+        .await
+        .expect("append dual-written body");
+    assert_eq!(
+        crate::team::count_pending_conversation_body_migration(&db)
+            .await
+            .unwrap(),
+        0,
+        "a completed backfill must not re-stage later dual-written messages"
+    );
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        16,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("skip already dual-written body");
+    assert_eq!(report.staged, 0);
+
+    let sqlite_only = sqlite_writer
+        .append_task_conversation_message(
+            &task.id,
+            "user",
+            None,
+            "group_chat",
+            json!({"type":"chat_message","text":"written while store disabled"}),
+        )
+        .await
+        .expect("append SQLite-only body");
+    assert_eq!(
+        crate::team::count_pending_conversation_body_migration(&db)
+            .await
+            .unwrap(),
+        1
+    );
+    let report = crate::team::migrate_conversation_bodies_into_store(
+        &db,
+        store.as_ref(),
+        16,
+        1_700_000_000,
+        std::time::Duration::ZERO,
+    )
+    .await
+    .expect("recover SQLite-only body");
+    assert_eq!(report.staged, 1);
+    assert!(store.contains(&AuthorityMessageId::new(format!(
+        "tcm:{}",
+        sqlite_only.message_id
+    ))));
+}
+
+#[tokio::test]
 async fn migrate_does_not_head_of_line_block_on_a_persistently_failing_body() {
     use agenthub_message_store::{AuthorityMessageId, MessageBodyStore};
 

--- a/src/team/manager/tests_support.rs
+++ b/src/team/manager/tests_support.rs
@@ -429,6 +429,18 @@ pub(super) async fn setup_test_db() -> SqlitePool {
 
     sqlx::query(
         r#"
+        CREATE TABLE message_body_backfill_checkpoint (
+            scope TEXT PRIMARY KEY,
+            last_message_id INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create message_body_backfill_checkpoint");
+
+    sqlx::query(
+        r#"
         CREATE TABLE team_actor_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id TEXT NOT NULL,
@@ -763,6 +775,13 @@ pub(super) async fn setup_concurrent_conversation_db() -> (SqlitePool, std::path
                 staged_at INTEGER NOT NULL
             );"#,
             "message_body_outbox",
+        ),
+        (
+            r#"CREATE TABLE message_body_backfill_checkpoint (
+                scope TEXT PRIMARY KEY,
+                last_message_id INTEGER NOT NULL
+            );"#,
+            "message_body_backfill_checkpoint",
         ),
     ] {
         sqlx::query(stmt)

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -42,7 +42,7 @@ pub use manager::{
     TeamTaskUpdateWithNoteInput,
 };
 pub(crate) use manager::{
-    count_inline_conversation_bodies, migrate_conversation_bodies_into_store,
+    count_pending_conversation_body_migration, migrate_conversation_bodies_into_store,
 };
 pub(crate) use permission_review::resolve_team_permission_review_target;
 pub use permission_review::{


### PR DESCRIPTION
fix(team): retain SQLite message bodies during phase one

## Summary

- retain `team_conversation_messages.payload_json` as the Phase 1 compatibility copy while staging compressed RocksDB bodies through the durable outbox
- add checkpointed, resumable historical backfill and restore legacy sentinel rows only after their body is available
- make the body store opt-in and align the migration CLI, feature spec, TODO, and rollout journal with the dual-write contract

## Why

The previous enabled-store write path replaced SQLite payloads with a sentinel before Phase 2. That contradicted the documented Phase 1 rollback contract and made normal reads depend on RocksDB availability.

## Validation

- `cargo fmt --check`
- `cargo test -p agenthub-config`
- `cargo test --lib` (702 passed)

## Follow-up

- `cf_index`, its repair path, and backup validation remain separate work; SQLite body removal remains a Phase 2 decision.
