### PR TITLE
feat(storage): add shared upload service

### DIFF
--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -72,11 +72,13 @@ agenthub actor upload --file report.json --scope teams/team-1
 agenthub actor upload --file screenshot.png --scope teams/team-1 --image
 ```
 
-The actor CLI upload path owns command parsing, local file reading, and publish compensation. The
+The actor CLI upload path owns command parsing and local file reading. The shared
+`ObjectUploadService` owns upload publication, metadata insertion, and best-effort compensation. The
 database owns `object_uploads` metadata through a dedicated `object_uploads` module. The object-store
 crate still owns byte storage only. If metadata publication fails after the byte write, AgentHub
 attempts to delete the just-written object before returning the error. When `[object_store].root` is
-omitted for the local filesystem backend, CLI upload defaults to `~/.agenthub/objects`.
+omitted for the local filesystem backend, runtime state and CLI upload both default to
+`~/.agenthub/objects`.
 
 Upload flows should follow a prepare/write/publish sequence:
 
@@ -126,16 +128,15 @@ that URL as a delivery address, not as the authorization decision.
 | Key normalization | Unit tests reject path escape shapes and accept scoped relative keys. |
 | Local backend | Focused async test writes, reads, checks existence, deletes, and verifies size/checksum. |
 | Image hosting helper | Focused async test writes a scoped raster image object, rejects nested image ids, and returns a normalized public URL. |
-| Agent upload entry | Parser and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
+| Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
 | Future S3 rollout | Add an integration test against MinIO or a provisioned S3-compatible bucket before enabling S3 in release builds. |
 
 ## Operational Notes
 
-- The default local root lives under `~/.agenthub/objects` for actor CLI uploads when `backend = "fs"`
-  and no explicit root is configured. Runtime application state should use the same default when the
-  browser/API upload surface lands.
+- The default local root lives under `~/.agenthub/objects` for shared runtime and actor CLI uploads
+  when `backend = "fs"` and no explicit root is configured.
 - Prefixes should include deployment or tenant scope when several AgentHub instances share one
   bucket.
 - `public_base_url` is optional. Use it only for deployments with a reviewed CDN/object gateway path

--- a/docs/journal/2026-07-16-object-storage-opendal.md
+++ b/docs/journal/2026-07-16-object-storage-opendal.md
@@ -64,6 +64,9 @@ The next slice adds the first agent-facing upload entry without exposing browser
 - Upload code is split by responsibility: actor CLI upload orchestration lives under
   `src/actor_cli/upload.rs`, upload metadata helpers live under `agenthub-db::object_uploads`, and
   `agenthub-object-store` remains the byte-storage boundary.
+- Runtime upload publication is centralized in `ObjectUploadService`; `AppState` owns the shared
+  service and actor CLI reuses the same owner-scope parser, default local root, metadata authority,
+  and cleanup compensation path that future API routes should call.
 - Local filesystem uploads default to `~/.agenthub/objects` when `[object_store].root` is omitted.
 - Metadata publication failure triggers a best-effort delete of the just-written object.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,8 +56,8 @@ Stable contract:
 
 ## Object Storage
 
-- [ ] `P1` Wire the OpenDAL object store into runtime application state so browser/API upload routes can reuse the same default local root and metadata authority as `agenthub actor upload`. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
-- [ ] `P1` Add graph-bed image hosting routes on top of `object_uploads`: accept allowlisted raster images, publish only after checksum/size verification, and return public URLs only after owner-scope authorization.
+- [ ] `P1` Add browser/API upload routes on top of the shared object upload service so non-CLI callers reuse the same default local root, owner-scope parser, metadata authority, and cleanup compensation as `agenthub actor upload`. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
+- [ ] `P1` Add graph-bed image hosting routes on top of the shared object upload service: accept allowlisted raster images, publish only after checksum/size verification, and return public URLs only after owner-scope authorization.
 - [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
 
 ## Observability, CI, And Docs

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope};
 use crate::team::{TeamActorMessageTransport, TeamTaskListQuery, TeamTaskPriority, TeamTaskStatus};
 use agenthub_team_actor::{
     ACTOR_MAIN_PEER_ID, ACTOR_NODE_PEER_ID, ActorMessageHandlingDisposition,
@@ -148,12 +149,6 @@ impl TeamTaskNoteKind {
             Self::Result => "result",
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ActorUploadKind {
-    Object,
-    Image,
 }
 
 #[derive(Debug)]
@@ -319,11 +314,11 @@ enum ActorCommand {
     },
     Upload {
         actor_id: String,
-        owner_scope: String,
+        owner_scope: ObjectUploadOwnerScope,
         file_path: String,
         content_type: Option<String>,
         display_name: Option<String>,
-        kind: ActorUploadKind,
+        kind: ObjectUploadKind,
     },
 }
 mod execute;
@@ -3803,11 +3798,12 @@ mod tests {
             (
                 ActorCommand::Upload {
                     actor_id: "worker".to_string(),
-                    owner_scope: "teams/team-1".to_string(),
+                    owner_scope: ObjectUploadOwnerScope::parse("teams/team-1")
+                        .expect("parse owner scope"),
                     file_path: "screenshot.png".to_string(),
                     content_type: Some("image/png".to_string()),
                     display_name: None,
-                    kind: ActorUploadKind::Image,
+                    kind: ObjectUploadKind::Image,
                 },
                 ActorOutputPreference::ToonPreferred,
             ),

--- a/src/actor_cli/parse.rs
+++ b/src/actor_cli/parse.rs
@@ -1,8 +1,8 @@
 use super::help::{actor_usage, is_help_flag, is_help_subcommand, resolve_actor_help_topic};
 use super::{
     ActorCommand, ActorOutputMode, ActorSendIdempotency, ActorSendPayloadSource,
-    ActorSendTargetRef, ActorUploadKind, TIME_TRIGGER_FUTURE_SAFETY_MARGIN_SECONDS,
-    TeamTaskNoteKind, build_actor_send_default_idempotency_key,
+    ActorSendTargetRef, TIME_TRIGGER_FUTURE_SAFETY_MARGIN_SECONDS, TeamTaskNoteKind,
+    build_actor_send_default_idempotency_key,
 };
 use std::fs;
 
@@ -10,6 +10,7 @@ use crate::actor_runtime_env::{
     ACTOR_RUNTIME_ACTOR_ID_ENV, ACTOR_RUNTIME_AGENT_ID_ENV, ACTOR_RUNTIME_CHANNEL_ENV,
     ACTOR_RUNTIME_CURRENT_RUN_ID_ENV, ACTOR_RUNTIME_TEAM_ID_ENV, normalized_env_var,
 };
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope};
 use crate::team::{
     TEAM_TASK_PRIORITY_VALUES, TEAM_TASK_STATUS_VALUES, TeamActorMessageTransport,
     TeamTaskListQuery, TeamTaskPriority, TeamTaskStatus,
@@ -2236,7 +2237,7 @@ pub(super) fn parse_actor_command(
             let mut file_path = None;
             let mut content_type = None;
             let mut display_name = None;
-            let mut kind = ActorUploadKind::Object;
+            let mut kind = ObjectUploadKind::Object;
             let mut idx = 1;
             while idx < args.len() {
                 match args[idx].as_str() {
@@ -2278,15 +2279,17 @@ pub(super) fn parse_actor_command(
                                 .ok_or_else(|| anyhow::anyhow!("--name requires a value"))?,
                         );
                     }
-                    "--image" => kind = ActorUploadKind::Image,
+                    "--image" => kind = ObjectUploadKind::Image,
                     other => return Err(anyhow::anyhow!("unknown flag for upload: {}", other)),
                 }
                 idx += 1;
             }
             Ok(ActorCommand::Upload {
                 actor_id: take_actor_id(actor_id)?,
-                owner_scope: owner_scope
-                    .ok_or_else(|| anyhow::anyhow!("upload requires --scope <owner_scope>"))?,
+                owner_scope: ObjectUploadOwnerScope::parse(
+                    &owner_scope
+                        .ok_or_else(|| anyhow::anyhow!("upload requires --scope <owner_scope>"))?,
+                )?,
                 file_path: file_path
                     .ok_or_else(|| anyhow::anyhow!("upload requires --file <path>"))?,
                 content_type,
@@ -2512,7 +2515,8 @@ pub(super) fn parse_actor_command(
 #[cfg(test)]
 mod tests {
     use super::parse_actor_args;
-    use crate::actor_cli::{ActorCommand, ActorUploadKind};
+    use crate::actor_cli::ActorCommand;
+    use crate::object_upload::ObjectUploadKind;
     use serde_json::json;
 
     #[test]
@@ -2600,11 +2604,11 @@ mod tests {
                 kind,
             } => {
                 assert_eq!(actor_id, "worker");
-                assert_eq!(owner_scope, "teams/team-1");
+                assert_eq!(owner_scope.to_string(), "teams/team-1");
                 assert_eq!(file_path, "screenshot.png");
                 assert_eq!(content_type.as_deref(), Some("image/png"));
                 assert_eq!(display_name.as_deref(), Some("screen.png"));
-                assert_eq!(kind, ActorUploadKind::Image);
+                assert_eq!(kind, ObjectUploadKind::Image);
             }
             other => panic!("expected upload command, got {other:?}"),
         }

--- a/src/actor_cli/upload.rs
+++ b/src/actor_cli/upload.rs
@@ -1,13 +1,8 @@
 use std::path::Path;
 
-use agenthub_object_store::{
-    AgentHubObjectStore, ObjectStoreBackend, ObjectStoreSettings, StoredObject,
+use crate::object_upload::{
+    ObjectUploadKind, ObjectUploadOwnerScope, ObjectUploadRequest, ObjectUploadService,
 };
-use anyhow::Context;
-use chrono::Utc;
-use uuid::Uuid;
-
-use super::ActorUploadKind;
 
 const MAX_UPLOAD_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
@@ -29,62 +24,28 @@ enum UploadError {
 
 pub(super) async fn run_actor_upload(
     actor_id: String,
-    owner_scope: String,
+    owner_scope: ObjectUploadOwnerScope,
     file_path: String,
     content_type: Option<String>,
     display_name: Option<String>,
-    kind: ActorUploadKind,
+    kind: ObjectUploadKind,
 ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
     let config = agenthub_config::AppConfig::load_with_info()?.0;
-    let settings = object_store_settings_from_config(&config)?;
-    let store = AgentHubObjectStore::from_settings(settings)?;
     let file_name = upload_display_name(&file_path, display_name)?;
     let content_type = infer_content_type(&file_path, content_type)?;
     let bytes = read_upload_file(&file_path).await?;
     let db = agenthub_db::init_db().await?;
-    let upload_id = Uuid::now_v7().to_string();
-    let (object, public_url) = store_actor_upload(
-        &store,
-        &upload_id,
-        &owner_scope,
-        &file_name,
-        &content_type,
-        kind,
-        bytes,
-    )
-    .await?;
-    let now = Utc::now().timestamp();
-    let size_bytes = i64::try_from(object.size_bytes)
-        .context("uploaded object is too large for SQLite metadata size_bytes")?;
-    let upload = agenthub_db::NewObjectUpload {
-        id: &upload_id,
-        owner_scope: &owner_scope,
-        backend: object_store_backend_name(store.backend()),
-        object_key: &object.key,
-        original_filename: &file_name,
-        content_type: &content_type,
-        size_bytes,
-        sha256: &object.sha256,
-        public_url: public_url.as_deref(),
-        created_by_actor_id: &actor_id,
-        publish_state: "published",
-        created_at: now,
-        published_at: Some(now),
-        cleanup_after: None,
-    };
-    match agenthub_db::insert_object_upload(&db, &upload).await {
-        Ok(record) => Ok(record),
-        Err(err) => {
-            if let Err(cleanup_err) = store.delete_stored_object(&object).await {
-                tracing::warn!(
-                    object_key = %object.key,
-                    error = %cleanup_err,
-                    "failed to delete object after upload metadata insert failure"
-                );
-            }
-            Err(err).context("failed to publish upload metadata")
-        }
-    }
+    let service = ObjectUploadService::from_config(db, &config)?;
+    service
+        .upload(ObjectUploadRequest {
+            actor_id,
+            owner_scope,
+            file_name,
+            content_type,
+            kind,
+            bytes,
+        })
+        .await
 }
 
 async fn read_upload_file(file_path: &str) -> Result<Vec<u8>, UploadError> {
@@ -108,55 +69,6 @@ async fn read_upload_file(file_path: &str) -> Result<Vec<u8>, UploadError> {
             path: file_path.to_string(),
             source,
         })
-}
-
-fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
-    match backend {
-        ObjectStoreBackend::Fs => "fs",
-        ObjectStoreBackend::S3 => "s3",
-    }
-}
-
-fn object_store_settings_from_config(
-    config: &agenthub_config::AppConfig,
-) -> anyhow::Result<ObjectStoreSettings> {
-    let backend = match config.object_store_backend().as_str() {
-        "fs" => ObjectStoreBackend::Fs,
-        "s3" => ObjectStoreBackend::S3,
-        other => anyhow::bail!("unsupported object_store.backend: {other}"),
-    };
-    let root = match config.object_store_root() {
-        Some(root) => Some(root),
-        None if backend == ObjectStoreBackend::Fs => Some(
-            agenthub_config::path_utils::expand_tilde("~/.agenthub/objects"),
-        ),
-        None => None,
-    };
-    let access_key_id = config
-        .object_store_access_key_id_env()
-        .map(|name| read_secret_env(&name, "object_store.access_key_id_env"))
-        .transpose()?;
-    let secret_access_key = config
-        .object_store_secret_access_key_env()
-        .map(|name| read_secret_env(&name, "object_store.secret_access_key_env"))
-        .transpose()?;
-
-    Ok(ObjectStoreSettings {
-        backend,
-        root,
-        public_base_url: config.object_store_public_base_url(),
-        bucket: config.object_store_bucket(),
-        endpoint: config.object_store_endpoint(),
-        region: config.object_store_region(),
-        access_key_id,
-        secret_access_key,
-        prefix: config.object_store_prefix(),
-    })
-}
-
-fn read_secret_env(name: &str, config_key: &str) -> anyhow::Result<String> {
-    std::env::var(name)
-        .with_context(|| format!("{config_key} references missing environment variable {name}"))
 }
 
 fn normalize_upload_segment(value: &str, field: &str) -> anyhow::Result<String> {
@@ -200,33 +112,10 @@ fn infer_content_type(file_path: &str, content_type: Option<String>) -> anyhow::
     }
 }
 
-async fn store_actor_upload(
-    store: &AgentHubObjectStore,
-    upload_id: &str,
-    owner_scope: &str,
-    file_name: &str,
-    content_type: &str,
-    kind: ActorUploadKind,
-    bytes: Vec<u8>,
-) -> anyhow::Result<(StoredObject, Option<String>)> {
-    match kind {
-        ActorUploadKind::Object => {
-            let key = format!("uploads/{owner_scope}/{upload_id}/{file_name}");
-            let object = store.put_bytes(&key, bytes).await?;
-            Ok((object, None))
-        }
-        ActorUploadKind::Image => {
-            let image = store
-                .put_image_bytes(owner_scope, upload_id, content_type, bytes)
-                .await?;
-            Ok((image.object, image.public_url))
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     fn temp_upload_path(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("agenthub-upload-{name}-{}", Uuid::new_v4()))

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1236,6 +1236,7 @@ mod tests {
     use crate::auth::AuthService;
     use crate::internal::client::InternalGrpcPeerClientConfig;
     use crate::internal::tls::InternalGrpcSecurityMode;
+    use crate::object_upload::ObjectUploadService;
     use crate::push::PushService;
     use crate::state::AppState;
     use crate::team::TeamManager;
@@ -1824,6 +1825,7 @@ mod tests {
             internal_peer_client,
         ));
         let teams = Arc::new(TeamManager::new_with_event_dbs(db.clone(), event_dbs));
+        let object_uploads = Arc::new(test_object_upload_service(db.clone()));
         AppState {
             db,
             linker_http: crate::linkers::AppLinkerService::default_http_client(),
@@ -1832,10 +1834,33 @@ mod tests {
             push,
             auth,
             acp_permissions: permissions,
+            object_uploads,
             agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
             default_worktree_root: config.default_worktree_root(),
             body_store: None,
         }
+    }
+
+    fn test_object_upload_service(db: SqlitePool) -> ObjectUploadService {
+        let root = std::env::temp_dir()
+            .join(format!("agenthub-api-agents-objects-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .to_string();
+        let config = AppConfig {
+            object_store: Some(agenthub_config::ObjectStoreConfig {
+                backend: Some("fs".to_string()),
+                root: Some(root),
+                public_base_url: None,
+                prefix: None,
+                bucket: None,
+                endpoint: None,
+                region: None,
+                access_key_id_env: None,
+                secret_access_key_env: None,
+            }),
+            ..Default::default()
+        };
+        ObjectUploadService::from_config(db, &config).expect("create object upload service")
     }
 
     async fn build_test_state_with_db(db: SqlitePool) -> AppState {

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -24,6 +24,7 @@ use crate::agent::AgentManager;
 use crate::agent::WorktreeMode;
 use crate::agenthub_binary::resolve_agenthub_binary_path;
 use crate::auth::AuthService;
+use crate::object_upload::ObjectUploadService;
 use crate::push::PushService;
 use crate::state::AppState;
 use crate::team::{
@@ -288,6 +289,7 @@ async fn build_test_state_with_db_source_and_archive(
         TeamManager::new_with_event_dbs_and_message_archive(db.clone(), event_dbs, message_archive)
             .with_body_store(body_store.clone()),
     );
+    let object_uploads = Arc::new(test_object_upload_service(db.clone()));
     let state = AppState {
         db,
         linker_http: crate::linkers::AppLinkerService::default_http_client(),
@@ -296,6 +298,7 @@ async fn build_test_state_with_db_source_and_archive(
         push,
         auth,
         acp_permissions: permissions,
+        object_uploads,
         agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
         default_worktree_root: config.default_worktree_root(),
         body_store,
@@ -304,6 +307,28 @@ async fn build_test_state_with_db_source_and_archive(
         seed_default_team_member_agents(&state).await;
     }
     state
+}
+
+fn test_object_upload_service(db: SqlitePool) -> ObjectUploadService {
+    let root = std::env::temp_dir()
+        .join(format!("agenthub-test-objects-{}", Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+    let config = AppConfig {
+        object_store: Some(agenthub_config::ObjectStoreConfig {
+            backend: Some("fs".to_string()),
+            root: Some(root),
+            prefix: None,
+            public_base_url: None,
+            bucket: None,
+            endpoint: None,
+            region: None,
+            access_key_id_env: None,
+            secret_access_key_env: None,
+        }),
+        ..Default::default()
+    };
+    ObjectUploadService::from_config(db, &config).expect("create object upload service")
 }
 
 async fn create_test_db() -> SqlitePool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod internal;
 mod linkers;
 pub mod message_body_store;
 mod migrate_cli;
+pub mod object_upload;
 pub use agenthub_config::path_utils;
 mod push;
 mod sse;

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -1,0 +1,255 @@
+use std::fmt;
+
+use agenthub_object_store::{
+    AgentHubObjectStore, ObjectStoreBackend, ObjectStoreSettings, StoredObject,
+};
+use anyhow::Context;
+use chrono::Utc;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectUploadKind {
+    Object,
+    Image,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectUploadOwnerScope {
+    Team(String),
+    Task(String),
+    Agent(String),
+}
+
+impl ObjectUploadOwnerScope {
+    pub fn parse(value: &str) -> anyhow::Result<Self> {
+        let trimmed = value.trim();
+        let Some((kind, id)) = trimmed.split_once('/') else {
+            anyhow::bail!(
+                "owner scope must be teams/<team_id>, tasks/<task_id>, or agents/<agent_id>"
+            );
+        };
+        if id.is_empty() || id.contains('/') || id.contains('\\') || id == "." || id == ".." {
+            anyhow::bail!("owner scope id must be a single non-empty path segment");
+        }
+        match kind {
+            "teams" => Ok(Self::Team(id.to_string())),
+            "tasks" => Ok(Self::Task(id.to_string())),
+            "agents" => Ok(Self::Agent(id.to_string())),
+            _ => anyhow::bail!(
+                "owner scope must be teams/<team_id>, tasks/<task_id>, or agents/<agent_id>"
+            ),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Team(value) | Self::Task(value) | Self::Agent(value) => value,
+        }
+    }
+
+    fn prefix(&self) -> &'static str {
+        match self {
+            Self::Team(_) => "teams",
+            Self::Task(_) => "tasks",
+            Self::Agent(_) => "agents",
+        }
+    }
+}
+
+impl fmt::Display for ObjectUploadOwnerScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.prefix(), self.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectUploadRequest {
+    pub actor_id: String,
+    pub owner_scope: ObjectUploadOwnerScope,
+    pub file_name: String,
+    pub content_type: String,
+    pub kind: ObjectUploadKind,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectUploadService {
+    db: SqlitePool,
+    store: AgentHubObjectStore,
+}
+
+impl ObjectUploadService {
+    pub fn new(db: SqlitePool, store: AgentHubObjectStore) -> Self {
+        Self { db, store }
+    }
+
+    pub fn from_config(
+        db: SqlitePool,
+        config: &agenthub_config::AppConfig,
+    ) -> anyhow::Result<Self> {
+        let settings = object_store_settings_from_config(config)?;
+        Ok(Self::new(db, AgentHubObjectStore::from_settings(settings)?))
+    }
+
+    pub async fn upload(
+        &self,
+        request: ObjectUploadRequest,
+    ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
+        let upload_id = Uuid::now_v7().to_string();
+        let owner_scope = request.owner_scope.to_string();
+        let (object, public_url) = self
+            .store_upload_bytes(
+                &upload_id,
+                &owner_scope,
+                &request.file_name,
+                &request.content_type,
+                request.kind,
+                request.bytes,
+            )
+            .await?;
+        let now = Utc::now().timestamp();
+        let size_bytes = i64::try_from(object.size_bytes)
+            .context("uploaded object is too large for SQLite metadata size_bytes")?;
+        let upload = agenthub_db::NewObjectUpload {
+            id: &upload_id,
+            owner_scope: &owner_scope,
+            backend: object_store_backend_name(self.store.backend()),
+            object_key: &object.key,
+            original_filename: &request.file_name,
+            content_type: &request.content_type,
+            size_bytes,
+            sha256: &object.sha256,
+            public_url: public_url.as_deref(),
+            created_by_actor_id: &request.actor_id,
+            publish_state: "published",
+            created_at: now,
+            published_at: Some(now),
+            cleanup_after: None,
+        };
+        match agenthub_db::insert_object_upload(&self.db, &upload).await {
+            Ok(record) => Ok(record),
+            Err(err) => {
+                if let Err(cleanup_err) = self.store.delete_stored_object(&object).await {
+                    tracing::warn!(
+                        object_key = %object.key,
+                        error = %cleanup_err,
+                        "failed to delete object after upload metadata insert failure"
+                    );
+                }
+                Err(err).context("failed to publish upload metadata")
+            }
+        }
+    }
+
+    async fn store_upload_bytes(
+        &self,
+        upload_id: &str,
+        owner_scope: &str,
+        file_name: &str,
+        content_type: &str,
+        kind: ObjectUploadKind,
+        bytes: Vec<u8>,
+    ) -> anyhow::Result<(StoredObject, Option<String>)> {
+        match kind {
+            ObjectUploadKind::Object => {
+                let key = format!("uploads/{owner_scope}/{upload_id}/{file_name}");
+                let object = self.store.put_bytes(&key, bytes).await?;
+                Ok((object, None))
+            }
+            ObjectUploadKind::Image => {
+                let image = self
+                    .store
+                    .put_image_bytes(owner_scope, upload_id, content_type, bytes)
+                    .await?;
+                Ok((image.object, image.public_url))
+            }
+        }
+    }
+}
+
+fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
+    match backend {
+        ObjectStoreBackend::Fs => "fs",
+        ObjectStoreBackend::S3 => "s3",
+    }
+}
+
+pub fn object_store_settings_from_config(
+    config: &agenthub_config::AppConfig,
+) -> anyhow::Result<ObjectStoreSettings> {
+    let backend = match config.object_store_backend().as_str() {
+        "fs" => ObjectStoreBackend::Fs,
+        "s3" => ObjectStoreBackend::S3,
+        other => anyhow::bail!("unsupported object_store.backend: {other}"),
+    };
+    let root = match config.object_store_root() {
+        Some(root) => Some(root),
+        None if backend == ObjectStoreBackend::Fs => Some(
+            agenthub_config::path_utils::expand_tilde("~/.agenthub/objects"),
+        ),
+        None => None,
+    };
+    let access_key_id = config
+        .object_store_access_key_id_env()
+        .map(|name| read_secret_env(&name, "object_store.access_key_id_env"))
+        .transpose()?;
+    let secret_access_key = config
+        .object_store_secret_access_key_env()
+        .map(|name| read_secret_env(&name, "object_store.secret_access_key_env"))
+        .transpose()?;
+
+    Ok(ObjectStoreSettings {
+        backend,
+        root,
+        public_base_url: config.object_store_public_base_url(),
+        bucket: config.object_store_bucket(),
+        endpoint: config.object_store_endpoint(),
+        region: config.object_store_region(),
+        access_key_id,
+        secret_access_key,
+        prefix: config.object_store_prefix(),
+    })
+}
+
+fn read_secret_env(name: &str, config_key: &str) -> anyhow::Result<String> {
+    std::env::var(name)
+        .with_context(|| format!("{config_key} references missing environment variable {name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_scope_parses_supported_scopes() {
+        assert_eq!(
+            ObjectUploadOwnerScope::parse("teams/team-1")
+                .expect("parse team scope")
+                .to_string(),
+            "teams/team-1"
+        );
+        assert_eq!(
+            ObjectUploadOwnerScope::parse("tasks/task-1")
+                .expect("parse task scope")
+                .to_string(),
+            "tasks/task-1"
+        );
+        assert_eq!(
+            ObjectUploadOwnerScope::parse("agents/agent-1")
+                .expect("parse agent scope")
+                .to_string(),
+            "agents/agent-1"
+        );
+    }
+
+    #[test]
+    fn owner_scope_rejects_ambiguous_or_nested_values() {
+        for value in ["team-1", "channels/main", "teams/", "teams/a/b", "teams/.."] {
+            assert!(
+                ObjectUploadOwnerScope::parse(value).is_err(),
+                "scope should be rejected: {value}"
+            );
+        }
+    }
+}

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, path::Path};
 
 use agenthub_object_store::{
     AgentHubObjectStore, ObjectStoreBackend, ObjectStoreSettings, StoredObject,
@@ -29,6 +29,7 @@ impl ObjectUploadOwnerScope {
                 "owner scope must be teams/<team_id>, tasks/<task_id>, or agents/<agent_id>"
             );
         };
+        let id = id.trim();
         if id.is_empty() || id.contains('/') || id.contains('\\') || id == "." || id == ".." {
             anyhow::bail!("owner scope id must be a single non-empty path segment");
         }
@@ -96,13 +97,14 @@ impl ObjectUploadService {
         &self,
         request: ObjectUploadRequest,
     ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
+        let file_name = normalize_upload_file_name(&request.file_name)?;
         let upload_id = Uuid::now_v7().to_string();
         let owner_scope = request.owner_scope.to_string();
         let (object, public_url) = self
             .store_upload_bytes(
                 &upload_id,
                 &owner_scope,
-                &request.file_name,
+                &file_name,
                 &request.content_type,
                 request.kind,
                 request.bytes,
@@ -116,7 +118,7 @@ impl ObjectUploadService {
             owner_scope: &owner_scope,
             backend: object_store_backend_name(self.store.backend()),
             object_key: &object.key,
-            original_filename: &request.file_name,
+            original_filename: &file_name,
             content_type: &request.content_type,
             size_bytes,
             sha256: &object.sha256,
@@ -175,6 +177,17 @@ fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
     }
 }
 
+fn normalize_upload_file_name(file_name: &str) -> anyhow::Result<String> {
+    let file_name = file_name.trim();
+    if file_name.is_empty() || file_name == "." || file_name == ".." {
+        anyhow::bail!("file_name must be a single non-empty path segment");
+    }
+    if file_name.contains('/') || file_name.contains('\\') {
+        anyhow::bail!("file_name must be a single path segment");
+    }
+    Ok(file_name.to_string())
+}
+
 pub fn object_store_settings_from_config(
     config: &agenthub_config::AppConfig,
 ) -> anyhow::Result<ObjectStoreSettings> {
@@ -185,9 +198,7 @@ pub fn object_store_settings_from_config(
     };
     let root = match config.object_store_root() {
         Some(root) => Some(root),
-        None if backend == ObjectStoreBackend::Fs => Some(
-            agenthub_config::path_utils::expand_tilde("~/.agenthub/objects"),
-        ),
+        None if backend == ObjectStoreBackend::Fs => Some(default_object_store_fs_root()?),
         None => None,
     };
     let access_key_id = config
@@ -210,6 +221,24 @@ pub fn object_store_settings_from_config(
         secret_access_key,
         prefix: config.object_store_prefix(),
     })
+}
+
+fn default_object_store_fs_root() -> anyhow::Result<String> {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let current_dir = std::env::current_dir().context("resolve current directory")?;
+    Ok(default_object_store_fs_root_from_home(
+        Path::new(&home),
+        &current_dir,
+    ))
+}
+
+fn default_object_store_fs_root_from_home(home: &Path, current_dir: &Path) -> String {
+    let root = home.join(".agenthub/objects");
+    if root.is_absolute() {
+        root.to_string_lossy().to_string()
+    } else {
+        current_dir.join(root).to_string_lossy().to_string()
+    }
 }
 
 fn read_secret_env(name: &str, config_key: &str) -> anyhow::Result<String> {
@@ -236,7 +265,7 @@ mod tests {
             "tasks/task-1"
         );
         assert_eq!(
-            ObjectUploadOwnerScope::parse("agents/agent-1")
+            ObjectUploadOwnerScope::parse("agents/ agent-1 ")
                 .expect("parse agent scope")
                 .to_string(),
             "agents/agent-1"
@@ -251,5 +280,38 @@ mod tests {
                 "scope should be rejected: {value}"
             );
         }
+    }
+
+    #[test]
+    fn upload_file_name_rejects_nested_or_empty_values() {
+        assert_eq!(
+            normalize_upload_file_name(" report.json ").expect("normalize file name"),
+            "report.json"
+        );
+        for value in [
+            "",
+            " ",
+            ".",
+            "..",
+            "nested/report.json",
+            "nested\\report.json",
+        ] {
+            assert!(
+                normalize_upload_file_name(value).is_err(),
+                "file name should be rejected: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_object_store_root_absolutizes_relative_home() {
+        let root = default_object_store_fs_root_from_home(
+            Path::new("target/test-home"),
+            Path::new("/workspace/agenthub"),
+        );
+        assert_eq!(
+            root,
+            "/workspace/agenthub/target/test-home/.agenthub/objects"
+        );
     }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1078,6 +1078,7 @@ mod tests {
         api::team_tests::build_test_state as build_team_test_state,
         auth::AuthService,
         config::{AppConfig, PushConfig, WebConfig},
+        object_upload::ObjectUploadService,
         push::PushService,
         state::AppState,
         team::{
@@ -1278,6 +1279,7 @@ mod tests {
             auth.clone(),
         ));
         let teams = Arc::new(TeamManager::new_with_event_dbs(db.clone(), event_dbs));
+        let object_uploads = Arc::new(test_object_upload_service(db.clone()));
         AppState {
             db,
             linker_http: crate::linkers::AppLinkerService::default_http_client(),
@@ -1286,10 +1288,33 @@ mod tests {
             push,
             auth,
             acp_permissions: permissions,
+            object_uploads,
             agent_node_join_bootstrap: crate::agent::AgentNodeJoinBootstrapInfo::disabled(),
             default_worktree_root: config.default_worktree_root(),
             body_store: None,
         }
+    }
+
+    fn test_object_upload_service(db: SqlitePool) -> ObjectUploadService {
+        let root = std::env::temp_dir()
+            .join(format!("agenthub-sse-objects-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .to_string();
+        let config = AppConfig {
+            object_store: Some(agenthub_config::ObjectStoreConfig {
+                backend: Some("fs".to_string()),
+                root: Some(root),
+                public_base_url: None,
+                prefix: None,
+                bucket: None,
+                endpoint: None,
+                region: None,
+                access_key_id_env: None,
+                secret_access_key_env: None,
+            }),
+            ..Default::default()
+        };
+        ObjectUploadService::from_config(db, &config).expect("create object upload service")
     }
 
     async fn create_auth_token(state: &AppState) -> String {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -19,6 +19,7 @@ use sqlx::SqlitePool;
 use crate::acp::AcpPermissionService;
 use crate::agent::{AgentManager, AgentNodeJoinBootstrapInfo};
 use crate::auth::AuthService;
+use crate::object_upload::ObjectUploadService;
 use crate::push::PushService;
 use crate::team::TeamManager;
 
@@ -31,6 +32,10 @@ pub struct AppState {
     pub push: Arc<PushService>,
     pub auth: Arc<AuthService>,
     pub acp_permissions: Arc<AcpPermissionService>,
+    /// Shared object upload publication service. API routes will read this once browser/image
+    /// upload surfaces are added; actor CLI uses the same service construction path directly.
+    #[allow(dead_code)]
+    pub object_uploads: Arc<ObjectUploadService>,
     pub agent_node_join_bootstrap: AgentNodeJoinBootstrapInfo,
     pub default_worktree_root: String,
     /// Tiered message body store, when enabled and compiled in. Held here so the read path can fetch
@@ -52,6 +57,7 @@ impl AppState {
         let event_dbs = agenthub_db::AgentEventDbRouter::with_default_base_dir();
 
         let body_store = crate::message_body_store::init_body_store(&config);
+        let object_uploads = Arc::new(ObjectUploadService::from_config(db.clone(), &config)?);
 
         let (agents, teams, push, auth, acp_permissions) =
             Self::initialize_services(&config, db.clone(), event_dbs.clone(), body_store.clone())
@@ -77,6 +83,7 @@ impl AppState {
             push,
             auth,
             acp_permissions,
+            object_uploads,
             agent_node_join_bootstrap,
             default_worktree_root,
             body_store,


### PR DESCRIPTION
## Summary

- add a shared `ObjectUploadService` for object upload publication, metadata insertion, and cleanup compensation
- move upload owner scopes to explicit `teams/<id>`, `tasks/<id>`, and `agents/<id>` parsing
- wire the shared upload service into `AppState` for future browser/API upload routes
- keep actor CLI responsible for local file reading while reusing the shared publication path
- update object-storage docs and TODOs for the next API route slice

## Purpose

This prepares browser/API and graph-bed upload routes to reuse the same default local root, metadata authority, owner-scope parser, and compensation behavior as `agenthub actor upload`.

## Related Issues

None.

## Tests

- `cargo fmt --all --check`
- `cargo test -p agenthub object_upload`
- `cargo test -p agenthub parse_upload`
- `cargo test -p agenthub read_upload_file`
- `cargo test -p agenthub-db insert_object_upload_persists_published_metadata`
- `cargo check -p agenthub`
- `cargo clippy -p agenthub --all-targets -- -D warnings`
- `git diff --check`
