### PR TITLE
docs(skills): define agent operating workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,19 @@ AgentHub is a single-binary control plane for long-lived AI agents.
 - Use `.agents/skills/agenthub-docs-spec/SKILL.md` when creating or revising canonical feature specs under `docs/features/`.
 - Use `.agents/skills/agenthub-docs-journal/SKILL.md` when creating or revising dated rollout notes under `docs/journal/`.
 - Frontend changes should use Chrome DevTools MCP for before/after validation.
+
+## 7. Prompt And Knowledge Organization
+
+- Keep root agent instructions short: product intent, hard engineering rules, and links to canonical
+  entry points only.
+- Store long-lived agent knowledge in an external, searchable memory or knowledge system instead of
+  expanding repository prompts or duplicating large manuals in this repo.
+- Use repository docs for stable, reviewable contracts only: feature specs for product/runtime/API
+  behavior, journals for dated implementation evidence, and TODO for active follow-up work.
+- Use `docs/features/agent-operating-workflows.md` as the canonical contract for SOP, skill,
+  checklist, testing, and observability workflow organization.
+- Keep runtime prompt templates bounded. They should carry role, task, allowed-action, and compact
+  blocker state, then point to durable memory or artifacts for detail.
+- When a repeated workflow becomes operationally important, encode it as a project-owned SOP, skill,
+  or checklist with triggers, inputs, expected evidence, and validation rather than adding prose to
+  every prompt.

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -26,6 +26,8 @@ or rollout shape.
   - [features/distributed-node-architecture.md](features/distributed-node-architecture.md)
 - Context, memory, and long-running continuity:
   - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+- Agent workflow organization:
+  - [features/agent-operating-workflows.md](features/agent-operating-workflows.md)
 
 ## By Question
 
@@ -58,6 +60,13 @@ or rollout shape.
 ### How is long-running memory and context handled?
 
 - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+
+### How are SOPs, skills, checklists, testing, and observability workflows organized?
+
+- [features/agent-operating-workflows.md](features/agent-operating-workflows.md)
+- [features/test-regression-guardrails.md](features/test-regression-guardrails.md)
+- [features/runtime-diagnostics.md](features/runtime-diagnostics.md)
+- [features/pyroscope-profiling.md](features/pyroscope-profiling.md)
 
 ## Related Contributor Docs
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -65,6 +65,10 @@ When older journals are superseded:
 
 ## Current Canonical Specs
 
+Categories are maintained in
+[`agent-operating-workflows.md`](agent-operating-workflows.md#2-feature-spec-categories). Use them
+when adding or compacting specs so this directory stays navigable.
+
 - `docs/features/frontend-design.md`
 - `docs/features/agent-nodes.md`
 - `docs/features/agents-teams.md`
@@ -82,6 +86,7 @@ When older journals are superseded:
 - `docs/features/logical-message-metadata-contract.md`
 - `docs/features/message-archive-lancedb.md`
 - `docs/features/message-storage-tiering.md`
+- `docs/features/agent-operating-workflows.md`
 - `docs/features/test-regression-guardrails.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -71,23 +71,31 @@ when adding or compacting specs so this directory stays navigable.
 
 - `docs/features/frontend-design.md`
 - `docs/features/agent-nodes.md`
+- `docs/features/acp-runtime.md`
 - `docs/features/agents-teams.md`
+- `docs/features/agent-runtime-profiles.md`
 - `docs/features/team-channels-threads.md`
 - `docs/features/team-create-flow.md`
 - `docs/features/team-agent-adoption.md`
+- `docs/features/team-execution-vocabulary.md`
 - `docs/features/teams-collaboration-playbook.md`
 - `docs/features/actor-foundation.md`
 - `docs/features/team-mailbox-intake-and-ownership.md`
 - `docs/features/team-conversation-event-bus.md`
 - `docs/features/backend-runtime-logic.md`
+- `docs/features/runtime-diagnostics.md`
 - `docs/features/rara-direct-integration.md`
 - `docs/features/distributed-node-architecture.md`
 - `docs/features/distributed-node-registry-and-gossip.md`
+- `docs/features/workspace-unified-ia.md`
 - `docs/features/logical-message-metadata-contract.md`
 - `docs/features/message-archive-lancedb.md`
 - `docs/features/message-storage-tiering.md`
 - `docs/features/agent-operating-workflows.md`
 - `docs/features/test-regression-guardrails.md`
+- `docs/features/pyroscope-profiling.md`
+- `docs/features/npm-binary-distribution.md`
+- `docs/features/debian-systemd-distribution.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`
 

--- a/docs/features/agent-operating-workflows.md
+++ b/docs/features/agent-operating-workflows.md
@@ -65,7 +65,7 @@ Use these categories when locating or compacting specs:
 | Category | Purpose | Current anchors |
 | --- | --- | --- |
 | Product and workspace surfaces | User-facing Team, agent, workspace, and UI contracts. | `agents-teams.md`, `team-channels-threads.md`, `workspace-unified-ia.md`, `frontend-design.md` |
-| Runtime and provider control | ACP, provider sessions, subprocess behavior, runtime prompt delivery. | `acp-runtime.md`, `backend-runtime-logic.md`, `runtime-diagnostics.md`, `agent-runtime-profiles.md` |
+| Runtime and provider control | ACP, provider sessions, subprocess behavior, runtime prompt delivery. | `acp-runtime.md`, `backend-runtime-logic.md`, `agent-runtime-profiles.md` |
 | Team execution and coordination | Task ownership, mailbox, actor CLI, collaboration behavior. | `team-execution-vocabulary.md`, `team-mailbox-intake-and-ownership.md`, `actor-foundation.md`, `teams-collaboration-playbook.md` |
 | Distributed and node operation | Nodes, node registry, internal transport, multi-node execution. | `agent-nodes.md`, `distributed-node-architecture.md`, `distributed-node-registry-and-gossip.md` |
 | Storage and message authority | Durable message state, metadata, archive, body tiering, migration safety. | `logical-message-metadata-contract.md`, `message-archive-lancedb.md`, `message-storage-tiering.md` |

--- a/docs/features/agent-operating-workflows.md
+++ b/docs/features/agent-operating-workflows.md
@@ -1,0 +1,151 @@
+# Agent Operating Workflows
+
+## Problem
+
+Agent-facing instructions need a place for repeatable engineering workflows without turning
+`AGENTS.md` or runtime prompts into large manuals. The repository already has feature specs,
+journals, TODO, and local skills; what was missing is a project-owned rule for when to use each
+surface.
+
+## Scope
+
+- Repository-level workflow organization for coding agents.
+- The boundary between `AGENTS.md`, feature specs, journals, TODO, and `.agents/skills`.
+- Testing and observability workflows that agents repeat during review, CI, runtime diagnosis, and
+  release work.
+- Tool-neutral handling of long-lived agent knowledge.
+
+## Non-Goals
+
+- Defining platform system prompts.
+- Copying another project's workflow taxonomy or business processes.
+- Requiring a private memory backend for contributors.
+- Moving all existing feature specs into a new directory tree.
+
+## Architecture
+
+Agent operating knowledge uses these repository-owned surfaces:
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| `AGENTS.md` | Short project charter, hard engineering rules, canonical entry points. | Long procedures, product manuals, personal memory. |
+| `docs/features/` | Stable contracts for product, runtime, API, testing, observability, and operations. | Chronological implementation logs. |
+| `docs/journal/` | Dated implementation records and validation evidence. | New normative contracts not promoted to a feature spec. |
+| `docs/todo.md` | Active remaining work only. | Completed history or long design notes. |
+| `.agents/skills/` | Executable, task-triggered procedures for local coding agents. | Broad product knowledge or human-facing documentation. |
+| External searchable memory/knowledge system | Durable long-lived knowledge that should not become an open-source repository contract. | Required project rules for contributors. |
+
+## Contracts
+
+### 1) Workflow Type Contract
+
+Use project-owned workflow types by weight:
+
+- `SOP`
+  - Stable, reviewable engineering procedure.
+  - Belongs in `docs/features/` when it defines a durable contract, or in a dedicated docs page when
+    it is operational but not product behavior.
+  - Must name scope, owner surface, required evidence, and failure handling.
+- `skill`
+  - Local executable procedure for an agent.
+  - Belongs under `.agents/skills/<name>/SKILL.md`.
+  - Must include trigger conditions, decision boundary, steps, validation, and fallback behavior.
+- `checklist`
+  - Lightweight repeated workflow that is not yet worth a skill.
+  - Belongs in the relevant feature spec, journal follow-up, or TODO item.
+  - Should be promoted to a skill only after repeated use shows the steps are stable.
+
+Do not introduce workflow categories named after another project. If a pattern is useful, rewrite it
+as an AgentHub-specific SOP, skill, or checklist with this repository's commands and evidence.
+
+### 2) Feature Spec Categories
+
+Use these categories when locating or compacting specs:
+
+| Category | Purpose | Current anchors |
+| --- | --- | --- |
+| Product and workspace surfaces | User-facing Team, agent, workspace, and UI contracts. | `agents-teams.md`, `team-channels-threads.md`, `workspace-unified-ia.md`, `frontend-design.md` |
+| Runtime and provider control | ACP, provider sessions, subprocess behavior, runtime prompt delivery. | `acp-runtime.md`, `backend-runtime-logic.md`, `runtime-diagnostics.md`, `agent-runtime-profiles.md` |
+| Team execution and coordination | Task ownership, mailbox, actor CLI, collaboration behavior. | `team-execution-vocabulary.md`, `team-mailbox-intake-and-ownership.md`, `actor-foundation.md`, `teams-collaboration-playbook.md` |
+| Distributed and node operation | Nodes, node registry, internal transport, multi-node execution. | `agent-nodes.md`, `distributed-node-architecture.md`, `distributed-node-registry-and-gossip.md` |
+| Storage and message authority | Durable message state, metadata, archive, body tiering, migration safety. | `logical-message-metadata-contract.md`, `message-archive-lancedb.md`, `message-storage-tiering.md` |
+| Testing and quality guardrails | Regression evidence, fixture consistency, protected objects. | `test-regression-guardrails.md` |
+| Observability and operations | Debugging, profiling, diagnostic evidence, release/install operation. | `runtime-diagnostics.md`, `pyroscope-profiling.md`, `npm-binary-distribution.md`, `debian-systemd-distribution.md` |
+| Integrations | Linkers, OAuth/linker boundaries, external runtime integration. | `app-linkers.md`, `slock-oauth-linkers.md` |
+
+### 3) Testing SOP Contract
+
+Testing workflow starts by naming the behavior at risk:
+
+1. Protected object
+   - Authority row, state transition, route target, permission boundary, UI behavior, or artifact.
+2. Invariant
+   - The property that must survive future edits.
+3. Terminal oracle
+   - Persisted state, visible UI behavior, emitted event, diagnostic classification, or release
+     artifact.
+4. Boundary proof
+   - Failing boundary plus closest valid neighbor.
+   - Persistence fixtures follow `test-regression-guardrails.md`.
+5. Validation layer
+   - Unit, contract, integration, browser/e2e, CI check, or manual acceptance surface.
+
+### 4) Observability SOP Contract
+
+Observability workflow starts from the acceptance surface and works backward:
+
+1. Name the acceptance surface.
+   - Browser state, API/CLI response, persisted event, release artifact, profile, trace, or CI job.
+2. Capture minimal reproducible evidence.
+   - Command, run id, job URL, trace bundle, log snippet, diagnostic JSON, screenshot, or artifact id.
+3. Classify the failure layer.
+   - Runtime/session, provider prompt, permission/tool gate, persistence, SSE/broadcaster, frontend
+     render/cache, CI environment, or release packaging.
+4. Use the narrow diagnostic surface first.
+   - Runtime diagnosis starts from `runtime-diagnostics.md`.
+   - CPU diagnosis starts from `pyroscope-profiling.md`.
+   - CI diagnosis starts from exact check/job evidence.
+5. Report proof boundaries.
+   - Say what the evidence proves, what it does not prove, and which acceptance surface remains
+     unverified.
+
+### 5) Initial Project-Owned Workflow Candidates
+
+Promote these into skills or checklists as they next need maintenance:
+
+- PR review follow-up and thread resolution.
+- CI failure triage and rerun evidence.
+- Protected-object test evidence.
+- Runtime stuck diagnosis.
+- Release artifact verification.
+- Prompt or skill update review.
+
+## Validation Matrix
+
+| Change | Required validation |
+| --- | --- |
+| Edit `AGENTS.md` workflow rules | `git diff --check`; confirm wording stays tool-neutral. |
+| Edit Team runtime prompt templates | `cargo test -p agenthub-team-prompts -- --nocapture`. |
+| Add a skill | Validate skill frontmatter and run any referenced focused check. |
+| Add or revise testing SOP guidance | Keep it consistent with `test-regression-guardrails.md`. |
+| Add or revise observability SOP guidance | Keep it consistent with `runtime-diagnostics.md` and `pyroscope-profiling.md`. |
+
+## Operational Notes
+
+- Prefer a checklist before adding a new skill when the workflow has not repeated enough to stabilize.
+- Prefer a feature spec before adding prompt prose when the workflow is a durable contract.
+- Prefer external memory before adding repository docs when the knowledge is personal, cross-tool, or
+  not required for open-source contributors.
+- Keep project-owned skills small and command-oriented.
+
+## Open Risks
+
+- Runtime prompts are already long; future workflow extraction should reduce prompt text rather than
+  add more.
+- Feature categories can drift as new domains appear; update this spec and `docs/features/README.md`
+  together.
+- Some workflow candidates may need code support before they can become useful skills.
+
+## Source Journals
+
+- [2026-07-15 Agent Operating Workflows](../journal/2026-07-15-agent-operating-workflows.md)

--- a/docs/journal/2026-07-15-agent-operating-workflows.md
+++ b/docs/journal/2026-07-15-agent-operating-workflows.md
@@ -1,0 +1,43 @@
+# 2026-07-15 Agent Operating Workflows
+
+## Summary
+
+Added a project-owned workflow organization contract for repository prompts, SOPs, skills,
+checklists, testing evidence, and observability evidence.
+
+## Background
+
+The repository already has short root agent instructions, Team runtime prompts, feature specs,
+journals, TODO, and local skills. The missing contract was how to decide which surface should own a
+repeated engineering workflow without copying another project's process taxonomy or expanding every
+prompt.
+
+## Scope
+
+- `AGENTS.md`
+- `docs/features/agent-operating-workflows.md`
+- `docs/features/README.md`
+- `docs/architecture-map.md`
+
+## Key Decisions
+
+- Use project-owned workflow types: `SOP`, `skill`, and `checklist`.
+- Keep the repository tool-neutral and avoid naming private memory systems as required
+  dependencies.
+- Treat testing workflow as protected object, invariant, terminal oracle, boundary proof, and
+  validation layer.
+- Treat observability workflow as acceptance surface, minimal evidence, failure-layer
+  classification, narrow diagnostic surface, and proof boundary.
+- Promote repeated workflows to skills/checklists only when the steps are stable enough to be useful.
+
+## Validation
+
+```bash
+git diff --check
+```
+
+## Follow-Ups
+
+- Promote the highest-frequency workflows into project-owned skills or checklists as they next need
+  maintenance: PR review follow-up, CI triage, runtime stuck diagnosis, release artifact
+  verification, and prompt/skill update review.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -140,10 +140,13 @@ Main shape:
 
 - Phase 1 message-body storage now keeps SQLite compatibility bodies while asynchronously staging
   compressed RocksDB copies through a durable outbox and checkpointed backfill.
+- Agent workflow organization now defines project-owned SOP, skill, checklist, testing, and
+  observability workflow contracts without copying another project's process taxonomy.
 
 Start with:
 
 - `2026-07-13-message-body-store-phase1-dual-write.md`
+- `2026-07-15-agent-operating-workflows.md`
 
 ## Compaction Rules
 


### PR DESCRIPTION
## Summary

- Add a canonical agent operating workflow spec for repository-owned SOPs, skills, and checklists.
- Link the new workflow contract from the root agent instructions, architecture map, feature index, and journal index.
- Define project-owned testing and observability workflow shapes without copying another project's process taxonomy.

## Purpose

This keeps root agent instructions and runtime prompts short while giving contributors a stable place to find workflow ownership rules, feature-spec categories, testing evidence expectations, and observability evidence expectations.

## Related

- No issue.

## Validation

- `git diff --check`
