### PR TITLE
test(ci): add object-store s3 minio fixture

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,53 @@ jobs:
       - name: Cargo check (workspace)
         run: cargo check --workspace --locked
 
+  rust-object-store-s3-minio:
+    name: Rust (Object Store S3 MinIO)
+    runs-on: ubuntu-latest
+    env:
+      MINIO_ROOT_USER: agenthubminio
+      MINIO_ROOT_PASSWORD: agenthubminio123
+      AGENTHUB_OBJECT_STORE_S3_TEST_ENDPOINT: http://127.0.0.1:9000
+      AGENTHUB_OBJECT_STORE_S3_TEST_BUCKET: agenthub-object-store-test
+      AGENTHUB_OBJECT_STORE_S3_TEST_REGION: us-east-1
+      AGENTHUB_OBJECT_STORE_S3_TEST_ACCESS_KEY_ID: agenthubminio
+      AGENTHUB_OBJECT_STORE_S3_TEST_SECRET_ACCESS_KEY: agenthubminio123
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y curl
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          profile: minimal
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Start MinIO
+        run: |
+          docker run -d --name agenthub-minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER="${MINIO_ROOT_USER}" \
+            -e MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD}" \
+            minio/minio:RELEASE.2025-06-13T11-33-47Z \
+            server /data --address ":9000"
+          for i in {1..30}; do
+            if curl -fsS "${AGENTHUB_OBJECT_STORE_S3_TEST_ENDPOINT}/minio/health/ready"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs agenthub-minio
+          exit 1
+      - name: Create fixture bucket
+        run: |
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          /tmp/mc alias set local "${AGENTHUB_OBJECT_STORE_S3_TEST_ENDPOINT}" "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
+          /tmp/mc mb --ignore-existing "local/${AGENTHUB_OBJECT_STORE_S3_TEST_BUCKET}"
+      - name: Cargo test object store S3 fixture
+        run: cargo test -p agenthub-object-store --features s3 --locked s3_compatible_store_writes_reads_and_deletes_bytes -- --nocapture
+
   rust-message-store-rocksdb:
     name: Rust (Message Store RocksDB)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,7 +4247,7 @@ dependencies = [
  "keyring",
  "memchr",
  "oauth2",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp 1.8.0",
  "serde",
  "serde_json",
@@ -5221,7 +5221,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6319,7 +6319,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6688,7 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8742,7 +8742,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9301,7 +9301,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11206,7 +11206,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11616,6 +11616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d02c6564e376d3670aaf66ad886cd34f83c0aca407b6364777c624a63e0e2d"
 dependencies = [
  "opendal-core",
+ "opendal-http-transport-reqwest",
  "opendal-service-fs",
  "opendal-service-s3",
 ]
@@ -11644,6 +11645,20 @@ dependencies = [
  "url",
  "uuid",
  "web-time",
+]
+
+[[package]]
+name = "opendal-http-transport-reqwest"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7fd001b204df76be5d2b3f7a81c48b5cf25b28e2cfb3b8a819bb89cdc0ea3a"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "opendal-core",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -12724,7 +12739,7 @@ dependencies = [
  "object 0.39.1",
  "once_cell",
  "prost",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "smallvec",
  "spin 0.12.0",
@@ -12775,7 +12790,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12813,9 +12828,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13561,9 +13576,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -13729,7 +13744,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp-macros 1.8.0",
  "schemars 1.2.1",
  "serde",
@@ -13931,7 +13946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13990,7 +14005,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15719,7 +15734,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15772,7 +15787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17294,7 +17309,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/agenthub-object-store/Cargo.toml
+++ b/crates/agenthub-object-store/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [features]
 default = []
-s3 = ["opendal/services-s3"]
+s3 = ["opendal/http-transport-reqwest", "opendal/services-s3"]
 
 [dependencies]
 anyhow = "1"

--- a/crates/agenthub-object-store/src/lib.rs
+++ b/crates/agenthub-object-store/src/lib.rs
@@ -557,8 +557,11 @@ mod tests {
         );
         assert_eq!(image.content_type, "image/png");
         assert_eq!(
-            image.public_url.as_deref(),
-            Some(format!("https://img.example.test/objects/{}", image.object.key).as_str())
+            image.public_url,
+            Some(format!(
+                "https://img.example.test/objects/{}",
+                image.object.key
+            ))
         );
 
         store.delete_stored_object(&stored).await.unwrap();

--- a/crates/agenthub-object-store/src/lib.rs
+++ b/crates/agenthub-object-store/src/lib.rs
@@ -196,6 +196,8 @@ impl AgentHubObjectStore {
         prefix: Option<String>,
         public_base_url: Option<String>,
     ) -> anyhow::Result<Self> {
+        opendal::install_default();
+
         let bucket = settings
             .bucket
             .as_deref()

--- a/crates/agenthub-object-store/src/lib.rs
+++ b/crates/agenthub-object-store/src/lib.rs
@@ -350,6 +350,32 @@ fn hex_sha256(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "s3")]
+    fn s3_fixture_settings_from_env() -> Option<ObjectStoreSettings> {
+        let endpoint = std::env::var("AGENTHUB_OBJECT_STORE_S3_TEST_ENDPOINT").ok()?;
+        let bucket = std::env::var("AGENTHUB_OBJECT_STORE_S3_TEST_BUCKET").ok()?;
+        let access_key_id = std::env::var("AGENTHUB_OBJECT_STORE_S3_TEST_ACCESS_KEY_ID").ok()?;
+        let secret_access_key =
+            std::env::var("AGENTHUB_OBJECT_STORE_S3_TEST_SECRET_ACCESS_KEY").ok()?;
+        let region = std::env::var("AGENTHUB_OBJECT_STORE_S3_TEST_REGION")
+            .unwrap_or_else(|_| "us-east-1".to_string());
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Some(ObjectStoreSettings {
+            backend: ObjectStoreBackend::S3,
+            bucket: Some(bucket),
+            endpoint: Some(endpoint),
+            region: Some(region),
+            access_key_id: Some(access_key_id),
+            secret_access_key: Some(secret_access_key),
+            prefix: Some(format!("agenthub-object-store-ci/{nonce}")),
+            public_base_url: Some("https://img.example.test/objects".to_string()),
+            ..ObjectStoreSettings::default()
+        })
+    }
+
     #[test]
     fn normalize_object_key_rejects_path_escape() {
         for key in [
@@ -477,6 +503,69 @@ mod tests {
                 .put_image_bytes("teams/team-1", "nested/avatar-1", "image/png", vec![1])
                 .await
                 .is_err()
+        );
+    }
+
+    #[cfg(feature = "s3")]
+    #[tokio::test]
+    async fn s3_compatible_store_writes_reads_and_deletes_bytes() {
+        let Some(settings) = s3_fixture_settings_from_env() else {
+            eprintln!("skipping s3 fixture: AGENTHUB_OBJECT_STORE_S3_TEST_* env is not set");
+            return;
+        };
+        let store = AgentHubObjectStore::from_settings(settings).unwrap();
+
+        let stored = store
+            .put_bytes(
+                "uploads/teams/team-1/report.json",
+                br#"{"ok":true}"#.to_vec(),
+            )
+            .await
+            .unwrap();
+        assert!(stored.key.starts_with("agenthub-object-store-ci/"));
+        assert!(stored.key.ends_with("/uploads/teams/team-1/report.json"));
+        assert_eq!(stored.size_bytes, 11);
+        assert_eq!(
+            stored.sha256,
+            "4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+        );
+        assert!(
+            store
+                .exists("uploads/teams/team-1/report.json")
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            store
+                .read_bytes("uploads/teams/team-1/report.json")
+                .await
+                .unwrap(),
+            br#"{"ok":true}"#.to_vec()
+        );
+
+        let image = store
+            .put_image_bytes("agents/agent-1", "image-1", "image/png", vec![1, 2, 3, 4])
+            .await
+            .unwrap();
+        assert!(
+            image
+                .object
+                .key
+                .contains("/images/agents/agent-1/image-1.png")
+        );
+        assert_eq!(image.content_type, "image/png");
+        assert_eq!(
+            image.public_url.as_deref(),
+            Some(format!("https://img.example.test/objects/{}", image.object.key).as_str())
+        );
+
+        store.delete_stored_object(&stored).await.unwrap();
+        store.delete_stored_object(&image.object).await.unwrap();
+        assert!(
+            !store
+                .exists("uploads/teams/team-1/report.json")
+                .await
+                .unwrap()
         );
     }
 }

--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -152,7 +152,8 @@ operations must still authorize against the Team-owned metadata row.
 | Graph-bed UX | Frontend tests cover raster MIME allowlisting, browser SHA-256/base64 request preparation, Team image endpoint wiring, and Markdown image insertion in the Team channel composer. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
-| Future S3 rollout | Add an integration test against MinIO or a provisioned S3-compatible bucket before enabling S3 in release builds. |
+| S3-compatible fixture | A MinIO-backed CI job runs `agenthub-object-store` with the `s3` feature and verifies write/read/exists/delete plus hosted-image URL behavior against a real S3-compatible endpoint. |
+| Future S3 rollout | Keep S3 out of release feature sets until the MinIO fixture is green in PR and push CI and one reviewed release build includes the feature intentionally. |
 
 ## Operational Notes
 
@@ -175,8 +176,9 @@ operations must still authorize against the Team-owned metadata row.
   schema migration and read-compatibility plan.
 - Browser-direct upload requires short-lived presign or upload-token semantics plus size/checksum
   verification at publish time.
-- S3-compatible providers differ in multipart, path-style, and checksum behavior; each supported
-  provider needs a small compatibility fixture before being documented as production-ready.
+- S3-compatible providers differ in multipart, path-style, and checksum behavior; MinIO is the first
+  CI fixture, but each documented production provider still needs compatibility evidence before it
+  is described as production-ready.
 - Object lifecycle bugs can leak storage cost or delete still-referenced bytes unless metadata
   reference checks are kept explicit.
 

--- a/docs/journal/2026-07-18-object-store-s3-minio-fixture.md
+++ b/docs/journal/2026-07-18-object-store-s3-minio-fixture.md
@@ -1,0 +1,41 @@
+# Object Store S3 MinIO Fixture
+
+## Summary
+
+This checkpoint adds the first S3-compatible integration fixture for the OpenDAL object-store
+backend. CI now starts MinIO, creates a fixture bucket, and runs the `agenthub-object-store` tests
+with the `s3` feature enabled.
+
+## Background
+
+The object-store foundation compiled S3 support behind an opt-in feature, but only local filesystem
+tests exercised byte storage and image-hosting behavior. Before enabling S3 in release builds, the
+backend needs a real S3-compatible endpoint fixture that verifies AgentHub key, prefix, checksum,
+read/delete, and hosted-image URL behavior through OpenDAL.
+
+## Scope
+
+- Add an env-gated S3 compatibility test to `agenthub-object-store`.
+- Add a Rust CI job that runs MinIO in Docker and creates the fixture bucket with `mc`.
+- Keep the S3 feature out of default workspace, Bazel, and release feature sets.
+- Keep provider-specific production certification out of this slice.
+
+## Key Decisions
+
+- The test skips when `AGENTHUB_OBJECT_STORE_S3_TEST_*` is unset, so local default test runs do not
+  require object-store credentials.
+- CI runs the test explicitly with `cargo test -p agenthub-object-store --features s3`.
+- MinIO is the first compatibility fixture, not proof that every S3-compatible provider is
+  production-ready.
+
+## Validation
+
+```bash
+cargo test -p agenthub-object-store --features s3 s3_compatible_store_writes_reads_and_deletes_bytes -- --nocapture
+```
+
+## Follow-Ups
+
+- Keep `agenthub-object-store/s3` out of release feature sets until the MinIO fixture is green in PR
+  and push CI.
+- Decide whether multipart or presigned upload tokens are the canonical large-object browser path.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -147,9 +147,8 @@ Main shape:
   skill/checklist entry points, and tool-neutral durable knowledge boundaries.
 - Access-control planning now defines user roles, capability gates, and route authorization
   guardrails for moving beyond root-only checks.
-- Object storage now has an OpenDAL-backed foundation, stable metadata/object-byte boundary, and
-  owner-scoped Team/task/agent upload API checkpoints for local filesystem and future
-  S3-compatible uploads.
+- Object storage now has an OpenDAL-backed foundation, stable metadata/object-byte boundary,
+  owner-scoped Team/task/agent upload API checkpoints, and a MinIO-backed S3-compatible fixture.
 
 Start with:
 
@@ -159,6 +158,7 @@ Start with:
 - `2026-07-16-access-control-roles.md`
 - `2026-07-16-object-storage-opendal.md`
 - `2026-07-18-object-upload-owner-scopes.md`
+- `2026-07-18-object-store-s3-minio-fixture.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,7 +57,7 @@ Stable contract:
 ## Object Storage
 
 - [ ] `P1` Decide whether browser-facing multipart or presigned upload tokens should become the canonical large-object path after the Team, task, and agent JSON/base64 owner-scope routes. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-16-object-storage-opendal.md](journal/2026-07-16-object-storage-opendal.md), [journal/2026-07-18-object-upload-owner-scopes.md](journal/2026-07-18-object-upload-owner-scopes.md).
-- [ ] `P1` Add an S3-compatible integration fixture, preferably MinIO in CI or a provisioned test bucket, before enabling the `agenthub-object-store/s3` feature in release builds.
+- [ ] `P1` Keep `agenthub-object-store/s3` out of release feature sets until the MinIO-backed S3-compatible fixture is green in PR and push CI and a reviewed release build intentionally includes it.
 
 ## Observability, CI, And Docs
 


### PR DESCRIPTION
## Summary

- add an env-gated S3 compatibility test for `agenthub-object-store`
- add a Rust CI job that starts MinIO, creates a fixture bucket, and runs the S3 feature test
- update object-storage docs, TODO, and journal evidence for the fixture boundary

## Purpose

This adds the first S3-compatible fixture before enabling `agenthub-object-store/s3` in release
feature sets. The test validates write/read/exists/delete and hosted-image URL behavior against a
real MinIO endpoint while keeping default local and Bazel paths free of S3-only dependencies.

## Related Issues

- None

## Tests

```bash
cargo test -p agenthub-object-store
cargo test -p agenthub-object-store --features s3
cargo test -p agenthub-object-store --features s3 s3_compatible_store_writes_reads_and_deletes_bytes -- --nocapture
cargo clippy -p agenthub-object-store --features s3 --all-targets -- -D warnings
git diff --check
```

Local note: Docker was not running locally, so the MinIO container path is expected to be validated
by the new CI job.
