### PR TITLE
feat(api): add owner-scoped upload routes

### DIFF
--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -148,6 +148,7 @@ operations must still authorize against the Team-owned metadata row.
 | Image hosting helper | Focused async test writes a scoped raster image object, rejects nested image ids, and returns a normalized public URL. |
 | Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
 | Team upload API | Handler and router tests cover authorization, owner-scope derivation, base64 upload publication, raster-image allowlist, and size/checksum mismatch rejection without publishing metadata. |
+| Task and agent upload APIs | Focused API tests cover parent Team authorization before task-scope publication, agent existence checks before agent-scope publication, object/image key prefixes, and OpenAPI fixture coverage for every new route. |
 | Graph-bed UX | Frontend tests cover raster MIME allowlisting, browser SHA-256/base64 request preparation, Team image endpoint wiring, and Markdown image insertion in the Team channel composer. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |

--- a/docs/journal/2026-07-18-object-upload-owner-scopes.md
+++ b/docs/journal/2026-07-18-object-upload-owner-scopes.md
@@ -1,0 +1,45 @@
+# Object Upload Owner Scopes
+
+## Summary
+
+This checkpoint extends browser/API object uploads beyond the initial Team-owned routes. Task and
+agent upload routes now derive their owner scope from authorized resource paths before publishing
+object metadata.
+
+## Background
+
+The OpenDAL storage foundation already centralized object publication in `ObjectUploadService` and
+limited owner scopes to `teams/<id>`, `tasks/<id>`, and `agents/<id>`. The first browser slice only
+exposed Team-scoped JSON/base64 upload routes, leaving task and agent API authorization as the next
+small follow-up.
+
+## Scope
+
+- Add shared API upload request decoding and publication helpers.
+- Add Team task object/image upload routes under the parent Team task path.
+- Add agent object/image upload routes under the agent resource path.
+- Keep object bytes and metadata publication inside `ObjectUploadService`.
+- Keep browser-direct multipart and presigned upload-token decisions out of this slice.
+
+## Key Decisions
+
+- Task uploads authorize the parent Team first, then verify the task belongs to that Team before
+  publishing `tasks/<task_id>` metadata.
+- Agent uploads require an authenticated user and an existing agent before publishing
+  `agents/<agent_id>` metadata, matching the existing agent API access model.
+- API handlers continue to derive owner scope from route resources; browsers still cannot submit a
+  raw owner-scope string.
+- OpenAPI path assertions cover the new routes so schema fixtures stay aligned with the route
+  surface.
+
+## Validation
+
+```bash
+cargo test upload
+cargo test openapi_json_contains_team_runs_list_path
+```
+
+## Follow-Ups
+
+- Decide whether multipart or presigned upload tokens are the canonical large-object browser path.
+- Add an S3-compatible integration fixture before enabling the S3 feature in release builds.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -147,8 +147,9 @@ Main shape:
   skill/checklist entry points, and tool-neutral durable knowledge boundaries.
 - Access-control planning now defines user roles, capability gates, and route authorization
   guardrails for moving beyond root-only checks.
-- Object storage now has an OpenDAL-backed foundation and stable metadata/object-byte boundary for
-  local filesystem and future S3-compatible uploads.
+- Object storage now has an OpenDAL-backed foundation, stable metadata/object-byte boundary, and
+  owner-scoped Team/task/agent upload API checkpoints for local filesystem and future
+  S3-compatible uploads.
 
 Start with:
 
@@ -157,6 +158,7 @@ Start with:
 - `2026-07-15-team-system-prompt-contract.md`
 - `2026-07-16-access-control-roles.md`
 - `2026-07-16-object-storage-opendal.md`
+- `2026-07-18-object-upload-owner-scopes.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,7 +56,7 @@ Stable contract:
 
 ## Object Storage
 
-- [ ] `P1` Extend object upload APIs beyond the initial Team-scoped JSON/base64 routes: add task/agent owner-scope authorization and decide whether browser-facing multipart or presigned upload tokens should become the canonical large-object path. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md).
+- [ ] `P1` Decide whether browser-facing multipart or presigned upload tokens should become the canonical large-object path after the Team, task, and agent JSON/base64 owner-scope routes. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md), [journal/2026-07-18-object-upload-owner-scopes.md](journal/2026-07-18-object-upload-owner-scopes.md).
 - [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
 
 ## Observability, CI, And Docs

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -26,6 +26,8 @@ use crate::api::authz::{require_capability, require_user};
 use crate::api::error::ApiError;
 use crate::api::ok_response;
 use crate::api::teams::prune_deleted_agent_from_team_specs;
+use crate::api::uploads::{UploadRequest, upload_scoped_object};
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope};
 use crate::state::AppState;
 use crate::team::effective_team_member_skills;
 
@@ -197,6 +199,8 @@ pub fn router(state: AppState) -> Router {
         .route("/{id}/start", post(start_agent))
         .route("/{id}/stop", post(stop_agent))
         .route("/{id}/input", post(send_input))
+        .route("/{id}/uploads", post(upload_agent_object))
+        .route("/{id}/images", post(upload_agent_image))
         .route(
             "/{id}/triggers",
             post(create_agent_time_trigger).get(list_agent_time_triggers),
@@ -455,6 +459,43 @@ async fn send_input(
         }
     }
     Ok(ok_response())
+}
+
+async fn upload_agent_object(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+    Json(payload): Json<UploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_agent_scoped_object(state, headers, agent_id, payload, ObjectUploadKind::Object).await
+}
+
+async fn upload_agent_image(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+    Json(payload): Json<UploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_agent_scoped_object(state, headers, agent_id, payload, ObjectUploadKind::Image).await
+}
+
+async fn upload_agent_scoped_object(
+    state: AppState,
+    headers: HeaderMap,
+    agent_id: String,
+    payload: UploadRequest,
+    kind: ObjectUploadKind,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    let agent = state.agents.get_agent(&agent_id).await?;
+    upload_scoped_object(
+        State(state),
+        &user,
+        ObjectUploadOwnerScope::Agent(agent.id),
+        payload,
+        kind,
+    )
+    .await
 }
 
 async fn create_agent_time_trigger(
@@ -1224,7 +1265,9 @@ mod tests {
     use axum::body::{Body, Bytes, to_bytes};
     use axum::http::{Method, Request, StatusCode, header};
     use axum::response::IntoResponse;
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
     use serde_json::{Value, json};
+    use sha2::{Digest, Sha256};
     use sqlx::Row;
     use sqlx::SqlitePool;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -1648,6 +1691,39 @@ mod tests {
 
         sqlx::query(
             r#"
+            CREATE TABLE object_uploads (
+                id TEXT PRIMARY KEY,
+                owner_scope TEXT NOT NULL,
+                backend TEXT NOT NULL,
+                object_key TEXT NOT NULL,
+                original_filename TEXT NOT NULL,
+                content_type TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                sha256 TEXT NOT NULL,
+                public_url TEXT,
+                created_by_actor_id TEXT NOT NULL,
+                publish_state TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                published_at INTEGER,
+                cleanup_after INTEGER
+            )
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create object_uploads");
+        sqlx::query(
+            r#"
+            CREATE UNIQUE INDEX idx_object_uploads_object_key
+            ON object_uploads(object_key)
+            "#,
+        )
+        .execute(db)
+        .await
+        .expect("create object upload object key index");
+
+        sqlx::query(
+            r#"
             CREATE TABLE agent_sessions (
                 id TEXT PRIMARY KEY,
                 agent_id TEXT NOT NULL,
@@ -1982,6 +2058,13 @@ mod tests {
             .await
             .expect("read response body");
         String::from_utf8(bytes.to_vec()).expect("decode response text")
+    }
+
+    fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
     }
 
     fn run_git(repo_dir: &std::path::Path, args: &[&str]) {
@@ -2352,6 +2435,114 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = decode_json_body(response).await;
         assert_eq!(body["error"], Value::from("name is required"));
+    }
+
+    #[tokio::test]
+    async fn agent_upload_routes_publish_agent_scoped_metadata() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let workdir = std::env::temp_dir()
+            .join(format!("agenthub-upload-agent-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .to_string();
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(&workdir)
+            .bind(chrono::Utc::now().timestamp())
+            .execute(&state.db)
+            .await
+            .expect("insert safe path");
+        let agent = state
+            .agents
+            .create_agent(crate::agent::AgentConfig {
+                name: "upload-agent".to_string(),
+                workdir,
+                command: "/bin/sh".to_string(),
+                args: vec!["-lc".to_string(), "sleep 10".to_string()],
+                target_node_id: None,
+                worktree_mode: WorktreeMode::UseExisting,
+                worktree_repo: None,
+                worktree_ref: None,
+                code_mode: true,
+                codex_acp_default_mode: None,
+                runtime_model: None,
+                thinking_level: None,
+                agent_loop_enabled: false,
+                agent_loop_idle_seconds: None,
+                agent_loop_prompt: None,
+            })
+            .await
+            .expect("seed upload agent");
+        let agent_id = agent.id;
+        let app = router(state);
+
+        let bytes = b"agent evidence";
+        let sha256 = sha256_hex(bytes);
+        let object_response = app
+            .clone()
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/uploads"),
+                Some(&token),
+                Some(json!({
+                    "file_name": "evidence.txt",
+                    "content_type": "text/plain",
+                    "bytes_base64": STANDARD.encode(bytes),
+                    "expected_size_bytes": bytes.len(),
+                    "expected_sha256": sha256
+                })),
+            ))
+            .await
+            .expect("upload agent object");
+        let object_status = object_response.status();
+        let object_upload = decode_json_body(object_response).await;
+        assert_eq!(
+            object_status,
+            StatusCode::OK,
+            "unexpected object upload body: {object_upload}"
+        );
+        assert_eq!(
+            object_upload["owner_scope"],
+            Value::from(format!("agents/{agent_id}"))
+        );
+        assert!(
+            object_upload["object_key"]
+                .as_str()
+                .is_some_and(|value| value.starts_with(&format!("uploads/agents/{agent_id}/")))
+        );
+        assert_eq!(
+            object_upload["original_filename"],
+            Value::from("evidence.txt")
+        );
+
+        let image_bytes = [5_u8, 6, 7, 8];
+        let image_sha256 = sha256_hex(image_bytes);
+        let image_response = app
+            .oneshot(build_json_request(
+                Method::POST,
+                &format!("/{agent_id}/images"),
+                Some(&token),
+                Some(json!({
+                    "file_name": "evidence.png",
+                    "content_type": "image/png",
+                    "bytes_base64": STANDARD.encode(image_bytes),
+                    "expected_size_bytes": image_bytes.len(),
+                    "expected_sha256": image_sha256
+                })),
+            ))
+            .await
+            .expect("upload agent image");
+        assert_eq!(image_response.status(), StatusCode::OK);
+        let image_upload = decode_json_body(image_response).await;
+        assert_eq!(
+            image_upload["owner_scope"],
+            Value::from(format!("agents/{agent_id}"))
+        );
+        assert!(
+            image_upload["object_key"]
+                .as_str()
+                .is_some_and(|value| value.starts_with(&format!("images/agents/{agent_id}/")))
+        );
+        assert_eq!(image_upload["content_type"], Value::from("image/png"));
     }
 
     #[tokio::test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -17,6 +17,7 @@ mod openapi;
 mod push;
 mod settings;
 mod teams;
+mod uploads;
 
 pub(crate) use self::error::ApiError;
 pub(crate) use self::error::ok_response;

--- a/src/api/openapi/spec.rs
+++ b/src/api/openapi/spec.rs
@@ -15,6 +15,7 @@ pub(super) fn openapi_spec() -> Value {
       ],
       "tags": [
         { "name": "openapi", "description": "OpenAPI discovery endpoints" },
+        { "name": "agents", "description": "Agent runtime resources" },
         { "name": "teams", "description": "Team definitions, runs, steps, and actor mailbox" }
       ],
       "components": {
@@ -355,6 +356,60 @@ pub(super) fn openapi_spec() -> Value {
             }
           }
         },
+        "/api/agents/{id}/uploads": {
+          "post": {
+            "tags": ["agents"],
+            "summary": "Upload agent object",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published object metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/agents/{id}/images": {
+          "post": {
+            "tags": ["agents"],
+            "summary": "Upload agent image",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published image metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
         "/api/teams": {
           "get": {
             "tags": ["teams"],
@@ -491,6 +546,62 @@ pub(super) fn openapi_spec() -> Value {
             "summary": "Upload team image",
             "parameters": [
               { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published image metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}/tasks/{task_id}/uploads": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Upload team task object",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "task_id", "in": "path", "required": true, "schema": { "type": "string" } }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/TeamUploadRequest" }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Published object metadata",
+                "content": {
+                  "application/json": {
+                    "schema": { "$ref": "#/components/schemas/ObjectUploadRecord" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/api/teams/{id}/tasks/{task_id}/images": {
+          "post": {
+            "tags": ["teams"],
+            "summary": "Upload team task image",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+              { "name": "task_id", "in": "path", "required": true, "schema": { "type": "string" } }
             ],
             "requestBody": {
               "required": true,

--- a/src/api/openapi/tests.rs
+++ b/src/api/openapi/tests.rs
@@ -49,6 +49,8 @@ async fn openapi_json_contains_team_runs_list_path() {
         .expect("read response body");
     let value: Value = serde_json::from_slice(&bytes).expect("decode openapi json");
     assert_eq!(value["openapi"], Value::from("3.0.3"));
+    assert!(value["paths"]["/api/agents/{id}/uploads"]["post"].is_object());
+    assert!(value["paths"]["/api/agents/{id}/images"]["post"].is_object());
     assert!(value["paths"]["/api/teams/prompt_defaults"]["get"].is_object());
     assert!(value["paths"]["/api/teams/{id}"]["delete"].is_object());
     assert!(value["paths"]["/api/teams/{id}/channels"]["get"].is_object());
@@ -56,6 +58,8 @@ async fn openapi_json_contains_team_runs_list_path() {
     assert!(value["paths"]["/api/teams/{id}/channels/{channel_id}"]["delete"].is_object());
     assert!(value["paths"]["/api/teams/{id}/uploads"]["post"].is_object());
     assert!(value["paths"]["/api/teams/{id}/images"]["post"].is_object());
+    assert!(value["paths"]["/api/teams/{id}/tasks/{task_id}/uploads"]["post"].is_object());
+    assert!(value["paths"]["/api/teams/{id}/tasks/{task_id}/images"]["post"].is_object());
     assert!(value["paths"]["/api/teams/{id}/runs"].is_object());
     assert!(value["paths"]["/api/teams/runs/{run_id}/resume"].is_object());
     assert!(value["paths"]["/api/teams/runs/{run_id}/restart"].is_object());

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -24,7 +24,6 @@ use axum::{
     http::HeaderMap,
     routing::{delete, get, post, put},
 };
-use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -34,8 +33,9 @@ use uuid::Uuid;
 
 use crate::api::authz::require_user;
 use crate::api::error::ApiError;
+use crate::api::uploads::{UploadRequest, upload_scoped_object};
 use crate::auth::UserRecord;
-use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope, ObjectUploadRequest};
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope};
 use crate::state::AppState;
 use crate::team::{
     TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport, TeamChannelRecord,
@@ -262,14 +262,7 @@ pub struct CreateTeamChannelRequest {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct TeamUploadRequest {
-    pub file_name: String,
-    pub content_type: String,
-    pub bytes_base64: String,
-    pub expected_size_bytes: Option<u64>,
-    pub expected_sha256: Option<String>,
-}
+pub type TeamUploadRequest = UploadRequest;
 
 #[derive(Debug, Deserialize)]
 pub struct CompileTeamTaskRunPreviewRequest {
@@ -548,6 +541,11 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/{id}/uploads", post(upload_team_object))
         .route("/{id}/images", post(upload_team_image))
+        .route(
+            "/{id}/tasks/{task_id}/uploads",
+            post(upload_team_task_object),
+        )
+        .route("/{id}/tasks/{task_id}/images", post(upload_team_task_image))
         .route("/{id}/channels/{channel_id}", delete(delete_team_channel))
         .route(
             "/{id}/tasks/{task_id}/compile_run_preview",
@@ -1107,49 +1105,76 @@ async fn upload_team_scoped_object(
 ) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
     let user = require_user(&headers, &state).await?;
     let team = load_team_for_user(&state, &team_id, &user).await?;
-    let content_type = normalize_upload_content_type(&payload.content_type)?;
-    let bytes = decode_upload_bytes(&payload.bytes_base64)?;
-    let upload = state
-        .object_uploads
-        .upload(ObjectUploadRequest {
-            actor_id: canonical_user_actor_id(&user),
-            owner_scope: ObjectUploadOwnerScope::Team(team.id),
-            file_name: payload.file_name,
-            content_type,
-            kind,
-            expected_size_bytes: payload.expected_size_bytes,
-            expected_sha256: payload.expected_sha256,
-            bytes,
-        })
+    upload_scoped_object(
+        State(state),
+        &user,
+        ObjectUploadOwnerScope::Team(team.id),
+        payload,
+        kind,
+    )
+    .await
+}
+
+async fn upload_team_task_object(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((team_id, task_id)): Path<(String, String)>,
+    Json(payload): Json<TeamUploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_team_task_scoped_object(
+        state,
+        headers,
+        team_id,
+        task_id,
+        payload,
+        ObjectUploadKind::Object,
+    )
+    .await
+}
+
+async fn upload_team_task_image(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((team_id, task_id)): Path<(String, String)>,
+    Json(payload): Json<TeamUploadRequest>,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    upload_team_task_scoped_object(
+        state,
+        headers,
+        team_id,
+        task_id,
+        payload,
+        ObjectUploadKind::Image,
+    )
+    .await
+}
+
+async fn upload_team_task_scoped_object(
+    state: AppState,
+    headers: HeaderMap,
+    team_id: String,
+    task_id: String,
+    payload: TeamUploadRequest,
+    kind: ObjectUploadKind,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    let user = require_user(&headers, &state).await?;
+    load_team_for_user(&state, &team_id, &user).await?;
+    let task = state
+        .teams
+        .get_task(&task_id)
         .await
-        .map_err(map_upload_error)?;
-    Ok(Json(upload))
-}
-
-fn normalize_upload_content_type(value: &str) -> Result<String, ApiError> {
-    let value = value.trim();
-    if value.is_empty() {
-        return Err(ApiError::bad_request("content_type is required"));
+        .map_err(|err| map_not_found_error(err, "task not found"))?;
+    if task.team_id != team_id {
+        return Err(ApiError::not_found("task not found"));
     }
-    Ok(value.to_ascii_lowercase())
-}
-
-fn decode_upload_bytes(value: &str) -> Result<Vec<u8>, ApiError> {
-    STANDARD
-        .decode(value.trim())
-        .map_err(|_| ApiError::bad_request("bytes_base64 must be valid standard base64"))
-}
-
-fn map_upload_error(err: anyhow::Error) -> ApiError {
-    let message = err.to_string();
-    if message.contains("file_name")
-        || message.contains("size mismatch")
-        || message.contains("sha256")
-        || message.contains("unsupported hosted image content type")
-    {
-        return ApiError::bad_request(&message);
-    }
-    err.into()
+    upload_scoped_object(
+        State(state),
+        &user,
+        ObjectUploadOwnerScope::Task(task.id),
+        payload,
+        kind,
+    )
+    .await
 }
 
 async fn get_team_task(

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -66,7 +66,8 @@ use super::{
     send_team_run_message, send_team_task_message, set_team_run_step_input_required, start_team,
     start_team_run_step, stop_team, submit_team_run_step, takeover_team_run_message,
     transfer_team_run_message, triage_team_run_message, update_team_spec, update_team_task,
-    upload_team_image, upload_team_object, validate_team_spec,
+    upload_team_image, upload_team_object, upload_team_task_image, upload_team_task_object,
+    validate_team_spec,
 };
 
 #[derive(Default)]

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -254,6 +254,104 @@ async fn team_image_upload_api_rejects_unsafe_content_types_and_checksum_mismatc
 }
 
 #[tokio::test]
+async fn team_task_upload_api_authorizes_parent_team_and_publishes_task_scope() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+    let outsider_headers = auth_headers(&state).await;
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: "task-upload-team".to_string(),
+            description: None,
+            spec: json!({"entrypoint":"planner","members":[{"member_id":"planner","role":"coordinator"}]}),
+        }),
+    )
+    .await
+    .expect("create task upload team");
+    let created = create_team_task(
+        &state,
+        &headers,
+        &team.id,
+        CreateTeamTaskRequest {
+            title: "Collect evidence".to_string(),
+            priority: "high".to_string(),
+            assigned_member_id: "planner".to_string(),
+            created_by_actor_id: None,
+            context: None,
+            conversation_mode: None,
+            topic: None,
+        },
+    )
+    .await
+    .expect("create upload task");
+
+    let bytes = b"task evidence";
+    let sha256 = hex_encode(&Sha256::digest(bytes));
+    let request = TeamUploadRequest {
+        file_name: "evidence.txt".to_string(),
+        content_type: "text/plain".to_string(),
+        bytes_base64: STANDARD.encode(bytes),
+        expected_size_bytes: Some(bytes.len() as u64),
+        expected_sha256: Some(sha256.clone()),
+    };
+
+    let forbidden = upload_team_task_object(
+        State(state.clone()),
+        outsider_headers,
+        Path((team.id.clone(), created.task.id.clone())),
+        Json(request.clone()),
+    )
+    .await
+    .expect_err("non-owner should not upload into task scope");
+    assert_eq!(forbidden.into_response().status(), StatusCode::NOT_FOUND);
+
+    let Json(upload) = upload_team_task_object(
+        State(state.clone()),
+        headers.clone(),
+        Path((team.id.clone(), created.task.id.clone())),
+        Json(request),
+    )
+    .await
+    .expect("upload task object");
+
+    assert_eq!(upload.owner_scope, format!("tasks/{}", created.task.id));
+    assert!(upload.object_key.starts_with(&format!(
+        "uploads/tasks/{}/",
+        created.task.id
+    )));
+    assert!(upload.object_key.ends_with("/evidence.txt"));
+    assert_eq!(upload.content_type, "text/plain");
+    assert_eq!(upload.size_bytes, bytes.len() as i64);
+    assert_eq!(upload.sha256, sha256);
+
+    let image_bytes = [9_u8, 8, 7, 6];
+    let image_sha256 = hex_encode(&Sha256::digest(image_bytes));
+    let Json(image_upload) = upload_team_task_image(
+        State(state),
+        headers,
+        Path((team.id, created.task.id.clone())),
+        Json(TeamUploadRequest {
+            file_name: "evidence.png".to_string(),
+            content_type: "image/png".to_string(),
+            bytes_base64: STANDARD.encode(image_bytes),
+            expected_size_bytes: Some(image_bytes.len() as u64),
+            expected_sha256: Some(image_sha256.clone()),
+        }),
+    )
+    .await
+    .expect("upload task image");
+    assert_eq!(image_upload.owner_scope, format!("tasks/{}", created.task.id));
+    assert!(image_upload.object_key.starts_with(&format!(
+        "images/tasks/{}/",
+        created.task.id
+    )));
+    assert!(image_upload.object_key.ends_with(".png"));
+    assert_eq!(image_upload.sha256, image_sha256);
+}
+
+#[tokio::test]
 async fn teams_api_create_list_get_and_reject_duplicate_name() {
     let state = build_test_state().await;
     let headers = auth_headers(&state).await;

--- a/src/api/uploads.rs
+++ b/src/api/uploads.rs
@@ -1,0 +1,74 @@
+use axum::Json;
+use axum::extract::State;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::Deserialize;
+
+use crate::api::error::ApiError;
+use crate::auth::UserRecord;
+use crate::object_upload::{ObjectUploadKind, ObjectUploadOwnerScope, ObjectUploadRequest};
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadRequest {
+    pub file_name: String,
+    pub content_type: String,
+    pub bytes_base64: String,
+    pub expected_size_bytes: Option<u64>,
+    pub expected_sha256: Option<String>,
+}
+
+pub(crate) fn canonical_user_actor_id(user: &UserRecord) -> String {
+    format!("user:{}", user.id)
+}
+
+pub(crate) async fn upload_scoped_object(
+    State(state): State<AppState>,
+    user: &UserRecord,
+    owner_scope: ObjectUploadOwnerScope,
+    payload: UploadRequest,
+    kind: ObjectUploadKind,
+) -> Result<Json<agenthub_db::ObjectUploadRecord>, ApiError> {
+    let content_type = normalize_upload_content_type(&payload.content_type)?;
+    let bytes = decode_upload_bytes(&payload.bytes_base64)?;
+    let upload = state
+        .object_uploads
+        .upload(ObjectUploadRequest {
+            actor_id: canonical_user_actor_id(user),
+            owner_scope,
+            file_name: payload.file_name,
+            content_type,
+            kind,
+            expected_size_bytes: payload.expected_size_bytes,
+            expected_sha256: payload.expected_sha256,
+            bytes,
+        })
+        .await
+        .map_err(map_upload_error)?;
+    Ok(Json(upload))
+}
+
+fn normalize_upload_content_type(value: &str) -> Result<String, ApiError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ApiError::bad_request("content_type is required"));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn decode_upload_bytes(value: &str) -> Result<Vec<u8>, ApiError> {
+    STANDARD
+        .decode(value.trim())
+        .map_err(|_| ApiError::bad_request("bytes_base64 must be valid standard base64"))
+}
+
+fn map_upload_error(err: anyhow::Error) -> ApiError {
+    let message = err.to_string();
+    if message.contains("file_name")
+        || message.contains("size mismatch")
+        || message.contains("sha256")
+        || message.contains("unsupported hosted image content type")
+    {
+        return ApiError::bad_request(&message);
+    }
+    err.into()
+}


### PR DESCRIPTION
## Summary

- add shared JSON/base64 object upload request handling for API routes
- add task-scoped Team upload routes and agent-scoped upload routes for objects and images
- update OpenAPI, object-storage docs, TODO, and rollout journal evidence

## Purpose

This closes the small owner-scope authorization slice after the Team graph-bed upload work. API
handlers now derive `tasks/<task_id>` and `agents/<agent_id>` scopes from authorized resource paths
instead of accepting raw browser-provided owner scopes.

## Related Issues

- None

## Tests

```bash
cargo test upload
cargo test openapi_json_contains_team_runs_list_path
cargo clippy --all-targets -- -D warnings
```
