### PR TITLE
feat(auth): add user capability gates

### DIFF
--- a/crates/agenthub-auth-domain/src/lib.rs
+++ b/crates/agenthub-auth-domain/src/lib.rs
@@ -41,6 +41,117 @@ pub struct UserRecord {
     pub password_hash: Option<String>,
 }
 
+impl UserRecord {
+    pub fn has_capability(&self, capability: UserCapability) -> bool {
+        user_has_capability(&self.role, capability)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UserRole {
+    Root,
+    Admin,
+    Operator,
+    Viewer,
+    Device,
+}
+
+impl UserRole {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "root" => Some(Self::Root),
+            "admin" => Some(Self::Admin),
+            "operator" => Some(Self::Operator),
+            "viewer" => Some(Self::Viewer),
+            "device" => Some(Self::Device),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Root => "root",
+            Self::Admin => "admin",
+            Self::Operator => "operator",
+            Self::Viewer => "viewer",
+            Self::Device => "device",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UserCapability {
+    InstanceConfigure,
+    UsersManage,
+    AuthManage,
+    AgentsManage,
+    TeamsManage,
+    NodesManage,
+    LinkersManage,
+    RuntimeOperate,
+    RuntimeInspect,
+    DiagnosticsRead,
+    PushSubscribe,
+}
+
+impl UserCapability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InstanceConfigure => "instance:configure",
+            Self::UsersManage => "users:manage",
+            Self::AuthManage => "auth:manage",
+            Self::AgentsManage => "agents:manage",
+            Self::TeamsManage => "teams:manage",
+            Self::NodesManage => "nodes:manage",
+            Self::LinkersManage => "linkers:manage",
+            Self::RuntimeOperate => "runtime:operate",
+            Self::RuntimeInspect => "runtime:inspect",
+            Self::DiagnosticsRead => "diagnostics:read",
+            Self::PushSubscribe => "push:subscribe",
+        }
+    }
+}
+
+pub fn user_has_capability(role: &str, capability: UserCapability) -> bool {
+    let Some(role) = UserRole::parse(role) else {
+        return false;
+    };
+    role_has_capability(role, capability)
+}
+
+pub fn role_has_capability(role: UserRole, capability: UserCapability) -> bool {
+    use UserCapability as Capability;
+    use UserRole as Role;
+
+    match role {
+        Role::Root => true,
+        Role::Admin => matches!(
+            capability,
+            Capability::AgentsManage
+                | Capability::TeamsManage
+                | Capability::NodesManage
+                | Capability::LinkersManage
+                | Capability::RuntimeOperate
+                | Capability::RuntimeInspect
+                | Capability::DiagnosticsRead
+                | Capability::PushSubscribe
+        ),
+        Role::Operator => matches!(
+            capability,
+            Capability::AgentsManage
+                | Capability::TeamsManage
+                | Capability::RuntimeOperate
+                | Capability::RuntimeInspect
+                | Capability::PushSubscribe
+        ),
+        Role::Viewer => matches!(
+            capability,
+            Capability::RuntimeInspect | Capability::PushSubscribe
+        ),
+        Role::Device => matches!(capability, Capability::PushSubscribe),
+    }
+}
+
 pub fn hash_password(password: &str) -> anyhow::Result<String> {
     let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();
@@ -55,4 +166,103 @@ pub fn verify_password(password: &str, hash: &str) -> anyhow::Result<bool> {
     let parsed = PasswordHash::new(hash).map_err(|e| anyhow::anyhow!(e.to_string()))?;
     let argon2 = Argon2::default();
     Ok(argon2.verify_password(password.as_bytes(), &parsed).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UserCapability, UserRecord, UserRole, role_has_capability, user_has_capability};
+
+    const CAPABILITIES: [UserCapability; 11] = [
+        UserCapability::InstanceConfigure,
+        UserCapability::UsersManage,
+        UserCapability::AuthManage,
+        UserCapability::AgentsManage,
+        UserCapability::TeamsManage,
+        UserCapability::NodesManage,
+        UserCapability::LinkersManage,
+        UserCapability::RuntimeOperate,
+        UserCapability::RuntimeInspect,
+        UserCapability::DiagnosticsRead,
+        UserCapability::PushSubscribe,
+    ];
+
+    #[test]
+    fn user_role_capability_matrix_is_explicit() {
+        let cases = [
+            (
+                UserRole::Root,
+                [
+                    true, true, true, true, true, true, true, true, true, true, true,
+                ],
+            ),
+            (
+                UserRole::Admin,
+                [
+                    false, false, false, true, true, true, true, true, true, true, true,
+                ],
+            ),
+            (
+                UserRole::Operator,
+                [
+                    false, false, false, true, true, false, false, true, true, false, true,
+                ],
+            ),
+            (
+                UserRole::Viewer,
+                [
+                    false, false, false, false, false, false, false, false, true, false, true,
+                ],
+            ),
+            (
+                UserRole::Device,
+                [
+                    false, false, false, false, false, false, false, false, false, false, true,
+                ],
+            ),
+        ];
+
+        for (role, expected) in cases {
+            for (capability, allowed) in CAPABILITIES.into_iter().zip(expected) {
+                assert_eq!(
+                    role_has_capability(role, capability),
+                    allowed,
+                    "role={} capability={}",
+                    role.as_str(),
+                    capability.as_str()
+                );
+                assert_eq!(
+                    user_has_capability(role.as_str(), capability),
+                    allowed,
+                    "raw role={} capability={}",
+                    role.as_str(),
+                    capability.as_str()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_user_role_denies_every_capability() {
+        for capability in CAPABILITIES {
+            assert!(
+                !user_has_capability("unknown", capability),
+                "capability={}",
+                capability.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn user_record_delegates_capability_checks_to_role_matrix() {
+        let user = UserRecord {
+            id: "user-1".to_string(),
+            username: "operator".to_string(),
+            display_name: "Operator".to_string(),
+            role: "operator".to_string(),
+            password_hash: None,
+        };
+
+        assert!(user.has_capability(UserCapability::AgentsManage));
+        assert!(!user.has_capability(UserCapability::NodesManage));
+    }
 }

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -12,6 +12,8 @@ or rollout shape.
 - Product and system framing:
   - [features/agents-teams.md](features/agents-teams.md)
   - [features/backend-runtime-logic.md](features/backend-runtime-logic.md)
+- Access control and authorization:
+  - [features/access-control-and-roles.md](features/access-control-and-roles.md)
 - Frontend and workspace shell:
   - [features/frontend-design.md](features/frontend-design.md)
   - [features/workspace-unified-ia.md](features/workspace-unified-ia.md)
@@ -47,6 +49,12 @@ or rollout shape.
 
 - [features/acp-runtime.md](features/acp-runtime.md)
 - related implementation journals in [journal/](journal/)
+
+### How are user roles, capabilities, and authorization boundaries organized?
+
+- [features/access-control-and-roles.md](features/access-control-and-roles.md)
+- [features/backend-runtime-logic.md](features/backend-runtime-logic.md)
+- [features/agents-teams.md](features/agents-teams.md)
 
 ### How does the shared workspace shell fit together?
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -72,6 +72,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/frontend-design.md`
 - `docs/features/agent-nodes.md`
 - `docs/features/acp-runtime.md`
+- `docs/features/access-control-and-roles.md`
 - `docs/features/agents-teams.md`
 - `docs/features/agent-runtime-profiles.md`
 - `docs/features/team-channels-threads.md`

--- a/docs/features/access-control-and-roles.md
+++ b/docs/features/access-control-and-roles.md
@@ -1,0 +1,199 @@
+# Access Control And Roles
+
+## Problem
+
+AgentHub currently has two useful but disconnected authorization models:
+
+- Browser/API auth is coarse-grained: authenticated `user` plus root-only admin gates.
+- Internal Team/runtime auth is action-based: internal tokens carry role, run scope, actor scope, and
+  explicit permissions.
+
+That split is workable for a local single-operator control plane, but it becomes too blunt for
+shared Team and node operation. Product surfaces need named user roles and capabilities without
+spreading direct `role == ...` checks across routes and services.
+
+## Scope
+
+- Human-facing user roles and HTTP/API capabilities.
+- Team/member runtime roles as a separate execution model.
+- Internal gRPC/runtime token permissions as a separate machine-auth model.
+- A migration path from root-only gates to capability gates.
+- Regression guardrails that prevent new authorization bypasses.
+
+## Non-Goals
+
+- Replacing existing authentication, sessions, passkeys, or device login.
+- Implementing multi-tenant organizations in this spec.
+- Changing Team coordinator/worker execution semantics.
+- Replacing internal gRPC action permissions.
+- Adding UI role-management workflows in the first implementation slice.
+
+## Architecture
+
+### 1) Identity Layers
+
+Use separate identity layers instead of one overloaded role string:
+
+| Layer | Principal | Role source | Capability source | Examples |
+| --- | --- | --- | --- | --- |
+| Human API | authenticated user | `users.role` | user capability matrix | configure instance, manage agents, manage nodes |
+| Device API | authenticated device user | `users.role = device` plus active device row | limited device capability matrix | push subscription, device heartbeat |
+| Team runtime | Team member | `spec.members[].role` | Team role/runtime policy | coordinator, worker |
+| Internal runtime | internal token principal | JWT `role` | token permission claims plus role defaults | Team actor CLI, node relay |
+
+The same account can participate in more than one layer, but authorization decisions must name the
+layer they are evaluating.
+
+### 2) User Role Model
+
+The v1 user roles are:
+
+| Role | Intent |
+| --- | --- |
+| `root` | Instance owner and break-glass administrator. Can configure security-critical instance state. |
+| `admin` | Day-to-day operator. Can manage normal agents, Teams, and nodes, but cannot change root-only security settings. |
+| `operator` | Power user for runtime operation. Can create/start/stop agents and inspect Team output, but cannot alter instance-wide config. |
+| `viewer` | Read-only human user. Can inspect visible agents, Teams, and logs exposed by policy. |
+| `device` | Device-scoped principal. Exists for device workflows and should not inherit human admin capabilities. |
+
+Compatibility path:
+
+- Existing `root` users retain all current authority.
+- Existing non-root human users should map to `operator` when the migration introduces the new roles.
+- Existing `device` users keep device-only behavior.
+
+### 3) Capability Matrix
+
+Capabilities are stable action names; routes and services should ask for a capability, not inspect a
+role directly.
+
+| Capability | root | admin | operator | viewer | device |
+| --- | --- | --- | --- | --- | --- |
+| `instance:configure` | yes | no | no | no | no |
+| `users:manage` | yes | no | no | no | no |
+| `auth:manage` | yes | no | no | no | no |
+| `agents:manage` | yes | yes | yes | no | no |
+| `teams:manage` | yes | yes | yes | no | no |
+| `nodes:manage` | yes | yes | no | no | no |
+| `linkers:manage` | yes | yes | no | no | no |
+| `runtime:operate` | yes | yes | yes | no | no |
+| `runtime:inspect` | yes | yes | yes | yes | no |
+| `diagnostics:read` | yes | yes | no | no | no |
+| `push:subscribe` | yes | yes | yes | yes | yes |
+
+`root` remains the only role that can change security-sensitive instance settings such as passkey
+mode, root lifecycle, root-owned safe paths, and user role assignments.
+
+### 4) Authorization Entry Points
+
+HTTP/API authorization should converge on a small entry-point module:
+
+- `require_user`: authenticate only.
+- `require_capability`: authenticate and check one user capability.
+- `require_any_capability`: authenticate and check at least one capability.
+- `require_root`: compatibility wrapper for `require_capability("instance:configure")` or a
+  dedicated break-glass check where root-only semantics are intentional.
+
+New code should not add direct user-role checks outside the canonical authz module and auth domain
+tests.
+
+### 5) Resource Boundary Contract
+
+Capability checks answer "may this principal attempt this kind of action." Resource-scoped checks
+must still happen after capability checks:
+
+- Agent and Team operations must still verify resource ownership/visibility.
+- Run-scoped APIs must still verify run/team/user boundaries.
+- Node operations must still verify main/node topology and internal gRPC scope.
+- Team runtime actions must still enforce internal token actor/run scope.
+
+Capabilities do not replace ownership checks.
+
+### 6) Runtime Role Separation
+
+Do not merge human user roles with Team member roles:
+
+- `coordinator` and `worker` are Team execution roles, not human authorization roles.
+- Internal token roles (`coordinator`, `worker`, `orchestrator`) remain runtime transport roles.
+- Human capabilities may allow starting or inspecting a Team, but they do not let a human impersonate
+  a Team member actor.
+
+### 7) Boundary Tests
+
+Authorization changes should include three guardrails:
+
+1. Matrix tests
+   - Assert every role/capability pair explicitly.
+   - Include null/unknown role denial.
+2. Route behavior tests
+   - Prove a lower role is denied for a protected route.
+   - Prove the nearest allowed role succeeds.
+3. Bypass guard
+   - Add a static or focused test that fails when new route/service code performs direct role checks
+     outside the canonical authz module.
+
+## Contracts
+
+### 1) Capability Names Are Product Contracts
+
+Capability names must be stable, readable, and action-oriented. Avoid naming capabilities after
+routes or implementation modules.
+
+### 2) Deny By Default
+
+Unknown roles and unknown capabilities deny. Missing sessions deny. Device users deny every human
+capability unless explicitly granted by the device matrix.
+
+### 3) Root Is Not The Default Implementation Shortcut
+
+Root-only should mean security-critical or break-glass. Normal operation should move toward
+capability gates so non-root operators can safely run agents and Teams.
+
+### 4) Compatibility Wrappers Must Be Temporary
+
+Existing `require_root` routes may remain during migration, but new routes should prefer
+capability-oriented helpers. When a root-only route is intentionally root-only, document why in the
+route or owning feature spec.
+
+### 5) Audit Sensitive Mutations
+
+Role changes, auth configuration changes, linker credential updates, node credential changes, and
+diagnostic export actions should write audit records with principal id, capability, target, and
+result.
+
+## Validation Matrix
+
+| Change | Required validation |
+| --- | --- |
+| Add or change a user role | Matrix tests for all capabilities and null/unknown denial. |
+| Add or change a capability | Matrix tests plus docs update in this spec. |
+| Convert a root-only route to capability auth | Focused route test for denied lower role and allowed nearest role. |
+| Add a new protected route | Route test plus bypass guard coverage. |
+| Change internal runtime permissions | Existing internal authz tests plus role-default permission tests. |
+| Change Team member roles | Team role tests; do not reuse human role capability tests. |
+
+## Operational Notes
+
+- Start with domain-only helpers and tests before migrating routes.
+- Convert routes by capability cluster, not file-by-file churn:
+  1. runtime inspect/operate;
+  2. agent/team management;
+  3. node management;
+  4. linker management;
+  5. root-only security settings.
+- Keep error messages precise but avoid resource existence leaks when the user lacks the surrounding
+  resource boundary.
+- Keep UI gates advisory; backend authorization remains authoritative.
+
+## Open Risks
+
+- Existing root-only routes mix true security settings with normal operator actions; migration needs
+  careful classification.
+- Adding roles without UI management can make tests pass while operators still cannot administer
+  users conveniently.
+- Bypass guard patterns can produce false positives; keep the baseline small and explicit.
+- Role migration must preserve local single-user setups without forcing a disruptive onboarding step.
+
+## Source Journals
+
+- [2026-07-16 Access Control Roles](../journal/2026-07-16-access-control-roles.md)

--- a/docs/features/agent-operating-workflows.md
+++ b/docs/features/agent-operating-workflows.md
@@ -66,6 +66,7 @@ Use these categories when locating or compacting specs:
 | --- | --- | --- |
 | Product and workspace surfaces | User-facing Team, agent, workspace, and UI contracts. | `agents-teams.md`, `team-channels-threads.md`, `workspace-unified-ia.md`, `frontend-design.md` |
 | Runtime and provider control | ACP, provider sessions, subprocess behavior, runtime prompt delivery. | `acp-runtime.md`, `backend-runtime-logic.md`, `agent-runtime-profiles.md` |
+| Access control and security | User roles, capabilities, route authorization, and runtime permission boundaries. | `access-control-and-roles.md`, `runtime-diagnostics.md` |
 | Team execution and coordination | Task ownership, mailbox, actor CLI, collaboration behavior. | `team-execution-vocabulary.md`, `team-mailbox-intake-and-ownership.md`, `actor-foundation.md`, `teams-collaboration-playbook.md` |
 | Distributed and node operation | Nodes, node registry, internal transport, multi-node execution. | `agent-nodes.md`, `distributed-node-architecture.md`, `distributed-node-registry-and-gossip.md` |
 | Storage and message authority | Durable message state, metadata, archive, body tiering, migration safety. | `logical-message-metadata-contract.md`, `message-archive-lancedb.md`, `message-storage-tiering.md` |

--- a/docs/journal/2026-07-16-access-control-roles.md
+++ b/docs/journal/2026-07-16-access-control-roles.md
@@ -1,0 +1,56 @@
+# Access Control Roles
+
+## Summary
+
+Added a canonical access-control and user-role spec. The spec adapts the role-to-capability matrix
+pattern into AgentHub's existing Rust/API/runtime boundaries without copying another project's
+implementation shape.
+
+## Background
+
+The current repository already has:
+
+- coarse browser/API auth with `require_user` and `require_root`;
+- `root` and `device` user roles in the auth store;
+- internal runtime tokens with roles, scopes, and explicit action permissions;
+- Team member roles (`coordinator`, `worker`) used for execution semantics.
+
+The missing contract is a human-facing user role and capability model that can replace broad
+root-only gates over time while keeping Team/runtime roles separate.
+
+## Scope
+
+- Added `docs/features/access-control-and-roles.md`.
+- Linked the spec from the feature index, architecture map, and journal summary.
+- Added role/capability domain helpers and matrix tests.
+- Added API capability auth helpers and a focused bypass guard for direct human-role route checks.
+- Converted remote-node agent creation from a direct root check to the `nodes:manage` capability.
+- Added a TODO item for the remaining route-cluster migration.
+
+## Key Decisions
+
+- Use capabilities as the stable authorization contract; routes should ask for capabilities rather
+  than inspect role strings directly.
+- Keep identity layers separate: human API users, device users, Team runtime members, and internal
+  runtime token principals.
+- Introduce a v1 user-role target of `root`, `admin`, `operator`, `viewer`, and `device`.
+- Preserve root-only behavior for security-critical settings while migrating normal operation to
+  capability gates.
+- Require matrix tests, route behavior tests, and a bypass guard for authorization changes.
+
+## Validation
+
+Validation:
+
+```bash
+git diff --check
+cargo test -p agenthub-auth-domain
+cargo test api::authz
+cargo test api::agents::tests::create_agent_route_rejects_remote_target_without_node_capability
+```
+
+## Follow-Ups
+
+- Implement role/capability domain helpers and matrix tests.
+- Add a bypass guard preventing new direct user-role checks outside the canonical authz module.
+- Convert the first route cluster from root-only to capability auth after the matrix is in place.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -35,6 +35,7 @@ rg -n "Validation|Follow-Ups|Key Decisions" docs/journal/2026-06-*.md
 | Agent nodes and distributed execution | `docs/features/agent-nodes.md`, `docs/features/distributed-node-architecture.md` | `*-node-*.md`, `*-distributed-*.md`, `*-p2p-*.md` |
 | Release, packaging, and install paths | `docs/features/npm-binary-distribution.md`, `docs/features/debian-systemd-distribution.md` | `*-release-*.md`, `*-npm-*.md`, `*-debian-*.md`, `*-homebrew-*.md` |
 | CI, Bazel, coverage, and dependencies | `docs/developer-setup.md` | `*-ci-*.md`, `*-bazel-*.md`, `*-codecov-*.md`, `*-dependabot-*.md` |
+| Access control, auth, and permissions | `docs/features/access-control-and-roles.md`, `docs/features/acp-runtime.md` | `*-auth-*.md`, `*-access-control-*.md`, `*-permission-*.md` |
 | Message archive and metadata | `docs/features/logical-message-metadata-contract.md`, `docs/features/message-archive-lancedb.md` | `*-message-*.md`, `*-metadata-*.md`, `*-lancedb-*.md` |
 | RARA and app integrations | `docs/features/rara-direct-integration.md`, `docs/features/app-linkers.md` | `*-rara-*.md`, `*-app-*.md`, `*-linker-*.md` |
 
@@ -144,12 +145,15 @@ Main shape:
   observability workflow contracts without copying another project's process taxonomy.
 - Team system prompt organization now defines prompt layers, pointer-first runtime tails,
   skill/checklist entry points, and tool-neutral durable knowledge boundaries.
+- Access-control planning now defines user roles, capability gates, and route authorization
+  guardrails for moving beyond root-only checks.
 
 Start with:
 
 - `2026-07-13-message-body-store-phase1-dual-write.md`
 - `2026-07-15-agent-operating-workflows.md`
 - `2026-07-15-team-system-prompt-contract.md`
+- `2026-07-16-access-control-roles.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -42,6 +42,14 @@ Stable contracts:
 - [ ] `P1` Verify remote Team direct-mailbox routing on real multi-node teams: after the local API regression and routing fix in [journal/2026-05-26-team-remote-direct-mailbox-routing.md](journal/2026-05-26-team-remote-direct-mailbox-routing.md), confirm direct single-member delivery still preserves mention metadata plus summary/`detail_ref` payloads when the recipient agent is remote and transport falls back to p2p relay in a real multi-node rollout. Existing notes: [journal/2026-03-26-team-direct-mailbox-summary-first.md](journal/2026-03-26-team-direct-mailbox-summary-first.md).
 - [ ] `P2` Verify Team agent self-maintenance and deferred follow-up flows: `profile_patch_proposal`, `agent_time_trigger_*`, and operator-controlled `agent_loop` should behave consistently without blocking normal task progress.
 
+## Access Control
+
+Stable contract:
+
+- [features/access-control-and-roles.md](features/access-control-and-roles.md)
+
+- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, and remote-node create-agent gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract.
+
 ## Message Storage
 
 - [ ] `P1` Implement the RocksDB `cf_index` delivery projection and its authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill is complete; keep normal reads on SQLite until ordered index reads, integrity checks, and backup validation are in place. Do not drop SQLite bodies before the Phase 2 rollout decision.

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
 
+use agenthub_auth_domain::UserCapability;
 use agenthub_config::{
     normalize_optional_codex_acp_mode_id, normalize_optional_runtime_model,
     normalize_optional_thinking_level,
@@ -21,7 +22,7 @@ use crate::agent::{
     AgentConfig, AgentRecord, AgentSendInputError, AgentTimeTriggerCreateInput,
     AgentTimeTriggerManager, AgentTimeTriggerRecord, WorktreeMode, normalize_target_node_id,
 };
-use crate::api::authz::require_user;
+use crate::api::authz::{require_capability, require_user};
 use crate::api::error::ApiError;
 use crate::api::ok_response;
 use crate::api::teams::prune_deleted_agent_from_team_specs;
@@ -247,7 +248,6 @@ async fn create_agent(
     headers: HeaderMap,
     Json(payload): Json<CreateAgentRequest>,
 ) -> Result<Json<AgentRecord>, ApiError> {
-    let user = require_user(&headers, &state).await?;
     let CreateAgentRequest {
         name,
         workdir,
@@ -288,11 +288,11 @@ async fn create_agent(
     )?;
     let source = parse_agent_source(source.as_deref())?;
     let target_node_id = normalize_target_node_id(target_node_id.as_deref());
-    if target_node_id.is_some() && user.role != "root" {
-        return Err(ApiError::unauthorized(
-            "root required for remote target node",
-        ));
-    }
+    let _user = if target_node_id.is_some() {
+        require_capability(&headers, &state, UserCapability::NodesManage).await?
+    } else {
+        require_user(&headers, &state).await?
+    };
     let default_worktree_root = resolve_create_agent_default_worktree_root(
         &state,
         target_node_id.as_deref(),
@@ -2139,7 +2139,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_agent_route_rejects_remote_target_for_non_root_user() {
+    async fn create_agent_route_rejects_remote_target_without_node_capability() {
         let db = create_test_db().await;
         init_test_schema(&db).await;
         add_agent_node_support(&db).await;
@@ -2185,10 +2185,10 @@ mod tests {
                 })),
             ))
             .await
-            .expect("create remote-target agent as non-root");
+            .expect("create remote-target agent without node capability");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let body = decode_json_body(response).await;
-        assert_eq!(body["error"], "root required for remote target node");
+        assert_eq!(body["error"], "nodes:manage required");
     }
 
     #[tokio::test]

--- a/src/api/authz.rs
+++ b/src/api/authz.rs
@@ -1,3 +1,4 @@
+use agenthub_auth_domain::UserCapability;
 use axum::http::HeaderMap;
 
 use crate::api::error::ApiError;
@@ -24,8 +25,85 @@ pub async fn require_user(headers: &HeaderMap, state: &AppState) -> Result<UserR
 
 pub async fn require_root(headers: &HeaderMap, state: &AppState) -> Result<UserRecord, ApiError> {
     let user = require_user(headers, state).await?;
-    if user.role != "root" {
+    if !user.has_capability(UserCapability::InstanceConfigure) {
         return Err(ApiError::unauthorized("root required"));
     }
     Ok(user)
+}
+
+pub async fn require_capability(
+    headers: &HeaderMap,
+    state: &AppState,
+    capability: UserCapability,
+) -> Result<UserRecord, ApiError> {
+    let user = require_user(headers, state).await?;
+    if !user.has_capability(capability) {
+        return Err(ApiError::unauthorized(&format!(
+            "{} required",
+            capability.as_str()
+        )));
+    }
+    Ok(user)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    const FORBIDDEN_HUMAN_ROLE_CHECKS: [&str; 8] = [
+        "user.role == \"root\"",
+        "user.role != \"root\"",
+        "user.role == \"admin\"",
+        "user.role != \"admin\"",
+        "user.role == \"operator\"",
+        "user.role != \"operator\"",
+        "user.role == \"viewer\"",
+        "user.role != \"viewer\"",
+    ];
+
+    #[test]
+    fn api_code_does_not_bypass_capability_authz_for_human_roles() {
+        let api_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api");
+        let mut violations = Vec::new();
+        collect_human_role_authz_violations(&api_dir, &mut violations);
+
+        assert!(
+            violations.is_empty(),
+            "direct human role checks must go through api::authz capability helpers:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    fn collect_human_role_authz_violations(dir: &Path, violations: &mut Vec<String>) {
+        for entry in fs::read_dir(dir).expect("read api dir") {
+            let entry = entry.expect("read api dir entry");
+            let path = entry.path();
+            if path.is_dir() {
+                collect_human_role_authz_violations(&path, violations);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            if path.file_name().and_then(|name| name.to_str()) == Some("authz.rs") {
+                continue;
+            }
+
+            let content = fs::read_to_string(&path).expect("read api source");
+            for (line_index, line) in content.lines().enumerate() {
+                if FORBIDDEN_HUMAN_ROLE_CHECKS
+                    .iter()
+                    .any(|forbidden| line.contains(forbidden))
+                {
+                    violations.push(format!(
+                        "{}:{}: {}",
+                        path.display(),
+                        line_index + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
 }

--- a/src/api/authz.rs
+++ b/src/api/authz.rs
@@ -48,9 +48,6 @@ pub async fn require_capability(
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use std::path::Path;
-
     const FORBIDDEN_HUMAN_ROLE_CHECKS: [&str; 8] = [
         "user.role == \"root\"",
         "user.role != \"root\"",
@@ -62,11 +59,28 @@ mod tests {
         "user.role != \"viewer\"",
     ];
 
+    const API_SOURCES: [(&str, &str); 13] = [
+        ("admin.rs", include_str!("admin.rs")),
+        ("agent_nodes.rs", include_str!("agent_nodes.rs")),
+        ("agents.rs", include_str!("agents.rs")),
+        ("auth.rs", include_str!("auth.rs")),
+        ("diagnostics.rs", include_str!("diagnostics.rs")),
+        ("error.rs", include_str!("error.rs")),
+        ("join.rs", include_str!("join.rs")),
+        ("linkers.rs", include_str!("linkers.rs")),
+        ("mod.rs", include_str!("mod.rs")),
+        ("openapi/mod.rs", include_str!("openapi/mod.rs")),
+        ("push.rs", include_str!("push.rs")),
+        ("settings.rs", include_str!("settings.rs")),
+        ("teams.rs", include_str!("teams.rs")),
+    ];
+
     #[test]
     fn api_code_does_not_bypass_capability_authz_for_human_roles() {
-        let api_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api");
         let mut violations = Vec::new();
-        collect_human_role_authz_violations(&api_dir, &mut violations);
+        for (path, content) in API_SOURCES {
+            collect_human_role_authz_violations(path, content, &mut violations);
+        }
 
         assert!(
             violations.is_empty(),
@@ -75,34 +89,17 @@ mod tests {
         );
     }
 
-    fn collect_human_role_authz_violations(dir: &Path, violations: &mut Vec<String>) {
-        for entry in fs::read_dir(dir).expect("read api dir") {
-            let entry = entry.expect("read api dir entry");
-            let path = entry.path();
-            if path.is_dir() {
-                collect_human_role_authz_violations(&path, violations);
-                continue;
-            }
-            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
-                continue;
-            }
-            if path.file_name().and_then(|name| name.to_str()) == Some("authz.rs") {
-                continue;
-            }
-
-            let content = fs::read_to_string(&path).expect("read api source");
-            for (line_index, line) in content.lines().enumerate() {
-                if FORBIDDEN_HUMAN_ROLE_CHECKS
-                    .iter()
-                    .any(|forbidden| line.contains(forbidden))
-                {
-                    violations.push(format!(
-                        "{}:{}: {}",
-                        path.display(),
-                        line_index + 1,
-                        line.trim()
-                    ));
-                }
+    fn collect_human_role_authz_violations(
+        path: &str,
+        content: &str,
+        violations: &mut Vec<String>,
+    ) {
+        for (line_index, line) in content.lines().enumerate() {
+            if FORBIDDEN_HUMAN_ROLE_CHECKS
+                .iter()
+                .any(|forbidden| line.contains(forbidden))
+            {
+                violations.push(format!("{}:{}: {}", path, line_index + 1, line.trim()));
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add a canonical user role and capability matrix for `root`, `admin`, `operator`, `viewer`, and `device`.
- Add API capability authorization helpers and a bypass guard for direct human-role checks in API code.
- Convert remote-node agent creation from a direct root check to the `nodes:manage` capability.
- Document the access-control contract, journal evidence, and remaining route-cluster migration TODO.

## Motivation

The existing API authorization model mostly distinguishes authenticated users from root-only gates.
That is too coarse for shared operation because normal runtime actions, node administration, and
security-sensitive instance configuration need separate authorization boundaries.

## Tests

```bash
cargo fmt
cargo test -p agenthub-auth-domain
cargo test api::authz
cargo test api::agents::tests::create_agent_route_rejects_remote_target_without_node_capability
git diff --check
```

## Related Issues

None.
