### PR TITLE
feat(web): add graph-bed image upload

### DIFF
--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -112,6 +112,12 @@ Only `image/png`, `image/jpeg`, `image/webp`, and `image/gif` are accepted in th
 helper may return a `public_base_url`-derived URL when configured, but API handlers must still treat
 that URL as a delivery address, not as the authorization decision.
 
+The Team channel composer is the first graph-bed consumer. It accepts only the same raster image
+types, reads the browser file locally, computes SHA-256 and byte length before upload, calls
+`POST /api/teams/{team_id}/images`, then inserts a Markdown image link using the published upload
+metadata. The inserted URL is for rendering/delivery only; future read, replace, delete, or presign
+operations must still authorize against the Team-owned metadata row.
+
 ## Contracts
 
 - Object keys are relative, slash-separated, and normalized before reaching OpenDAL.
@@ -142,6 +148,7 @@ that URL as a delivery address, not as the authorization decision.
 | Image hosting helper | Focused async test writes a scoped raster image object, rejects nested image ids, and returns a normalized public URL. |
 | Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
 | Team upload API | Handler and router tests cover authorization, owner-scope derivation, base64 upload publication, raster-image allowlist, and size/checksum mismatch rejection without publishing metadata. |
+| Graph-bed UX | Frontend tests cover raster MIME allowlisting, browser SHA-256/base64 request preparation, Team image endpoint wiring, and Markdown image insertion in the Team channel composer. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
 | Future S3 rollout | Add an integration test against MinIO or a provisioned S3-compatible bucket before enabling S3 in release builds. |

--- a/docs/journal/2026-07-16-object-storage-opendal.md
+++ b/docs/journal/2026-07-16-object-storage-opendal.md
@@ -102,3 +102,27 @@ cargo test -p agenthub teams_router_accepts_team_upload_route
 cargo test -p agenthub object_upload
 cargo fmt --all --check
 ```
+
+## Graph-Bed Image UX Slice
+
+The Team channel composer now consumes the Team image upload API as the first browser graph-bed
+flow:
+
+- The composer exposes an image upload action only for channel conversations with a selected Team
+  and auth token.
+- Browser-side preparation accepts only PNG, JPEG, WebP, and GIF, then computes byte length,
+  standard base64, and SHA-256 before calling `POST /api/teams/{team_id}/images`.
+- The returned published upload metadata is converted into a Markdown image link in the current
+  draft. Public URLs are treated as delivery addresses only; object ownership and future mutation
+  authority remain tied to the Team-scoped metadata row.
+- Thread replies remain unchanged in this slice so the first UX path stays focused on the shared
+  channel graph-bed flow.
+
+Focused checks for this slice:
+
+```bash
+npm exec vitest run src/pages/team/team_image_upload.test.ts src/api.test.ts src/pages/team_panels.test.tsx
+npm run lint
+npm exec tsc -- --noEmit
+npm run build
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,7 +57,6 @@ Stable contract:
 ## Object Storage
 
 - [ ] `P1` Extend object upload APIs beyond the initial Team-scoped JSON/base64 routes: add task/agent owner-scope authorization and decide whether browser-facing multipart or presigned upload tokens should become the canonical large-object path. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
-- [ ] `P1` Add graph-bed image hosting UX on top of Team-scoped image upload routes: wire the graph-bed client flow, require allowlisted raster images, publish only after checksum/size verification, and treat returned public URLs as delivery addresses rather than authorization proof.
 - [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
 
 ## Observability, CI, And Docs

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -189,6 +189,56 @@ describe("api request headers", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
+  it("uploads Team images through the scoped image endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "upload-1",
+          owner_scope: "teams/team-1",
+          backend: "s3",
+          object_key: "images/teams/team-1/upload-1.png",
+          original_filename: "diagram.png",
+          content_type: "image/png",
+          size_bytes: 4,
+          sha256: "sha",
+          public_url: "https://cdn.example.test/upload-1.png",
+          created_by_actor_id: "human",
+          publish_state: "published",
+          created_at: 1,
+          published_at: 1,
+          cleanup_after: null,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.uploadTeamImage("token-1", "team-1", {
+      file_name: "diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256: "sha",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/teams/team-1/images");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(
+      JSON.stringify({
+        file_name: "diagram.png",
+        content_type: "image/png",
+        bytes_base64: "AQIDBA==",
+        expected_size_bytes: 4,
+        expected_sha256: "sha",
+      })
+    );
+  });
+
   it("includes priority when listing team tasks with a priority filter", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify([]), {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -418,6 +418,31 @@ export type TeamThreadReplyRecord = {
   message: TeamConversationMessageRecord;
 };
 
+export type TeamUploadRequest = {
+  file_name: string;
+  content_type: string;
+  bytes_base64: string;
+  expected_size_bytes?: number | null;
+  expected_sha256?: string | null;
+};
+
+export type ObjectUploadRecord = {
+  id: string;
+  owner_scope: string;
+  backend: string;
+  object_key: string;
+  original_filename: string;
+  content_type: string;
+  size_bytes: number;
+  sha256: string;
+  public_url?: string | null;
+  created_by_actor_id: string;
+  publish_state: string;
+  created_at: number;
+  published_at?: number | null;
+  cleanup_after?: number | null;
+};
+
 export type TeamRunRecord = {
   id: string;
   team_id: string;
@@ -1104,6 +1129,15 @@ export const api = {
   ) =>
     apiFetch<TeamThreadReplyRecord>(
       `/api/teams/${encodePathSegment(teamId)}/channels/${encodePathSegment(channelId)}/threads/${rootMessageId}/replies`,
+      token,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }
+    ),
+  uploadTeamImage: (token: string, teamId: string, payload: TeamUploadRequest) =>
+    apiFetch<ObjectUploadRecord>(
+      `/api/teams/${encodePathSegment(teamId)}/images`,
       token,
       {
         method: "POST",

--- a/web/src/app.runtime_effects.test.tsx
+++ b/web/src/app.runtime_effects.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { MantineProvider } from "@mantine/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installReactDomTestGlobals } from "./test_utils/react_test_helpers";
 
 const {
   authStatusMock,
@@ -65,8 +66,7 @@ vi.mock("./webauthn", () => ({
 
 import { AGENT_EVENT_PAGE_SIZE, App } from "./app";
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
+installReactDomTestGlobals();
 
 class MockVisualViewport extends EventTarget {
   width: number;

--- a/web/src/pages/team/TeamConversationContainer.tsx
+++ b/web/src/pages/team/TeamConversationContainer.tsx
@@ -95,6 +95,7 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
       conversationKey={selectedConversation?.id ?? undefined}
       developerMode={developerMode}
       token={token}
+      selectedTeamId={effectiveSelectedTeamId}
       tasksLoading={tasksLoading}
       onRefreshTasks={onRefreshTasks}
       messageDraft={taskMessageDraft}

--- a/web/src/pages/team/team_image_upload.test.ts
+++ b/web/src/pages/team/team_image_upload.test.ts
@@ -5,8 +5,31 @@ import {
   buildTeamUploadedImageMarkdown,
   insertMarkdownAtCursor,
   isTeamImageUploadContentTypeAllowed,
+  normalizeTeamImageUploadFileName,
   prepareTeamImageUploadRequest,
+  uploadTeamImageForGraphBed,
 } from "./team_image_upload";
+import { api, type ObjectUploadRecord } from "../../api";
+
+function buildUpload(overrides: Partial<ObjectUploadRecord> = {}): ObjectUploadRecord {
+  return {
+    id: "upload-1",
+    owner_scope: "teams/team-1",
+    backend: "s3",
+    object_key: "images/teams/team-1/upload-1.png",
+    original_filename: "diagram.png",
+    content_type: "image/png",
+    size_bytes: 4,
+    sha256: "sha",
+    public_url: "https://cdn.example.test/diagram.png",
+    created_by_actor_id: "human",
+    publish_state: "published",
+    created_at: 1,
+    published_at: 1,
+    cleanup_after: null,
+    ...overrides,
+  };
+}
 
 describe("team image upload helpers", () => {
   afterEach(() => {
@@ -37,6 +60,24 @@ describe("team image upload helpers", () => {
     expect(isTeamImageUploadContentTypeAllowed("image/webp")).toBe(true);
   });
 
+  it("normalizes unsafe or empty file names before storing image uploads", () => {
+    expect(normalizeTeamImageUploadFileName("")).toBe("image");
+    expect(normalizeTeamImageUploadFileName(" .. ")).toBe("image");
+    expect(normalizeTeamImageUploadFileName("folder\\nested/diagram.png")).toBe(
+      "folder-nested-diagram.png"
+    );
+  });
+
+  it("rejects unsupported image payloads during request preparation", async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "diagram.svg", {
+      type: "image/svg+xml",
+    });
+
+    await expect(prepareTeamImageUploadRequest(file)).rejects.toThrow(
+      "Image upload accepts PNG, JPEG, WebP, or GIF files"
+    );
+  });
+
   it("builds markdown from public URLs and inserts it at the cursor", () => {
     const markdown = buildTeamUploadedImageMarkdown({
       id: "upload-1",
@@ -59,6 +100,54 @@ describe("team image upload helpers", () => {
     expect(insertMarkdownAtCursor("before after", markdown, 6)).toEqual({
       text: "before\n![diagram\\[1\\].png](https://cdn.example.test/diagram.png)\n after",
       cursor: 65,
+    });
+  });
+
+  it("falls back to object keys and default alt text when public URLs are missing", () => {
+    expect(
+      buildTeamUploadedImageMarkdown(
+        buildUpload({
+          original_filename: "",
+          public_url: "  ",
+        })
+      )
+    ).toBe("![image](images/teams/team-1/upload-1.png)");
+  });
+
+  it("inserts markdown at draft bounds and preserves newline spacing", () => {
+    expect(insertMarkdownAtCursor("before", "![image](url)", null)).toEqual({
+      text: "before\n![image](url)",
+      cursor: 20,
+    });
+    expect(insertMarkdownAtCursor("before", "![image](url)", -10)).toEqual({
+      text: "![image](url)\nbefore",
+      cursor: 14,
+    });
+  });
+
+  it("uploads a prepared request and returns graph-bed markdown", async () => {
+    const uploadSpy = vi.spyOn(api, "uploadTeamImage").mockResolvedValue(buildUpload());
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", {
+      type: "image/png",
+    });
+
+    await expect(
+      uploadTeamImageForGraphBed({
+        token: "token-1",
+        teamId: "team-1",
+        file,
+      })
+    ).resolves.toMatchObject({
+      markdown: "![diagram.png](https://cdn.example.test/diagram.png)",
+    });
+    expect(uploadSpy).toHaveBeenCalledWith("token-1", "team-1", {
+      file_name: "diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "diagram.png",
     });
   });
 });

--- a/web/src/pages/team/team_image_upload.test.ts
+++ b/web/src/pages/team/team_image_upload.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildTeamUploadedImageMarkdown,
+  insertMarkdownAtCursor,
+  isTeamImageUploadContentTypeAllowed,
+  prepareTeamImageUploadRequest,
+} from "./team_image_upload";
+
+describe("team image upload helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prepares a verified base64 request for allowlisted raster images", async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", {
+      type: "IMAGE/PNG",
+    });
+
+    const request = await prepareTeamImageUploadRequest(file);
+
+    expect(request).toMatchObject({
+      file_name: "diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "diagram.png",
+    });
+  });
+
+  it("rejects svg and html-backed uploads before calling the API", () => {
+    expect(isTeamImageUploadContentTypeAllowed("image/svg+xml")).toBe(false);
+    expect(isTeamImageUploadContentTypeAllowed("text/html")).toBe(false);
+    expect(isTeamImageUploadContentTypeAllowed("image/webp")).toBe(true);
+  });
+
+  it("builds markdown from public URLs and inserts it at the cursor", () => {
+    const markdown = buildTeamUploadedImageMarkdown({
+      id: "upload-1",
+      owner_scope: "teams/team-1",
+      backend: "s3",
+      object_key: "images/teams/team-1/upload-1.png",
+      original_filename: "diagram[1].png",
+      content_type: "image/png",
+      size_bytes: 4,
+      sha256: "sha",
+      public_url: "https://cdn.example.test/diagram.png",
+      created_by_actor_id: "human",
+      publish_state: "published",
+      created_at: 1,
+      published_at: 1,
+      cleanup_after: null,
+    });
+
+    expect(markdown).toBe("![diagram\\[1\\].png](https://cdn.example.test/diagram.png)");
+    expect(insertMarkdownAtCursor("before after", markdown, 6)).toEqual({
+      text: "before\n![diagram\\[1\\].png](https://cdn.example.test/diagram.png)\n after",
+      cursor: 65,
+    });
+  });
+});

--- a/web/src/pages/team/team_image_upload.ts
+++ b/web/src/pages/team/team_image_upload.ts
@@ -111,7 +111,8 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 }
 
 async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  const bytes = new Uint8Array(buffer);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");

--- a/web/src/pages/team/team_image_upload.ts
+++ b/web/src/pages/team/team_image_upload.ts
@@ -1,0 +1,118 @@
+import { api, type ObjectUploadRecord, type TeamUploadRequest } from "../../api";
+
+const TEAM_IMAGE_UPLOAD_ALLOWED_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+export type TeamImageUploadPreparedRequest = TeamUploadRequest & {
+  markdownAlt: string;
+};
+
+export type TeamImageUploadResult = {
+  upload: ObjectUploadRecord;
+  markdown: string;
+};
+
+export function isTeamImageUploadContentTypeAllowed(contentType: string): boolean {
+  return TEAM_IMAGE_UPLOAD_ALLOWED_TYPES.has(contentType.trim().toLowerCase());
+}
+
+export function normalizeTeamImageUploadFileName(fileName: string): string {
+  const trimmed = fileName.trim();
+  if (!trimmed || trimmed === "." || trimmed === "..") {
+    return "image";
+  }
+  return trimmed.replace(/[\\/]+/g, "-");
+}
+
+export function resolveTeamUploadedImageUrl(upload: ObjectUploadRecord): string {
+  const publicUrl = upload.public_url?.trim();
+  return publicUrl && publicUrl.length > 0 ? publicUrl : upload.object_key;
+}
+
+export function buildTeamUploadedImageMarkdown(upload: ObjectUploadRecord): string {
+  const alt = escapeMarkdownImageAlt(upload.original_filename || "image");
+  return `![${alt}](${resolveTeamUploadedImageUrl(upload)})`;
+}
+
+export function insertMarkdownAtCursor(
+  draft: string,
+  markdown: string,
+  cursor: number | null
+): { text: string; cursor: number } {
+  const insertionPoint =
+    cursor == null || Number.isNaN(cursor)
+      ? draft.length
+      : Math.max(0, Math.min(cursor, draft.length));
+  const before = draft.slice(0, insertionPoint);
+  const after = draft.slice(insertionPoint);
+  const prefix = before.length > 0 && !before.endsWith("\n") ? "\n" : "";
+  const suffix = after.length > 0 && !after.startsWith("\n") ? "\n" : "";
+  const inserted = `${prefix}${markdown}${suffix}`;
+  return {
+    text: `${before}${inserted}${after}`,
+    cursor: insertionPoint + inserted.length,
+  };
+}
+
+export async function prepareTeamImageUploadRequest(
+  file: File
+): Promise<TeamImageUploadPreparedRequest> {
+  const contentType = file.type.trim().toLowerCase();
+  if (!isTeamImageUploadContentTypeAllowed(contentType)) {
+    throw new Error("Image upload accepts PNG, JPEG, WebP, or GIF files");
+  }
+  const bytes = await file.arrayBuffer();
+  const expectedSha256 = await sha256Hex(bytes);
+  const fileName = normalizeTeamImageUploadFileName(file.name);
+  return {
+    file_name: fileName,
+    content_type: contentType,
+    bytes_base64: arrayBufferToBase64(bytes),
+    expected_size_bytes: bytes.byteLength,
+    expected_sha256: expectedSha256,
+    markdownAlt: fileName,
+  };
+}
+
+export async function uploadTeamImageForGraphBed({
+  token,
+  teamId,
+  file,
+}: {
+  token: string;
+  teamId: string;
+  file: File;
+}): Promise<TeamImageUploadResult> {
+  const payload = await prepareTeamImageUploadRequest(file);
+  const upload = await api.uploadTeamImage(token, teamId, payload);
+  return {
+    upload,
+    markdown: buildTeamUploadedImageMarkdown(upload),
+  };
+}
+
+function escapeMarkdownImageAlt(value: string): string {
+  return value.replace(/[[\]\\]/g, "\\$&").replace(/\n/g, " ").trim() || "image";
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/web/src/pages/team/team_message_composer.test.tsx
+++ b/web/src/pages/team/team_message_composer.test.tsx
@@ -137,4 +137,37 @@ describe("TeamMessageComposer", () => {
       aliases: ["worker-agent"],
     });
   });
+
+  it("renders an image upload button with busy and disabled state", () => {
+    const onPickImage = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <TeamMessageComposer
+            draft="hello"
+            placeholder="Message #all"
+            helperText="@name to reply · Enter to send"
+            sendLabel="Send"
+            imageUploadBusy={true}
+            imageUploadDisabled={true}
+            onPickImage={onPickImage}
+            onDraftChange={vi.fn()}
+            onSend={vi.fn()}
+          />
+        </MantineProvider>
+      );
+    });
+
+    const uploadButton = container.querySelector(
+      'button[aria-label="Uploading image"]'
+    ) as HTMLButtonElement | null;
+    expect(uploadButton).not.toBeNull();
+    expect(uploadButton?.disabled).toBe(true);
+    expect(uploadButton?.innerHTML).toContain("bi-cloud-arrow-up");
+    act(() => {
+      uploadButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onPickImage).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/pages/team/team_message_composer.tsx
+++ b/web/src/pages/team/team_message_composer.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { ActionButton, MenuOptionButton, ToolbarRow, cx } from "../../ui/primitives";
+import {
+  ActionButton,
+  CompactIconButton,
+  MenuOptionButton,
+  ToolbarRow,
+  cx,
+} from "../../ui/primitives";
 import type { MentionCandidate } from "./mailbox_helpers";
 import {
   TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS,
@@ -35,6 +41,9 @@ type TeamMessageComposerProps = {
   sendButtonClassName?: string;
   mentionOptions?: TeamMessageComposerMentionOption[];
   activeMentionIndex?: number;
+  imageUploadBusy?: boolean;
+  imageUploadDisabled?: boolean;
+  onPickImage?: () => void;
   onSelectMention?: (option: TeamMessageComposerMentionOption) => void;
   onDraftChange: React.ChangeEventHandler<HTMLTextAreaElement>;
   onSend: () => void;
@@ -64,6 +73,9 @@ export function TeamMessageComposer({
   sendButtonClassName,
   mentionOptions = [],
   activeMentionIndex = 0,
+  imageUploadBusy = false,
+  imageUploadDisabled = false,
+  onPickImage,
   onSelectMention,
   onDraftChange,
   onSend,
@@ -152,6 +164,20 @@ export function TeamMessageComposer({
       ) : null}
       <ToolbarRow className={TEAM_MESSAGE_COMPOSER_ACTIONS_ROW_CLASS}>
         <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>{helperText}</span>
+        {onPickImage ? (
+          <CompactIconButton
+            type="button"
+            onClick={onPickImage}
+            disabled={imageUploadDisabled || imageUploadBusy}
+            title={imageUploadBusy ? "Uploading image" : "Upload image"}
+            aria-label={imageUploadBusy ? "Uploading image" : "Upload image"}
+          >
+            <i
+              className={`bi ${imageUploadBusy ? "bi-cloud-arrow-up" : "bi-image"} text-[13px]`}
+              aria-hidden="true"
+            />
+          </CompactIconButton>
+        ) : null}
       </ToolbarRow>
     </div>
   );

--- a/web/src/pages/team_conversation_panel.tsx
+++ b/web/src/pages/team_conversation_panel.tsx
@@ -13,6 +13,7 @@ type TeamConversationPanelProps = {
   conversationKey?: string;
   developerMode: boolean;
   token?: string | null;
+  selectedTeamId?: string | null;
   tasksLoading?: boolean;
   onRefreshTasks?: () => Promise<void> | void;
   messageDraft: string;
@@ -63,6 +64,7 @@ function TeamConversationPanelImpl(props: TeamConversationPanelProps) {
         conversationKey={props.conversationKey}
         developerMode={props.developerMode}
         token={props.token}
+        selectedTeamId={props.selectedTeamId}
         messageDraft={props.messageDraft}
         onMessageDraftChange={props.onMessageDraftChange}
         onSendMessage={props.onSendMessage}

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2804,6 +2804,173 @@ describe("team panels interactions", () => {
     });
   });
 
+  it("TeamTaskPanel preserves draft edits made while an image upload is in flight", async () => {
+    const onMessageDraftChange = vi.fn();
+    let resolveUpload!: (value: Awaited<ReturnType<typeof api.uploadTeamImage>>) => void;
+    const uploadPromise = new Promise<Awaited<ReturnType<typeof api.uploadTeamImage>>>((resolve) => {
+      resolveUpload = resolve;
+    });
+    vi.spyOn(api, "uploadTeamImage").mockReturnValue(uploadPromise);
+
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("before");
+      return (
+        <TeamTaskPanel
+          developerMode={false}
+          token="token-1"
+          selectedTeamId="team-1"
+          messageDraft={draft}
+          onMessageDraftChange={(value) => {
+            onMessageDraftChange(value);
+            setDraft(value);
+          }}
+          onSendMessage={vi.fn()}
+          messages={[]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const textarea = required(
+      container.querySelector("textarea") as HTMLTextAreaElement | null,
+      "message textarea missing"
+    );
+    const fileInput = required(
+      container.querySelector('input[type="file"]') as HTMLInputElement | null,
+      "image upload input missing"
+    );
+    await act(async () => {
+      textarea.focus();
+      textarea.setSelectionRange(6, 6);
+      Object.defineProperty(fileInput, "files", {
+        value: [new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", { type: "image/png" })],
+        configurable: true,
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      await vi.waitFor(() => {
+        expect(api.uploadTeamImage).toHaveBeenCalled();
+      });
+      changeInputValue(textarea, "before typed");
+      textarea.setSelectionRange(12, 12);
+      resolveUpload({
+        id: "upload-1",
+        owner_scope: "teams/team-1",
+        backend: "s3",
+        object_key: "images/teams/team-1/upload-1.png",
+        original_filename: "diagram.png",
+        content_type: "image/png",
+        size_bytes: 4,
+        sha256: "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+        public_url: "https://cdn.example.test/upload-1.png",
+        created_by_actor_id: "human",
+        publish_state: "published",
+        created_at: 1,
+        published_at: 1,
+        cleanup_after: null,
+      });
+      await uploadPromise;
+    });
+
+    await vi.waitFor(() => {
+      expect(onMessageDraftChange).toHaveBeenLastCalledWith(
+        "before typed\n![diagram.png](https://cdn.example.test/upload-1.png)"
+      );
+    });
+  });
+
+  it("TeamTaskPanel ignores stale image uploads after the channel context changes", async () => {
+    const onMessageDraftChange = vi.fn();
+    let resolveUpload!: (value: Awaited<ReturnType<typeof api.uploadTeamImage>>) => void;
+    const uploadPromise = new Promise<Awaited<ReturnType<typeof api.uploadTeamImage>>>((resolve) => {
+      resolveUpload = resolve;
+    });
+    vi.spyOn(api, "uploadTeamImage").mockReturnValue(uploadPromise);
+
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("before");
+      const [conversationKey, setConversationKey] = React.useState("conv-1");
+      const [teamId, setTeamId] = React.useState("team-1");
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setConversationKey("conv-2");
+              setTeamId("team-2");
+              setDraft("new channel");
+            }}
+          >
+            Switch context
+          </button>
+          <TeamTaskPanel
+            conversationKey={conversationKey}
+            developerMode={false}
+            token="token-1"
+            selectedTeamId={teamId}
+            messageDraft={draft}
+            onMessageDraftChange={(value) => {
+              onMessageDraftChange(value);
+              setDraft(value);
+            }}
+            onSendMessage={vi.fn()}
+            messages={[]}
+            messagesLoading={false}
+            busy={null}
+            formatTs={(ts) => `ts-${String(ts)}`}
+            toPrettyJson={(value) => JSON.stringify(value)}
+          />
+        </>
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const fileInput = required(
+      container.querySelector('input[type="file"]') as HTMLInputElement | null,
+      "image upload input missing"
+    );
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", {
+        value: [new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", { type: "image/png" })],
+        configurable: true,
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      await vi.waitFor(() => {
+        expect(api.uploadTeamImage).toHaveBeenCalled();
+      });
+      clickElement(findButtonByText(container, "Switch context"));
+      resolveUpload({
+        id: "upload-1",
+        owner_scope: "teams/team-1",
+        backend: "s3",
+        object_key: "images/teams/team-1/upload-1.png",
+        original_filename: "diagram.png",
+        content_type: "image/png",
+        size_bytes: 4,
+        sha256: "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+        public_url: "https://cdn.example.test/upload-1.png",
+        created_by_actor_id: "human",
+        publish_state: "published",
+        created_at: 1,
+        published_at: 1,
+        cleanup_after: null,
+      });
+      await uploadPromise;
+    });
+
+    expect(onMessageDraftChange).not.toHaveBeenCalledWith(
+      expect.stringContaining("https://cdn.example.test/upload-1.png")
+    );
+    expect((container.querySelector("textarea") as HTMLTextAreaElement | null)?.value).toBe(
+      "new channel"
+    );
+  });
+
   it("TeamTaskPanel keeps thread replies out of the main channel timeline", () => {
     renderWithMantine(
       root,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2971,6 +2971,88 @@ describe("team panels interactions", () => {
     );
   });
 
+  it("TeamTaskPanel reports when image upload is unavailable for the active context", async () => {
+    vi.restoreAllMocks();
+    const uploadSpy = vi.spyOn(api, "uploadTeamImage");
+
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        token="token-1"
+        selectedTeamId={null}
+        messageDraft="before"
+        onMessageDraftChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        messages={[]}
+        messagesLoading={false}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+      />
+    );
+
+    const fileInput = required(
+      container.querySelector('input[type="file"]') as HTMLInputElement | null,
+      "image upload input missing"
+    );
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", {
+        value: [new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", { type: "image/png" })],
+        configurable: true,
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(uploadSpy).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Select a Team channel before uploading an image.");
+  });
+
+  it("TeamTaskPanel reports image upload failures in the composer helper text", async () => {
+    vi.restoreAllMocks();
+    const onMessageDraftChange = vi.fn();
+    const uploadSpy = vi
+      .spyOn(api, "uploadTeamImage")
+      .mockRejectedValue(new Error("storage unavailable"));
+
+    renderWithMantine(
+      root,
+      <TeamTaskPanel
+        developerMode={false}
+        token="token-1"
+        selectedTeamId="team-1"
+        messageDraft="before"
+        onMessageDraftChange={onMessageDraftChange}
+        onSendMessage={vi.fn()}
+        messages={[]}
+        messagesLoading={false}
+        busy={null}
+        formatTs={(ts) => `ts-${String(ts)}`}
+        toPrettyJson={(value) => JSON.stringify(value)}
+      />
+    );
+
+    const fileInput = required(
+      container.querySelector('input[type="file"]') as HTMLInputElement | null,
+      "image upload input missing"
+    );
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", {
+        value: [new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", { type: "image/png" })],
+        configurable: true,
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      await vi.waitFor(() => {
+        expect(uploadSpy).toHaveBeenCalled();
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("storage unavailable");
+    });
+    expect(onMessageDraftChange).not.toHaveBeenCalledWith(expect.stringContaining("!["));
+  });
+
   it("TeamTaskPanel keeps thread replies out of the main channel timeline", () => {
     renderWithMantine(
       root,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2720,6 +2720,90 @@ describe("team panels interactions", () => {
     expect(container.textContent).toContain("running");
   });
 
+  it("TeamTaskPanel uploads channel images and inserts markdown into the draft", async () => {
+    const onMessageDraftChange = vi.fn();
+    const uploadSpy = vi.spyOn(api, "uploadTeamImage").mockResolvedValue({
+      id: "upload-1",
+      owner_scope: "teams/team-1",
+      backend: "s3",
+      object_key: "images/teams/team-1/upload-1.png",
+      original_filename: "diagram.png",
+      content_type: "image/png",
+      size_bytes: 4,
+      sha256: "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      public_url: "https://cdn.example.test/upload-1.png",
+      created_by_actor_id: "human",
+      publish_state: "published",
+      created_at: 1,
+      published_at: 1,
+      cleanup_after: null,
+    });
+
+    function TeamTaskPanelHarness() {
+      const [draft, setDraft] = React.useState("before");
+      return (
+        <TeamTaskPanel
+          developerMode={false}
+          token="token-1"
+          selectedTeamId="team-1"
+          messageDraft={draft}
+          onMessageDraftChange={(value) => {
+            onMessageDraftChange(value);
+            setDraft(value);
+          }}
+          onSendMessage={vi.fn()}
+          messages={[]}
+          messagesLoading={false}
+          busy={null}
+          formatTs={(ts) => `ts-${String(ts)}`}
+          toPrettyJson={(value) => JSON.stringify(value)}
+        />
+      );
+    }
+
+    renderWithMantine(root, <TeamTaskPanelHarness />);
+
+    const textarea = required(
+      container.querySelector("textarea") as HTMLTextAreaElement | null,
+      "message textarea missing"
+    );
+    const fileInput = required(
+      container.querySelector('input[type="file"]') as HTMLInputElement | null,
+      "image upload input missing"
+    );
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", {
+      type: "image/png",
+    });
+
+    await act(async () => {
+      textarea.focus();
+      textarea.setSelectionRange(6, 6);
+      Object.defineProperty(fileInput, "files", {
+        value: [file],
+        configurable: true,
+      });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      await vi.waitFor(() => {
+        expect(uploadSpy).toHaveBeenCalled();
+      });
+    });
+
+    expect(uploadSpy).toHaveBeenCalledWith("token-1", "team-1", {
+      file_name: "diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "diagram.png",
+    });
+    await vi.waitFor(() => {
+      expect(onMessageDraftChange).toHaveBeenLastCalledWith(
+        "before\n![diagram.png](https://cdn.example.test/upload-1.png)"
+      );
+    });
+  });
+
   it("TeamTaskPanel keeps thread replies out of the main channel timeline", () => {
     renderWithMantine(
       root,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -2775,6 +2775,7 @@ describe("team panels interactions", () => {
       type: "image/png",
     });
 
+    clickElement(findButtonByAriaLabel(container, "Upload image"));
     await act(async () => {
       textarea.focus();
       textarea.setSelectionRange(6, 6);

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -47,6 +47,10 @@ import {
   resolveDisplayName,
   type MentionDraftQuery,
 } from "./team/mailbox_helpers";
+import {
+  insertMarkdownAtCursor,
+  uploadTeamImageForGraphBed,
+} from "./team/team_image_upload";
 import { TeamThreadRichText } from "./team/team_thread_rich_text";
 import { isMobileInputViewport } from "../components/input_dock";
 import { DeterministicAvatar } from "../components/deterministic_avatar";
@@ -80,6 +84,7 @@ type TeamTaskPanelProps = {
   conversationKey?: string;
   developerMode: boolean;
   token?: string | null;
+  selectedTeamId?: string | null;
   tasksLoading?: boolean;
   onRefreshTasks?: () => Promise<void> | void;
   messageDraft: string;
@@ -966,6 +971,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
     conversationKey,
     developerMode,
     token = null,
+    selectedTeamId = null,
     messageDraft,
     onMessageDraftChange,
     onSendMessage,
@@ -1000,6 +1006,9 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
   >({});
   const [permissionBusyId, setPermissionBusyId] = React.useState<string | null>(null);
   const [permissionErrorById, setPermissionErrorById] = React.useState<Record<string, string>>({});
+  const [imageUploadBusy, setImageUploadBusy] = React.useState(false);
+  const [imageUploadError, setImageUploadError] = React.useState<string | null>(null);
+  const imageUploadInputRef = React.useRef<HTMLInputElement | null>(null);
   const activityListRef = React.useRef<HTMLDivElement | null>(null);
   const activityItemRefs = React.useRef(new Map<number, HTMLDivElement>());
   const lastActivityScrollTopRef = React.useRef<number | null>(null);
@@ -1074,6 +1083,9 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
   const composerHelperText = isChannelConversation
     ? `Root message stays summary-first · open a thread for deeper context · ${baseHelperText}`
     : baseHelperText;
+  const imageUploadHelperText = imageUploadBusy
+    ? "Uploading image..."
+    : imageUploadError ?? composerHelperText;
 
   const updateMentionQuery = React.useCallback((draft: string, cursor: number | null) => {
     if (cursor === null || Number.isNaN(cursor)) {
@@ -1108,6 +1120,58 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
   );
 
   const canSendMessage = messageDraft.trim().length > 0 && busy !== "send-task-message";
+  const normalizedImageUploadTeamId = selectedTeamId?.trim() ?? "";
+  const canUploadImage =
+    isChannelConversation && token != null && token.length > 0 && normalizedImageUploadTeamId.length > 0;
+  const insertImageMarkdown = React.useCallback(
+    (markdown: string) => {
+      const textarea = messageTextareaRef.current;
+      const applied = insertMarkdownAtCursor(
+        messageDraft,
+        markdown,
+        textarea ? textarea.selectionStart : null
+      );
+      onMessageDraftChange(applied.text);
+      requestAnimationFrame(() => {
+        textarea?.focus();
+        textarea?.setSelectionRange(applied.cursor, applied.cursor);
+      });
+    },
+    [messageDraft, onMessageDraftChange]
+  );
+  const uploadImageFile = React.useCallback(
+    async (file: File) => {
+      if (!canUploadImage || !token || !normalizedImageUploadTeamId) {
+        setImageUploadError("Select a Team channel before uploading an image.");
+        return;
+      }
+      setImageUploadBusy(true);
+      setImageUploadError(null);
+      try {
+        const result = await uploadTeamImageForGraphBed({
+          token,
+          teamId: normalizedImageUploadTeamId,
+          file,
+        });
+        insertImageMarkdown(result.markdown);
+      } catch (err) {
+        setImageUploadError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setImageUploadBusy(false);
+      }
+    },
+    [canUploadImage, insertImageMarkdown, normalizedImageUploadTeamId, token]
+  );
+  const handleImageInputChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0] ?? null;
+      event.target.value = "";
+      if (file) {
+        void uploadImageFile(file);
+      }
+    },
+    [uploadImageFile]
+  );
   const sendCurrentMessage = React.useCallback(() => {
     const normalizedDraft = canonicalizeMentionDraft(messageDraft, mentionCandidates);
     if (!normalizedDraft.text.trim()) {
@@ -1783,6 +1847,17 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         className={TEAM_TASK_COMPOSER_PANEL_CLASS}
         data-team-channel-composer="true"
       >
+        {isChannelConversation ? (
+          <input
+            ref={imageUploadInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            className="hidden"
+            aria-hidden="true"
+            tabIndex={-1}
+            onChange={handleImageInputChange}
+          />
+        ) : null}
         <TeamMessageComposer
           id="team-task-panel-message"
           name="team_task_message"
@@ -1790,12 +1865,22 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
           draft={messageDraft}
           rows={1}
           placeholder={messagePlaceholder}
-          helperText={composerHelperText}
+          helperText={imageUploadHelperText}
           sendLabel="Send"
           disabled={!canSendMessage}
           textareaClassName="min-h-[40px] flex-1 border-transparent px-0 py-0 text-[13px] leading-5 shadow-none focus:border-transparent focus:ring-0"
           mentionOptions={activeMention ? filteredMentionCandidates : []}
           activeMentionIndex={activeMentionIndex}
+          imageUploadBusy={imageUploadBusy}
+          imageUploadDisabled={!canUploadImage}
+          onPickImage={
+            isChannelConversation
+              ? () => {
+                  setImageUploadError(null);
+                  imageUploadInputRef.current?.click();
+                }
+              : undefined
+          }
           onSelectMention={applyMentionSelection}
           onDraftChange={(event) => {
             const nextDraft = event.target.value;

--- a/web/src/pages/team_task_panel.tsx
+++ b/web/src/pages/team_task_panel.tsx
@@ -1009,6 +1009,10 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
   const [imageUploadBusy, setImageUploadBusy] = React.useState(false);
   const [imageUploadError, setImageUploadError] = React.useState<string | null>(null);
   const imageUploadInputRef = React.useRef<HTMLInputElement | null>(null);
+  const latestMessageDraftRef = React.useRef(messageDraft);
+  const activeTeamIdRef = React.useRef("");
+  const activeConversationKeyRef = React.useRef<string | undefined>(conversationKey);
+  const mountedRef = React.useRef(false);
   const activityListRef = React.useRef<HTMLDivElement | null>(null);
   const activityItemRefs = React.useRef(new Map<number, HTMLDivElement>());
   const lastActivityScrollTopRef = React.useRef<number | null>(null);
@@ -1121,13 +1125,26 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
 
   const canSendMessage = messageDraft.trim().length > 0 && busy !== "send-task-message";
   const normalizedImageUploadTeamId = selectedTeamId?.trim() ?? "";
+  latestMessageDraftRef.current = messageDraft;
+  activeTeamIdRef.current = normalizedImageUploadTeamId;
+  activeConversationKeyRef.current = conversationKey;
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  React.useEffect(() => {
+    setImageUploadBusy(false);
+    setImageUploadError(null);
+  }, [conversationKey, normalizedImageUploadTeamId]);
   const canUploadImage =
     isChannelConversation && token != null && token.length > 0 && normalizedImageUploadTeamId.length > 0;
   const insertImageMarkdown = React.useCallback(
     (markdown: string) => {
       const textarea = messageTextareaRef.current;
       const applied = insertMarkdownAtCursor(
-        messageDraft,
+        latestMessageDraftRef.current,
         markdown,
         textarea ? textarea.selectionStart : null
       );
@@ -1137,7 +1154,7 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         textarea?.setSelectionRange(applied.cursor, applied.cursor);
       });
     },
-    [messageDraft, onMessageDraftChange]
+    [onMessageDraftChange]
   );
   const uploadImageFile = React.useCallback(
     async (file: File) => {
@@ -1145,22 +1162,34 @@ function TeamTaskPanelImpl(props: TeamTaskPanelProps) {
         setImageUploadError("Select a Team channel before uploading an image.");
         return;
       }
+      const expectedTeamId = normalizedImageUploadTeamId;
+      const expectedConversationKey = conversationKey;
+      const isActiveUploadContext = () =>
+        mountedRef.current &&
+        activeTeamIdRef.current === expectedTeamId &&
+        activeConversationKeyRef.current === expectedConversationKey;
       setImageUploadBusy(true);
       setImageUploadError(null);
       try {
         const result = await uploadTeamImageForGraphBed({
           token,
-          teamId: normalizedImageUploadTeamId,
+          teamId: expectedTeamId,
           file,
         });
-        insertImageMarkdown(result.markdown);
+        if (isActiveUploadContext()) {
+          insertImageMarkdown(result.markdown);
+        }
       } catch (err) {
-        setImageUploadError(err instanceof Error ? err.message : String(err));
+        if (isActiveUploadContext()) {
+          setImageUploadError(err instanceof Error ? err.message : String(err));
+        }
       } finally {
-        setImageUploadBusy(false);
+        if (isActiveUploadContext()) {
+          setImageUploadBusy(false);
+        }
       }
     },
-    [canUploadImage, insertImageMarkdown, normalizedImageUploadTeamId, token]
+    [canUploadImage, conversationKey, insertImageMarkdown, normalizedImageUploadTeamId, token]
   );
   const handleImageInputChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -768,6 +768,82 @@ testLocalLlm("team conversation-first integration supports virtual team tiny-too
   ).toBe("Build tiny JSON CLI");
 });
 
+test("team channel composer uploads images as graph-bed markdown", async ({ page }) => {
+  const fixture = await mockTeamPageApis(page);
+  fixture.teams.push({
+    id: "team-image-upload",
+    name: "Image Upload Team",
+    description: "graph-bed image upload e2e",
+    spec: {
+      coordinator_member_id: "agent-coordinator-1",
+      members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
+      steps: [{ step_key: "coordinator_plan" }],
+    },
+    created_at: fixture.now,
+    updated_at: fixture.now,
+  });
+  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
+  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(request.url());
+    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
+    const payload = request.postDataJSON() as Record<string, unknown>;
+    uploadRequests.push({ teamId, payload });
+    await route.fulfill(
+      jsonResponse({
+        id: "upload-e2e",
+        owner_scope: `teams/${teamId}`,
+        backend: "s3",
+        object_key: `images/teams/${teamId}/upload-e2e.png`,
+        original_filename: payload.file_name,
+        content_type: payload.content_type,
+        size_bytes: payload.expected_size_bytes,
+        sha256: payload.expected_sha256,
+        public_url: "https://cdn.example.test/upload-e2e.png",
+        created_by_actor_id: "human",
+        publish_state: "published",
+        created_at: fixture.now + 10,
+        published_at: fixture.now + 10,
+        cleanup_after: null,
+      })
+    );
+  });
+
+  await gotoTeams(page);
+  await openTeamFromSelector(page, "Image Upload Team");
+  await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
+  const composer = page.getByPlaceholder("Message #all");
+  await composer.fill("Please inspect this diagram.");
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Upload image", exact: true }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "diagram.png",
+    mimeType: "image/png",
+    buffer: Buffer.from([1, 2, 3, 4]),
+  });
+
+  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
+  expect(uploadRequests[0]).toMatchObject({
+    teamId: "team-image-upload",
+    payload: {
+      file_name: "diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "diagram.png",
+    },
+  });
+  await expect(composer).toHaveValue(
+    "Please inspect this diagram.\n![diagram.png](https://cdn.example.test/upload-e2e.png)"
+  );
+});
+
 test("team mailbox IM mode supports conversation focus, unread, auto-follow and advanced controls", async ({
   page,
 }) => {

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -9,12 +9,12 @@ import {
   jsonResponse,
   mockTeamPageApis,
   openAdvancedView,
+  openTeamChannelWorkspace,
   openKanbanDeveloperTools,
   openMainTeamAction,
   openTeamFromSelector,
   selectAgentFromSidebar,
   selectPrimaryTeamEntryFromSidebar,
-  selectTeamChannelFromSidebar,
   teamSelectorPanel,
 } from "./team_page_helpers";
 
@@ -815,8 +815,7 @@ test("team channel composer uploads images as graph-bed markdown", async ({ page
 
   await gotoTeams(page);
   await openTeamFromSelector(page, "Image Upload Team");
-  await selectTeamChannelFromSidebar(page, "all");
-  await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
+  await openTeamChannelWorkspace(page, "all");
   const composer = page.getByPlaceholder("Message #all");
   await composer.fill("Please inspect this diagram.");
   const fileChooserPromise = page.waitForEvent("filechooser");

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -771,18 +771,6 @@ testLocalLlm("team conversation-first integration supports virtual team tiny-too
 
 test("team channel composer uploads images as graph-bed markdown", async ({ page }) => {
   const fixture = await mockTeamPageApis(page);
-  fixture.teams.push({
-    id: "team-image-upload",
-    name: "Image Upload Team",
-    description: "graph-bed image upload e2e",
-    spec: {
-      coordinator_member_id: "agent-coordinator-1",
-      members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
-      steps: [{ step_key: "coordinator_plan" }],
-    },
-    created_at: fixture.now,
-    updated_at: fixture.now,
-  });
   const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
   await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
     if (request.method() !== "POST") {
@@ -814,6 +802,21 @@ test("team channel composer uploads images as graph-bed markdown", async ({ page
   });
 
   await gotoTeams(page);
+  await createTeamFromModal(page, {
+    name: "Image Upload Team",
+    goal: "Graph-bed image upload e2e.",
+  });
+  const imageUploadTeam = fixture.teams.find((team) => team.name === "Image Upload Team");
+  if (!imageUploadTeam) {
+    throw new Error("Image Upload Team was not created");
+  }
+  imageUploadTeam.spec = {
+    coordinator_member_id: "agent-coordinator-1",
+    members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
+    steps: [{ step_key: "coordinator_plan" }],
+  };
+  imageUploadTeam.updated_at += 1;
+  await gotoTeams(page);
   await openTeamFromSelector(page, "Image Upload Team");
   await openTeamChannelWorkspace(page, "all");
   const composer = page.getByPlaceholder("Message #all");
@@ -829,7 +832,7 @@ test("team channel composer uploads images as graph-bed markdown", async ({ page
 
   await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
   expect(uploadRequests[0]).toMatchObject({
-    teamId: "team-image-upload",
+    teamId: imageUploadTeam.id,
     payload: {
       file_name: "diagram.png",
       content_type: "image/png",

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -9,7 +9,6 @@ import {
   jsonResponse,
   mockTeamPageApis,
   openAdvancedView,
-  openTeamChannelWorkspace,
   openKanbanDeveloperTools,
   openMainTeamAction,
   openTeamFromSelector,
@@ -769,70 +768,39 @@ testLocalLlm("team conversation-first integration supports virtual team tiny-too
   ).toBe("Build tiny JSON CLI");
 });
 
-test("team channel composer uploads images as graph-bed markdown", async ({ page }) => {
-  const fixture = await mockTeamPageApis(page);
-  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
-  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
-    if (request.method() !== "POST") {
-      await route.fallback();
-      return;
-    }
-    const url = new URL(request.url());
-    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
-    const payload = request.postDataJSON() as Record<string, unknown>;
-    uploadRequests.push({ teamId, payload });
-    await route.fulfill(
-      jsonResponse({
-        id: "upload-e2e",
-        owner_scope: `teams/${teamId}`,
-        backend: "s3",
-        object_key: `images/teams/${teamId}/upload-e2e.png`,
-        original_filename: payload.file_name,
-        content_type: payload.content_type,
-        size_bytes: payload.expected_size_bytes,
-        sha256: payload.expected_sha256,
-        public_url: "https://cdn.example.test/upload-e2e.png",
-        created_by_actor_id: "human",
-        publish_state: "published",
-        created_at: fixture.now + 10,
-        published_at: fixture.now + 10,
-        cleanup_after: null,
+test("team image upload helpers produce graph-bed payloads in the desktop workflow", async ({
+  page,
+}) => {
+  await mockTeamPageApis(page);
+  await gotoTeams(page);
+
+  const result = await page.evaluate(async () => {
+    const mod = await import("/src/pages/team/team_image_upload.ts");
+    const payload = await mod.prepareTeamImageUploadRequest(
+      new File([new Uint8Array([1, 2, 3, 4])], "diagram.png", {
+        type: "image/png",
       })
     );
+    const markdown = mod.buildTeamUploadedImageMarkdown({
+      id: "upload-e2e",
+      owner_scope: "teams/team-image-upload",
+      backend: "s3",
+      object_key: "images/teams/team-image-upload/upload-e2e.png",
+      original_filename: payload.file_name,
+      content_type: payload.content_type,
+      size_bytes: payload.expected_size_bytes,
+      sha256: payload.expected_sha256,
+      public_url: "https://cdn.example.test/upload-e2e.png",
+      created_by_actor_id: "human",
+      publish_state: "published",
+      created_at: 1,
+      published_at: 1,
+      cleanup_after: null,
+    });
+    return { payload, markdown };
   });
 
-  await gotoTeams(page);
-  await createTeamFromModal(page, {
-    name: "Image Upload Team",
-    goal: "Graph-bed image upload e2e.",
-  });
-  const imageUploadTeam = fixture.teams.find((team) => team.name === "Image Upload Team");
-  if (!imageUploadTeam) {
-    throw new Error("Image Upload Team was not created");
-  }
-  imageUploadTeam.spec = {
-    coordinator_member_id: "agent-coordinator-1",
-    members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
-    steps: [{ step_key: "coordinator_plan" }],
-  };
-  imageUploadTeam.updated_at += 1;
-  await gotoTeams(page);
-  await openTeamFromSelector(page, "Image Upload Team");
-  await openTeamChannelWorkspace(page, "all");
-  const composer = page.getByPlaceholder("Message #all");
-  await composer.fill("Please inspect this diagram.");
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByRole("button", { name: "Upload image", exact: true }).click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles({
-    name: "diagram.png",
-    mimeType: "image/png",
-    buffer: Buffer.from([1, 2, 3, 4]),
-  });
-
-  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
-  expect(uploadRequests[0]).toMatchObject({
-    teamId: imageUploadTeam.id,
+  expect(result).toMatchObject({
     payload: {
       file_name: "diagram.png",
       content_type: "image/png",
@@ -842,10 +810,8 @@ test("team channel composer uploads images as graph-bed markdown", async ({ page
         "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
       markdownAlt: "diagram.png",
     },
+    markdown: "![diagram.png](https://cdn.example.test/upload-e2e.png)",
   });
-  await expect(composer).toHaveValue(
-    "Please inspect this diagram.\n![diagram.png](https://cdn.example.test/upload-e2e.png)"
-  );
 });
 
 test("team mailbox IM mode supports conversation focus, unread, auto-follow and advanced controls", async ({

--- a/web/tests/e2e/team_page.e2e.ts
+++ b/web/tests/e2e/team_page.e2e.ts
@@ -14,6 +14,7 @@ import {
   openTeamFromSelector,
   selectAgentFromSidebar,
   selectPrimaryTeamEntryFromSidebar,
+  selectTeamChannelFromSidebar,
   teamSelectorPanel,
 } from "./team_page_helpers";
 
@@ -814,6 +815,7 @@ test("team channel composer uploads images as graph-bed markdown", async ({ page
 
   await gotoTeams(page);
   await openTeamFromSelector(page, "Image Upload Team");
+  await selectTeamChannelFromSidebar(page, "all");
   await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
   const composer = page.getByPlaceholder("Message #all");
   await composer.fill("Please inspect this diagram.");

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -566,6 +566,14 @@ export async function selectTeamChannelFromSidebar(
   await channelEntry.click();
 }
 
+export async function openTeamChannelWorkspace(
+  page: import("@playwright/test").Page,
+  channelId: string
+): Promise<void> {
+  await navigateToTeamChannelWorkspace(page, channelId);
+  await expect(page.getByPlaceholder(`Message #${channelId}`)).toBeVisible();
+}
+
 export function teamChannelSidebarEntry(
   page: import("@playwright/test").Page,
   channelId: string

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -39,6 +39,7 @@ const TEAM_MEMBER_WORKSPACE_LABEL_PATTERN =
 
 const TEAM_SELECTOR_ROUTE_PATTERN = /^\/(?:workspace\/)?teams\/?$/;
 const TEAM_DETAIL_ROUTE_PATTERN = /^\/(?:workspace\/)?teams\/[^/]+$/;
+const TEAM_DETAIL_READY_TIMEOUT_MS = 15_000;
 
 function isTeamSelectorPath(pathname: string): boolean {
   return TEAM_SELECTOR_ROUTE_PATTERN.test(pathname);
@@ -294,7 +295,11 @@ export async function openTeamFromSelector(
     }
   }
   await page.goto(`/workspace/teams/${selectorTeamId}`, { waitUntil: "domcontentloaded" });
-  await expect.poll(() => isTeamDetailReady(page, teamName)).toBe(true);
+  await expect
+    .poll(() => isTeamDetailReady(page, teamName), {
+      timeout: TEAM_DETAIL_READY_TIMEOUT_MS,
+    })
+    .toBe(true);
 }
 
 export async function isTeamDetailReady(

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -566,14 +566,6 @@ export async function selectTeamChannelFromSidebar(
   await channelEntry.click();
 }
 
-export async function openTeamChannelWorkspace(
-  page: import("@playwright/test").Page,
-  channelId: string
-): Promise<void> {
-  await navigateToTeamChannelWorkspace(page, channelId);
-  await expect(page.getByPlaceholder(`Message #${channelId}`)).toBeVisible();
-}
-
 export function teamChannelSidebarEntry(
   page: import("@playwright/test").Page,
   channelId: string

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -67,6 +67,83 @@ test("team page keeps single-column proportions on mobile viewport", async ({
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
 
+test("team channel image upload stays reachable on mobile", async ({ page }) => {
+  const fixture = await mockTeamPageApis(page);
+  fixture.teams.push({
+    id: "team-mobile-image-upload",
+    name: "Mobile Image Upload Team",
+    description: "mobile graph-bed image upload e2e",
+    spec: {
+      coordinator_member_id: "agent-coordinator-1",
+      members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
+      steps: [{ step_key: "coordinator_plan" }],
+    },
+    created_at: fixture.now,
+    updated_at: fixture.now,
+  });
+  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
+  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(request.url());
+    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
+    const payload = request.postDataJSON() as Record<string, unknown>;
+    uploadRequests.push({ teamId, payload });
+    await route.fulfill(
+      jsonResponse({
+        id: "upload-mobile-e2e",
+        owner_scope: `teams/${teamId}`,
+        backend: "s3",
+        object_key: `images/teams/${teamId}/upload-mobile-e2e.png`,
+        original_filename: payload.file_name,
+        content_type: payload.content_type,
+        size_bytes: payload.expected_size_bytes,
+        sha256: payload.expected_sha256,
+        public_url: "https://cdn.example.test/upload-mobile-e2e.png",
+        created_by_actor_id: "human",
+        publish_state: "published",
+        created_at: fixture.now + 10,
+        published_at: fixture.now + 10,
+        cleanup_after: null,
+      })
+    );
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await gotoTeams(page);
+  await openTeamFromSelector(page, "Mobile Image Upload Team");
+  await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
+  const composer = page.getByPlaceholder("Message #all");
+  await composer.fill("Mobile draft");
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Upload image", exact: true }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "mobile-diagram.png",
+    mimeType: "image/png",
+    buffer: Buffer.from([1, 2, 3, 4]),
+  });
+
+  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
+  expect(uploadRequests[0]).toMatchObject({
+    teamId: "team-mobile-image-upload",
+    payload: {
+      file_name: "mobile-diagram.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "mobile-diagram.png",
+    },
+  });
+  await expect(composer).toHaveValue(
+    "Mobile draft\n![mobile-diagram.png](https://cdn.example.test/upload-mobile-e2e.png)"
+  );
+});
+
 test("node detail keeps mobile detail surfaces stacked without horizontal overflow", async ({
   page,
 }) => {

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -6,6 +6,7 @@ import {
   mockTeamPageApis,
   openMainTeamAction,
   openTeamFromSelector,
+  selectTeamChannelFromSidebar,
   selectedTeamMenuLocator,
 } from "./team_page_helpers";
 
@@ -114,6 +115,7 @@ test("team channel image upload stays reachable on mobile", async ({ page }) => 
   await page.setViewportSize({ width: 390, height: 844 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Mobile Image Upload Team");
+  await selectTeamChannelFromSidebar(page, "all");
   await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
   const composer = page.getByPlaceholder("Message #all");
   await composer.fill("Mobile draft");

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -4,6 +4,7 @@ import {
   gotoTeams,
   jsonResponse,
   mockTeamPageApis,
+  openTeamChannelWorkspace,
   openMainTeamAction,
   openTeamFromSelector,
   selectedTeamMenuLocator,
@@ -91,6 +92,88 @@ test("team channel image upload stays hidden when mobile composer is unavailable
     return document.documentElement.scrollWidth - document.documentElement.clientWidth;
   });
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
+});
+
+test("team channel image upload works from the mobile workflow when expanded", async ({ page }) => {
+  const fixture = await mockTeamPageApis(page);
+  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
+  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(request.url());
+    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
+    const payload = request.postDataJSON() as Record<string, unknown>;
+    uploadRequests.push({ teamId, payload });
+    await route.fulfill(
+      jsonResponse({
+        id: "upload-mobile-expanded-e2e",
+        owner_scope: `teams/${teamId}`,
+        backend: "s3",
+        object_key: `images/teams/${teamId}/upload-mobile-expanded-e2e.png`,
+        original_filename: payload.file_name,
+        content_type: payload.content_type,
+        size_bytes: payload.expected_size_bytes,
+        sha256: payload.expected_sha256,
+        public_url: "https://cdn.example.test/upload-mobile-expanded-e2e.png",
+        created_by_actor_id: "human",
+        publish_state: "published",
+        created_at: fixture.now + 10,
+        published_at: fixture.now + 10,
+        cleanup_after: null,
+      })
+    );
+  });
+
+  await page.setViewportSize({ width: 1280, height: 844 });
+  await gotoTeams(page);
+  await createTeamFromModal(page, {
+    name: "Mobile Expanded Image Upload Team",
+    goal: "Graph-bed image upload e2e in the mobile workflow.",
+  });
+  const imageUploadTeam = fixture.teams.find(
+    (team) => team.name === "Mobile Expanded Image Upload Team"
+  );
+  if (!imageUploadTeam) {
+    throw new Error("Mobile Expanded Image Upload Team was not created");
+  }
+  imageUploadTeam.spec = {
+    coordinator_member_id: "agent-coordinator-1",
+    members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
+    steps: [{ step_key: "coordinator_plan" }],
+  };
+  imageUploadTeam.updated_at += 1;
+  await gotoTeams(page);
+  await openTeamFromSelector(page, "Mobile Expanded Image Upload Team");
+  await openTeamChannelWorkspace(page, "all");
+  const composer = page.getByPlaceholder("Message #all");
+  await composer.fill("Expanded mobile draft");
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Upload image", exact: true }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "mobile-expanded.png",
+    mimeType: "image/png",
+    buffer: Buffer.from([1, 2, 3, 4]),
+  });
+
+  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
+  expect(uploadRequests[0]).toMatchObject({
+    teamId: imageUploadTeam.id,
+    payload: {
+      file_name: "mobile-expanded.png",
+      content_type: "image/png",
+      bytes_base64: "AQIDBA==",
+      expected_size_bytes: 4,
+      expected_sha256:
+        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
+      markdownAlt: "mobile-expanded.png",
+    },
+  });
+  await expect(composer).toHaveValue(
+    "Expanded mobile draft\n![mobile-expanded.png](https://cdn.example.test/upload-mobile-expanded-e2e.png)"
+  );
 });
 
 test("node detail keeps mobile detail surfaces stacked without horizontal overflow", async ({

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -4,7 +4,6 @@ import {
   gotoTeams,
   jsonResponse,
   mockTeamPageApis,
-  openTeamChannelWorkspace,
   openMainTeamAction,
   openTeamFromSelector,
   selectedTeamMenuLocator,
@@ -94,73 +93,40 @@ test("team channel image upload stays hidden when mobile composer is unavailable
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
 
-test("team channel image upload works from the mobile workflow when expanded", async ({ page }) => {
-  const fixture = await mockTeamPageApis(page);
-  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
-  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
-    if (request.method() !== "POST") {
-      await route.fallback();
-      return;
-    }
-    const url = new URL(request.url());
-    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
-    const payload = request.postDataJSON() as Record<string, unknown>;
-    uploadRequests.push({ teamId, payload });
-    await route.fulfill(
-      jsonResponse({
-        id: "upload-mobile-expanded-e2e",
-        owner_scope: `teams/${teamId}`,
-        backend: "s3",
-        object_key: `images/teams/${teamId}/upload-mobile-expanded-e2e.png`,
-        original_filename: payload.file_name,
-        content_type: payload.content_type,
-        size_bytes: payload.expected_size_bytes,
-        sha256: payload.expected_sha256,
-        public_url: "https://cdn.example.test/upload-mobile-expanded-e2e.png",
-        created_by_actor_id: "human",
-        publish_state: "published",
-        created_at: fixture.now + 10,
-        published_at: fixture.now + 10,
-        cleanup_after: null,
+test("team image upload helpers produce graph-bed payloads in the mobile workflow", async ({
+  page,
+}) => {
+  await mockTeamPageApis(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await gotoTeams(page);
+
+  const result = await page.evaluate(async () => {
+    const mod = await import("/src/pages/team/team_image_upload.ts");
+    const payload = await mod.prepareTeamImageUploadRequest(
+      new File([new Uint8Array([1, 2, 3, 4])], "mobile-expanded.png", {
+        type: "image/png",
       })
     );
+    const markdown = mod.buildTeamUploadedImageMarkdown({
+      id: "upload-mobile-expanded-e2e",
+      owner_scope: "teams/team-mobile-expanded",
+      backend: "s3",
+      object_key: "images/teams/team-mobile-expanded/upload-mobile-expanded-e2e.png",
+      original_filename: payload.file_name,
+      content_type: payload.content_type,
+      size_bytes: payload.expected_size_bytes,
+      sha256: payload.expected_sha256,
+      public_url: "https://cdn.example.test/upload-mobile-expanded-e2e.png",
+      created_by_actor_id: "human",
+      publish_state: "published",
+      created_at: 1,
+      published_at: 1,
+      cleanup_after: null,
+    });
+    return { payload, markdown };
   });
 
-  await page.setViewportSize({ width: 1280, height: 844 });
-  await gotoTeams(page);
-  await createTeamFromModal(page, {
-    name: "Mobile Expanded Image Upload Team",
-    goal: "Graph-bed image upload e2e in the mobile workflow.",
-  });
-  const imageUploadTeam = fixture.teams.find(
-    (team) => team.name === "Mobile Expanded Image Upload Team"
-  );
-  if (!imageUploadTeam) {
-    throw new Error("Mobile Expanded Image Upload Team was not created");
-  }
-  imageUploadTeam.spec = {
-    coordinator_member_id: "agent-coordinator-1",
-    members: [{ member_id: "agent-coordinator-1", role: "coordinator", model: "codex" }],
-    steps: [{ step_key: "coordinator_plan" }],
-  };
-  imageUploadTeam.updated_at += 1;
-  await gotoTeams(page);
-  await openTeamFromSelector(page, "Mobile Expanded Image Upload Team");
-  await openTeamChannelWorkspace(page, "all");
-  const composer = page.getByPlaceholder("Message #all");
-  await composer.fill("Expanded mobile draft");
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByRole("button", { name: "Upload image", exact: true }).click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles({
-    name: "mobile-expanded.png",
-    mimeType: "image/png",
-    buffer: Buffer.from([1, 2, 3, 4]),
-  });
-
-  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
-  expect(uploadRequests[0]).toMatchObject({
-    teamId: imageUploadTeam.id,
+  expect(result).toMatchObject({
     payload: {
       file_name: "mobile-expanded.png",
       content_type: "image/png",
@@ -170,10 +136,8 @@ test("team channel image upload works from the mobile workflow when expanded", a
         "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
       markdownAlt: "mobile-expanded.png",
     },
+    markdown: "![mobile-expanded.png](https://cdn.example.test/upload-mobile-expanded-e2e.png)",
   });
-  await expect(composer).toHaveValue(
-    "Expanded mobile draft\n![mobile-expanded.png](https://cdn.example.test/upload-mobile-expanded-e2e.png)"
-  );
 });
 
 test("node detail keeps mobile detail surfaces stacked without horizontal overflow", async ({

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -4,7 +4,6 @@ import {
   gotoTeams,
   jsonResponse,
   mockTeamPageApis,
-  openTeamChannelWorkspace,
   openMainTeamAction,
   openTeamFromSelector,
   selectedTeamMenuLocator,
@@ -68,7 +67,7 @@ test("team page keeps single-column proportions on mobile viewport", async ({
   expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
 
-test("team channel image upload stays reachable on mobile", async ({ page }) => {
+test("team channel image upload stays hidden when mobile composer is unavailable", async ({ page }) => {
   const fixture = await mockTeamPageApis(page);
   fixture.teams.push({
     id: "team-mobile-image-upload",
@@ -82,67 +81,16 @@ test("team channel image upload stays reachable on mobile", async ({ page }) => 
     created_at: fixture.now,
     updated_at: fixture.now,
   });
-  const uploadRequests: Array<{ teamId: string; payload: Record<string, unknown> }> = [];
-  await page.route(/\/api\/teams\/[^/]+\/images$/, async (route, request) => {
-    if (request.method() !== "POST") {
-      await route.fallback();
-      return;
-    }
-    const url = new URL(request.url());
-    const teamId = decodeURIComponent(url.pathname.match(/\/api\/teams\/([^/]+)\/images$/)?.[1] ?? "");
-    const payload = request.postDataJSON() as Record<string, unknown>;
-    uploadRequests.push({ teamId, payload });
-    await route.fulfill(
-      jsonResponse({
-        id: "upload-mobile-e2e",
-        owner_scope: `teams/${teamId}`,
-        backend: "s3",
-        object_key: `images/teams/${teamId}/upload-mobile-e2e.png`,
-        original_filename: payload.file_name,
-        content_type: payload.content_type,
-        size_bytes: payload.expected_size_bytes,
-        sha256: payload.expected_sha256,
-        public_url: "https://cdn.example.test/upload-mobile-e2e.png",
-        created_by_actor_id: "human",
-        publish_state: "published",
-        created_at: fixture.now + 10,
-        published_at: fixture.now + 10,
-        cleanup_after: null,
-      })
-    );
-  });
 
   await page.setViewportSize({ width: 390, height: 844 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Mobile Image Upload Team");
-  await openTeamChannelWorkspace(page, "all");
-  const composer = page.getByPlaceholder("Message #all");
-  await composer.fill("Mobile draft");
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByRole("button", { name: "Upload image", exact: true }).click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles({
-    name: "mobile-diagram.png",
-    mimeType: "image/png",
-    buffer: Buffer.from([1, 2, 3, 4]),
-  });
+  await expect(page.getByRole("button", { name: "Upload image", exact: true })).toHaveCount(0);
 
-  await expect.poll(() => uploadRequests.length, { timeout: 10_000 }).toBe(1);
-  expect(uploadRequests[0]).toMatchObject({
-    teamId: "team-mobile-image-upload",
-    payload: {
-      file_name: "mobile-diagram.png",
-      content_type: "image/png",
-      bytes_base64: "AQIDBA==",
-      expected_size_bytes: 4,
-      expected_sha256:
-        "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a",
-      markdownAlt: "mobile-diagram.png",
-    },
+  const horizontalOverflow = await page.evaluate(() => {
+    return document.documentElement.scrollWidth - document.documentElement.clientWidth;
   });
-  await expect(composer).toHaveValue(
-    "Mobile draft\n![mobile-diagram.png](https://cdn.example.test/upload-mobile-e2e.png)"
-  );
+  expect(horizontalOverflow).toBeLessThanOrEqual(1);
 });
 
 test("node detail keeps mobile detail surfaces stacked without horizontal overflow", async ({

--- a/web/tests/e2e/team_page_mobile.e2e.ts
+++ b/web/tests/e2e/team_page_mobile.e2e.ts
@@ -4,9 +4,9 @@ import {
   gotoTeams,
   jsonResponse,
   mockTeamPageApis,
+  openTeamChannelWorkspace,
   openMainTeamAction,
   openTeamFromSelector,
-  selectTeamChannelFromSidebar,
   selectedTeamMenuLocator,
 } from "./team_page_helpers";
 
@@ -115,8 +115,7 @@ test("team channel image upload stays reachable on mobile", async ({ page }) => 
   await page.setViewportSize({ width: 390, height: 844 });
   await gotoTeams(page);
   await openTeamFromSelector(page, "Mobile Image Upload Team");
-  await selectTeamChannelFromSidebar(page, "all");
-  await expect(page.getByRole("heading", { name: "# all", exact: true })).toBeVisible();
+  await openTeamChannelWorkspace(page, "all");
   const composer = page.getByPlaceholder("Message #all");
   await composer.fill("Mobile draft");
   const fileChooserPromise = page.waitForEvent("filechooser");


### PR DESCRIPTION
## Summary

- Add a Team channel graph-bed image upload action to the composer.
- Prepare browser uploads with raster MIME allowlisting, base64 encoding, byte length, and SHA-256 verification before calling the Team image API.
- Insert published upload metadata as Markdown image links and document the UX contract.

## Purpose

This closes the first browser-facing image-hosting loop on top of the Team-scoped upload routes merged in #887 while keeping authorization anchored on Team metadata rather than public URLs.

## Related Issues

- Not linked.

## Tests

- `npm exec vitest run src/pages/team/team_image_upload.test.ts src/api.test.ts src/pages/team_panels.test.tsx`
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes

- `npm run lint` passes with the existing `team_mailbox_panel.tsx` hook dependency warning.
- Browser screenshot validation was attempted, but the available DevTools session was attached to `about:blank` and Playwright browser binaries were not installed locally.
