### PR TITLE
feat(api): add team upload routes

### DIFF
--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -64,21 +64,33 @@ access_key_id_env = "AGENTHUB_OBJECT_STORE_ACCESS_KEY_ID"
 secret_access_key_env = "AGENTHUB_OBJECT_STORE_SECRET_ACCESS_KEY"
 ```
 
-Agent-scoped CLI uploads use the same storage contract while staying separated from browser/API
-upload surfaces:
+Agent-scoped CLI uploads and Team-scoped browser/API uploads use the same storage contract:
 
 ```bash
 agenthub actor upload --file report.json --scope teams/team-1
 agenthub actor upload --file screenshot.png --scope teams/team-1 --image
 ```
 
-The actor CLI upload path owns command parsing and local file reading. The shared
-`ObjectUploadService` owns upload publication, metadata insertion, and best-effort compensation. The
-database owns `object_uploads` metadata through a dedicated `object_uploads` module. The object-store
-crate still owns byte storage only. If metadata publication fails after the byte write, AgentHub
-attempts to delete the just-written object before returning the error. When `[object_store].root` is
-omitted for the local filesystem backend, runtime state and CLI upload both default to
-`~/.agenthub/objects`.
+The actor CLI upload path owns command parsing and local file reading. Team upload API routes own
+authorization, owner-scope derivation from the route, and request decoding. The shared
+`ObjectUploadService` owns upload publication, metadata insertion, size/checksum verification, and
+best-effort compensation. The database owns `object_uploads` metadata through a dedicated
+`object_uploads` module. The object-store crate still owns byte storage only. If verification or
+metadata publication fails after the byte write, AgentHub attempts to delete the just-written object
+before returning the error. When `[object_store].root` is omitted for the local filesystem backend,
+runtime state and CLI upload both default to `~/.agenthub/objects`.
+
+The initial browser/API surface is intentionally Team-scoped and JSON/base64 based:
+
+```text
+POST /api/teams/{team_id}/uploads
+POST /api/teams/{team_id}/images
+```
+
+Handlers derive `teams/<team_id>` from the authorized Team route and do not accept a raw owner scope
+from the browser. The request includes `file_name`, `content_type`, `bytes_base64`, and optional
+`expected_size_bytes` / `expected_sha256` verification fields. Larger browser uploads may later move
+to multipart or presigned upload-token semantics, but that is a separate contract.
 
 Upload flows should follow a prepare/write/publish sequence:
 
@@ -129,6 +141,7 @@ that URL as a delivery address, not as the authorization decision.
 | Local backend | Focused async test writes, reads, checks existence, deletes, and verifies size/checksum. |
 | Image hosting helper | Focused async test writes a scoped raster image object, rejects nested image ids, and returns a normalized public URL. |
 | Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
+| Team upload API | Handler and router tests cover authorization, owner-scope derivation, base64 upload publication, raster-image allowlist, and size/checksum mismatch rejection without publishing metadata. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
 | Future S3 rollout | Add an integration test against MinIO or a provisioned S3-compatible bucket before enabling S3 in release builds. |

--- a/docs/journal/2026-07-16-object-storage-opendal.md
+++ b/docs/journal/2026-07-16-object-storage-opendal.md
@@ -78,3 +78,27 @@ cargo test -p agenthub parse_upload
 cargo test -p agenthub actor_output_preference_contract_covers_all_command_variants
 cargo fmt --all --check
 ```
+
+## Team Upload API Slice
+
+The browser/API slice adds the first non-CLI upload surface without opening a raw owner-scope API:
+
+- `POST /api/teams/{team_id}/uploads` publishes generic objects through the shared
+  `ObjectUploadService`.
+- `POST /api/teams/{team_id}/images` publishes allowlisted raster images through the same service
+  and image-hosting helper.
+- API handlers derive `teams/<team_id>` from the authorized Team route instead of accepting an
+  owner scope string from the browser.
+- Requests use JSON/base64 for this first slice and include optional expected size and SHA-256
+  checks. Verification failures do not publish `object_uploads` metadata.
+- The remaining browser large-object decision is whether multipart or presigned upload-token
+  semantics should become the canonical path beyond small JSON/base64 uploads.
+
+Focused checks for this slice:
+
+```bash
+cargo test -p agenthub team_upload
+cargo test -p agenthub teams_router_accepts_team_upload_route
+cargo test -p agenthub object_upload
+cargo fmt --all --check
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,8 +56,8 @@ Stable contract:
 
 ## Object Storage
 
-- [ ] `P1` Add browser/API upload routes on top of the shared object upload service so non-CLI callers reuse the same default local root, owner-scope parser, metadata authority, and cleanup compensation as `agenthub actor upload`. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
-- [ ] `P1` Add graph-bed image hosting routes on top of the shared object upload service: accept allowlisted raster images, publish only after checksum/size verification, and return public URLs only after owner-scope authorization.
+- [ ] `P1` Extend object upload APIs beyond the initial Team-scoped JSON/base64 routes: add task/agent owner-scope authorization and decide whether browser-facing multipart or presigned upload tokens should become the canonical large-object path. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
+- [ ] `P1` Add graph-bed image hosting UX on top of Team-scoped image upload routes: wire the graph-bed client flow, require allowlisted raster images, publish only after checksum/size verification, and treat returned public URLs as delivery addresses rather than authorization proof.
 - [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
 
 ## Observability, CI, And Docs

--- a/src/actor_cli/upload.rs
+++ b/src/actor_cli/upload.rs
@@ -43,6 +43,8 @@ pub(super) async fn run_actor_upload(
             file_name,
             content_type,
             kind,
+            expected_size_bytes: None,
+            expected_sha256: None,
             bytes,
         })
         .await

--- a/src/api/openapi/spec.rs
+++ b/src/api/openapi/spec.rs
@@ -235,6 +235,49 @@ pub(super) fn openapi_spec() -> Value {
               "description": { "type": ["string", "null"] }
             }
           },
+          "TeamUploadRequest": {
+            "type": "object",
+            "required": ["file_name", "content_type", "bytes_base64"],
+            "properties": {
+              "file_name": { "type": "string" },
+              "content_type": { "type": "string" },
+              "bytes_base64": { "type": "string", "format": "byte" },
+              "expected_size_bytes": { "type": ["integer", "null"], "format": "int64" },
+              "expected_sha256": { "type": ["string", "null"] }
+            }
+          },
+          "ObjectUploadRecord": {
+            "type": "object",
+            "required": [
+              "id",
+              "owner_scope",
+              "backend",
+              "object_key",
+              "original_filename",
+              "content_type",
+              "size_bytes",
+              "sha256",
+              "created_by_actor_id",
+              "publish_state",
+              "created_at"
+            ],
+            "properties": {
+              "id": { "type": "string" },
+              "owner_scope": { "type": "string" },
+              "backend": { "type": "string" },
+              "object_key": { "type": "string" },
+              "original_filename": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size_bytes": { "type": "integer", "format": "int64" },
+              "sha256": { "type": "string" },
+              "public_url": { "type": ["string", "null"] },
+              "created_by_actor_id": { "type": "string" },
+              "publish_state": { "type": "string" },
+              "created_at": { "type": "integer", "format": "int64" },
+              "published_at": { "type": ["integer", "null"], "format": "int64" },
+              "cleanup_after": { "type": ["integer", "null"], "format": "int64" }
+            }
+          },
           "CreateTeamRunRequest": {
             "type": "object",
             "properties": {
@@ -409,6 +452,60 @@ pub(super) fn openapi_spec() -> Value {
                 "content": {
                   "application/json": {
                     "schema": { "$ref": "#/components/schemas/TeamDefinitionRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}/uploads": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Upload team object",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published object metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}/images": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Upload team image",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published image metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
                   }
                 }
               }

--- a/src/api/openapi/tests.rs
+++ b/src/api/openapi/tests.rs
@@ -54,12 +54,16 @@ async fn openapi_json_contains_team_runs_list_path() {
     assert!(value["paths"]["/api/teams/{id}/channels"]["get"].is_object());
     assert!(value["paths"]["/api/teams/{id}/channels"]["post"].is_object());
     assert!(value["paths"]["/api/teams/{id}/channels/{channel_id}"]["delete"].is_object());
+    assert!(value["paths"]["/api/teams/{id}/uploads"]["post"].is_object());
+    assert!(value["paths"]["/api/teams/{id}/images"]["post"].is_object());
     assert!(value["paths"]["/api/teams/{id}/runs"].is_object());
     assert!(value["paths"]["/api/teams/runs/{run_id}/resume"].is_object());
     assert!(value["paths"]["/api/teams/runs/{run_id}/restart"].is_object());
     assert!(value["paths"]["/api/teams/runs/{run_id}/snapshot"].is_object());
     assert!(value["components"]["schemas"]["TeamChannelRecord"].is_object());
     assert!(value["components"]["schemas"]["CreateTeamChannelRequest"].is_object());
+    assert!(value["components"]["schemas"]["TeamUploadRequest"].is_object());
+    assert!(value["components"]["schemas"]["ObjectUploadRecord"].is_object());
 }
 
 #[tokio::test]

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -24,6 +24,7 @@ use axum::{
     http::HeaderMap,
     routing::{delete, get, post, put},
 };
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -34,6 +35,7 @@ use uuid::Uuid;
 use crate::api::authz::require_user;
 use crate::api::error::ApiError;
 use crate::auth::UserRecord;
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope, ObjectUploadRequest};
 use crate::state::AppState;
 use crate::team::{
     TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport, TeamChannelRecord,
@@ -258,6 +260,15 @@ pub struct ReplyTeamThreadRequest {
 pub struct CreateTeamChannelRequest {
     pub channel_id: String,
     pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TeamUploadRequest {
+    pub file_name: String,
+    pub content_type: String,
+    pub bytes_base64: String,
+    pub expected_size_bytes: Option<u64>,
+    pub expected_sha256: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -535,6 +546,8 @@ pub fn router(state: AppState) -> Router {
             "/{id}/channels",
             get(list_team_channels).post(create_team_channel),
         )
+        .route("/{id}/uploads", post(upload_team_object))
+        .route("/{id}/images", post(upload_team_image))
         .route("/{id}/channels/{channel_id}", delete(delete_team_channel))
         .route(
             "/{id}/tasks/{task_id}/compile_run_preview",
@@ -1065,6 +1078,78 @@ async fn delete_team_channel(
         .await
         .map_err(map_channel_delete_error)?;
     Ok(Json(deleted))
+}
+
+async fn upload_team_object(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(team_id): Path<String>,
+    Json(payload): Json<TeamUploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_team_scoped_object(state, headers, team_id, payload, ObjectUploadKind::Object).await
+}
+
+async fn upload_team_image(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(team_id): Path<String>,
+    Json(payload): Json<TeamUploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_team_scoped_object(state, headers, team_id, payload, ObjectUploadKind::Image).await
+}
+
+async fn upload_team_scoped_object(
+    state: AppState,
+    headers: HeaderMap,
+    team_id: String,
+    payload: TeamUploadRequest,
+    kind: ObjectUploadKind,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    let team = load_team_for_user(&state, &team_id, &user).await?;
+    let content_type = normalize_upload_content_type(&payload.content_type)?;
+    let bytes = decode_upload_bytes(&payload.bytes_base64)?;
+    let upload = state
+        .object_uploads
+        .upload(ObjectUploadRequest {
+            actor_id: canonical_user_actor_id(&user),
+            owner_scope: ObjectUploadOwnerScope::Team(team.id),
+            file_name: payload.file_name,
+            content_type,
+            kind,
+            expected_size_bytes: payload.expected_size_bytes,
+            expected_sha256: payload.expected_sha256,
+            bytes,
+        })
+        .await
+        .map_err(map_upload_error)?;
+    Ok(Json(upload))
+}
+
+fn normalize_upload_content_type(value: &str) -> Result<String, ApiError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ApiError::bad_request("content_type is required"));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn decode_upload_bytes(value: &str) -> Result<Vec<u8>, ApiError> {
+    STANDARD
+        .decode(value.trim())
+        .map_err(|_| ApiError::bad_request("bytes_base64 must be valid standard base64"))
+}
+
+fn map_upload_error(err: anyhow::Error) -> ApiError {
+    let message = err.to_string();
+    if message.contains("file_name")
+        || message.contains("size mismatch")
+        || message.contains("sha256")
+        || message.contains("unsupported hosted image content type")
+    {
+        return ApiError::bad_request(&message);
+    }
+    err.into()
 }
 
 async fn get_team_task(

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -39,6 +39,8 @@ use agenthub_team_actor::{
     ACTOR_NODE_PEER_ID, ActorAckRequest, ActorInboxRequest, ActorMailboxService, ActorSendRequest,
 };
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use sha2::{Digest, Sha256};
 
 use super::{
     AckTeamRunMessageRequest, CompileTeamTaskRunPreviewRequest, CompleteTeamRunStepRequest,
@@ -49,21 +51,22 @@ use super::{
     SendTeamRunMessageRequest, SendTeamTaskMessageRequest, SetTeamRunStepInputRequiredRequest,
     StartTeamRunStepRequest, SubmitTeamRunStepRequest, TakeoverTeamRunMessageRequest,
     TeamMemberSpec, TeamMessageSearchHitResponse, TeamRunSnapshotQuery, TeamTaskDetailResponse,
-    TransferTeamRunMessageRequest, TriageTeamRunMessageRequest, UpdateTeamSpecRequest,
-    UpdateTeamTaskRequest, ack_team_run_message, cancel_team_run, compile_team_task_run_preview,
-    complete_team_run_step, create_team, create_team_channel, create_team_run, delete_team,
-    delete_team_channel, ensure_team_shared_thread, escalate_team_run_message, fail_team_run_step,
-    flush_team_run_context, force_new_session_for_team_member, get_team, get_team_run,
-    get_team_run_snapshot, get_team_runtime, get_team_shared_thread, get_team_task,
-    list_team_channels, list_team_run_events, list_team_run_inbox, list_team_run_steps,
-    list_team_runs, list_team_task_messages, list_team_tasks, list_teams, load_team_for_user,
+    TeamUploadRequest, TransferTeamRunMessageRequest, TriageTeamRunMessageRequest,
+    UpdateTeamSpecRequest, UpdateTeamTaskRequest, ack_team_run_message, cancel_team_run,
+    compile_team_task_run_preview, complete_team_run_step, create_team, create_team_channel,
+    create_team_run, delete_team, delete_team_channel, ensure_team_shared_thread,
+    escalate_team_run_message, fail_team_run_step, flush_team_run_context,
+    force_new_session_for_team_member, get_team, get_team_run, get_team_run_snapshot,
+    get_team_runtime, get_team_shared_thread, get_team_task, hex_encode, list_team_channels,
+    list_team_run_events, list_team_run_inbox, list_team_run_steps, list_team_runs,
+    list_team_task_messages, list_team_tasks, list_teams, load_team_for_user,
     map_team_internal_error, normalize_conversation_mode, normalize_task_created_by_actor_id,
     normalize_team_spec, parse_message_archive_source_kind, reply_team_thread, require_user,
     restart_team_run, resume_team_run, resume_team_run_step, search_team_messages,
     send_team_run_message, send_team_task_message, set_team_run_step_input_required, start_team,
     start_team_run_step, stop_team, submit_team_run_step, takeover_team_run_message,
     transfer_team_run_message, triage_team_run_message, update_team_spec, update_team_task,
-    validate_team_spec,
+    upload_team_image, upload_team_object, validate_team_spec,
 };
 
 #[derive(Default)]
@@ -387,6 +390,40 @@ async fn init_test_schema(db: &SqlitePool) {
     .execute(db)
     .await
     .expect("create auth_sessions");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE object_uploads (
+            id TEXT PRIMARY KEY,
+            owner_scope TEXT NOT NULL,
+            backend TEXT NOT NULL,
+            object_key TEXT NOT NULL,
+            original_filename TEXT NOT NULL,
+            content_type TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            sha256 TEXT NOT NULL,
+            public_url TEXT,
+            created_by_actor_id TEXT NOT NULL,
+            publish_state TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            published_at INTEGER,
+            cleanup_after INTEGER
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create object_uploads");
+
+    sqlx::query(
+        r#"
+        CREATE UNIQUE INDEX idx_object_uploads_object_key
+        ON object_uploads(object_key);
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create object upload object key index");
 
     sqlx::query(
         r#"

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -83,6 +83,177 @@ async fn teams_api_requires_authorization() {
 }
 
 #[tokio::test]
+async fn team_upload_api_requires_team_access_and_publishes_metadata() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+    let outsider_headers = auth_headers(&state).await;
+
+    let Json(created) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "upload-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"coordinator"}]}),
+        }),
+    )
+    .await
+    .expect("create upload team");
+
+    let bytes = b"hello upload";
+    let sha256 = hex_encode(&Sha256::digest(bytes));
+    let request = TeamUploadRequest {
+        file_name: " report.txt ".to_string(),
+        content_type: " Text/Plain ".to_string(),
+        bytes_base64: STANDARD.encode(bytes),
+        expected_size_bytes: Some(bytes.len() as u64),
+        expected_sha256: Some(sha256.clone()),
+    };
+
+    let unauthorized = upload_team_object(
+        State(state.clone()),
+        HeaderMap::new(),
+        Path(created.id.clone()),
+        Json(request.clone()),
+    )
+    .await
+    .expect_err("missing auth should reject");
+    assert_eq!(unauthorized.into_response().status(), StatusCode::UNAUTHORIZED);
+
+    let forbidden = upload_team_object(
+        State(state.clone()),
+        outsider_headers,
+        Path(created.id.clone()),
+        Json(request.clone()),
+    )
+    .await
+    .expect_err("non-owner should not upload into team scope");
+    assert_eq!(forbidden.into_response().status(), StatusCode::NOT_FOUND);
+
+    let Json(upload) = upload_team_object(
+        State(state.clone()),
+        headers,
+        Path(created.id.clone()),
+        Json(request),
+    )
+    .await
+    .expect("upload team object");
+
+    assert_eq!(upload.owner_scope, format!("teams/{}", created.id));
+    assert!(upload.object_key.starts_with(&format!(
+        "uploads/teams/{}/",
+        created.id
+    )));
+    assert!(upload.object_key.ends_with("/report.txt"));
+    assert_eq!(upload.original_filename, "report.txt");
+    assert_eq!(upload.content_type, "text/plain");
+    assert_eq!(upload.size_bytes, bytes.len() as i64);
+    assert_eq!(upload.sha256, sha256);
+    assert_eq!(upload.publish_state, "published");
+    assert_eq!(upload.public_url, None);
+
+    let persisted = agenthub_db::object_uploads::get_object_upload(&state.db, &upload.id)
+        .await
+        .expect("load persisted upload");
+    assert_eq!(persisted, upload);
+}
+
+#[tokio::test]
+async fn team_image_upload_api_rejects_unsafe_content_types_and_checksum_mismatch() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let Json(created) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "image-upload-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"coordinator"}]}),
+        }),
+    )
+    .await
+    .expect("create image upload team");
+
+    let svg = TeamUploadRequest {
+        file_name: "diagram.svg".to_string(),
+        content_type: "image/svg+xml".to_string(),
+        bytes_base64: STANDARD.encode(b"<svg></svg>"),
+        expected_size_bytes: None,
+        expected_sha256: None,
+    };
+    let svg_err = upload_team_image(
+        State(state.clone()),
+        headers.clone(),
+        Path(created.id.clone()),
+        Json(svg),
+    )
+    .await
+    .expect_err("svg image uploads should reject");
+    assert_eq!(svg_err.into_response().status(), StatusCode::BAD_REQUEST);
+
+    let checksum_mismatch = TeamUploadRequest {
+        file_name: "screenshot.png".to_string(),
+        content_type: "image/png".to_string(),
+        bytes_base64: STANDARD.encode([1_u8, 2, 3, 4]),
+        expected_size_bytes: Some(4),
+        expected_sha256: Some(
+            "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        ),
+    };
+    let checksum_err = upload_team_image(
+        State(state.clone()),
+        headers.clone(),
+        Path(created.id.clone()),
+        Json(checksum_mismatch),
+    )
+    .await
+    .expect_err("checksum mismatch should reject");
+    assert_eq!(
+        checksum_err.into_response().status(),
+        StatusCode::BAD_REQUEST
+    );
+
+    let count_after_rejections: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM object_uploads WHERE owner_scope = ?1")
+            .bind(format!("teams/{}", created.id))
+            .fetch_one(&state.db)
+            .await
+            .expect("count rejected uploads");
+    assert_eq!(count_after_rejections, 0);
+
+    let image_bytes = [1_u8, 2, 3, 4];
+    let sha256 = hex_encode(&Sha256::digest(image_bytes));
+    let valid = TeamUploadRequest {
+        file_name: "screenshot.png".to_string(),
+        content_type: "image/png".to_string(),
+        bytes_base64: STANDARD.encode(image_bytes),
+        expected_size_bytes: Some(image_bytes.len() as u64),
+        expected_sha256: Some(sha256.clone()),
+    };
+    let Json(upload) = upload_team_image(
+        State(state.clone()),
+        headers,
+        Path(created.id.clone()),
+        Json(valid),
+    )
+    .await
+    .expect("upload team image");
+
+    assert_eq!(upload.owner_scope, format!("teams/{}", created.id));
+    assert!(upload.object_key.starts_with(&format!(
+        "images/teams/{}/",
+        created.id
+    )));
+    assert!(upload.object_key.ends_with(".png"));
+    assert_eq!(upload.content_type, "image/png");
+    assert_eq!(upload.size_bytes, image_bytes.len() as i64);
+    assert_eq!(upload.sha256, sha256);
+    assert_eq!(upload.publish_state, "published");
+}
+
+#[tokio::test]
 async fn teams_api_create_list_get_and_reject_duplicate_name() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/api/teams/tests_router.rs
+++ b/src/api/teams/tests_router.rs
@@ -1735,3 +1735,55 @@ async fn teams_router_resume_restart_strategy_survives_state_reopen() {
 
     let _ = std::fs::remove_dir_all(&base);
 }
+
+#[tokio::test]
+async fn teams_router_accepts_team_upload_route() {
+    let state = build_test_state().await;
+    let token = create_auth_token(&state).await;
+    let app = super::router(state.clone());
+
+    let create_team_resp = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            "/",
+            Some(&token),
+            Some(json!({
+                "name": "router-upload-team",
+                "description": null,
+                "spec": {
+                    "entrypoint":"planner",
+                    "members":[{"member_id":"planner","role":"coordinator"}]
+                }
+            })),
+        ))
+        .await
+        .expect("create upload team via router");
+    assert_eq!(create_team_resp.status(), StatusCode::OK);
+    let created_team = decode_json_body(create_team_resp).await;
+    let team_id = created_team["id"].as_str().expect("team id");
+
+    let bytes = b"router upload";
+    let response = app
+        .clone()
+        .oneshot(build_json_request(
+            Method::POST,
+            &format!("/{team_id}/uploads"),
+            Some(&token),
+            Some(json!({
+                "file_name": "router.txt",
+                "content_type": "text/plain",
+                "bytes_base64": STANDARD.encode(bytes),
+                "expected_size_bytes": bytes.len(),
+                "expected_sha256": hex_encode(&Sha256::digest(bytes))
+            })),
+        ))
+        .await
+        .expect("upload via router");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = decode_json_body(response).await;
+    assert_eq!(body["owner_scope"], Value::from(format!("teams/{team_id}")));
+    assert_eq!(body["original_filename"], Value::from("router.txt"));
+    assert_eq!(body["content_type"], Value::from("text/plain"));
+    assert_eq!(body["size_bytes"], Value::from(bytes.len() as i64));
+}

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -71,6 +71,8 @@ pub struct ObjectUploadRequest {
     pub file_name: String,
     pub content_type: String,
     pub kind: ObjectUploadKind,
+    pub expected_size_bytes: Option<u64>,
+    pub expected_sha256: Option<String>,
     pub bytes: Vec<u8>,
 }
 
@@ -98,6 +100,8 @@ impl ObjectUploadService {
         request: ObjectUploadRequest,
     ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
         let file_name = normalize_upload_file_name(&request.file_name)?;
+        let expected_size_bytes = request.expected_size_bytes;
+        let expected_sha256 = request.expected_sha256.clone();
         let upload_id = Uuid::now_v7().to_string();
         let owner_scope = request.owner_scope.to_string();
         let (object, public_url) = self
@@ -110,6 +114,18 @@ impl ObjectUploadService {
                 request.bytes,
             )
             .await?;
+        if let Err(err) =
+            verify_stored_object(&object, expected_size_bytes, expected_sha256.as_deref())
+        {
+            if let Err(cleanup_err) = self.store.delete_stored_object(&object).await {
+                tracing::warn!(
+                    object_key = %object.key,
+                    error = %cleanup_err,
+                    "failed to delete object after upload verification failure"
+                );
+            }
+            return Err(err);
+        }
         let now = Utc::now().timestamp();
         let size_bytes = i64::try_from(object.size_bytes)
             .context("uploaded object is too large for SQLite metadata size_bytes")?;
@@ -168,6 +184,33 @@ impl ObjectUploadService {
             }
         }
     }
+}
+
+fn verify_stored_object(
+    object: &StoredObject,
+    expected_size_bytes: Option<u64>,
+    expected_sha256: Option<&str>,
+) -> anyhow::Result<()> {
+    if let Some(expected_size_bytes) = expected_size_bytes {
+        anyhow::ensure!(
+            object.size_bytes == expected_size_bytes,
+            "uploaded object size mismatch: expected {expected_size_bytes}, got {}",
+            object.size_bytes
+        );
+    }
+    if let Some(expected_sha256) = expected_sha256 {
+        let expected_sha256 = expected_sha256.trim().to_ascii_lowercase();
+        anyhow::ensure!(
+            expected_sha256.len() == 64
+                && expected_sha256.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "expected_sha256 must be a lowercase or uppercase SHA-256 hex digest"
+        );
+        anyhow::ensure!(
+            object.sha256 == expected_sha256,
+            "uploaded object sha256 mismatch"
+        );
+    }
+    Ok(())
 }
 
 fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
@@ -313,5 +356,59 @@ mod tests {
             root,
             "/workspace/agenthub/target/test-home/.agenthub/objects"
         );
+    }
+
+    #[tokio::test]
+    async fn stored_object_verification_rejects_size_or_checksum_mismatch() {
+        let object = StoredObject {
+            key: "uploads/teams/team-1/upload-1/report.txt".to_string(),
+            size_bytes: 4,
+            sha256: "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7".to_string(),
+        };
+        let request = ObjectUploadRequest {
+            actor_id: "user-1".to_string(),
+            owner_scope: ObjectUploadOwnerScope::Team("team-1".to_string()),
+            file_name: "report.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            kind: ObjectUploadKind::Object,
+            expected_size_bytes: Some(5),
+            expected_sha256: None,
+            bytes: Vec::new(),
+        };
+        assert!(
+            verify_stored_object(
+                &object,
+                request.expected_size_bytes,
+                request.expected_sha256.as_deref()
+            )
+            .is_err()
+        );
+
+        let request = ObjectUploadRequest {
+            expected_size_bytes: Some(4),
+            expected_sha256: Some(
+                "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            ),
+            ..request
+        };
+        assert!(
+            verify_stored_object(
+                &object,
+                request.expected_size_bytes,
+                request.expected_sha256.as_deref()
+            )
+            .is_err()
+        );
+
+        let request = ObjectUploadRequest {
+            expected_sha256: Some(object.sha256.to_ascii_uppercase()),
+            ..request
+        };
+        verify_stored_object(
+            &object,
+            request.expected_size_bytes,
+            request.expected_sha256.as_deref(),
+        )
+        .expect("uppercase checksum should normalize");
     }
 }

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -101,7 +101,7 @@ impl ObjectUploadService {
     ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
         let file_name = normalize_upload_file_name(&request.file_name)?;
         let expected_size_bytes = request.expected_size_bytes;
-        let expected_sha256 = request.expected_sha256.clone();
+        let expected_sha256 = normalize_expected_sha256(request.expected_sha256.as_deref())?;
         let upload_id = Uuid::now_v7().to_string();
         let owner_scope = request.owner_scope.to_string();
         let (object, public_url) = self
@@ -198,19 +198,25 @@ fn verify_stored_object(
             object.size_bytes
         );
     }
-    if let Some(expected_sha256) = expected_sha256 {
-        let expected_sha256 = expected_sha256.trim().to_ascii_lowercase();
-        anyhow::ensure!(
-            expected_sha256.len() == 64
-                && expected_sha256.bytes().all(|byte| byte.is_ascii_hexdigit()),
-            "expected_sha256 must be a lowercase or uppercase SHA-256 hex digest"
-        );
+    if let Some(expected_sha256) = normalize_expected_sha256(expected_sha256)? {
         anyhow::ensure!(
             object.sha256 == expected_sha256,
             "uploaded object sha256 mismatch"
         );
     }
     Ok(())
+}
+
+fn normalize_expected_sha256(expected_sha256: Option<&str>) -> anyhow::Result<Option<String>> {
+    let Some(expected_sha256) = expected_sha256 else {
+        return Ok(None);
+    };
+    let expected_sha256 = expected_sha256.trim().to_ascii_lowercase();
+    anyhow::ensure!(
+        expected_sha256.len() == 64 && expected_sha256.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "expected_sha256 must be a lowercase or uppercase SHA-256 hex digest"
+    );
+    Ok(Some(expected_sha256))
 }
 
 fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
@@ -356,6 +362,28 @@ mod tests {
             root,
             "/workspace/agenthub/target/test-home/.agenthub/objects"
         );
+    }
+
+    #[test]
+    fn expected_sha256_normalization_rejects_malformed_values() {
+        assert_eq!(
+            normalize_expected_sha256(Some(
+                " 3A6EB0790F39AC87C94F3856B2DD2C5D110E6811602261A9A923D3BB23ADC8B7 "
+            ))
+            .expect("normalize expected sha256"),
+            Some("3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7".to_string())
+        );
+        for value in [
+            "",
+            "abc",
+            "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b",
+            "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8xz",
+        ] {
+            assert!(
+                normalize_expected_sha256(Some(value)).is_err(),
+                "checksum should be rejected: {value:?}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add Team-scoped JSON/base64 upload routes for general objects and image hosting.
- Reuse `ObjectUploadService` for object key construction, metadata publication, and storage cleanup on validation failure.
- Document the Team upload API contract and keep larger multipart/presigned upload work as a follow-up.

## Purpose

This moves the object-storage slice beyond the actor CLI by giving browser/API callers a scoped upload path that derives ownership from Team authorization instead of trusting a caller-supplied owner scope.

## Related Issues

- Not linked.

## Tests

- `cargo fmt --all --check`
- `cargo test -p agenthub openapi_json_contains_team_runs_list_path`
- `cargo test -p agenthub team_upload`
- `cargo test -p agenthub object_upload`
- `cargo clippy -p agenthub --all-targets -- -D warnings`
- `git diff --check`
