### PR TITLE
test(team): enforce body-store fixture contract

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -82,6 +82,7 @@ When older journals are superseded:
 - `docs/features/logical-message-metadata-contract.md`
 - `docs/features/message-archive-lancedb.md`
 - `docs/features/message-storage-tiering.md`
+- `docs/features/test-regression-guardrails.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`
 

--- a/docs/features/message-storage-tiering.md
+++ b/docs/features/message-storage-tiering.md
@@ -402,6 +402,8 @@ it must not authorize or redefine message authority.
   - backfill is idempotent and never clobbers a newer live write;
   - Phase 2 drop leaves single-message reads correct from `cf_body`;
   - rollback before Phase 2 reads the body from SQLite without data loss.
+  - fixtures include every authority table, durable outbox, and checkpoint touched by the exercised
+    path, following [test-regression-guardrails.md](test-regression-guardrails.md).
 - Distributed tests:
   - node-local cache preserves `source_node_id`, `target_node_id`, and `idempotency_key`;
   - rebuilding a node-local index from main authority rows plus body restores the same delivery window.

--- a/docs/features/test-regression-guardrails.md
+++ b/docs/features/test-regression-guardrails.md
@@ -1,0 +1,101 @@
+# Test Regression Guardrails
+
+## Problem
+
+State migration and message-routing regressions can be locally invisible when a test fixture omits a
+table, index, or constraint that the production schema requires. A passing focused test then proves
+only the incomplete fixture, not the production behavior.
+
+## Scope
+
+- Define the minimum regression evidence for changes to durable state transitions and message routing.
+- Define when a test fixture must reuse the production schema initializer or verify equivalence with it.
+- Apply to SQLite authority tables, durable outboxes, checkpoints, routing state, and their API and
+  manager tests.
+
+## Non-Goals
+
+- Replacing every focused fixture with a full application bootstrap.
+- Requiring an end-to-end test for every state-transition or routing change.
+- Making test-only seed data mirror unrelated production data.
+
+## Architecture
+
+Focused tests may use reduced seed data, but their schema is part of the test contract. A fixture that
+exercises production persistence must either:
+
+1. initialize through the production schema/migration entrypoint; or
+2. explicitly create every table, index, trigger, and constraint used by the exercised code path.
+
+The second option is acceptable only when full initialization would obscure the behavior under test or
+make the test materially slower. It must name the protected schema objects in the test or nearby helper.
+
+## Contracts
+
+### 1) Protected Object Declaration
+
+Every change to a durable state transition or message-routing path must name the object protected from
+regression. The declaration belongs in the test name, a concise test comment, or the PR validation
+summary and includes:
+
+- the authority object or transition, such as `team_actor_messages.status` or a task ownership claim;
+- the invariant, such as no duplicate delivery, monotonic checkpoint, or unauthorized transition is
+  rejected;
+- the focused automated test that proves it.
+
+The test must cover the failing boundary and its closest valid neighbor. For a bugfix, the failing shape
+must be reproducible before the fix or otherwise be represented by a targeted negative assertion.
+
+### 2) Schema Fixture Consistency
+
+Any test that calls code touching durable tables must keep its fixture consistent with the production
+schema for the objects on that path.
+
+- A new table, index, trigger, or required column must update each reduced fixture that exercises it in
+  the same change.
+- A fixture may not silently substitute a missing table or weaker constraint for the production object.
+- Migration and backfill tests must exercise the real migration entrypoint or include an explicit
+  legacy-schema fixture plus the post-migration assertion.
+- New durable objects need one focused test that fails when the object is absent from the fixture,
+  typically by executing the production path rather than only querying the object directly.
+
+### 3) Routing And Transition Boundaries
+
+For message-routing and state-transition changes, tests must assert the authority result rather than
+only a response payload. Relevant assertions include persisted status, ownership, routing target,
+idempotency key, checkpoint, or durable outbox state.
+
+Tests should keep transport mocks at the edge. They must not bypass the authorization, scope, or
+transition resolver that the production route uses.
+
+## Validation Matrix
+
+| Change | Required focused evidence |
+| --- | --- |
+| New durable schema object | Production-path test using a fixture that contains the object; absent-object failure is covered by the fixture contract. |
+| State transition | Invalid transition is rejected and the closest valid transition persists the expected authority state. |
+| Message route | Canonical target/scope is persisted, duplicate/replay behavior is asserted, and the route cannot bypass authorization. |
+| Backfill or recovery | Resume checkpoint and idempotency are asserted across an interrupted or repeated execution. |
+| Fixture helper change | The helper is checked through at least one representative production path. |
+
+## Operational Notes
+
+- Prefer a shared production initializer when a fixture already needs many authority tables.
+- Keep deliberately reduced fixtures small, but colocate their schema declarations and name the paths
+  they support.
+- Treat a missing-table error in a broader test as a fixture-contract regression, not as a reason to
+  weaken the production path.
+- CI can later enforce a shrink-only ratchet for known fixture drift; this contract is the prerequisite
+  for defining that ratchet without false positives.
+
+## Open Risks
+
+- Handwritten fixtures can still drift when they cover many unrelated tables; migrate those fixtures to
+  a shared initializer incrementally when they next change.
+- Full schema initialization can make narrowly-scoped tests slower, so it should not be mandatory when
+  an explicit reduced fixture is clearer and complete for its path.
+
+## Source Journals
+
+- [docs/journal/2026-03-10-pr-118-ci-fixture-alignment.md](../journal/2026-03-10-pr-118-ci-fixture-alignment.md)
+- [docs/journal/2026-07-13-message-body-store-phase1-dual-write.md](../journal/2026-07-13-message-body-store-phase1-dual-write.md)

--- a/docs/journal/2026-07-13-message-body-store-phase1-dual-write.md
+++ b/docs/journal/2026-07-13-message-body-store-phase1-dual-write.md
@@ -24,6 +24,10 @@ outbox row only after acknowledgement.
 - Focused conversation tests cover dual writes, outbox retry, checkpointed idempotent backfill,
   legacy-sentinel restoration, store outage/corruption isolation for Phase 1 reads, and concurrent
   append/drain/read behavior.
+- The task-message API route test enables the in-memory body store and asserts that its normalized
+  payload remains in SQLite while the same bytes are staged in `message_body_outbox` before success is
+  returned. Its test fixture creates the outbox table, its `staged_at` index, and the backfill
+  checkpoint so the exercised schema cannot silently omit a Phase 1 durable object.
 - `cargo fmt --check` was run after the changes.
 
 ## Follow-Up

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -204,25 +204,31 @@ fn long_lived_test_agent_args() -> String {
 }
 
 pub(crate) async fn build_test_state() -> AppState {
-    build_test_state_with_db_source_and_archive(None, true, true, None).await
+    build_test_state_with_db_source_and_archive(None, true, true, None, None).await
 }
 
 pub(crate) async fn build_test_state_without_seeded_team_member_agents() -> AppState {
-    build_test_state_with_db_source_and_archive(None, true, false, None).await
+    build_test_state_with_db_source_and_archive(None, true, false, None, None).await
 }
 
 pub(crate) async fn build_test_state_with_db_path(path: &StdPath) -> AppState {
-    build_test_state_with_db_source_and_archive(Some(path), true, true, None).await
+    build_test_state_with_db_source_and_archive(Some(path), true, true, None, None).await
 }
 
 pub(crate) async fn reopen_test_state_with_db_path(path: &StdPath) -> AppState {
-    build_test_state_with_db_source_and_archive(Some(path), false, false, None).await
+    build_test_state_with_db_source_and_archive(Some(path), false, false, None, None).await
 }
 
 pub(crate) async fn build_test_state_with_message_archive(
     archive: Arc<dyn MessageArchiveStore>,
 ) -> AppState {
-    build_test_state_with_db_source_and_archive(None, true, false, Some(archive)).await
+    build_test_state_with_db_source_and_archive(None, true, false, Some(archive), None).await
+}
+
+pub(crate) async fn build_test_state_with_body_store(
+    body_store: crate::message_body_store::SharedBodyStore,
+) -> AppState {
+    build_test_state_with_db_source_and_archive(None, true, true, None, Some(body_store)).await
 }
 
 async fn build_test_state_with_db_source_and_archive(
@@ -230,6 +236,7 @@ async fn build_test_state_with_db_source_and_archive(
     initialize_schema: bool,
     seed_default_agents: bool,
     message_archive: Option<Arc<dyn MessageArchiveStore>>,
+    body_store: Option<crate::message_body_store::SharedBodyStore>,
 ) -> AppState {
     let db = match path {
         Some(path) => create_test_db_at(path).await,
@@ -277,11 +284,10 @@ async fn build_test_state_with_db_source_and_archive(
         permissions.clone(),
         auth.clone(),
     ));
-    let teams = Arc::new(TeamManager::new_with_event_dbs_and_message_archive(
-        db.clone(),
-        event_dbs,
-        message_archive,
-    ));
+    let teams = Arc::new(
+        TeamManager::new_with_event_dbs_and_message_archive(db.clone(), event_dbs, message_archive)
+            .with_body_store(body_store.clone()),
+    );
     let state = AppState {
         db,
         linker_http: crate::linkers::AppLinkerService::default_http_client(),
@@ -292,7 +298,7 @@ async fn build_test_state_with_db_source_and_archive(
         acp_permissions: permissions,
         agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
         default_worktree_root: config.default_worktree_root(),
-        body_store: None,
+        body_store,
     };
     if seed_default_agents {
         seed_default_team_member_agents(&state).await;
@@ -690,6 +696,29 @@ async fn init_test_schema(db: &SqlitePool) {
     .execute(db)
     .await
     .expect("create team_conversation_messages");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE message_body_outbox (
+            authority_message_id TEXT PRIMARY KEY,
+            body BLOB NOT NULL,
+            staged_at INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create message_body_outbox");
+
+    sqlx::query(
+        r#"
+        CREATE INDEX idx_message_body_outbox_staged_at
+        ON message_body_outbox(staged_at);
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create message_body_outbox staged_at index");
 
     sqlx::query(
         r#"

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -6924,10 +6924,7 @@ async fn team_task_messages_api_supports_route_and_redaction() {
     use agenthub_message_store::InMemoryBodyStore;
 
     let body_store = std::sync::Arc::new(InMemoryBodyStore::new());
-    let state = build_test_state_with_body_store(
-        body_store as crate::message_body_store::SharedBodyStore,
-    )
-    .await;
+    let state = build_test_state_with_body_store(body_store).await;
     let headers = auth_headers(&state).await;
 
     let Json(team) = create_team(

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -6921,7 +6921,13 @@ async fn team_task_api_enforces_team_owner_access_for_existing_tasks() {
 
 #[tokio::test]
 async fn team_task_messages_api_supports_route_and_redaction() {
-    let state = build_test_state().await;
+    use agenthub_message_store::InMemoryBodyStore;
+
+    let body_store = std::sync::Arc::new(InMemoryBodyStore::new());
+    let state = build_test_state_with_body_store(
+        body_store as crate::message_body_store::SharedBodyStore,
+    )
+    .await;
     let headers = auth_headers(&state).await;
 
     let Json(team) = create_team(
@@ -7048,6 +7054,31 @@ async fn team_task_messages_api_supports_route_and_redaction() {
     );
     assert_eq!(message.payload["authorization"], json!("[redacted]"));
     assert_eq!(message.payload["nested"]["api_key"], json!("[redacted]"));
+
+    // Protected object: a routed task message must retain its SQLite compatibility body and stage the
+    // same normalized payload in the durable outbox before the API reports success.
+    let sqlite_payload: String = sqlx::query_scalar(
+        "SELECT payload_json FROM team_conversation_messages WHERE id = ?1",
+    )
+    .bind(message.message_id)
+    .fetch_one(&state.db)
+    .await
+    .expect("load routed message SQLite payload");
+    assert_eq!(
+        serde_json::from_str::<Value>(&sqlite_payload).expect("SQLite payload is valid JSON"),
+        message.payload
+    );
+    let staged_body: Vec<u8> = sqlx::query_scalar(
+        "SELECT body FROM message_body_outbox WHERE authority_message_id = ?1",
+    )
+    .bind(format!("tcm:{}", message.message_id))
+    .fetch_one(&state.db)
+    .await
+    .expect("load routed message durable outbox body");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&staged_body).expect("outbox body is valid JSON"),
+        message.payload
+    );
 
     let Json(to_coordinator_message) = send_team_task_message(
         State(state.clone()),


### PR DESCRIPTION
## Summary

- Add a canonical regression guardrail spec for durable state migrations and message routing.
- Extend the task-message API test fixture with the Phase 1 body outbox table, staged-at index, and backfill checkpoint.
- Assert the routed task message persists the normalized payload in SQLite and stages the same bytes in the durable outbox before success.

## Purpose

This keeps reduced test fixtures aligned with the schema objects used by the production path, so fixture omissions cannot hide state migration or message-routing regressions.

## Related

- Follow-up to #860

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --lib team_task_messages_api_supports_route_and_redaction -- --nocapture`
- `cargo test --lib`
