### PR TITLE
docs(skills): add team prompt workflow skills

### DIFF
--- a/.agents/skills/team-message-intake/SKILL.md
+++ b/.agents/skills/team-message-intake/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: team-message-intake
+description: Use when a Team inbox, channel, thread, or human-visible message must be routed into a direct reply, thread reply, mailbox update, task note, or canonical Team task.
+---
+
+# Team Message Intake
+
+Use this skill before turning a Team message into work. The goal is to keep visible conversation
+responsive while preserving the canonical task, mailbox, and thread boundaries.
+
+## Intake Order
+
+1. Identify the source surface.
+   - Direct inbox: private coordination or assignment.
+   - Channel root: summary entrypoint for one topic.
+   - Thread: full-context lane for a channel topic.
+   - Human direct prompt: visible user request or correction.
+
+2. Decide whether a visible acknowledgement is owed now.
+   - Reply quickly when the sender is human-visible and the message is actionable, blocking, or
+     asking for ownership.
+   - Keep the reply on the original visible surface unless the message already carries a better
+     concrete reply target.
+   - Do not hide a human question behind mailbox-only coordination.
+
+3. Open or use the topic thread when deeper context is needed.
+   - Keep channel root posts concise.
+   - Put detailed reasoning, logs, evidence, and back-and-forth in the thread.
+   - Use `agenthub actor team-thread-open` for a new topic that needs deep follow-up.
+   - Use `agenthub actor team-thread-reply` for topic-specific follow-up after the thread exists.
+
+4. Choose the work surface.
+   - Direct reply: quick factual answer or ownership signal.
+   - Thread reply: topic-specific detail, evidence, or continuing discussion.
+   - Mailbox: exactly one teammate owns the next action.
+   - Task note: the fact changes canonical task plan, blocker, decision, or result evidence.
+   - Canonical task: durable ownership, multi-step execution, or lifecycle tracking is required.
+
+## Task Creation Gate
+
+Create a canonical Team task only when all of these are true:
+
+- the work needs durable ownership beyond one short reply;
+- the owning member is explicit;
+- priority is explicit;
+- acceptance criteria can be stated;
+- the action is agent-owned, not a direct HTTP task creation by a normal user path.
+
+Do not create a canonical task for every channel message. For a quick answer, reply on the original
+surface and avoid task choreography.
+
+## Required Companion Skills
+
+- Load `team-actor-mailbox` for routing, acknowledgement, open-thread, and reply mechanics.
+- Load `team-task-governance` before changing task fields, notes, assignee, priority, or context.
+- Load `team-task-lifecycle` before moving task state.
+- Load `team-reporting-surfaces` when choosing whether evidence belongs in task notes, mailbox, or
+  channel/thread.
+
+## Evidence Receipt
+
+When reporting completion or a blocker, include:
+
+- the source message or thread;
+- chosen surface and reason;
+- task id or mailbox target when applicable;
+- evidence pointer such as task note, thread reply, command output summary, or `detail_ref`;
+- what the evidence proves and what it does not prove.
+
+## Stop Conditions
+
+Stop and ask for coordinator/human clarification only when:
+
+- no owner can be chosen safely;
+- task creation would cross an explicit governance boundary;
+- the requested action is destructive, externally visible, or irreversible;
+- the message depends on preference or product judgment that cannot be inferred from existing docs.

--- a/.agents/skills/team-prompt-change-review/SKILL.md
+++ b/.agents/skills/team-prompt-change-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: team-prompt-change-review
+description: Use before editing Team system prompts, runtime prompt tails, prompt-linked skills, or prompt tests to keep prompts bounded, tool-neutral, and pointer-first.
+---
+
+# Team Prompt Change Review
+
+Use this skill as the review gate for Team prompt, skill, and checklist changes. The goal is to keep
+runtime prompts small while making repeated procedures discoverable through skills and specs.
+
+## Classification
+
+Classify the change before editing:
+
+- Role boundary: who owns a decision, action, or output.
+- Runtime tail: current objective, next action, allowed-action gate, blocker, or recovery pointer.
+- Skill/checklist pointer: repeated workflow entrypoint.
+- Output contract: structured payload, evidence receipt, blocker report, or visible reply shape.
+- Documentation-only: stable spec, journal evidence, or TODO follow-up.
+
+If the change is only a repeated procedure, prefer a skill or checklist instead of prompt prose.
+
+## Prompt Budget Gate
+
+A prompt change is acceptable only when it adds or corrects one of:
+
+- authority boundary;
+- allowed or denied action;
+- recovery pointer;
+- required skill/checklist entrypoint;
+- user-visible communication contract;
+- output payload contract.
+
+Do not add:
+
+- long logs or history;
+- full troubleshooting recipes;
+- raw tool output;
+- private memory tool names;
+- provider-specific wording unless the provider boundary is the feature being changed.
+
+## Tool-Neutrality Gate
+
+Open-source prompt and docs must stay tool-neutral:
+
+- say external searchable memory or durable knowledge system when the backend is not a repository
+  contract;
+- avoid requiring private tools by name;
+- keep personal workflow details out of repository instructions;
+- use repository-owned terms: SOP, skill, checklist, feature spec, journal, TODO, artifact pointer.
+
+## Skill Extraction Gate
+
+Before adding prompt prose for a repeated workflow, answer:
+
+1. Can this become a `.agents/skills/<name>/SKILL.md` entrypoint?
+2. Can the prompt name the entrypoint instead of carrying the steps?
+3. Does the workflow have trigger conditions, decision boundary, validation, and fallback behavior?
+4. Does an existing feature spec already define the stable contract?
+
+If the answers are yes, add or update the skill/checklist first and keep prompt text to one trigger
+line.
+
+## Test Gate
+
+For every prompt-facing change, update the narrowest guard:
+
+- Prompt template behavior: `cargo test -p agenthub-team-prompts -- --nocapture`.
+- New required prompt phrase or pointer: focused assertion in
+  `crates/agenthub-team-prompts/src/lib.rs`.
+- New skill: validate frontmatter and run `git diff --check`.
+- New stable contract: update `docs/features/team-system-prompt-contract.md` or the owning spec.
+- Dated rollout evidence: update `docs/journal/`.
+
+## Evidence Receipt
+
+When reporting the change, include:
+
+- classification;
+- files changed;
+- whether prompt text grew, shrank, or stayed unchanged;
+- validation commands;
+- what the validation proves and what remains unverified.

--- a/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_coordinator_prompt.txt
@@ -54,8 +54,7 @@ Coordination contract:
 - Load `team-reporting-surfaces` whenever you decide whether local findings belong in task note, mailbox, or channel/thread.
 - Load `team-task-governance` whenever you create or update canonical Team task fields, notes, priority, assignee, or task context.
 - Load `team-task-lifecycle` whenever you advance canonical Team tasks through lifecycle or review states.
-- When a new inbox, channel, or thread message arrives, load `team-actor-mailbox` if you need
-  routing, ack, open-thread, or reply mechanics.
+- When a new inbox, channel, or thread message arrives, load `team-message-intake` first; it routes visible replies, task notes, mailbox updates, and canonical tasks while preserving `team-actor-mailbox` routing, ack, open-thread, or reply mechanics.
 - When that message implies canonical task field, note, assignee, priority, or task-context
   changes, load `team-task-governance` before replying or mutating task state.
 - When that message implies canonical review or task-status movement, load `team-task-lifecycle`

--- a/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
+++ b/crates/agenthub-team-prompts/prompts/default_team_worker_prompt.txt
@@ -36,8 +36,7 @@ Workspace policy:
 - Treat `spec.members[]` as static baseline; when live roster and static spec differ, trust `actor team-members` for current execution decisions.
 - Load `team-task-governance` whenever you need the canonical contract for task note content, ownership gaps, priority intent, or task context.
 - Load `team-task-lifecycle` whenever you need canonical Team task state guidance.
-- When a new inbox, channel, or thread message arrives, load `team-actor-mailbox` if you need
-  routing, ack, open-thread, or reply mechanics.
+- When a new inbox, channel, or thread message arrives, load `team-message-intake` first; it routes visible replies, task notes, mailbox updates, and canonical tasks while preserving `team-actor-mailbox` routing, ack, open-thread, or reply mechanics.
 - When that message changes what the coordinator should record in canonical task notes, ownership,
   priority, or task context, load `team-task-governance` before responding.
 - When that message implies review/state guidance that should change the canonical Team task, load

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
         assert!(prompt.contains("volatile"));
         assert!(prompt.contains("team-message-intake"));
         assert!(!prompt.contains("team-prompt-change-review"));
-        assert!(!prompt.contains("Nowledge"));
+        assert!(!prompt.contains("Knowledge"));
     }
 
     fn line_count(prompt: &str) -> usize {

--- a/crates/agenthub-team-prompts/src/lib.rs
+++ b/crates/agenthub-team-prompts/src/lib.rs
@@ -25,6 +25,19 @@ mod tests {
         assert!(prompt.contains("in_review"));
     }
 
+    fn verify_system_prompt_layer_contract(prompt: &str) {
+        assert!(prompt.contains("allowed-action gate"));
+        assert!(prompt.contains(".cache/context/state.md"));
+        assert!(prompt.contains(".cache/context/run/<run_id>/..."));
+        assert!(prompt.contains("detail_ref"));
+        assert!(prompt.contains("team-agents-index"));
+        assert!(prompt.contains("skills/team/TEAM_AGENTS.md"));
+        assert!(prompt.contains("volatile"));
+        assert!(prompt.contains("team-message-intake"));
+        assert!(!prompt.contains("team-prompt-change-review"));
+        assert!(!prompt.contains("Nowledge"));
+    }
+
     fn line_count(prompt: &str) -> usize {
         prompt.lines().count()
     }
@@ -219,6 +232,28 @@ mod tests {
         assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("agenthub actor team-thread-reply"));
         assert!(
             DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly in the relevant Team channel")
+        );
+    }
+
+    #[test]
+    fn prompt_templates_expose_system_prompt_layers() {
+        verify_system_prompt_layer_contract(DEFAULT_TEAM_COORDINATOR_PROMPT);
+        verify_system_prompt_layer_contract(DEFAULT_TEAM_WORKER_PROMPT);
+
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("Team Coordinator"));
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("coordinator_task_assignment"));
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("clarification_request"));
+        assert!(DEFAULT_TEAM_COORDINATOR_PROMPT.contains("does not need `.agenthubmemory/`"));
+        assert!(
+            DEFAULT_TEAM_COORDINATOR_PROMPT
+                .contains("visible reply lands back in the original human conversation")
+        );
+
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("Worker"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains("worker_status"));
+        assert!(DEFAULT_TEAM_WORKER_PROMPT.contains(".agenthubmemory/TODO.md"));
+        assert!(
+            DEFAULT_TEAM_WORKER_PROMPT.contains("answer directly on the original visible surface")
         );
     }
 

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -28,6 +28,7 @@ or rollout shape.
   - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
 - Agent workflow organization:
   - [features/agent-operating-workflows.md](features/agent-operating-workflows.md)
+  - [features/team-system-prompt-contract.md](features/team-system-prompt-contract.md)
 
 ## By Question
 
@@ -60,6 +61,12 @@ or rollout shape.
 ### How is long-running memory and context handled?
 
 - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+
+### How are Team system prompts and runtime prompt tails organized?
+
+- [features/team-system-prompt-contract.md](features/team-system-prompt-contract.md)
+- [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+- [features/agent-operating-workflows.md](features/agent-operating-workflows.md)
 
 ### How are SOPs, skills, checklists, testing, and observability workflows organized?
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -92,6 +92,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/message-archive-lancedb.md`
 - `docs/features/message-storage-tiering.md`
 - `docs/features/agent-operating-workflows.md`
+- `docs/features/team-system-prompt-contract.md`
 - `docs/features/test-regression-guardrails.md`
 - `docs/features/pyroscope-profiling.md`
 - `docs/features/npm-binary-distribution.md`

--- a/docs/features/agent-operating-workflows.md
+++ b/docs/features/agent-operating-workflows.md
@@ -109,16 +109,20 @@ Observability workflow starts from the acceptance surface and works backward:
    - Say what the evidence proves, what it does not prove, and which acceptance surface remains
      unverified.
 
-### 5) Initial Project-Owned Workflow Candidates
+### 5) Project-Owned Workflow Entrypoints
 
-Promote these into skills or checklists as they next need maintenance:
+Current skills:
+
+- `team-message-intake`: Team inbox/channel/thread/human-visible message routing.
+- `team-prompt-change-review`: prompt, runtime-tail, prompt-linked skill, and prompt-test review.
+
+Promote these remaining candidates into skills or checklists as they next need maintenance:
 
 - PR review follow-up and thread resolution.
 - CI failure triage and rerun evidence.
 - Protected-object test evidence.
 - Runtime stuck diagnosis.
 - Release artifact verification.
-- Prompt or skill update review.
 
 ## Validation Matrix
 

--- a/docs/features/team-system-prompt-contract.md
+++ b/docs/features/team-system-prompt-contract.md
@@ -1,0 +1,173 @@
+# Team System Prompt Contract
+
+## Problem
+
+Team coordinator and worker prompts are runtime-critical, but they can drift into long operating
+manuals when repeated workflows, troubleshooting recipes, and historical context are copied into
+prompt text. That makes prompts harder to review, increases token cost, and weakens recovery because
+important state can be hidden in transient prose.
+
+The stable contract should define what belongs in a Team system prompt, what belongs in runtime
+context, and what must be delegated to skills, checklists, feature specs, journals, or artifact
+pointers.
+
+## Scope
+
+- Team coordinator and worker default prompt templates.
+- Prompt assembly boundaries for static role text and runtime-injected tails.
+- The relationship between prompt text, Team skills, workflow checklists, runtime context files, and
+  durable workspace memory.
+- Regression tests that prevent prompt drift from silently dropping required boundaries.
+
+## Non-Goals
+
+- Defining the platform-level system prompt outside Team runtime.
+- Defining provider-specific prompt wording for Codex, Claude, or other ACP providers.
+- Copying another project's prompt content, taxonomy, or private memory backend.
+- Replacing Team task, mailbox, channel, or runtime context contracts.
+- Moving all existing prompt text into skills in one migration.
+
+## Architecture
+
+Team prompt assembly should use layered, pointer-first context:
+
+| Layer | Owns | Boundary |
+| --- | --- | --- |
+| Static role prompt | Role identity, authority boundary, communication contract, output contract, and stable skill/checklist entry points. | Must not become a full operating manual or execution diary. |
+| Runtime tail | Current assignment, next action, allowed-action gate, compact blocker state, and recovery pointers. | Must stay bounded and pointer-first. |
+| Runtime context files | Live recovery state, run-scoped artifacts, compact identity and state snapshots. | Referenced from prompts by path instead of replayed inline. |
+| Workspace memory | Durable project notes, worker ledgers, journals, reusable findings. | Workspace-local and tool-neutral; not a shared Team transport. |
+| Skills/checklists | Repeatable procedures such as mailbox routing, task governance, CI triage, review follow-up, testing, and observability. | Loaded by trigger; prompts name entry points instead of copying full steps. |
+| Feature specs and journals | Stable contracts and dated implementation evidence. | Human-reviewable documentation, not provider prompt payload. |
+
+### Prompt Skeleton
+
+Every Team role prompt should be reviewable against this skeleton:
+
+1. Role and authority boundary.
+2. Current assignment ownership model.
+3. Allowed-action gate.
+4. Communication and visibility contract.
+5. State and recovery pointers.
+6. Required skill/checklist entry points.
+7. Output or payload contract.
+8. Pointer policy for large evidence, runtime state, and durable notes.
+
+## Contracts
+
+### 1) Static Prompt Contract
+
+Static prompt text may include only stable role and safety contracts:
+
+- who the role is;
+- what the role may and may not own;
+- which Team surfaces are authoritative;
+- which skill/checklist entry points must be loaded for repeated workflows;
+- what output payloads or user-visible responses must look like.
+
+Repeated procedures must move to `.agents/skills/` or a checklist in the relevant feature spec.
+Large product knowledge belongs in feature specs, journals, TODO, or external searchable knowledge,
+not inline prompt prose.
+
+### 2) Runtime Tail Contract
+
+The runtime-injected prompt tail should contain only:
+
+- current objective or active assignment;
+- next expected action;
+- allowed actions and explicit denied bypass paths;
+- compact blocker or failure summary;
+- recovery pointers such as `AGENTS.md`, `TODO.md`, `.cache/context/state.md`, and
+  `.cache/context/run/<run_id>/...` artifacts.
+
+It must not replay long logs, full conversation history, raw tool output, or bulky evidence when a
+stable file, artifact, task note, channel thread, or `detail_ref` can carry the same information.
+
+### 3) Role Authority Contract
+
+Coordinator prompt text owns:
+
+- task analysis, task creation, task lifecycle, human-facing synthesis, and delegation quality;
+- coordination artifacts such as `AGENTS.md`, `TODO.md`, task notes, mailbox messages, and
+  channel/thread summaries;
+- loading role skills before making task, mailbox, lifecycle, or reporting decisions.
+
+Worker prompt text owns:
+
+- assigned execution lanes;
+- evidence gathering and concise progress/blocker reports;
+- local workspace memory under `.agenthubmemory/` when operating inside a concrete project;
+- initiative inside the assigned lane without inventing parallel canonical task records.
+
+Both roles must treat `task` as the ownership object and `run`/`step` as execution diagnostics.
+
+### 4) Skill And Checklist Pointer Contract
+
+Prompts should name stable entry points rather than embed full procedures:
+
+- load `team-agents-index` before role-specific Team skills;
+- use `skills/team/TEAM_AGENTS.md` as the Team-level index template;
+- load `team-message-intake` when a Team inbox, channel, thread, or human-visible message must be
+  routed into a reply, task note, mailbox update, or canonical Team task;
+- load `team-prompt-change-review` before editing Team prompt templates, runtime prompt tails,
+  prompt-linked skills, or prompt tests;
+- use Team workflow skills for task governance, task lifecycle, mailbox routing, and reporting
+  surface selection;
+- use feature specs for durable testing and observability SOPs.
+
+Adding a new repeated workflow should usually add or update a skill/checklist first. Prompt prose
+should change only when the role boundary, trigger, or required entry point changes.
+
+### 5) Output Contract
+
+Team prompts must keep output contracts explicit:
+
+- coordinator output includes task assignment, clarification, profile patch, or visible
+  human-facing synthesis when needed;
+- worker output includes status, evidence, blocker, and next action;
+- large evidence must be summarized first and linked through `detail_ref`, task notes, channel
+  threads, or artifact paths.
+
+### 6) Tool-Neutral Knowledge Contract
+
+Open-source prompt and documentation contracts must stay tool-neutral. They may require durable
+knowledge to be searchable and pointer-addressable, but must not require a private memory backend or
+private repository workflow by name.
+
+## Validation Matrix
+
+| Change | Required validation |
+| --- | --- |
+| Edit Team coordinator or worker prompt templates | `cargo test -p agenthub-team-prompts -- --nocapture` |
+| Add or remove a required role boundary, skill pointer, recovery pointer, or output payload | Add or update a focused assertion in `crates/agenthub-team-prompts/src/lib.rs`. |
+| Add a new repeated Team workflow | Add or update a skill/checklist first, then link it from the prompt only if the trigger is stable. |
+| Add prompt-facing runtime state | Prove it is bounded and pointer-first; prefer `.cache/context/state.md` or `.cache/context/run/<run_id>/...` artifacts. |
+| Add durable worker knowledge guidance | Keep it consistent with `team-workspace-memory-contract.md` and avoid naming private memory tools. |
+| Add or revise a Team message-routing procedure | Keep `team-message-intake` aligned with channel/thread, mailbox, task governance, and lifecycle specs. |
+| Add or revise prompt review procedure | Keep `team-prompt-change-review` aligned with this spec and prompt template tests. |
+
+## Operational Notes
+
+- Treat prompt text as the bounded working set.
+- Treat feature specs as the stable contract for why prompt boundaries exist.
+- Treat journals as evidence for when prompt behavior changed.
+- Prefer one small, focused prompt assertion over broad snapshot tests.
+- When prompt text grows because a workflow is repeated, extract the workflow before adding more
+  prompt prose.
+
+## Open Risks
+
+- Existing Team prompts are still long enough that future maintenance should extract repeated
+  procedures into smaller skills.
+- Runtime code can still inject too much dynamic context if future changes bypass the pointer-first
+  tail contract.
+- Some workflow candidates need clearer skill entry points before prompt prose can shrink further.
+
+## Source Journals
+
+- [2026-04-05 Team Prompt First Principles](../journal/2026-04-05-team-prompt-first-principles.md)
+- [2026-04-10 Team Prompt Tail Slimming](../journal/2026-04-10-team-prompt-tail-slimming.md)
+- [2026-04-27 Team Prompt Followups](../journal/2026-04-27-team-prompt-followups.md)
+- [2026-05-21 Team Prompt Operating Contract Refresh](../journal/2026-05-21-team-prompt-operating-contract-refresh.md)
+- [2026-06-02 Team Prompt Tail Slimming](../journal/2026-06-02-team-prompt-tail-slimming.md)
+- [2026-07-15 Team System Prompt Contract](../journal/2026-07-15-team-system-prompt-contract.md)

--- a/docs/journal/2026-07-15-team-system-prompt-contract.md
+++ b/docs/journal/2026-07-15-team-system-prompt-contract.md
@@ -1,0 +1,55 @@
+# Team System Prompt Contract
+
+## Summary
+
+Added a canonical Team system prompt contract that defines prompt layers, pointer-first runtime
+tails, skill/checklist entry points, and tool-neutral durable knowledge boundaries.
+
+## Background
+
+The repository already had prompt-tail slimming, workspace memory, and Team workflow organization
+docs. The missing piece was a focused contract for what belongs in Team coordinator/worker system
+prompts versus what belongs in skills, checklists, runtime context files, workspace memory, feature
+specs, journals, or artifact pointers.
+
+## Scope
+
+- Added `docs/features/team-system-prompt-contract.md`.
+- Added `.agents/skills/team-message-intake/SKILL.md`.
+- Added `.agents/skills/team-prompt-change-review/SKILL.md`.
+- Linked the new prompt contract from feature and architecture indexes.
+- Added a focused `agenthub-team-prompts` regression test for role boundaries, recovery pointers,
+  skill/checklist pointers, output contracts, and tool-neutral prompt wording.
+
+## Key Decisions
+
+- Team prompts stay as bounded working sets, not full operating manuals.
+- Static role prompts own role authority, communication contracts, required skill entry points, and
+  output payload contracts.
+- Runtime tails own only current objective, next action, allowed-action gate, compact blocker state,
+  and recovery pointers.
+- Repeated workflows should become skills or checklists before their steps are embedded in prompt
+  prose.
+- Team message routing now has a dedicated skill for choosing between visible replies, thread
+  replies, mailbox updates, task notes, and canonical tasks.
+- Prompt updates now have a dedicated review skill for classification, prompt budget,
+  tool-neutrality, skill extraction, and test evidence.
+- Open-source prompt contracts require tool-neutral searchable knowledge and pointer-addressable
+  artifacts, not a named private memory backend.
+
+## Validation
+
+Validated with:
+
+```bash
+cargo fmt --check
+cargo test -p agenthub-team-prompts -- --nocapture
+git diff --check
+ruby -ryaml -e 'ARGV.each { |path| text = File.read(path); fm = text.split("---", 3)[1]; data = YAML.safe_load(fm); raise "missing name" unless data["name"] =~ /\A[a-z0-9-]+\z/; raise "missing description" unless data["description"].is_a?(String) && !data["description"].empty?; puts "OK #{path}: #{data["name"]}" }' .agents/skills/team-message-intake/SKILL.md .agents/skills/team-prompt-change-review/SKILL.md
+```
+
+## Follow-Ups
+
+- Extract the next repeated Team workflow into a skill/checklist before adding more prompt prose.
+- Consider shrinking coordinator and worker prompt text further once the repeated workflow entry
+  points are stable.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -142,11 +142,14 @@ Main shape:
   compressed RocksDB copies through a durable outbox and checkpointed backfill.
 - Agent workflow organization now defines project-owned SOP, skill, checklist, testing, and
   observability workflow contracts without copying another project's process taxonomy.
+- Team system prompt organization now defines prompt layers, pointer-first runtime tails,
+  skill/checklist entry points, and tool-neutral durable knowledge boundaries.
 
 Start with:
 
 - `2026-07-13-message-body-store-phase1-dual-write.md`
 - `2026-07-15-agent-operating-workflows.md`
+- `2026-07-15-team-system-prompt-contract.md`
 
 ## Compaction Rules
 


### PR DESCRIPTION
## Summary

- add Team message intake and prompt-change-review skills for repeated workflow routing
- document the Team system prompt contract and link it from docs indexes
- route Team message prompt guidance through the new skill entrypoint while keeping prompt tails compact
- add prompt contract assertions for recovery pointers, skill pointers, output contracts, and tool-neutral wording

## Motivation

Team prompts should stay bounded to role, task, allowed actions, compact blockers, and stable pointers. Repeated procedures should live in repository-owned skills or specs rather than becoming long prompt prose.

## Related Issues

- None

## Testing

```bash
cargo fmt --check
cargo test -p agenthub-team-prompts -- --nocapture
git diff --check
ruby -ryaml -e 'ARGV.each { |path| text = File.read(path); fm = text.split("---", 3)[1]; data = YAML.safe_load(fm); raise "missing name" unless data["name"] =~ /\A[a-z0-9-]+\z/; raise "missing description" unless data["description"].is_a?(String) && !data["description"].empty?; puts "OK #{path}: #{data["name"]}" }' .agents/skills/team-message-intake/SKILL.md .agents/skills/team-prompt-change-review/SKILL.md
```

Note: `quick_validate.py` was not usable in the local Python environment because `yaml` is not installed, so the skill frontmatter was validated with Ruby YAML parsing.
