### PR TITLE
feat(storage): add opendal object store foundation

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,6 +27,7 @@ env:
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
     //crates/agenthub-message-archive:agenthub_message_archive_tests
     //crates/agenthub-message-store:agenthub_message_store_tests
+    //crates/agenthub-object-store:agenthub_object_store_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests
@@ -45,6 +46,7 @@ env:
     //crates/agenthub-managed-skills:agenthub_managed_skills_tests
     //crates/agenthub-message-archive:agenthub_message_archive_tests
     //crates/agenthub-message-store:agenthub_message_store_tests
+    //crates/agenthub-object-store:agenthub_object_store_tests
     //crates/agenthub-pyroscope:agenthub_pyroscope_tests
     //crates/agenthub-team-actor:agenthub_team_actor_tests
     //crates/agenthub-team-domain:agenthub_team_domain_tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "agenthub-object-store"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "opendal",
+ "sha2 0.11.0",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "agenthub-push"
 version = "0.0.10"
 dependencies = [
@@ -4979,6 +4990,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6340,6 +6361,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -9374,24 +9404,26 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10592,9 +10624,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"
@@ -10810,6 +10842,15 @@ name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "mea"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
+]
 
 [[package]]
 name = "memchr"
@@ -11568,6 +11609,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "opendal"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d02c6564e376d3670aaf66ad886cd34f83c0aca407b6364777c624a63e0e2d"
+dependencies = [
+ "opendal-core",
+ "opendal-service-fs",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8564bd76b75d2aea59178cb5b6e9f770be1da73b1bca062720ec151cc56215a"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "jiff",
+ "log",
+ "md-5 0.11.0",
+ "mea",
+ "percent-encoding",
+ "quick-xml",
+ "reqsign-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f26a923b72b96d1a3dbbe961fcad4d534bf586c3f48c583e9f35649b1b6175f"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "750d9cc8588c19b27c4c2c5d06d7eb6f2bff62549c48652f1f9a7603cd872377"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc-fast",
+ "http 1.4.0",
+ "log",
+ "md-5 0.11.0",
+ "opendal-core",
+ "quick-xml",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11738,6 +11851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -12410,7 +12533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -12431,7 +12554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13329,6 +13452,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqsign-aws-v4"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9e1168fab3883ec6afed1c2e20c25b2a09f366cdb662ac3e0878ae0332d63e"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "http 1.4.0",
+ "log",
+ "percent-encoding",
+ "quick-xml",
+ "reqsign-core",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514a1e0b4aa288652a3fdbda4f0a610f379cdf5374e55a37c9edd03d57ed856b"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.4.0",
+ "jiff",
+ "log",
+ "percent-encoding",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b472a8d1f2e5a4be8ce13bb7bdf4b59e9bee613ce124aca23959ddb42176b39"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
+ "tokio",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13671,6 +13849,16 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -14823,6 +15011,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spin"
@@ -17646,6 +17840,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/agenthub-pyroscope",
     "crates/agenthub-message-archive",
     "crates/agenthub-message-store",
+    "crates/agenthub-object-store",
 ]
 exclude = ["cmd/agenthub"]
 

--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -29,6 +29,7 @@ pub struct AppConfig {
     pub history: Option<HistoryConfig>,
     pub message_archive: Option<MessageArchiveConfig>,
     pub message_body_store: Option<MessageBodyStoreConfig>,
+    pub object_store: Option<ObjectStoreConfig>,
     pub push: Option<PushConfig>,
     pub internal_grpc: Option<InternalGrpcConfig>,
     pub safe_paths: Option<Vec<String>>,
@@ -145,6 +146,19 @@ pub struct MessageBodyStoreConfig {
     /// Whether to backfill existing SQLite compatibility bodies into the store on startup. Default-on
     /// once the store itself is enabled; set `auto_migrate = false` to use `agenthub migrate`.
     pub auto_migrate: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ObjectStoreConfig {
+    pub backend: Option<String>,
+    pub root: Option<String>,
+    pub public_base_url: Option<String>,
+    pub prefix: Option<String>,
+    pub bucket: Option<String>,
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub access_key_id_env: Option<String>,
+    pub secret_access_key_env: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -468,6 +482,85 @@ impl AppConfig {
             .unwrap_or(true)
     }
 
+    pub fn object_store_backend(&self) -> String {
+        self.object_store
+            .as_ref()
+            .and_then(|config| config.backend.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("fs")
+            .to_ascii_lowercase()
+    }
+
+    pub fn object_store_root(&self) -> Option<String> {
+        self.object_store
+            .as_ref()
+            .and_then(|config| config.root.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_tilde)
+    }
+
+    pub fn object_store_prefix(&self) -> Option<String> {
+        self.object_store
+            .as_ref()
+            .and_then(|config| config.prefix.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.trim_matches('/').to_string())
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn object_store_public_base_url(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.public_base_url.as_deref()),
+        )
+        .map(|value| value.trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+    }
+
+    pub fn object_store_bucket(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.bucket.as_deref()),
+        )
+    }
+
+    pub fn object_store_endpoint(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.endpoint.as_deref()),
+        )
+    }
+
+    pub fn object_store_region(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.region.as_deref()),
+        )
+    }
+
+    pub fn object_store_access_key_id_env(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.access_key_id_env.as_deref()),
+        )
+    }
+
+    pub fn object_store_secret_access_key_env(&self) -> Option<String> {
+        trimmed_object_store_value(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.secret_access_key_env.as_deref()),
+        )
+    }
+
     pub fn history_event_retention_days(&self) -> Option<u32> {
         let days = self
             .history
@@ -618,6 +711,13 @@ impl AppConfig {
     }
 }
 
+fn trimmed_object_store_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 pub fn normalize_codex_acp_mode_id(mode_id: &str) -> String {
     match mode_id.trim() {
         "yolo" | "yalo" | "danger_full_access" | "danger-full-access" => "full-access".to_string(),
@@ -703,8 +803,8 @@ fn detect_env_overrides() -> Vec<String> {
 mod tests {
     use super::{
         AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig, MessageBodyStoreConfig,
-        NowledgeMemConfig, NowledgeMemProfileConfig, NowledgeMemTeamBindingConfig, ServerConfig,
-        ServerRole, WorktreeConfig,
+        NowledgeMemConfig, NowledgeMemProfileConfig, NowledgeMemTeamBindingConfig,
+        ObjectStoreConfig, ServerConfig, ServerRole, WorktreeConfig,
     };
 
     #[test]
@@ -828,6 +928,63 @@ mod tests {
             ..Default::default()
         };
         assert!(!config.message_body_store_auto_migrate());
+    }
+
+    #[test]
+    fn object_store_defaults_to_local_fs_backend() {
+        let config = AppConfig::default();
+        assert_eq!(config.object_store_backend(), "fs");
+        assert_eq!(config.object_store_root(), None);
+        assert_eq!(config.object_store_prefix(), None);
+        assert_eq!(config.object_store_bucket(), None);
+    }
+
+    #[test]
+    fn object_store_config_trims_secret_free_s3_references() {
+        let config = AppConfig {
+            object_store: Some(ObjectStoreConfig {
+                backend: Some(" S3 ".to_string()),
+                root: Some(" /tenant-root/ ".to_string()),
+                public_base_url: Some(" https://img.example.test/ ".to_string()),
+                prefix: Some("/agenthub/prod/".to_string()),
+                bucket: Some(" agenthub-artifacts ".to_string()),
+                endpoint: Some(" https://s3.example.test ".to_string()),
+                region: Some(" auto ".to_string()),
+                access_key_id_env: Some(" AGENTHUB_OBJECT_STORE_ACCESS_KEY_ID ".to_string()),
+                secret_access_key_env: Some(
+                    " AGENTHUB_OBJECT_STORE_SECRET_ACCESS_KEY ".to_string(),
+                ),
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(config.object_store_backend(), "s3");
+        assert_eq!(config.object_store_root().as_deref(), Some("/tenant-root/"));
+        assert_eq!(
+            config.object_store_public_base_url().as_deref(),
+            Some("https://img.example.test")
+        );
+        assert_eq!(
+            config.object_store_prefix().as_deref(),
+            Some("agenthub/prod")
+        );
+        assert_eq!(
+            config.object_store_bucket().as_deref(),
+            Some("agenthub-artifacts")
+        );
+        assert_eq!(
+            config.object_store_endpoint().as_deref(),
+            Some("https://s3.example.test")
+        );
+        assert_eq!(config.object_store_region().as_deref(), Some("auto"));
+        assert_eq!(
+            config.object_store_access_key_id_env().as_deref(),
+            Some("AGENTHUB_OBJECT_STORE_ACCESS_KEY_ID")
+        );
+        assert_eq!(
+            config.object_store_secret_access_key_env().as_deref(),
+            Some("AGENTHUB_OBJECT_STORE_SECRET_ACCESS_KEY")
+        );
     }
 
     #[test]

--- a/crates/agenthub-object-store/BUILD.bazel
+++ b/crates/agenthub-object-store/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "agenthub_object_store",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "agenthub_object_store",
+    edition = "2024",
+    aliases = aliases(),
+    deps = all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "agenthub_object_store_tests",
+    crate = ":agenthub_object_store",
+    edition = "2024",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/agenthub-object-store/Cargo.toml
+++ b/crates/agenthub-object-store/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "agenthub-object-store"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[features]
+default = []
+s3 = ["opendal/services-s3"]
+
+[dependencies]
+anyhow = "1"
+opendal = { version = "0.58", default-features = false, features = ["services-fs"] }
+sha2 = "0.11"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/agenthub-object-store/src/lib.rs
+++ b/crates/agenthub-object-store/src/lib.rs
@@ -106,15 +106,17 @@ impl AgentHubObjectStore {
         bytes: impl Into<Vec<u8>>,
     ) -> anyhow::Result<StoredObject> {
         let bytes = bytes.into();
+        let size_bytes = bytes.len() as u64;
+        let sha256 = hex_sha256(&bytes);
         let normalized_key = self.scoped_key(key)?;
         self.operator
-            .write(&normalized_key, bytes.clone())
+            .write(&normalized_key, bytes)
             .await
             .with_context(|| format!("write object {normalized_key:?}"))?;
         Ok(StoredObject {
             key: normalized_key,
-            size_bytes: bytes.len() as u64,
-            sha256: hex_sha256(&bytes),
+            size_bytes,
+            sha256,
         })
     }
 
@@ -327,7 +329,13 @@ fn normalize_public_base_url(public_base_url: Option<&str>) -> Option<String> {
 
 fn hex_sha256(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
-    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 #[cfg(test)]

--- a/crates/agenthub-object-store/src/lib.rs
+++ b/crates/agenthub-object-store/src/lib.rs
@@ -1,0 +1,444 @@
+use std::path::Path;
+
+use anyhow::{Context, anyhow};
+use opendal::{Operator, services::Fs};
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "s3")]
+use opendal::services::S3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectStoreBackend {
+    Fs,
+    S3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStoreSettings {
+    pub backend: ObjectStoreBackend,
+    pub root: Option<String>,
+    pub public_base_url: Option<String>,
+    pub bucket: Option<String>,
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub prefix: Option<String>,
+}
+
+impl Default for ObjectStoreSettings {
+    fn default() -> Self {
+        Self {
+            backend: ObjectStoreBackend::Fs,
+            root: None,
+            public_base_url: None,
+            bucket: None,
+            endpoint: None,
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            prefix: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredObject {
+    pub key: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostedImageObject {
+    pub object: StoredObject,
+    pub content_type: String,
+    pub public_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentHubObjectStore {
+    operator: Operator,
+    prefix: Option<String>,
+    public_base_url: Option<String>,
+    backend: ObjectStoreBackend,
+}
+
+impl AgentHubObjectStore {
+    pub fn from_settings(settings: ObjectStoreSettings) -> anyhow::Result<Self> {
+        let prefix = normalize_prefix(settings.prefix.as_deref())?;
+        let public_base_url = normalize_public_base_url(settings.public_base_url.as_deref());
+        match settings.backend {
+            ObjectStoreBackend::Fs => {
+                let root = settings
+                    .root
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| anyhow!("object store fs root is required"))?;
+                let root_path = Path::new(root);
+                if !root_path.is_absolute() {
+                    anyhow::bail!("object store fs root must be absolute: {root}");
+                }
+                std::fs::create_dir_all(root_path)
+                    .with_context(|| format!("create object store fs root {root:?}"))?;
+
+                let builder = Fs::default().root(root);
+                let operator = Operator::new(builder)?;
+                Ok(Self {
+                    operator,
+                    prefix,
+                    public_base_url,
+                    backend: ObjectStoreBackend::Fs,
+                })
+            }
+            ObjectStoreBackend::S3 => Self::from_s3_settings(settings, prefix, public_base_url),
+        }
+    }
+
+    pub fn backend(&self) -> ObjectStoreBackend {
+        self.backend
+    }
+
+    pub async fn put_bytes(
+        &self,
+        key: &str,
+        bytes: impl Into<Vec<u8>>,
+    ) -> anyhow::Result<StoredObject> {
+        let bytes = bytes.into();
+        let normalized_key = self.scoped_key(key)?;
+        self.operator
+            .write(&normalized_key, bytes.clone())
+            .await
+            .with_context(|| format!("write object {normalized_key:?}"))?;
+        Ok(StoredObject {
+            key: normalized_key,
+            size_bytes: bytes.len() as u64,
+            sha256: hex_sha256(&bytes),
+        })
+    }
+
+    pub async fn read_bytes(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        let normalized_key = self.scoped_key(key)?;
+        let bytes = self
+            .operator
+            .read(&normalized_key)
+            .await
+            .with_context(|| format!("read object {normalized_key:?}"))?;
+        Ok(bytes.to_vec())
+    }
+
+    pub async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        let normalized_key = self.scoped_key(key)?;
+        self.operator
+            .delete(&normalized_key)
+            .await
+            .with_context(|| format!("delete object {normalized_key:?}"))?;
+        Ok(())
+    }
+
+    pub async fn exists(&self, key: &str) -> anyhow::Result<bool> {
+        let normalized_key = self.scoped_key(key)?;
+        self.operator
+            .exists(&normalized_key)
+            .await
+            .with_context(|| format!("stat object {normalized_key:?}"))
+    }
+
+    pub fn scoped_key(&self, key: &str) -> anyhow::Result<String> {
+        let key = normalize_object_key(key)?;
+        Ok(match self.prefix.as_deref() {
+            Some(prefix) => format!("{prefix}/{key}"),
+            None => key,
+        })
+    }
+
+    pub async fn put_image_bytes(
+        &self,
+        scope: &str,
+        image_id: &str,
+        content_type: &str,
+        bytes: impl Into<Vec<u8>>,
+    ) -> anyhow::Result<HostedImageObject> {
+        let content_type = normalize_image_content_type(content_type)?;
+        let scope = normalize_object_key(scope)?;
+        let image_id = normalize_object_segment(image_id, "image_id")?;
+        let extension = image_extension(&content_type)?;
+        let key = format!("images/{scope}/{image_id}.{extension}");
+        let object = self.put_bytes(&key, bytes).await?;
+        let public_url = self.public_url_for_key(&object.key);
+        Ok(HostedImageObject {
+            object,
+            content_type,
+            public_url,
+        })
+    }
+
+    pub fn public_url_for_key(&self, key: &str) -> Option<String> {
+        self.public_base_url
+            .as_ref()
+            .map(|base_url| format!("{base_url}/{}", key.trim_start_matches('/')))
+    }
+
+    #[cfg(feature = "s3")]
+    fn from_s3_settings(
+        settings: ObjectStoreSettings,
+        prefix: Option<String>,
+        public_base_url: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let bucket = settings
+            .bucket
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("object store s3 bucket is required"))?;
+
+        let mut builder = S3::default().bucket(bucket);
+        if let Some(root) = settings
+            .root
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            builder = builder.root(root);
+        }
+        if let Some(endpoint) = settings
+            .endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            builder = builder.endpoint(endpoint);
+        }
+        if let Some(region) = settings
+            .region
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            builder = builder.region(region);
+        }
+        if let Some(access_key_id) = settings
+            .access_key_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            builder = builder.access_key_id(access_key_id);
+        }
+        if let Some(secret_access_key) = settings
+            .secret_access_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            builder = builder.secret_access_key(secret_access_key);
+        }
+
+        let operator = Operator::new(builder)?;
+        Ok(Self {
+            operator,
+            prefix,
+            public_base_url,
+            backend: ObjectStoreBackend::S3,
+        })
+    }
+
+    #[cfg(not(feature = "s3"))]
+    fn from_s3_settings(
+        _settings: ObjectStoreSettings,
+        _prefix: Option<String>,
+        _public_base_url: Option<String>,
+    ) -> anyhow::Result<Self> {
+        anyhow::bail!("object store s3 backend requires the agenthub-object-store s3 feature")
+    }
+}
+
+pub fn normalize_object_key(key: &str) -> anyhow::Result<String> {
+    let trimmed = key.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("object key is required");
+    }
+    if trimmed.starts_with('/') {
+        anyhow::bail!("object key must be relative");
+    }
+    if trimmed.contains('\\') {
+        anyhow::bail!("object key must use forward slashes");
+    }
+
+    let mut parts = Vec::new();
+    for part in trimmed.split('/') {
+        match part {
+            "" | "." | ".." => anyhow::bail!("object key contains an invalid segment"),
+            _ => parts.push(part),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+pub fn normalize_image_content_type(content_type: &str) -> anyhow::Result<String> {
+    let content_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    match content_type.as_str() {
+        "image/png" | "image/jpeg" | "image/webp" | "image/gif" => Ok(content_type),
+        _ => anyhow::bail!("unsupported hosted image content type: {content_type}"),
+    }
+}
+
+fn image_extension(content_type: &str) -> anyhow::Result<&'static str> {
+    match content_type {
+        "image/png" => Ok("png"),
+        "image/jpeg" => Ok("jpg"),
+        "image/webp" => Ok("webp"),
+        "image/gif" => Ok("gif"),
+        _ => anyhow::bail!("unsupported hosted image content type: {content_type}"),
+    }
+}
+
+fn normalize_object_segment(segment: &str, field_name: &str) -> anyhow::Result<String> {
+    let segment = normalize_object_key(segment)?;
+    if segment.contains('/') {
+        anyhow::bail!("{field_name} must be a single path segment");
+    }
+    Ok(segment)
+}
+
+fn normalize_prefix(prefix: Option<&str>) -> anyhow::Result<Option<String>> {
+    let Some(prefix) = prefix.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let trimmed = prefix.trim_matches('/');
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(normalize_object_key(trimmed)?))
+}
+
+fn normalize_public_base_url(public_base_url: Option<&str>) -> Option<String> {
+    public_base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.trim_end_matches('/').to_string())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_object_key_rejects_path_escape() {
+        for key in [
+            "",
+            " ",
+            "/absolute",
+            "../escape",
+            "a/../b",
+            "a//b",
+            "a\\b",
+            "./a",
+        ] {
+            assert!(
+                normalize_object_key(key).is_err(),
+                "key should fail: {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_object_key_keeps_scoped_relative_keys() {
+        assert_eq!(
+            normalize_object_key(" team/run/artifact.json ").unwrap(),
+            "team/run/artifact.json"
+        );
+    }
+
+    #[test]
+    fn normalize_image_content_type_allows_raster_images_only() {
+        assert_eq!(
+            normalize_image_content_type(" IMAGE/PNG; charset=binary ").unwrap(),
+            "image/png"
+        );
+        assert!(normalize_image_content_type("image/svg+xml").is_err());
+        assert!(normalize_image_content_type("text/html").is_err());
+    }
+
+    #[tokio::test]
+    async fn fs_store_writes_reads_and_deletes_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AgentHubObjectStore::from_settings(ObjectStoreSettings {
+            backend: ObjectStoreBackend::Fs,
+            root: Some(dir.path().to_string_lossy().to_string()),
+            prefix: Some("teams/team-1".to_string()),
+            ..ObjectStoreSettings::default()
+        })
+        .unwrap();
+
+        let stored = store
+            .put_bytes("runs/run-1/artifact.json", br#"{"ok":true}"#.to_vec())
+            .await
+            .unwrap();
+        assert_eq!(stored.key, "teams/team-1/runs/run-1/artifact.json");
+        assert_eq!(stored.size_bytes, 11);
+        assert_eq!(
+            stored.sha256,
+            "4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+        );
+        assert!(store.exists("runs/run-1/artifact.json").await.unwrap());
+        assert_eq!(
+            store.read_bytes("runs/run-1/artifact.json").await.unwrap(),
+            br#"{"ok":true}"#.to_vec()
+        );
+
+        store.delete("runs/run-1/artifact.json").await.unwrap();
+        assert!(!store.exists("runs/run-1/artifact.json").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn put_image_bytes_scopes_image_keys_and_public_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AgentHubObjectStore::from_settings(ObjectStoreSettings {
+            backend: ObjectStoreBackend::Fs,
+            root: Some(dir.path().to_string_lossy().to_string()),
+            prefix: Some("agenthub/local".to_string()),
+            public_base_url: Some("https://img.example.test/".to_string()),
+            ..ObjectStoreSettings::default()
+        })
+        .unwrap();
+
+        let hosted = store
+            .put_image_bytes("teams/team-1", "avatar-1", "image/png", vec![1, 2, 3, 4])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hosted.object.key,
+            "agenthub/local/images/teams/team-1/avatar-1.png"
+        );
+        assert_eq!(hosted.content_type, "image/png");
+        assert_eq!(
+            hosted.public_url.as_deref(),
+            Some("https://img.example.test/agenthub/local/images/teams/team-1/avatar-1.png")
+        );
+        assert!(
+            store
+                .exists("images/teams/team-1/avatar-1.png")
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .put_image_bytes("teams/team-1", "nested/avatar-1", "image/png", vec![1])
+                .await
+                .is_err()
+        );
+    }
+}

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -28,6 +28,9 @@ or rollout shape.
   - [features/distributed-node-architecture.md](features/distributed-node-architecture.md)
 - Context, memory, and long-running continuity:
   - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+- Storage, object bytes, and metadata authority:
+  - [features/object-storage-opendal.md](features/object-storage-opendal.md)
+  - [features/message-storage-tiering.md](features/message-storage-tiering.md)
 - Agent workflow organization:
   - [features/agent-operating-workflows.md](features/agent-operating-workflows.md)
   - [features/team-system-prompt-contract.md](features/team-system-prompt-contract.md)
@@ -69,6 +72,11 @@ or rollout shape.
 ### How is long-running memory and context handled?
 
 - [features/team-workspace-memory-contract.md](features/team-workspace-memory-contract.md)
+
+### How are uploaded files and object bytes stored?
+
+- [features/object-storage-opendal.md](features/object-storage-opendal.md)
+- [features/logical-message-metadata-contract.md](features/logical-message-metadata-contract.md)
 
 ### How are Team system prompts and runtime prompt tails organized?
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -92,6 +92,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/logical-message-metadata-contract.md`
 - `docs/features/message-archive-lancedb.md`
 - `docs/features/message-storage-tiering.md`
+- `docs/features/object-storage-opendal.md`
 - `docs/features/agent-operating-workflows.md`
 - `docs/features/team-system-prompt-contract.md`
 - `docs/features/test-regression-guardrails.md`

--- a/docs/features/agent-operating-workflows.md
+++ b/docs/features/agent-operating-workflows.md
@@ -69,7 +69,7 @@ Use these categories when locating or compacting specs:
 | Access control and security | User roles, capabilities, route authorization, and runtime permission boundaries. | `access-control-and-roles.md`, `runtime-diagnostics.md` |
 | Team execution and coordination | Task ownership, mailbox, actor CLI, collaboration behavior. | `team-execution-vocabulary.md`, `team-mailbox-intake-and-ownership.md`, `actor-foundation.md`, `teams-collaboration-playbook.md` |
 | Distributed and node operation | Nodes, node registry, internal transport, multi-node execution. | `agent-nodes.md`, `distributed-node-architecture.md`, `distributed-node-registry-and-gossip.md` |
-| Storage and message authority | Durable message state, metadata, archive, body tiering, migration safety. | `logical-message-metadata-contract.md`, `message-archive-lancedb.md`, `message-storage-tiering.md` |
+| Storage and message authority | Durable message state, metadata, archive, body tiering, object bytes, migration safety. | `logical-message-metadata-contract.md`, `message-archive-lancedb.md`, `message-storage-tiering.md`, `object-storage-opendal.md` |
 | Testing and quality guardrails | Regression evidence, fixture consistency, protected objects. | `test-regression-guardrails.md` |
 | Observability and operations | Debugging, profiling, diagnostic evidence, release/install operation. | `runtime-diagnostics.md`, `pyroscope-profiling.md`, `npm-binary-distribution.md`, `debian-systemd-distribution.md` |
 | Integrations | Linkers, OAuth/linker boundaries, external runtime integration. | `app-linkers.md`, `slock-oauth-linkers.md` |

--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -1,0 +1,147 @@
+# Object Storage With OpenDAL
+
+## Problem
+
+AgentHub needs a storage boundary for uploaded files, generated artifacts, and future large
+attachments that can outlive local browser sessions and move from local disk to AWS S3 or
+S3-compatible services without rewriting every caller. Local paths alone are not a stable contract
+for multi-node operation, cleanup, access checks, or remote upload flows.
+
+## Scope
+
+- A repository-owned object storage abstraction backed by Apache OpenDAL.
+- A default local filesystem backend for development and single-node installs.
+- An optional S3-compatible backend for AWS S3, Cloudflare R2, MinIO, and similar providers.
+- Secret-free configuration shape for object store endpoints, buckets, prefixes, and credential
+  environment variable references.
+- Stable key, checksum, metadata, image-hosting, and publish/link rules that future file upload APIs
+  must follow.
+
+## Non-Goals
+
+- Replacing SQLite metadata tables with object storage.
+- Migrating existing Team context artifact rows in this slice.
+- Exposing public object URLs as an authorization boundary.
+- Implementing multipart uploads, resumable uploads, or presigned browser uploads in the first
+  backend slice.
+- Accepting SVG or HTML-backed image uploads in the first image-hosting slice.
+- Storing access keys, secret keys, or session tokens in SQLite or committed config.
+
+## Architecture
+
+Object storage is split into two planes:
+
+- Metadata/control plane: SQLite rows own resource identity, authorization scope, lifecycle state,
+  checksum, size, MIME type, and attachment-to-message links.
+- Data plane: OpenDAL writes and reads object bytes from the configured backend.
+
+The first implementation adds `agenthub-object-store` as a focused crate. It owns key validation,
+prefix joining, OpenDAL operator construction, byte writes, reads, deletes, existence checks, and
+SHA-256/size reporting. The crate defaults to OpenDAL `fs`; S3 support is compiled behind the crate
+`s3` feature so normal local and Bazel builds do not pull S3-only dependencies unless the release
+profile asks for them.
+
+Configuration lives under `[object_store]`:
+
+```toml
+[object_store]
+backend = "fs"
+root = "~/.agenthub/objects"
+prefix = "agenthub/local"
+```
+
+S3-compatible deployments use the same logical surface and keep credentials indirect:
+
+```toml
+[object_store]
+backend = "s3"
+bucket = "agenthub-artifacts"
+endpoint = "https://s3.amazonaws.com"
+region = "us-east-1"
+prefix = "agenthub/prod"
+public_base_url = "https://img.example.com"
+access_key_id_env = "AGENTHUB_OBJECT_STORE_ACCESS_KEY_ID"
+secret_access_key_env = "AGENTHUB_OBJECT_STORE_SECRET_ACCESS_KEY"
+```
+
+Future upload flows should follow a prepare/write/publish sequence:
+
+1. Prepare a metadata intent with owner scope, expected size, MIME type, and optional checksum.
+2. Generate a scoped object key from server-owned identifiers, never from raw user paths.
+3. Write bytes through OpenDAL.
+4. Verify actual size and checksum.
+5. Publish or link the metadata row only after the durable write succeeds.
+6. Clean up unlinked or failed intents from metadata state, not by blindly scanning object prefixes.
+
+Image hosting is a specialized object-storage consumer. The storage layer provides a constrained
+helper that writes raster image bytes under:
+
+```text
+images/<scope>/<image_id>.<extension>
+```
+
+Only `image/png`, `image/jpeg`, `image/webp`, and `image/gif` are accepted in the first slice. The
+helper may return a `public_base_url`-derived URL when configured, but API handlers must still treat
+that URL as a delivery address, not as the authorization decision.
+
+## Contracts
+
+- Object keys are relative, slash-separated, and normalized before reaching OpenDAL.
+- Empty keys, absolute paths, `.`/`..` segments, duplicate slashes, and backslashes are rejected.
+- Callers may provide a logical key only inside their authorized resource scope; storage prefixes are
+  joined by the object-store layer.
+- SQLite metadata remains the authority for ownership, access control, lifecycle, and deletion
+  eligibility.
+- Object store presence does not grant read access. API handlers must authorize against the owning
+  Team, channel, task, agent, or artifact row before reading bytes or issuing a future presigned URL.
+- Public image URLs must be issued only after the owner scope is validated and the metadata row is
+  published. A CDN URL is not proof that a user may create, replace, or delete an image.
+- Writes must record size and SHA-256 so repair and migration jobs can verify object integrity.
+- Hosted images use server-generated object keys and allowlisted MIME types. SVG support needs a
+  separate sanitization and content-security review before it can be enabled.
+- Credentials are loaded from environment variables named by config, or by the provider chain when
+  intentionally left unset; secret values must not be stored in DB rows, config fixtures, logs, or
+  user-visible diagnostics.
+- S3-compatible endpoints are treated as backend configuration, not product authority. AWS S3, R2,
+  MinIO, and similar providers should share the same AgentHub metadata and key rules.
+
+## Validation Matrix
+
+| Area | Evidence |
+| --- | --- |
+| Key normalization | Unit tests reject path escape shapes and accept scoped relative keys. |
+| Local backend | Focused async test writes, reads, checks existence, deletes, and verifies size/checksum. |
+| Image hosting helper | Focused async test writes a scoped raster image object, rejects nested image ids, and returns a normalized public URL. |
+| Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
+| Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
+| Future S3 rollout | Add an integration test against MinIO or a provisioned S3-compatible bucket before enabling S3 in release builds. |
+
+## Operational Notes
+
+- The default local root should live under `~/.agenthub/objects` once the runtime wires the store into
+  application state.
+- Prefixes should include deployment or tenant scope when several AgentHub instances share one
+  bucket.
+- `public_base_url` is optional. Use it only for deployments with a reviewed CDN/object gateway path
+  and keep mutating API authorization on AgentHub metadata.
+- Cleanup should be metadata-driven: delete unlinked failed uploads only after their metadata state
+  is older than the grace period and no published row references the same object key.
+- S3/R2/MinIO production use should add operation latency, byte count, error-class, and cleanup
+  counters before large user-facing uploads become default-on.
+- Existing local Team context artifacts remain compatible until their metadata schema is explicitly
+  migrated to record backend/key instead of only absolute local paths.
+
+## Open Risks
+
+- Existing artifact tables store local filesystem paths; moving those rows to object storage needs a
+  schema migration and read-compatibility plan.
+- Browser-direct upload requires short-lived presign or upload-token semantics plus size/checksum
+  verification at publish time.
+- S3-compatible providers differ in multipart, path-style, and checksum behavior; each supported
+  provider needs a small compatibility fixture before being documented as production-ready.
+- Object lifecycle bugs can leak storage cost or delete still-referenced bytes unless metadata
+  reference checks are kept explicit.
+
+## Source Journals
+
+- [2026-07-16-object-storage-opendal.md](../journal/2026-07-16-object-storage-opendal.md)

--- a/docs/journal/2026-07-16-object-storage-opendal.md
+++ b/docs/journal/2026-07-16-object-storage-opendal.md
@@ -1,0 +1,53 @@
+# Object Storage OpenDAL Foundation
+
+## Summary
+
+Added the first AgentHub object storage foundation around OpenDAL. The slice introduces a small Rust
+crate for normalized object keys, local filesystem writes, size/checksum reporting, and optional
+S3-compatible construction behind a feature gate. It also adds the first constrained image-hosting
+helper for future graph-bed style uploads.
+
+## Background
+
+AgentHub needs file upload and artifact storage that can start local and later target AWS S3 or
+S3-compatible services. The design follows the existing AgentHub storage boundary: SQLite remains
+the metadata/control plane, while object storage stores bytes only.
+
+## Scope
+
+- New `agenthub-object-store` crate.
+- Secret-free `[object_store]` config accessors in `agenthub-config`.
+- Optional `public_base_url` config for deployments that front object bytes through a CDN or object
+  gateway.
+- Bazel test and coverage target registration for the new crate.
+- Canonical feature spec for object storage contracts and rollout risks.
+
+## Key Decisions
+
+- Keep OpenDAL behind a focused crate instead of letting upload handlers build operators directly.
+- Compile S3 support behind the crate `s3` feature while keeping local `fs` available by default.
+- Reject unsafe object keys before they reach a backend.
+- Treat graph-bed uploads as a constrained image-hosting consumer: server-scoped keys, raster MIME
+  allowlist, checksum/size recording, and optional public URL derivation.
+- Treat object store writes as unpublished until DB metadata verifies and links size/checksum.
+- Defer Team context artifact migration because its current table stores absolute local paths.
+
+## Validation
+
+Planned focused checks:
+
+```bash
+cargo test -p agenthub-object-store
+cargo test -p agenthub-config object_store
+cargo check -p agenthub-object-store --features s3
+cargo fmt --all --check
+```
+
+## Follow-Ups
+
+- Wire the object store into runtime application state with a default `~/.agenthub/objects` local
+  root.
+- Add a metadata schema for uploaded files that stores backend, object key, size, checksum, MIME
+  type, owner scope, publish state, and cleanup timestamps.
+- Add image-hosting API routes for graph-bed uploads after the metadata schema exists.
+- Add an S3-compatible integration fixture before enabling the S3 feature in release builds.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -36,7 +36,7 @@ rg -n "Validation|Follow-Ups|Key Decisions" docs/journal/2026-06-*.md
 | Release, packaging, and install paths | `docs/features/npm-binary-distribution.md`, `docs/features/debian-systemd-distribution.md` | `*-release-*.md`, `*-npm-*.md`, `*-debian-*.md`, `*-homebrew-*.md` |
 | CI, Bazel, coverage, and dependencies | `docs/developer-setup.md` | `*-ci-*.md`, `*-bazel-*.md`, `*-codecov-*.md`, `*-dependabot-*.md` |
 | Access control, auth, and permissions | `docs/features/access-control-and-roles.md`, `docs/features/acp-runtime.md` | `*-auth-*.md`, `*-access-control-*.md`, `*-permission-*.md` |
-| Message archive and metadata | `docs/features/logical-message-metadata-contract.md`, `docs/features/message-archive-lancedb.md` | `*-message-*.md`, `*-metadata-*.md`, `*-lancedb-*.md` |
+| Message archive, metadata, and object storage | `docs/features/logical-message-metadata-contract.md`, `docs/features/message-archive-lancedb.md`, `docs/features/object-storage-opendal.md` | `*-message-*.md`, `*-metadata-*.md`, `*-lancedb-*.md`, `*-object-storage-*.md` |
 | RARA and app integrations | `docs/features/rara-direct-integration.md`, `docs/features/app-linkers.md` | `*-rara-*.md`, `*-app-*.md`, `*-linker-*.md` |
 
 ## Monthly Rollups
@@ -147,6 +147,8 @@ Main shape:
   skill/checklist entry points, and tool-neutral durable knowledge boundaries.
 - Access-control planning now defines user roles, capability gates, and route authorization
   guardrails for moving beyond root-only checks.
+- Object storage now has an OpenDAL-backed foundation and stable metadata/object-byte boundary for
+  local filesystem and future S3-compatible uploads.
 
 Start with:
 
@@ -154,6 +156,7 @@ Start with:
 - `2026-07-15-agent-operating-workflows.md`
 - `2026-07-15-team-system-prompt-contract.md`
 - `2026-07-16-access-control-roles.md`
+- `2026-07-16-object-storage-opendal.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -54,6 +54,12 @@ Stable contract:
 
 - [ ] `P1` Implement the RocksDB `cf_index` delivery projection and its authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill is complete; keep normal reads on SQLite until ordered index reads, integrity checks, and backup validation are in place. Do not drop SQLite bodies before the Phase 2 rollout decision.
 
+## Object Storage
+
+- [ ] `P1` Wire the OpenDAL object store into runtime application state with a default local root, then add the upload metadata schema that stores backend, object key, size, checksum, MIME type, owner scope, publish state, and cleanup timestamps. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
+- [ ] `P1` Add graph-bed image hosting routes after the upload metadata schema lands: accept allowlisted raster images, publish only after checksum/size verification, and return public URLs only after owner-scope authorization.
+- [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
+
 ## Observability, CI, And Docs
 
 - [ ] `P2` Continue `features` compaction wave 2: finish a second pass over residual Team/UI micro-journals, extract stable decisions into canonical feature specs, and leave explicit supersession pointers on merged journals so only records with distinct implementation evidence remain. See [features/README.md](features/README.md).


### PR DESCRIPTION
## Summary

- Add `agenthub-object-store`, an OpenDAL-backed object storage crate with local filesystem support by default and optional S3-compatible support behind the `s3` feature.
- Add a constrained image-hosting helper for graph-bed uploads: server-scoped keys, raster MIME allowlist, checksum/size reporting, and optional public URL derivation.
- Add secret-free `[object_store]` config accessors plus canonical docs, rollout notes, TODO follow-ups, and Bazel workflow target registration.

## Why

AgentHub needs a file/object storage boundary that can start on local disk and later move to AWS S3, R2, MinIO, or another S3-compatible backend without tying upload handlers to provider SDKs. The graph-bed use case needs the same storage boundary with tighter image-specific constraints.

## Design Notes

- SQLite metadata remains the control plane for owner scope, publish state, authorization, lifecycle, size, checksum, and cleanup.
- OpenDAL stores bytes only.
- Hosted images currently allow `image/png`, `image/jpeg`, `image/webp`, and `image/gif`; SVG is intentionally excluded until sanitization and content-security rules exist.
- `public_base_url` is a delivery URL helper, not an authorization boundary.

## Tests

```bash
cargo test -p agenthub-object-store
cargo test -p agenthub-config object_store
cargo check -p agenthub-object-store --features s3
cargo fmt --all --check
git diff --check
```

Not completed locally:

```bash
bazel query '//crates/agenthub-object-store:*'
```

Local Bazel query stayed in the loading phase. The same loading hang reproduced with an existing crate query (`//crates/agenthub-message-store:*`), so this looks like a local Bazel/crate_universe state issue rather than a new object-store-only build error.

## Related Issues

None.
