### PR TITLE
chore(team): unify workspace route shell

### DIFF
--- a/docs/features/workspace-unified-ia.md
+++ b/docs/features/workspace-unified-ia.md
@@ -279,6 +279,38 @@ Agent and ACP panes should stay quiet while preserving runtime depth:
 - message metadata should use compact language such as `Pending` and `Seen x/y`
 - composer helper copy should be short enough to read as an input hint, not onboarding text
 
+### 8.2) Three-Zone Workbench Composition
+
+Desktop workspace pages should converge on a three-zone composition when there is enough horizontal
+space:
+
+1. Object directory zone: the persistent left rail for Teams, Agents, channels, and compact
+   cross-object switching.
+2. Primary work zone: the dominant middle pane for the current workflow, such as channel timeline,
+   Kanban lane, Agent workspace, or ACP activity.
+3. Context zone: a right-side detail or thread dock for subordinate context, such as message
+   threads, selected task detail, selected member profile, or inspector state.
+
+This composition is a hierarchy, not three equal dashboards:
+
+- the primary work zone should own most horizontal space and remain the visual anchor
+- the context zone should be optional, route-addressable where useful, and cheap to close without
+  losing the primary selection
+- the object directory should stay narrow, scannable, and action-light
+- secondary context should not introduce another full navigation model inside the dock
+- each zone should have an explicit empty/loading state so collapsing one zone does not create
+  ambiguous blank space
+- the shared layout primitives should encode stable width ratios and overflow behavior before
+  individual Team or Agent panes add local wrappers
+
+On narrow screens this model degrades to two reachable states instead of three persistent columns:
+
+- directory or primary work surface
+- primary work surface or context dock
+
+Mobile behavior should preserve operator location with explicit back/close affordances rather than
+stacking all three zones into one long page.
+
 ### 9) Route Model Direction
 
 The rollout should converge current top-level routes toward one workspace shell.

--- a/docs/features/workspace-unified-ia.md
+++ b/docs/features/workspace-unified-ia.md
@@ -243,6 +243,42 @@ Explicit anti-goals:
 - do not over-segment the screen with too many persistent panels
 - do not make runtime/debug chrome louder than the primary content
 
+### 8.1) Shell Density And Chrome Contract
+
+The workspace shell should behave like a compact object directory plus one active work surface, not
+like a status dashboard.
+
+Stable shell-density rules:
+
+- keep the shell header short; do not add descriptive subtitles when the selected entity or lens
+  already explains the context
+- render global lenses as a quiet segmented row or compact tab strip, not as a second explanatory
+  navigation block
+- keep `Channels / Tasks / Members / Search` as the canonical global lens language
+- keep `thread` subordinate to `channel`; legacy `chat` or `threads` route values should normalize
+  to the canonical `channels` lens during compatibility rollout
+- keep Team and Agent rail rows in a `title + one compact meta line` shape where possible
+- keep row actions visually recessed until hover or focus on desktop
+- keep Team selector rows as directory choices instead of heavyweight cards
+- avoid persistent connection/status badges in the shell header unless the status changes operator
+  action
+- avoid duplicated object-local tabs when the left rail already exposes the same primary lane
+- reuse shared workspace section chrome, content stacks, and split-pane layout primitives for
+  embedded workspace header bands, body layout, and primary/secondary panes before adding
+  Team-specific wrapper markup; compact embedded agent workspaces may opt into tighter vertical
+  spacing, but should not fork the base border/background/overflow contract
+
+Agent and ACP panes should stay quiet while preserving runtime depth:
+
+- Agent object entry points should read as compact object/menu affordances, not action-heavy
+  command labels
+- ACP secondary tabs should use light page-tab treatment when embedded in the workspace shell
+- `Activity / Plan / Inspect` is the preferred ACP surface language for embedded Team member panes
+- channel and thread refresh controls should stay out of the primary conversation header when the
+  workspace already auto-refreshes
+- message metadata should use compact language such as `Pending` and `Seen x/y`
+- composer helper copy should be short enough to read as an input hint, not onboarding text
+
 ### 9) Route Model Direction
 
 The rollout should converge current top-level routes toward one workspace shell.
@@ -296,6 +332,61 @@ Compatibility rules:
   migration
 - existing Agent-root entry points should continue to resolve into the same shell instead of
   redirecting operators into a different product
+- Team-scoped path routes are the canonical subpath shape for new route-aware helpers while the Team
+  surface remains team-owned:
+  - `/workspace/teams/:team_id/channels/:channel_id`
+  - `/workspace/teams/:team_id/channels/:channel_id/threads/:thread_root_message_id`
+  - `/workspace/teams/:team_id/channels/:channel_id/tasks/:task_id`
+  - `/workspace/teams/:team_id/channels/:channel_id/members/:member_id`
+  - `/workspace/teams/:team_id/channels/:channel_id/tasks/:task_id/members/:member_id`
+  - `/workspace/teams/:team_id/tasks/:task_id`
+  - `/workspace/teams/:team_id/members/:member_id/:member_tab`
+- Query parameters stay compatible and take precedence over path-derived Team selection state during
+  migration. `thread` remains subordinate to `channels`; `/workspace/teams/:team_id/thread` must
+  not become a new top-level lens.
+- The legacy Team workspace builder may continue emitting query-string deep links until each caller
+  is migrated intentionally. New migration slices should use the explicit canonical subpath builder
+  instead of changing every existing navigation call at once.
+
+Team-owned route facade contract:
+
+- Team-aware callers should consume `web/src/pages/team/team_route_helpers.ts` for Team route
+  parsing, path construction, route types, workspace-lens resolution, active-lens fallback,
+  route-lens to Team-tab mapping, sidebar subject-pane resolution, Team detail paths, and Team
+  member workspace paths.
+- Team pages should consume a single route-selection snapshot from the facade when they need the
+  current workspace lens, Team tab, channel, thread root, selected task, and selected member. Page
+  components should not independently parse the same `pathname + search` state into parallel local
+  route facts.
+- The facade is the only Team surface boundary that should call the global route selection helpers
+  for Team semantics. Team page components, Team subcomponents, Agent Nodes Team drill-down links,
+  and Team-focused tests should depend on the Team facade instead of importing Team-specific path
+  semantics directly from `app_route_selection`.
+- App-level exports should not re-expose Team route parser or builder symbols. Callers that need
+  Team route semantics should import from the Team facade directly.
+- Direct use of the legacy query-string Team workspace builder should stay inside the Team facade
+  and compatibility tests. New route-aware navigation should use canonical Team subpaths unless the
+  caller is intentionally preserving a compatibility-only state shape.
+- Direct use of the low-level canonical Team subpath builder should also stay inside the Team
+  facade. Team callers should prefer named helpers for channel baselines, channel threads,
+  channel-scoped tasks, channel-scoped member profile panels, Team task paths, Team member
+  workspaces, and lens-preserving Team switches so callers do not depend on positional
+  route-builder arguments.
+- Team selector, deprecated search-lens compatibility, and tab-only compatibility URLs should also
+  be named helpers on the facade. Tests and fallback navigation may exercise those compatibility
+  paths, but they should not hand-roll Team route strings or mutate Team query parameters directly.
+- Team E2E entrypoints should navigate through named Team route helpers instead of direct
+  `page.goto("/teams...")` or `page.goto("/workspace/teams...")` strings, so browser fixtures
+  exercise the same canonical path construction as production callers.
+- Shell-level Team selector entrypoints, including the workbench menu and workspace lens selector,
+  should also navigate through the Team facade instead of hard-coded Team selector paths.
+- Channel-scoped member profile panel state should use canonical channel subpaths and remain
+  distinct from canonical member workspaces:
+  `/workspace/teams/:team_id/channels/:channel_id/members/:member_id` opens a lightweight
+  channel-local profile panel, while `/workspace/teams/:team_id/members/:member_id/:member_tab`
+  opens the full member workspace. Query `member=` remains a migration compatibility override.
+- Deprecated `search` lens input must continue to map through the channel surface for Team tabs and
+  sidebar panes. It must not become a Team content tab or a new Team-local workspace lens.
 
 ### 11) Deep-Link Contract
 
@@ -436,3 +527,8 @@ Suggested minimum validation by phase:
 - `docs/features/agents-teams.md`
 - `docs/features/frontend-design.md`
 - `docs/features/team-execution-vocabulary.md`
+- `docs/journal/2026-04-18-workspace-shell-compactness.md`
+- `docs/journal/2026-04-18-workspace-slock-notion-density-pass.md`
+- `docs/journal/2026-04-19-workspace-agent-pane-chrome-tightening.md`
+- `docs/journal/2026-04-19-workspace-channel-first-lens-language.md`
+- `docs/journal/2026-07-19-workspace-ui-compaction-wave2.md`

--- a/docs/journal/2026-04-18-workspace-shell-route-phase1.md
+++ b/docs/journal/2026-04-18-workspace-shell-route-phase1.md
@@ -21,3 +21,169 @@ Agent inner surfaces.
 - `cd web && npm run test -- vite.config.test.ts src/workbench_header_menu.test.tsx src/app_route_selection.test.ts src/app.route_auth.test.ts`
 - Chrome DevTools MCP should confirm that the top menu now renders `Workspace` and still exposes
   `Teams` as a sibling shell entry.
+
+## 2026-07-19 Follow-up
+
+- Added Team workspace subpath parsing for channel, channel thread, channel task, task, and member
+  deep links under `/workspace/teams/:team_id/...`.
+- Added an explicit canonical Team workspace subpath builder for gradual caller migration without
+  changing the legacy query-string builder globally.
+- Migrated the channel thread open/close navigation and Agent Nodes member drill-down links onto
+  canonical Team workspace subpaths. Channel-local profile links were initially left on the legacy
+  query builder and later migrated to canonical channel profile paths in this follow-up.
+- Migrated TeamPage channel route canonicalization, stale task cleanup, sidebar channel selection,
+  channel creation, channel deletion, and sidebar Team switching onto the same canonical subpath
+  helper.
+- Migrated TeamPage member workspace navigation onto canonical member subpaths.
+- Migrated TeamPage shell lens navigation onto the shared canonical subpath builder, and renamed the
+  local legacy-query builder import so compatibility-only route state remains intentionally
+  query-string-only instead of being confused with canonical workspace subpaths.
+- Centralized Team member workspace tab parsing in the exported route helper so canonical member
+  subpaths and legacy `tab=` query state keep one query-first precedence rule.
+- Moved Team route parsing and path construction helpers from the large `TeamPage` component module
+  into `web/src/pages/team/team_route_helpers.ts`, so later shell reuse can depend on a focused
+  route surface instead of importing page component internals.
+- Moved route-helper expectations into `web/src/pages/team/team_route_helpers.test.ts`, leaving the
+  larger `team_page.helpers.test.ts` focused on page-specific state and action helpers.
+- Updated Team conversation, thread, and workbench container path construction to use the Team route
+  helper module instead of importing Team path builders directly from the global app route module.
+- Updated TeamPage smoke expectations for Kanban "Open conversation" actions to assert canonical
+  `/workspace/teams/:team_id/channels/.../tasks/:task_id` URLs rather than the older query-string
+  route shape.
+- Migrated the Team channel Playwright helper fallback to the canonical Team subpath builder, so
+  sidebar subject reveal and direct channel recovery no longer construct channel workspace state by
+  mutating `?lens=` / `?channel=` query parameters.
+- Updated Team channel browser coverage to exercise canonical
+  `/workspace/teams/:team_id/channels/all/threads/:message_id` direct links and to assert
+  non-default channel selection with `/channels/:channel_id` URLs.
+- Updated the Team layout browser contract test to use canonical channel/task and channel/thread
+  subpaths instead of mutating `?channel=...&task=...&thread=...` query state for split-pane
+  validation.
+- Updated the Team agent-loop profile tests to open member ACP workspaces through canonical
+  `/workspace/teams/:team_id/members/:member_id/thread` subpaths instead of the legacy
+  `?lens=members&member=...&tab=thread` builder.
+- Updated TeamPage smoke coverage for normal channel restore, close-thread, and view-in-channel
+  flows to start from canonical channel/thread subpaths; compatibility-only tests still cover old
+  query strings where query-first behavior or redundant query cleanup is the explicit assertion.
+- Re-exported Team route parsing through the Team route helper module and moved the Team route
+  container, Team agent-loop tests, and Team channel/layout Playwright helpers onto that Team-owned
+  route surface instead of importing Team path semantics directly from the global app route module.
+- Re-exported Team route types and Team workspace-lens resolution through the Team route helper
+  module, then moved TeamPage, Team workspace context/container types, Team sidebar types, and Team
+  view-model/header helper types onto that Team-owned facade.
+- Moved active Team workspace-lens fallback from the Team view-model into the Team route helper, so
+  route-first precedence, Team-tab fallback, and deprecated `search` compatibility are tested beside
+  the rest of the Team route semantics.
+- Moved Team sidebar subject-pane resolution into the Team route helper, preserving the route-lens
+  first rule for `tasks` and `members`, the Team-tab fallback for agent-focused tabs, and the
+  deprecated `search` fallback to the channel pane.
+- Added explicit Team route helpers for channel-scoped profile panel open/close paths, then moved
+  the profile panel onto canonical channel subpaths while keeping legacy `member=` query parsing as
+  a compatibility override.
+- Added a named Team member workspace path helper and moved Agent Nodes Team detail/member
+  drill-down links plus TeamPage member navigation onto the Team route facade.
+- Migrated the remaining TeamPage channel-baseline navigation off the legacy query builder, leaving
+  direct `buildTeamWorkspacePath` usage only inside the Team route helper and its compatibility
+  tests.
+- Updated the stable unified workspace IA contract to make `team_route_helpers.ts` the Team-owned
+  route facade for Team route parsing, path construction, route types, workspace-lens resolution,
+  active-lens fallback, Team-tab mapping, sidebar subject-pane resolution, and compatibility-only
+  legacy query construction.
+- Added named canonical Team route helpers for channel baselines, channel threads, channel-scoped
+  tasks, Team task paths, Team member workspaces, and lens-preserving Team switches, then moved
+  TeamPage, Team conversation/thread containers, Team smoke tests, Team agent-loop tests, and Team
+  browser helpers off direct low-level canonical builder calls.
+- Added a Team route-selection snapshot helper so TeamPage consumes one facade-owned parse result
+  for workspace lens, Team tab, channel, thread root, selected task, and selected member instead of
+  independently deriving each route fact in the page component.
+- Added named Team selector, deprecated search-lens compatibility, and tab-only compatibility path
+  helpers, then moved TeamPage selector navigation and Team browser helper fallbacks off hand-written
+  Team route strings and direct Team query-parameter mutation.
+- Added a Team route split helper for callers that receive a facade-built path but must pass
+  `pathname` and `search` separately, then moved more TeamPage smoke entrypoints for canonical
+  channel, channel-task, and task-lens behavior onto named Team route helpers.
+- Added a static Team route facade boundary test that scans Team production sources plus Agent Nodes
+  Team drill-down code and fails if global Team route parser/builder symbols leak outside
+  `team_route_helpers.ts`.
+- Extended the Team route facade boundary test to scan Team E2E sources and reject direct
+  `page.goto("/teams...")` / `page.goto("/workspace/teams...")` navigation, then moved the shared
+  E2E Team selector entrypoint and channel-thread deep link onto named Team route helpers.
+- Extended the same direct-navigation guard to the shell menu and global workspace-lens selector,
+  then moved both production Team selector entrypoints onto `buildTeamSelectorPath()`.
+- Removed the `resolveTeamRoute` re-export from the app module and added a boundary check that keeps
+  app-level exports from re-exposing Team route symbols.
+- Moved the route-lens to Team-tab mapping into the same Team route helper module, including the
+  `search` compatibility rule that keeps deprecated shell search from becoming a Team content tab.
+- Aligned the shared workspace lens label for `members` with the canonical `Members` language
+  instead of the older Agent-specific label.
+- Extracted the Team workspace header visibility rule into a tested helper so deeper shell reuse
+  can keep `search` routed through the channel surface while preserving task-first suppression of
+  the chat workspace header.
+- Moved the deprecated `search` lens normalization used by Team workspace header decisions into the
+  Team route helper module, keeping lens compatibility semantics beside the rest of the Team-owned
+  facade instead of in the UI content component.
+- Extracted Team active workspace-lens resolution into a tested helper and aligned the Team
+  view-model test expectations with canonical `Members` language.
+- Aligned the shell-level Search placeholder copy with canonical `Channels`, `Tasks`, and
+  `Members` language while leaving Team sidebar search behavior unchanged.
+- Kept query-string deep links compatible and query-first during migration, so existing links such
+  as `?channel=...`, `?thread=...`, `?task=...`, `?member=...`, and `?tab=...` still override
+  path-derived state.
+- Preserved the v1 route guardrail that `thread` is not a top-level shell lens: thread path state is
+  only recognized under the channel surface, and unknown `/workspace/teams/:team_id/thread` paths
+  still resolve to the channel baseline.
+- Tightened the Team route facade boundary guard so `TeamPage` and `AgentNodesWorkbench` are no
+  longer allowlisted for direct global Team route symbols, and expanded direct Team navigation
+  scanning across the Team page, Team submodules, node workbench, workspace shell lens entrypoints,
+  and Team E2E helpers.
+- Extended the production-source navigation guard to reject literal Team `href` / `to` links in the
+  same Team page, Team submodule, node workbench, and shell lens entrypoint surfaces, keeping
+  browser-visible Team URLs behind named facade builders.
+- Extended the Team route facade boundary guard so production sources cannot import the positional
+  `buildCanonicalTeamSubpath` helper from the facade. Canonical Team navigation should stay behind
+  named builders such as channel, task, member, selector, and compatibility helpers.
+- Migrated channel-scoped member profile panel open paths to
+  `/workspace/teams/:team_id/channels/:channel_id/members/:member_id` and task-scoped profile
+  panels to `/workspace/teams/:team_id/channels/:channel_id/tasks/:task_id/members/:member_id`.
+  Profile close paths now return to the canonical channel baseline instead of the legacy
+  `?channel=` compatibility URL. Query `member=` continues to take precedence when old links are
+  parsed during migration.
+- Added shared `WorkspaceSectionShell`, `WorkspaceContentStack`, and `WorkspaceSplitPaneLayout`
+  primitives, then moved the Team workspace header wrapper, selected-team/body stack wrappers, and
+  channel/thread primary-secondary layout onto them. Deeper shell reuse now owns the base section
+  chrome, overflow, spacing variants, and secondary pane dock sizing while Team keeps only its
+  domain header/content decisions and compact agent-workspace signals.
+
+Focused validation for this follow-up:
+
+- `cd web && npm exec vitest -- run src/pages/team_page.helpers.test.ts src/pages/team_panels.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec vitest -- run src/app_route_selection.test.ts src/pages/team_page.helpers.test.ts src/components/agent_nodes_workbench.test.tsx`
+- `cd web && npm exec vitest -- run src/components/workspace_lens_items.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_workbench_content.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/use_team_workspace_view_model.test.tsx`
+- `cd web && npm exec vitest -- run src/components/workspace_lens_placeholder.test.tsx src/routes/agents_route_container.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team_page.helpers.test.ts src/app_route_selection.test.ts src/pages/team/use_team_workspace_view_model.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team_page.helpers.test.ts src/pages/team/team_thread_pane.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team_page.agent_loop.test.tsx src/pages/team/team_route_helpers.test.ts src/app_route_selection.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team_page.smoke.test.tsx src/pages/team/team_route_helpers.test.ts src/app_route_selection.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/routes/team_route_container.test.tsx src/pages/team_page.agent_loop.test.tsx src/app_route_selection.test.ts`
+- `cd web && npm exec tsc -- --noEmit`
+- `cd web && npm run lint`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team/use_team_workspace_view_model.test.tsx src/pages/team/team_workbench_content.test.tsx src/pages/team_page.helpers.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team_panels.test.tsx src/pages/team/use_team_workspace_view_model.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team_panels.test.tsx src/pages/team/team_workbench_content.test.tsx src/pages/team_page.smoke.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/components/agent_nodes_workbench.test.tsx src/pages/team_page.smoke.test.tsx src/pages/team_page.agent_loop.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team_page.smoke.test.tsx src/pages/team/team_route_helpers.test.ts src/app_route_selection.test.ts`
+- `cd web && PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/team_page_channels.e2e.ts --project=system-chrome`
+- `cd web && PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/team_page_layout.e2e.ts --project=system-chrome`
+- `cd web && PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/team_page_channels.e2e.ts tests/e2e/team_page_layout.e2e.ts --project=system-chrome`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team_page.helpers.test.ts src/pages/team/use_team_workspace_view_model.test.tsx src/pages/team/team_workbench_content.test.tsx src/routes/team_route_container.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_helpers.test.ts src/pages/team/team_workbench_content.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team_page.smoke.test.tsx src/pages/team/team_route_helpers.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_boundary.test.ts src/pages/team/team_route_helpers.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_boundary.test.ts src/pages/team/team_route_helpers.test.ts src/routes/use_workspace_route_state.test.tsx src/workbench_header_menu.test.tsx`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_boundary.test.ts src/app.route_auth.test.ts src/pages/team/team_route_helpers.test.ts`
+- `cd web && npm exec vitest -- run src/pages/team/team_route_boundary.test.ts`
+- `cd web && npm exec vitest -- run src/components/layout/workspace_section_shell.test.tsx src/pages/team/team_workbench_content.test.tsx`
+- `cd web && npm exec tsc -- --noEmit`
+- `git diff --check`

--- a/web/src/app.route_auth.test.ts
+++ b/web/src/app.route_auth.test.ts
@@ -5,10 +5,10 @@ import {
   removeAgentNodeRecord,
   replaceAgentNodeRecord,
   resolvePostAuthRedirectTarget,
-  resolveTeamRoute,
   shouldRedirectTeamsToLogin,
   upsertAgentNodeRecord,
 } from "./app";
+import { resolveTeamRoute } from "./pages/team/team_route_helpers";
 
 describe("team route auth redirect", () => {
   const makeNode = (id: string, name = id, createdAt = 1) => ({

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -130,7 +130,6 @@ export {
   resolveAppRouteKind,
   resolveWorkspaceAgentRoute,
   resolvePostAuthRedirectTarget,
-  resolveTeamRoute,
   shouldRedirectTeamsToLogin,
 } from "./app_route_selection";
 

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -222,7 +222,12 @@ describe("app route selection", () => {
   });
 
   it("builds canonical team workspace subpaths for gradual route migration", () => {
+    expect(buildCanonicalTeamWorkspaceSubpath(null)).toBe("/workspace/teams");
+    expect(buildCanonicalTeamWorkspaceSubpath("   ")).toBe("/workspace/teams");
     expect(buildCanonicalTeamWorkspaceSubpath("team-1")).toBe("/workspace/teams/team-1");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(" team/1 ", "members", null, null, " worker/1 ", "mailbox")
+    ).toBe("/workspace/teams/team%2F1/members/worker%2F1/mailbox");
     expect(buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "review")).toBe(
       "/workspace/teams/team-1/channels/review"
     );
@@ -276,12 +281,80 @@ describe("app route selection", () => {
         "member_console"
       )
     ).toBe("/workspace/teams/team-1/members/worker-1/member_console");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(
+        "team-1",
+        "members",
+        null,
+        null,
+        "worker-1",
+        "conversation" as never
+      )
+    ).toBe("/workspace/teams/team-1/members/worker-1");
     expect(buildCanonicalTeamWorkspaceSubpath("team-1", "members")).toBe(
       "/workspace/teams/team-1?lens=members"
     );
     expect(buildCanonicalTeamWorkspaceSubpath("team-1", "tasks")).toBe(
       "/workspace/teams/team-1?lens=tasks"
     );
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(
+        "team-1",
+        "nodes",
+        "review",
+        42,
+        "worker-1",
+        "mailbox",
+        "task-9"
+      )
+    ).toBe(
+      "/workspace/teams/team-1?lens=nodes&channel=review&thread=42&task=task-9&member=worker-1&tab=mailbox"
+    );
+  });
+
+  it("parses malformed or partial canonical team subpaths defensively", () => {
+    expect(resolveTeamRoute("/workspace/teams/%E0%A4%A")).toEqual({
+      mode: "detail",
+      teamId: "%E0%A4%A",
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/%E0%A4%A/channels/%E0%A4%A")
+    ).toEqual({
+      lens: "channels",
+      channelId: "%E0%A4%A",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/threads/not-a-number")
+    ).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/members/worker-1/overview")
+    ).toEqual({
+      lens: "members",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: "worker-1",
+      tab: null,
+    });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/unknown/review")).toEqual({
+      lens: null,
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
   });
 
   it("derives the post-auth redirect target only on the workspace root aliases", () => {

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -337,6 +337,14 @@ describe("app route selection", () => {
       memberId: null,
       tab: null,
     });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/threads")).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
     expect(
       resolveTeamWorkspacePathState("/workspace/teams/team-1/members/worker-1/overview")
     ).toEqual({

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -150,6 +150,14 @@ describe("app route selection", () => {
   });
 
   it("parses canonical team workspace subpaths without treating thread as a top-level lens", () => {
+    expect(resolveTeamWorkspacePathState("/teams")).toEqual({
+      lens: null,
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
     expect(resolveTeamWorkspacePathState("/workspace/teams/team-1")).toEqual({
       lens: null,
       channelId: null,
@@ -190,6 +198,40 @@ describe("app route selection", () => {
       memberId: "worker/1",
       tab: null,
     });
+    expect(resolveTeamWorkspacePathState("/teams/team-1/channels")).toEqual({
+      lens: "channels",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/tasks")).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/tasks/task-77/members")
+    ).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: "task-77",
+      memberId: null,
+      tab: null,
+    });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/members")).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
     expect(
       resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/all/members/worker-1")
     ).toEqual({
@@ -208,6 +250,14 @@ describe("app route selection", () => {
       memberId: null,
       tab: null,
     });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/tasks")).toEqual({
+      lens: "tasks",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
     expect(
       resolveTeamWorkspacePathState("/workspace/teams/team-1/members/worker-1/thread")
     ).toEqual({
@@ -217,6 +267,14 @@ describe("app route selection", () => {
       taskId: null,
       memberId: "worker-1",
       tab: "agent_acp",
+    });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/members")).toEqual({
+      lens: "members",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
     });
     expect(resolveWorkspaceLens("/workspace/teams/team-1/thread", "")).toBe("channels");
   });

--- a/web/src/app_route_selection.test.ts
+++ b/web/src/app_route_selection.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthState } from "./types";
 import {
   buildTeamDetailPath,
+  buildCanonicalTeamWorkspaceSubpath,
   buildTeamWorkspacePath,
   buildWorkspaceNodePath,
   buildWorkspacePath,
@@ -16,6 +17,7 @@ import {
   resolveTeamMemberRouteTab,
   resolveTeamRoute,
   resolveTeamSelectedTaskId,
+  resolveTeamWorkspacePathState,
   resolveWorkspaceLens,
   resolveWorkspaceAgentRoute,
   resolveWorkspaceNodeId,
@@ -97,6 +99,9 @@ describe("app route selection", () => {
     expect(resolveWorkspaceLens("/workspace/teams/team-1", "")).toBe("channels");
     expect(resolveWorkspaceLens("/workspace/teams/team-1", "?lens=search")).toBe("channels");
     expect(resolveWorkspaceLens("/workspace/teams/team-1", "?lens=tasks")).toBe("tasks");
+    expect(resolveWorkspaceLens("/workspace/teams/team-1/channels/review", "")).toBe("channels");
+    expect(resolveWorkspaceLens("/workspace/teams/team-1/tasks/task-1", "")).toBe("tasks");
+    expect(resolveWorkspaceLens("/workspace/teams/team-1/members/worker-1", "")).toBe("members");
     expect(buildWorkspacePath("agent-1", "channels")).toBe(
       "/workspace/agents/agent-1"
     );
@@ -142,6 +147,141 @@ describe("app route selection", () => {
     expect(resolveTeamMemberRouteTab("?tab=overview")).toBeNull();
     expect(isTeamMemberRouteTab("agent_acp")).toBe(true);
     expect(isTeamMemberRouteTab("overview")).toBe(false);
+  });
+
+  it("parses canonical team workspace subpaths without treating thread as a top-level lens", () => {
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1")).toEqual({
+      lens: null,
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/threads/42")
+    ).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: 42,
+      taskId: null,
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/review/tasks/task%2F77")
+    ).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: "task/77",
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState(
+        "/workspace/teams/team-1/channels/review/tasks/task%2F77/members/worker%2F1"
+      )
+    ).toEqual({
+      lens: "channels",
+      channelId: "review",
+      threadRootMessageId: null,
+      taskId: "task/77",
+      memberId: "worker/1",
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/channels/all/members/worker-1")
+    ).toEqual({
+      lens: "channels",
+      channelId: "all",
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: "worker-1",
+      tab: null,
+    });
+    expect(resolveTeamWorkspacePathState("/workspace/teams/team-1/tasks/task-77")).toEqual({
+      lens: "tasks",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: "task-77",
+      memberId: null,
+      tab: null,
+    });
+    expect(
+      resolveTeamWorkspacePathState("/workspace/teams/team-1/members/worker-1/thread")
+    ).toEqual({
+      lens: "members",
+      channelId: null,
+      threadRootMessageId: null,
+      taskId: null,
+      memberId: "worker-1",
+      tab: "agent_acp",
+    });
+    expect(resolveWorkspaceLens("/workspace/teams/team-1/thread", "")).toBe("channels");
+  });
+
+  it("builds canonical team workspace subpaths for gradual route migration", () => {
+    expect(buildCanonicalTeamWorkspaceSubpath("team-1")).toBe("/workspace/teams/team-1");
+    expect(buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "review")).toBe(
+      "/workspace/teams/team-1/channels/review"
+    );
+    expect(buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "all", 42)).toBe(
+      "/workspace/teams/team-1/channels/all/threads/42"
+    );
+    expect(
+      buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "review", 42)
+    ).toBe("/workspace/teams/team-1/channels/review/threads/42");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "review", null, null, null, "task/77")
+    ).toBe("/workspace/teams/team-1/channels/review/tasks/task%2F77");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath("team-1", "channels", "all", null, null, null, "task-77")
+    ).toBe("/workspace/teams/team-1/channels/all/tasks/task-77");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(
+        "team-1",
+        "channels",
+        "review",
+        null,
+        "worker/1",
+        null,
+        "task/77"
+      )
+    ).toBe("/workspace/teams/team-1/channels/review/tasks/task%2F77/members/worker%2F1");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(
+        "team-1",
+        "channels",
+        "all",
+        null,
+        "worker-1",
+        null,
+        null
+      )
+    ).toBe("/workspace/teams/team-1/channels/all/members/worker-1");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath("team-1", "tasks", null, null, null, null, "task-77")
+    ).toBe("/workspace/teams/team-1/tasks/task-77");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath("team-1", "members", null, null, "worker-1", "agent_acp")
+    ).toBe("/workspace/teams/team-1/members/worker-1/thread");
+    expect(
+      buildCanonicalTeamWorkspaceSubpath(
+        "team-1",
+        "members",
+        null,
+        null,
+        "worker-1",
+        "member_console"
+      )
+    ).toBe("/workspace/teams/team-1/members/worker-1/member_console");
+    expect(buildCanonicalTeamWorkspaceSubpath("team-1", "members")).toBe(
+      "/workspace/teams/team-1?lens=members"
+    );
+    expect(buildCanonicalTeamWorkspaceSubpath("team-1", "tasks")).toBe(
+      "/workspace/teams/team-1?lens=tasks"
+    );
   });
 
   it("derives the post-auth redirect target only on the workspace root aliases", () => {

--- a/web/src/app_route_selection.ts
+++ b/web/src/app_route_selection.ts
@@ -48,6 +48,14 @@ export type AppRouteKind =
 
 export type WorkspaceLens = "teams" | "channels" | "tasks" | "members" | "search" | "nodes";
 export type TeamMemberRouteTab = "agent_acp" | "mailbox" | "member_console";
+export type TeamWorkspacePathState = {
+  lens: Extract<WorkspaceLens, "channels" | "tasks" | "members"> | null;
+  channelId: string | null;
+  threadRootMessageId: number | null;
+  taskId: string | null;
+  memberId: string | null;
+  tab: TeamMemberRouteTab | null;
+};
 const TEAM_MEMBER_ROUTE_TABS = new Set<TeamMemberRouteTab>([
   "agent_acp",
   "mailbox",
@@ -74,8 +82,12 @@ export function resolveWorkspaceLens(pathname: string, search: string): Workspac
     if (route?.mode === "selector") {
       return "teams";
     }
+    const pathState = resolveTeamWorkspacePathState(pathname);
     if (lens === "tasks" || lens === "members") {
       return lens;
+    }
+    if (pathState.lens) {
+      return pathState.lens;
     }
     return "channels";
   }
@@ -162,6 +174,80 @@ export function buildTeamWorkspacePath(
   return search ? `${pathname}?${search}` : pathname;
 }
 
+export function buildCanonicalTeamWorkspaceSubpath(
+  teamId?: string | null,
+  lens?: WorkspaceLens | null,
+  channelId?: string | null,
+  threadRootMessageId?: number | null,
+  memberId?: string | null,
+  tab?: TeamMemberRouteTab | null,
+  taskId?: string | null
+): string {
+  const normalizedTeamId = teamId?.trim();
+  if (!normalizedTeamId) {
+    return "/workspace/teams";
+  }
+  const teamPath = `/workspace/teams/${encodeURIComponent(normalizedTeamId)}`;
+  const normalizedTaskId = taskId?.trim() ?? "";
+  const normalizedMemberId = memberId?.trim() ?? "";
+  const normalizedChannelId = channelId?.trim() ?? "";
+  if (lens === "members") {
+    if (!normalizedMemberId) {
+      return `${teamPath}?lens=members`;
+    }
+    const memberPath = `${teamPath}/members/${encodeURIComponent(normalizedMemberId)}`;
+    if (!isTeamMemberRouteTab(tab)) {
+      return memberPath;
+    }
+    return `${memberPath}/${encodeURIComponent(tab === "agent_acp" ? "thread" : tab)}`;
+  }
+  if (lens === "tasks") {
+    return normalizedTaskId
+      ? `${teamPath}/tasks/${encodeURIComponent(normalizedTaskId)}`
+      : `${teamPath}?lens=tasks`;
+  }
+  if (lens === "channels" || lens === "search" || !lens) {
+    const channelPath =
+      normalizedChannelId && normalizedChannelId !== "all"
+        ? `${teamPath}/channels/${encodeURIComponent(normalizedChannelId)}`
+        : teamPath;
+    if (threadRootMessageId && threadRootMessageId > 0) {
+      const basePath =
+        normalizedChannelId && normalizedChannelId !== "all"
+          ? channelPath
+          : `${teamPath}/channels/all`;
+      return `${basePath}/threads/${encodeURIComponent(String(threadRootMessageId))}`;
+    }
+    if (normalizedTaskId) {
+      const basePath =
+        normalizedChannelId && normalizedChannelId !== "all"
+          ? channelPath
+          : `${teamPath}/channels/all`;
+      const taskPath = `${basePath}/tasks/${encodeURIComponent(normalizedTaskId)}`;
+      return normalizedMemberId
+        ? `${taskPath}/members/${encodeURIComponent(normalizedMemberId)}`
+        : taskPath;
+    }
+    if (normalizedMemberId) {
+      const basePath =
+        normalizedChannelId && normalizedChannelId !== "all"
+          ? channelPath
+          : `${teamPath}/channels/all`;
+      return `${basePath}/members/${encodeURIComponent(normalizedMemberId)}`;
+    }
+    return channelPath;
+  }
+  return buildTeamWorkspacePath(
+    normalizedTeamId,
+    lens,
+    normalizedChannelId,
+    threadRootMessageId,
+    normalizedMemberId,
+    tab,
+    normalizedTaskId
+  );
+}
+
 export function resolveTeamSelectedTaskId(search: string): string {
   const params = new URLSearchParams(search);
   return (params.get("task") ?? "").trim();
@@ -174,6 +260,93 @@ export function resolveTeamMemberRouteTab(search: string): TeamMemberRouteTab | 
     return "agent_acp";
   }
   return isTeamMemberRouteTab(raw) ? raw : null;
+}
+
+function decodePathSegment(segment: string | undefined): string {
+  if (!segment) {
+    return "";
+  }
+  try {
+    return decodeURIComponent(segment).trim();
+  } catch {
+    return segment.trim();
+  }
+}
+
+function parsePositiveIntegerSegment(segment: string | undefined): number | null {
+  const value = decodePathSegment(segment);
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeMemberPathTab(segment: string | undefined): TeamMemberRouteTab | null {
+  const tab = decodePathSegment(segment);
+  if (tab === "thread") {
+    return "agent_acp";
+  }
+  return isTeamMemberRouteTab(tab) ? tab : null;
+}
+
+function resolveTeamWorkspacePathSegments(pathname: string): string[] {
+  if (!isTeamsRoute(pathname)) {
+    return [];
+  }
+  const prefix = pathname.startsWith("/workspace/teams") ? "/workspace/teams" : "/teams";
+  const suffix = pathname.slice(prefix.length);
+  const normalized = suffix.startsWith("/") ? suffix.slice(1) : suffix;
+  const segments = normalized.split("/").filter((segment) => segment.length > 0);
+  return segments.slice(1);
+}
+
+export function resolveTeamWorkspacePathState(pathname: string): TeamWorkspacePathState {
+  const state: TeamWorkspacePathState = {
+    lens: null,
+    channelId: null,
+    threadRootMessageId: null,
+    taskId: null,
+    memberId: null,
+    tab: null,
+  };
+  const segments = resolveTeamWorkspacePathSegments(pathname);
+  const [surface] = segments;
+  if (!surface) {
+    return state;
+  }
+
+  if (surface === "channels" || surface === "chat" || surface === "threads") {
+    state.lens = "channels";
+    state.channelId = decodePathSegment(segments[1]) || null;
+    const nestedSurface = segments[2];
+    if (nestedSurface === "threads") {
+      state.threadRootMessageId = parsePositiveIntegerSegment(segments[3]);
+    } else if (nestedSurface === "tasks") {
+      state.taskId = decodePathSegment(segments[3]) || null;
+      if (segments[4] === "members") {
+        state.memberId = decodePathSegment(segments[5]) || null;
+      }
+    } else if (nestedSurface === "members") {
+      state.memberId = decodePathSegment(segments[3]) || null;
+    }
+    return state;
+  }
+
+  if (surface === "tasks") {
+    state.lens = "tasks";
+    state.taskId = decodePathSegment(segments[1]) || null;
+    return state;
+  }
+
+  if (surface === "members") {
+    state.lens = "members";
+    state.memberId = decodePathSegment(segments[1]) || null;
+    state.tab = normalizeMemberPathTab(segments[2]);
+    return state;
+  }
+
+  return state;
 }
 
 export function navigateToPath(pathname: string): void {

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -156,10 +156,10 @@ describe("AgentNodesWorkbench", () => {
     expect(html).toContain("Working");
     expect(html).toContain("AgentHub Runtime");
     expect(html).toContain("Worktree: Existing workdir");
-    expect(html).toContain('href="/workspace/teams/team-1?lens=members&amp;member=agent-remote-1&amp;tab=thread"');
+    expect(html).toContain('href="/workspace/teams/team-1/members/agent-remote-1/thread"');
     expect(
       html
-    ).toContain('href="/workspace/teams/team-1?lens=members&amp;member=agent-remote-1&amp;tab=member_console"');
+    ).toContain('href="/workspace/teams/team-1/members/agent-remote-1/member_console"');
     expect(html).toContain("Thread");
     expect(html).toContain("Console");
     expect(html).toContain("Danger Zone");

--- a/web/src/components/agent_nodes_workbench.test.tsx
+++ b/web/src/components/agent_nodes_workbench.test.tsx
@@ -68,6 +68,25 @@ const renderWorkbench = (overrides?: Partial<ComponentProps<typeof AgentNodesWor
     </MantineProvider>
   );
 
+function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  return required(
+    Array.from(container.querySelectorAll("button")).find((node) =>
+      node.textContent?.includes(text)
+    ) as HTMLButtonElement | undefined,
+    `${text} button missing`
+  );
+}
+
+function changeInputValue(input: HTMLInputElement, value: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(input) as HTMLInputElement,
+    "value"
+  );
+  descriptor?.set?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 describe("AgentNodesWorkbench", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -373,6 +392,16 @@ describe("AgentNodesWorkbench", () => {
     ).toBeNull();
   });
 
+  it("disables remote node name saves until the required routing metadata exists", () => {
+    const html = renderWorkbench({
+      nodes: baseProps.nodes.map((node) =>
+        node.id === "node-east" ? { ...node, grpc_target: null } : node
+      ),
+    });
+
+    expect(html).toContain("This node is missing a persisted gRPC target.");
+  });
+
   it("renders the no-team empty state when no teams use the selected node", () => {
     const html = renderWorkbench({
       agents: [],
@@ -465,5 +494,108 @@ describe("AgentNodesWorkbench", () => {
     });
 
     expect(onDeleteNode).toHaveBeenCalledWith("node-east");
+  });
+
+  it("routes remote node editor saves and drill-down links", () => {
+    const onUpdateNode = vi.fn();
+    renderWithMantine(
+      root,
+      <AgentNodesWorkbench
+        {...baseProps}
+        teams={[
+          {
+            id: "team-1",
+            name: "Team One",
+            description: null,
+            spec: {
+              members: [{ member_id: "agent-remote-1", role: "coordinator" }],
+            },
+            created_at: 1,
+            updated_at: 1,
+          },
+        ]}
+        agents={[
+          {
+            id: "agent-remote-1",
+            name: "Worker A",
+            command: "agenthub",
+            args: [],
+            workdir: "/tmp/worker-a",
+            status: "running",
+            target_node_id: "node-east",
+            worktree_mode: "use_existing",
+            code_mode: false,
+            created_at: 1,
+            updated_at: 1,
+          },
+        ]}
+        onUpdateNode={onUpdateNode}
+      />
+    );
+
+    const inputs = Array.from(container.querySelectorAll("input"));
+    const [nameInput, grpcTargetInput, tlsServerNameInput, worktreeRootInput] = inputs;
+    expect(nameInput).toBeDefined();
+    expect(grpcTargetInput).toBeDefined();
+    expect(tlsServerNameInput).toBeDefined();
+    expect(worktreeRootInput).toBeDefined();
+
+    act(() => {
+      changeInputValue(nameInput, "Node East Renamed");
+    });
+    act(() => {
+      findButtonByText(container, "Save Name").dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    act(() => {
+      changeInputValue(grpcTargetInput, "https://node-east.internal:60061");
+      changeInputValue(tlsServerNameInput, "node-east-alt.internal");
+      changeInputValue(worktreeRootInput, "/srv/agenthub/worktrees/node-east");
+    });
+    act(() => {
+      findButtonByText(container, "Save Settings").dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onUpdateNode).toHaveBeenNthCalledWith(1, "node-east", {
+      name: "Node East Renamed",
+      grpc_target: "https://node-east.internal:50051",
+      tls_server_name: "node-east.internal",
+      default_worktree_root: "~/.agenthub/worktrees/node-east",
+    });
+    expect(onUpdateNode).toHaveBeenNthCalledWith(2, "node-east", {
+      name: "Node East",
+      grpc_target: "https://node-east.internal:60061",
+      tls_server_name: "node-east-alt.internal",
+      default_worktree_root: "/srv/agenthub/worktrees/node-east",
+    });
+
+    const links = Array.from(container.querySelectorAll("a")) as HTMLAnchorElement[];
+    const teamLink = links.find((link) => link.textContent?.includes("Team One"));
+    const threadLink = links.find((link) => link.textContent?.trim() === "Thread");
+    const consoleLink = links.find((link) => link.textContent?.trim() === "Console");
+    expect(teamLink).toBeDefined();
+    expect(threadLink).toBeDefined();
+    expect(consoleLink).toBeDefined();
+
+    act(() => {
+      teamLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(window.location.pathname).toBe("/workspace/teams/team-1");
+
+    act(() => {
+      threadLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(window.location.pathname).toBe("/workspace/teams/team-1/members/agent-remote-1/thread");
+
+    act(() => {
+      consoleLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(window.location.pathname).toBe(
+      "/workspace/teams/team-1/members/agent-remote-1/member_console"
+    );
   });
 });

--- a/web/src/components/agent_nodes_workbench.tsx
+++ b/web/src/components/agent_nodes_workbench.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Button, Stack, Text, TextInput } from "@mantine/core";
 import {
-  buildTeamDetailPath,
-  buildTeamWorkspacePath,
   navigateToPath,
   shouldHandleInAppLinkClick,
 } from "../app_route_selection";
+import {
+  buildTeamDetailPath,
+  buildTeamMemberWorkspacePath,
+} from "../pages/team/team_route_helpers";
 import { isAgentActiveStatus } from "../agent_ws";
 import type { AgentNodeUpdate, TeamDefinitionRecord } from "../api";
 import {
@@ -412,25 +414,11 @@ function RemoteNodeDangerZone({
 }
 
 function buildTeamMemberAcpPath(teamId: string, memberId: string): string {
-  return buildTeamWorkspacePath(
-    teamId,
-    "members",
-    null,
-    null,
-    memberId,
-    "agent_acp",
-  );
+  return buildTeamMemberWorkspacePath(teamId, memberId, "agent_acp");
 }
 
 function buildTeamMemberConsolePath(teamId: string, memberId: string): string {
-  return buildTeamWorkspacePath(
-    teamId,
-    "members",
-    null,
-    null,
-    memberId,
-    "member_console",
-  );
+  return buildTeamMemberWorkspacePath(teamId, memberId, "member_console");
 }
 
 type AgentNodesWorkbenchProps = {

--- a/web/src/components/layout/workspace_section_shell.test.tsx
+++ b/web/src/components/layout/workspace_section_shell.test.tsx
@@ -63,7 +63,7 @@ describe("WorkspaceSectionShell", () => {
     expect(html).toContain('data-workspace-split-pane-layout="true"');
     expect(html).toContain('data-secondary-open="false"');
     expect(html).toContain("primary-pane");
-    expect(html).not.toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(html).not.toContain("lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.9fr)]");
     expect(html).not.toContain("max-h-[40vh]");
   });
 
@@ -77,7 +77,7 @@ describe("WorkspaceSectionShell", () => {
     );
 
     expect(html).toContain('data-secondary-open="true"');
-    expect(html).toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(html).toContain("lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.9fr)]");
     expect(html).toContain("max-h-[40vh]");
     expect(html).toContain("secondary-dock");
   });

--- a/web/src/components/layout/workspace_section_shell.test.tsx
+++ b/web/src/components/layout/workspace_section_shell.test.tsx
@@ -1,0 +1,84 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  WorkspaceContentStack,
+  WorkspaceSectionShell,
+  WorkspaceSplitPaneLayout,
+} from "./workspace_section_shell";
+
+describe("WorkspaceSectionShell", () => {
+  it("renders shared workspace section chrome", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceSectionShell className="custom-shell">Content</WorkspaceSectionShell>
+    );
+
+    expect(html).toContain('data-workspace-section-shell="true"');
+    expect(html).toContain("rounded-xl");
+    expect(html).toContain("border-notion-border");
+    expect(html).toContain("custom-shell");
+  });
+
+  it("uses compact vertical padding for embedded agent workspaces", () => {
+    const html = renderToStaticMarkup(<WorkspaceSectionShell compact>Content</WorkspaceSectionShell>);
+
+    expect(html).toContain("py-0.5");
+  });
+
+  it("renders shared workspace content stack chrome", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceContentStack className="content-stack">Content</WorkspaceContentStack>
+    );
+
+    expect(html).toContain('data-workspace-content-stack="true"');
+    expect(html).toContain("min-h-0");
+    expect(html).toContain("overflow-hidden");
+    expect(html).toContain("gap-4");
+    expect(html).toContain("content-stack");
+  });
+
+  it("uses compact spacing for embedded agent content stacks", () => {
+    const html = renderToStaticMarkup(<WorkspaceContentStack compact>Content</WorkspaceContentStack>);
+
+    expect(html).toContain("gap-2");
+    expect(html).not.toContain("gap-4");
+  });
+
+  it("supports tight workspace body spacing without conflicting gap classes", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceContentStack gap="tight">Content</WorkspaceContentStack>
+    );
+
+    expect(html).toContain("gap-3");
+    expect(html).not.toContain("gap-4");
+  });
+
+  it("renders single-pane workspace layout without desktop split classes", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceSplitPaneLayout
+        primary={<main data-testid="primary-pane">Primary</main>}
+        primaryClassName="primary-pane"
+      />
+    );
+
+    expect(html).toContain('data-workspace-split-pane-layout="true"');
+    expect(html).toContain('data-secondary-open="false"');
+    expect(html).toContain("primary-pane");
+    expect(html).not.toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(html).not.toContain("max-h-[40vh]");
+  });
+
+  it("renders split workspace layout with constrained secondary dock", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceSplitPaneLayout
+        primary={<main data-testid="primary-pane">Primary</main>}
+        secondary={<aside data-testid="secondary-pane">Secondary</aside>}
+        secondaryClassName="secondary-dock"
+      />
+    );
+
+    expect(html).toContain('data-secondary-open="true"');
+    expect(html).toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(html).toContain("max-h-[40vh]");
+    expect(html).toContain("secondary-dock");
+  });
+});

--- a/web/src/components/layout/workspace_section_shell.tsx
+++ b/web/src/components/layout/workspace_section_shell.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { cx } from "../../ui/primitives";
+
+const WORKSPACE_SECTION_SHELL_BASE_CLASS =
+  "min-w-0 rounded-xl border border-notion-border bg-white shadow-sm";
+const WORKSPACE_CONTENT_STACK_BASE_CLASS =
+  "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden";
+
+type WorkspaceSectionShellProps = React.ComponentPropsWithoutRef<"div"> & {
+  compact?: boolean;
+};
+
+export const WorkspaceSectionShell = React.memo(function WorkspaceSectionShell({
+  className,
+  compact = false,
+  ...props
+}: WorkspaceSectionShellProps) {
+  return (
+    <div
+      className={cx(WORKSPACE_SECTION_SHELL_BASE_CLASS, compact ? "py-0.5" : null, className)}
+      data-workspace-section-shell="true"
+      {...props}
+    />
+  );
+});
+
+WorkspaceSectionShell.displayName = "WorkspaceSectionShell";
+
+type WorkspaceContentStackProps = React.ComponentPropsWithoutRef<"div"> & {
+  compact?: boolean;
+  gap?: "compact" | "normal" | "tight";
+};
+
+export const WorkspaceContentStack = React.memo(function WorkspaceContentStack({
+  className,
+  compact = false,
+  gap,
+  ...props
+}: WorkspaceContentStackProps) {
+  const resolvedGap = gap ?? (compact ? "compact" : "normal");
+  const gapClassName =
+    resolvedGap === "compact" ? "gap-2" : resolvedGap === "tight" ? "gap-3" : "gap-4";
+  return (
+    <div
+      className={cx(WORKSPACE_CONTENT_STACK_BASE_CLASS, gapClassName, className)}
+      data-workspace-content-stack="true"
+      {...props}
+    />
+  );
+});
+
+WorkspaceContentStack.displayName = "WorkspaceContentStack";
+
+type WorkspaceSplitPaneLayoutProps = Omit<React.ComponentPropsWithoutRef<"div">, "children"> & {
+  primary: React.ReactNode;
+  secondary?: React.ReactNode;
+  primaryClassName?: string;
+  secondaryClassName?: string;
+};
+
+export const WorkspaceSplitPaneLayout = React.memo(function WorkspaceSplitPaneLayout({
+  className,
+  primary,
+  secondary = null,
+  primaryClassName,
+  secondaryClassName,
+  ...props
+}: WorkspaceSplitPaneLayoutProps) {
+  const hasSecondary = Boolean(secondary);
+  return (
+    <div
+      className={cx(
+        "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden",
+        hasSecondary ? "lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]" : null,
+        className
+      )}
+      data-workspace-split-pane-layout="true"
+      data-secondary-open={hasSecondary ? "true" : "false"}
+      {...props}
+    >
+      <div className={cx("min-h-0 min-w-0 flex-1 overflow-hidden", primaryClassName)}>
+        {primary}
+      </div>
+      {hasSecondary ? (
+        <div
+          className={cx(
+            "flex max-h-[40vh] min-h-0 w-full shrink-0 flex-col overflow-hidden lg:h-full lg:max-h-none lg:min-w-0",
+            secondaryClassName
+          )}
+        >
+          {secondary}
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+WorkspaceSplitPaneLayout.displayName = "WorkspaceSplitPaneLayout";

--- a/web/src/components/layout/workspace_section_shell.tsx
+++ b/web/src/components/layout/workspace_section_shell.tsx
@@ -5,6 +5,8 @@ const WORKSPACE_SECTION_SHELL_BASE_CLASS =
   "min-w-0 rounded-xl border border-notion-border bg-white shadow-sm";
 const WORKSPACE_CONTENT_STACK_BASE_CLASS =
   "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden";
+const WORKSPACE_SPLIT_WITH_CONTEXT_CLASS =
+  "lg:grid lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.9fr)]";
 
 type WorkspaceSectionShellProps = React.ComponentPropsWithoutRef<"div"> & {
   compact?: boolean;
@@ -71,7 +73,7 @@ export const WorkspaceSplitPaneLayout = React.memo(function WorkspaceSplitPaneLa
     <div
       className={cx(
         "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden",
-        hasSecondary ? "lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]" : null,
+        hasSecondary ? WORKSPACE_SPLIT_WITH_CONTEXT_CLASS : null,
         className
       )}
       data-workspace-split-pane-layout="true"

--- a/web/src/components/workbench_header_menu.tsx
+++ b/web/src/components/workbench_header_menu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Menu, UnstyledButton } from "@mantine/core";
 import { buildWorkspaceNodePath } from "../app_route_selection";
+import { buildTeamSelectorPath } from "../pages/team/team_route_helpers";
 import { NOTION_FLOATING_MENU_PROPS } from "../ui/floating_surfaces";
 
 type WorkbenchHeaderMenuProps = {
@@ -46,7 +47,10 @@ export const WorkbenchHeaderMenu = React.memo(function WorkbenchHeaderMenu({
         <Menu.Item onClick={() => onNavigate("/workspace")} disabled={active === "workspace"}>
           Workspace
         </Menu.Item>
-        <Menu.Item onClick={() => onNavigate("/workspace/teams")} disabled={active === "teams"}>
+        <Menu.Item
+          onClick={() => onNavigate(buildTeamSelectorPath())}
+          disabled={active === "teams"}
+        >
           Teams
         </Menu.Item>
         {isRoot ? (

--- a/web/src/components/workspace_lens_items.test.ts
+++ b/web/src/components/workspace_lens_items.test.ts
@@ -11,6 +11,12 @@ describe("buildStandardWorkspaceLensItems", () => {
       "tasks",
       "members",
     ]);
+    expect(items.map((item) => item.label)).toEqual([
+      "Teams",
+      "Channels",
+      "Tasks",
+      "Members",
+    ]);
     expect(items.find((item) => item.value === "tasks")?.active).toBe(true);
     expect(items.find((item) => item.value === "search")).toBeUndefined();
   });

--- a/web/src/components/workspace_lens_items.ts
+++ b/web/src/components/workspace_lens_items.ts
@@ -32,7 +32,7 @@ export function buildStandardWorkspaceLensItems(
     },
     {
       value: "members",
-      label: "Agents",
+      label: "Members",
       active: activeLens === "members",
       onPrefetch: onPrefetch ? () => onPrefetch("members") : undefined,
     },

--- a/web/src/components/workspace_lens_placeholder.test.tsx
+++ b/web/src/components/workspace_lens_placeholder.test.tsx
@@ -39,7 +39,10 @@ describe("WorkspaceLensPlaceholder", () => {
 
     expect(html).toContain("Search");
     expect(html).toContain("Search workspace");
-    expect(html).toContain("Use the sidebar search command");
+    expect(html).toContain(
+      "Use the sidebar search command to jump across Channels, Tasks, and Members."
+    );
+    expect(html).not.toContain("channels, tasks, and agents");
     expect(html).not.toContain("type=\"search\"");
     expect(html).toContain("shared-search-card");
   });

--- a/web/src/components/workspace_lens_placeholder.tsx
+++ b/web/src/components/workspace_lens_placeholder.tsx
@@ -55,7 +55,7 @@ export function WorkspaceSearchLensPlaceholder({
       <EmptyState
         className="mt-2 border-0 bg-transparent px-0 py-0"
         title="Search workspace"
-        body="Use the sidebar search command to jump across channels, tasks, and agents."
+        body="Use the sidebar search command to jump across Channels, Tasks, and Members."
       />
     </SurfaceCard>
   );

--- a/web/src/pages/team/TeamConversationContainer.tsx
+++ b/web/src/pages/team/TeamConversationContainer.tsx
@@ -5,7 +5,10 @@ import {
   formatTs,
   toPrettyJson,
 } from "./page_helpers";
-import { buildTeamWorkspacePath } from "../../app_route_selection";
+import {
+  buildTeamChannelThreadPath,
+  buildTeamChannelProfilePath,
+} from "./team_route_helpers";
 import {
   useTeamConversationContext,
   useTeamTasksContext,
@@ -37,7 +40,6 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
     busy,
     routeThreadRootMessageId,
     effectiveSelectedTeamId,
-    routeWorkspaceLens,
     routeChannelId,
     activeChannelConversationTaskId,
     navigateTeamRoute,
@@ -47,13 +49,10 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
     (messageId: number) => {
       if (effectiveSelectedTeamId && selectedConversationMatchesChannelLane) {
         navigateTeamRoute(
-          buildTeamWorkspacePath(
+          buildTeamChannelThreadPath(
             effectiveSelectedTeamId,
-            routeWorkspaceLens,
             routeChannelId,
             messageId,
-            null,
-            null,
             activeChannelConversationTaskId
           )
         );
@@ -63,7 +62,6 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
       effectiveSelectedTeamId,
       selectedConversationMatchesChannelLane,
       navigateTeamRoute,
-      routeWorkspaceLens,
       routeChannelId,
       activeChannelConversationTaskId,
     ]
@@ -76,19 +74,19 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
         return;
       }
       navigateTeamRoute(
-        buildTeamWorkspacePath(
+        buildTeamChannelProfilePath(
           effectiveSelectedTeamId,
-          "channels",
           routeChannelId,
-          null,
           normalizedMemberId,
-          null,
           activeChannelConversationTaskId
         )
       );
     },
     [activeChannelConversationTaskId, effectiveSelectedTeamId, navigateTeamRoute, routeChannelId]
   );
+  const onJumpToMessageSettled = useCallback(() => {
+    setChannelFocusMessageId(null);
+  }, [setChannelFocusMessageId]);
 
   return (
     <TeamConversationPanel
@@ -117,9 +115,7 @@ export const TeamConversationContainer = React.memo(function TeamConversationCon
       activeThreadMessageId={selectedConversationMatchesChannelLane ? routeThreadRootMessageId : null}
       onOpenMemberProfile={onOpenMemberProfile}
       jumpToMessageId={channelFocusMessageId}
-      onJumpToMessageSettled={() => {
-        setChannelFocusMessageId(null);
-      }}
+      onJumpToMessageSettled={onJumpToMessageSettled}
       onOpenThread={onOpenThread}
     />
   );

--- a/web/src/pages/team/TeamSidebarContainer.tsx
+++ b/web/src/pages/team/TeamSidebarContainer.tsx
@@ -3,7 +3,7 @@ import { TeamSidebar } from "../team_sidebar";
 import type { TeamDefinitionRecord, TeamTaskRecord } from "../../api";
 import type { TeamChannelItem } from "./channel_metadata";
 import type { TeamMemberLiveState } from "./member_helpers";
-import type { WorkspaceLens } from "../../app_route_selection";
+import type { WorkspaceLens } from "./team_route_helpers";
 import type { TeamTab } from "./state";
 
 type TeamSidebarProps = React.ComponentProps<typeof TeamSidebar>;

--- a/web/src/pages/team/TeamThreadContainer.tsx
+++ b/web/src/pages/team/TeamThreadContainer.tsx
@@ -6,7 +6,7 @@ import {
   resolveChatMessageText,
   resolveThreadRootMessageIdFromPayload,
 } from "./page_helpers";
-import { buildTeamWorkspacePath } from "../../app_route_selection";
+import { buildTeamChannelPath, buildTeamChannelTaskPath } from "./team_route_helpers";
 import {
   createDisplayNameLookup,
   isHumanMailboxActor,
@@ -52,7 +52,6 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
     selectedTeamMemberLiveStates,
     selectedConversationMatchesChannelLane,
     effectiveSelectedTeamId,
-    routeWorkspaceLens,
     routeChannelId,
     activeChannelConversationTaskId,
     navigateTeamRoute,
@@ -179,20 +178,17 @@ export const TeamThreadContainer = React.memo(function TeamThreadContainer() {
     if (!effectiveSelectedTeamId) {
       return null;
     }
-    return buildTeamWorkspacePath(
-      effectiveSelectedTeamId,
-      routeWorkspaceLens,
-      routeChannelId,
-      null,
-      null,
-      null,
-      activeChannelConversationTaskId
-    );
+    return activeChannelConversationTaskId
+      ? buildTeamChannelTaskPath(
+          effectiveSelectedTeamId,
+          routeChannelId,
+          activeChannelConversationTaskId
+        )
+      : buildTeamChannelPath(effectiveSelectedTeamId, routeChannelId);
   }, [
     activeChannelConversationTaskId,
     effectiveSelectedTeamId,
     routeChannelId,
-    routeWorkspaceLens,
   ]);
 
   const onViewInChannel = useCallback(() => {

--- a/web/src/pages/team/TeamWorkbenchContainer.test.tsx
+++ b/web/src/pages/team/TeamWorkbenchContainer.test.tsx
@@ -1,0 +1,431 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TeamWorkspaceProvider, type TeamWorkspaceContextValue } from "./team_workspace_context";
+import { TeamWorkbenchContainer, type TeamWorkbenchRuntimeContext } from "./TeamWorkbenchContainer";
+
+vi.mock("./team_workbench_content", () => ({
+  TeamPanelLoadingFallback: () => <div data-testid="team-panel-loading" />,
+  TeamWorkbenchContent: ({ debugPanel }: { debugPanel?: React.ReactNode }) => (
+    <div data-testid="team-workbench-content">{debugPanel}</div>
+  ),
+}));
+
+vi.mock("./team_debug_panels", () => ({
+  TeamDebugToolsHeader: () => <div data-testid="team-debug-tools-header" />,
+  TeamRunRequiredPanel: () => <div data-testid="team-run-required-panel" />,
+  TeamRunOpsPanel: ({
+    onUseExampleJson,
+    onSetEmptyObject,
+    onFormatJson,
+    onClearRunInput,
+    runInput,
+  }: {
+    onUseExampleJson: () => void;
+    onSetEmptyObject: () => void;
+    onFormatJson: () => void;
+    onClearRunInput: () => void;
+    runInput: string;
+  }) => (
+    <div>
+      <pre data-testid="run-input">{runInput}</pre>
+      <button type="button" onClick={onUseExampleJson}>
+        Example
+      </button>
+      <button type="button" onClick={onSetEmptyObject}>
+        Empty object
+      </button>
+      <button type="button" onClick={onFormatJson}>
+        Format
+      </button>
+      <button type="button" onClick={onClearRunInput}>
+        Clear
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./TeamConversationContainer", () => ({
+  TeamConversationContainer: () => <div data-testid="team-conversation" />,
+}));
+
+vi.mock("./TeamTasksContainer", () => ({
+  TeamTasksContainer: () => <div data-testid="team-tasks" />,
+}));
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((node) =>
+    node.textContent?.includes(label)
+  );
+  if (!button) {
+    throw new Error(`button not found: ${label}`);
+  }
+  return button as HTMLButtonElement;
+}
+
+function buildRuntimeContext(runInput: string, setRunInput: (value: string) => void): TeamWorkbenchRuntimeContext {
+  const activeRun = {
+    id: "run-1",
+    team_id: "team-1",
+    context_id: "ctx-1",
+    status: "working" as const,
+    input: {},
+    created_at: 1,
+    started_at: null,
+    ended_at: null,
+  };
+  let parsed: unknown;
+  let error: string | null = null;
+  try {
+    parsed = runInput.trim() ? JSON.parse(runInput) : undefined;
+  } catch (err) {
+    parsed = undefined;
+    error = err instanceof Error ? err.message : "Invalid JSON";
+  }
+  return {
+    shell: {
+      showTeamBootstrapLoading: false,
+      showTeamUnavailable: false,
+      onBackToSelector: vi.fn(),
+      selectedTeam: { id: "team-1", name: "Team One" } as never,
+      isAgentWorkspace: false,
+      teamSectionCardClassName: "panel",
+      panelSecondaryButtonClassName: "secondary",
+      teamWorkbenchWorkspaceShellClassName: "shell",
+      tab: "runs",
+      activeWorkspaceLens: "channels",
+      developerMode: true,
+      busy: null,
+      selectedTeamHasConfiguredMembers: true,
+      selectedTeamDescription: null,
+      teamMemberForgeLabel: "Forge",
+      teamMemberCopyExistingLabel: "Copy",
+      onOpenTeamMemberForge: vi.fn(),
+      onOpenTeamMemberCopyExisting: vi.fn(),
+      showRunContextLoading: false,
+      showNoActiveRunNotice: false,
+      onGoToRuns: vi.fn(),
+    },
+    header: {
+      workspaceEyebrow: null,
+      showDedicatedWorkspaceHeading: false,
+      workspaceTitle: "Team One",
+      workspaceDescription: null,
+      selectedAgentLabel: "",
+      selectedAgentWorkspaceMemberId: "",
+      selectedAgentStatusView: {
+        role: "worker",
+        lifecycle: "Idle",
+        work: "Idle",
+        inbox: "0 pending",
+        currentWork: "",
+      },
+      selectedAgentSpecDraft: null,
+      selectedAgentControlState: { canStart: false, canStop: false, canDelete: false },
+      showWorkspaceRuntimeBadge: false,
+      selectedTeamRuntimeStatus: null,
+      selectedTeamRuntimeControlTone: { statusColor: "gray", countColor: "gray" },
+      workspaceAdvancedTabItems: [],
+      isAdvancedWorkspace: false,
+      showRunActionsInAdvanced: false,
+      canResumeActiveRun: false,
+      canRestartActiveRun: false,
+      workspaceDetailsOpen: false,
+      workspaceDetailItems: [],
+      workspaceNoticeText: null,
+      workspaceNoticeDotClassName: "",
+      teamWorkbenchMutedButtonClassName: "",
+      teamWorkbenchHeaderActionButtonClassName: "",
+      workspaceToolbarClassName: "",
+      workspaceToolbarButtonActiveClassName: "",
+      workspaceToolbarButtonIdleClassName: "",
+      workspaceNoticeClassName: "",
+      workspaceNoticeTextClassName: "",
+      teamRunMetaItemClassName: "",
+      onTabChange: vi.fn(),
+      onToggleWorkspaceDetails: vi.fn(),
+      onRefreshActiveRun: vi.fn(),
+      onCancelRun: vi.fn(),
+      onResumeRun: vi.fn(),
+      onRestartRun: vi.fn(),
+      onOpenTeamMemberEditModal: vi.fn(),
+      onStartSelectedTeamAgent: vi.fn(),
+      onStopSelectedTeamAgent: vi.fn(),
+      onDeleteSelectedTeamAgent: vi.fn(),
+    },
+    runs: {
+      onDeleteTeam: vi.fn(),
+      runStatusFilter: "all",
+      TEAM_RUN_STATUS_FILTER_OPTIONS: [],
+      onRunStatusFilterChange: vi.fn(),
+      onRefreshRuns: vi.fn(),
+      runsLoading: false,
+      visibleRuns: [activeRun],
+      activeRunIdForSelectedTeam: "run-1",
+      setActiveRunId: vi.fn(),
+      isActiveRunHiddenByFilter: false,
+      activeRunForSelectedTeam: activeRun,
+      totalLoadedRunsForTeam: 1,
+      runsHasMore: false,
+      effectiveSelectedTeamId: "team-1",
+      onLoadMoreRuns: vi.fn(),
+    },
+    overview: {
+      snapshot: null,
+      snapshotLoading: false,
+      onRefreshOverviewSnapshot: vi.fn(),
+      mailboxDisplayNameByActorId: {},
+    },
+    memberConsole: {
+      selectedAgentWorkspaceSessionId: null,
+      memberEvents: [],
+      memberEventsLoading: false,
+      memberEventsHasMore: false,
+      onLoadOlderMemberConsole: vi.fn(),
+      onRefreshMemberConsole: vi.fn(),
+    },
+    debugRun: {
+      teamDebugTag: "run_ops",
+      setTeamDebugTag: vi.fn(),
+      runContextId: "ctx-1",
+      setRunContextId: vi.fn(),
+      runInput,
+      setRunInput,
+      runLookupId: "",
+      setRunLookupId: vi.fn(),
+      canCreateRun: true,
+      runInputHasError: Boolean(error),
+      runInputValidation: { parsed, error },
+      teamExecutionBlockedReason: null,
+      onCreateRun: vi.fn(),
+      onLoadRunById: vi.fn(),
+      steps: [],
+      onRefreshActiveRunSteps: vi.fn(),
+      stepKey: "",
+      setStepKey: vi.fn(),
+      stepMemberId: "",
+      onStepMemberIdChange: vi.fn(),
+      stepDependsOn: "",
+      onStepDependsOnChange: vi.fn(),
+      stepInput: "",
+      onStepInputChange: vi.fn(),
+      onSubmitStep: vi.fn(),
+      selectedStepId: "",
+      setSelectedStepId: vi.fn(),
+      stepAction: "complete",
+      setStepAction: vi.fn(),
+      stepRemoteTaskId: "",
+      onStepRemoteTaskIdChange: vi.fn(),
+      stepOutput: "",
+      onStepOutputChange: vi.fn(),
+      stepFailText: "",
+      onStepFailTextChange: vi.fn(),
+      stepInputReason: "",
+      onStepInputReasonChange: vi.fn(),
+      stepInputRequiredPayload: "",
+      onStepInputRequiredPayloadChange: vi.fn(),
+      stepResumePayload: "",
+      onStepResumePayloadChange: vi.fn(),
+      onApplyStepAction: vi.fn(),
+    },
+    conversation: {
+      unreadByMemberId: {},
+      chatActors: { fromActorId: "", toActorId: "", inboxActorId: "" },
+      chatStickToBottom: true,
+      chatMessagesRef: { current: null },
+      onConversationScroll: vi.fn(),
+      onJumpConversationToBottom: vi.fn(),
+      conversationMessages: [],
+      onAcceptMessage: vi.fn(),
+      onAcceptVisibleMessages: vi.fn(),
+      onSendChatMessage: vi.fn(),
+      MAILBOX_TEMPLATE_OPTIONS: [],
+      onMailboxTemplateChange: vi.fn(),
+      onApplyMessageTemplate: vi.fn(),
+      onSendMessage: vi.fn(),
+      onRefreshInbox: vi.fn(),
+      chatDraft: "",
+      onChatDraftChange: vi.fn(),
+    },
+    memberAcp: {
+      selectedAgentWorkspaceSnapshot: null,
+      selectedMemberSnapshot: null,
+      selectedAgentWorkspaceRuntimeMember: null,
+      selectedAgentWorkspaceAgent: null,
+      oldestMemberEventId: null,
+      onSendAgentAcpInput: vi.fn(),
+      onCancelTeamMemberAcp: vi.fn(),
+      onSetTeamMemberAcpMode: vi.fn(),
+      onSetTeamMemberAcpModel: vi.fn(),
+      onSetTeamMemberAcpConfig: vi.fn(),
+      onForceNewTeamMemberSession: vi.fn(),
+      memberTargetNodeById: {},
+      selectedMemberId: "",
+      setSelectedMemberId: vi.fn(),
+      selectedMemberDiscoveryCard: null,
+      selectedMemberDiscoveryCardLoading: false,
+      onOpenMailboxForMember: vi.fn(),
+    },
+    events: {
+      eventsLoading: false,
+      oldestEventId: null,
+      displayedRunEvents: [],
+      previewMode: false,
+      eventsAutoRefresh: false,
+      setEventsAutoRefresh: vi.fn(),
+      onRefreshEventsPanel: vi.fn(),
+      onLoadOlderEventsPanel: vi.fn(),
+      eventsHasMore: false,
+      TEAM_EVENT_PREVIEW_LIMIT: 5,
+    },
+    mailboxDebug: {
+      msgFromActorId: "",
+      onMsgFromActorIdChange: vi.fn(),
+      msgToActorId: "",
+      onMsgToActorIdChange: vi.fn(),
+      msgChannel: "",
+      onMsgChannelChange: vi.fn(),
+      msgTransport: "local",
+      onMsgTransportChange: vi.fn(),
+      msgRoute: "",
+      onMsgRouteChange: vi.fn(),
+      msgTemplate: "",
+      msgPayload: "",
+      onMsgPayloadChange: vi.fn(),
+      msgIdempotencyKey: "",
+      onMsgIdempotencyKeyChange: vi.fn(),
+      inboxActorId: "",
+      onInboxActorIdChange: vi.fn(),
+      inboxLimit: "",
+      onInboxLimitChange: vi.fn(),
+      inboxAfterId: "",
+      onInboxAfterIdChange: vi.fn(),
+      inboxIncludeDelivered: false,
+      onInboxIncludeDeliveredChange: vi.fn(),
+      mailboxHasActiveRun: true,
+      mailboxEmptyTitle: "Mailbox",
+      mailboxEmptyBody: "No messages.",
+    },
+  };
+}
+
+function buildWorkspaceContext(workbench: TeamWorkbenchRuntimeContext): TeamWorkspaceContextValue {
+  return {
+    workbench,
+    developerMode: true,
+    busy: null,
+    snapshot: null,
+    mailboxDisplayNameByActorId: {},
+    selectedTeamMemberLiveStates: [],
+    selectedConversationMatchesChannelLane: true,
+    routeThreadRootMessageId: null,
+    routeSelectedMemberId: "",
+    effectiveSelectedTeamId: "team-1",
+    routeWorkspaceLens: "channels",
+    routeChannelId: "all",
+    activeChannelConversationTaskId: null,
+    navigateTeamRoute: vi.fn(),
+    isCompactWorkbench: false,
+    selectedChannelItem: null,
+    selectedConversation: null,
+    token: "token",
+    taskMessageDraft: "",
+    setTaskMessageDraft: vi.fn(),
+    onSendTaskMessage: vi.fn(),
+    taskMessages: [],
+    conversationMailboxMessages: [],
+    taskConversationMemberIds: [],
+    activeConversationTitle: "# all",
+    taskMessagesLoading: false,
+    channelFocusMessageId: null,
+    setChannelFocusMessageId: vi.fn(),
+    onSendThreadReply: vi.fn(),
+    threadReplyDraft: "",
+    setThreadReplyDraft: vi.fn(),
+    tasksLoading: false,
+    onRefreshTasks: vi.fn(),
+    workspaceTasks: [],
+    selectedTaskId: "",
+    selectedTaskDetail: null,
+    setSelectedTaskId: vi.fn(),
+    onSelectConversationSubject: vi.fn(),
+    runs: [],
+    onOpenTaskRun: vi.fn(),
+    compilePreviewContextId: "",
+    setCompilePreviewContextId: vi.fn(),
+    onCompileTaskRunPreview: vi.fn(),
+    canCompileTask: false,
+    compiledRunPreview: null,
+    onUseCompiledRunPayload: vi.fn(),
+    onCreateRunFromCompiledPreview: vi.fn(),
+  };
+}
+
+function Harness() {
+  const [runInput, setRunInput] = React.useState("");
+  const workbench = React.useMemo(
+    () => buildRuntimeContext(runInput, setRunInput),
+    [runInput]
+  );
+  return (
+    <TeamWorkspaceProvider value={buildWorkspaceContext(workbench)}>
+      <TeamWorkbenchContainer />
+    </TeamWorkspaceProvider>
+  );
+}
+
+describe("TeamWorkbenchContainer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("routes run input helper actions through the debug run panel", () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+
+    act(() => {
+      findButton(container, "Format").click();
+    });
+    expect(container.querySelector("[data-testid='run-input']")?.textContent).toBe("{}");
+
+    act(() => {
+      findButton(container, "Example").click();
+    });
+    expect(container.querySelector("[data-testid='run-input']")?.textContent).toContain(
+      "improve-team-run"
+    );
+
+    act(() => {
+      findButton(container, "Format").click();
+    });
+    expect(container.querySelector("[data-testid='run-input']")?.textContent).toBe(
+      '{\n  "task": "investigate",\n  "objective": "improve-team-run"\n}'
+    );
+
+    act(() => {
+      findButton(container, "Clear").click();
+    });
+    expect(container.querySelector("[data-testid='run-input']")?.textContent).toBe("");
+
+    act(() => {
+      findButton(container, "Empty object").click();
+    });
+    expect(container.querySelector("[data-testid='run-input']")?.textContent).toBe("{}");
+  });
+});

--- a/web/src/pages/team/TeamWorkbenchContainer.tsx
+++ b/web/src/pages/team/TeamWorkbenchContainer.tsx
@@ -12,12 +12,14 @@ import type {
   AgentRecord,
   AgentDiscoveryCardRecord,
 } from "../../api";
-import type { WorkspaceLens } from "../../app_route_selection";
 import type { StepAction, TeamTab } from "./state";
 import type { TeamMemberProfileDraft } from "./create_helpers";
 import type { MailboxTemplateKey, TeamMailboxChatActors } from "./mailbox_helpers";
 import type { TeamRunStatusFilter } from "./run_helpers";
-import { buildTeamWorkspacePath } from "../../app_route_selection";
+import {
+  buildTeamChannelProfileClosePath,
+  type WorkspaceLens,
+} from "./team_route_helpers";
 import { TeamConversationContainer } from "./TeamConversationContainer";
 import { TeamTasksContainer } from "./TeamTasksContainer";
 import { TeamThreadContainer } from "./TeamThreadContainer";
@@ -43,7 +45,10 @@ import {
   buildTeamWorkbenchBodyProps,
 } from "./team_page_route_props";
 import { isAgentActiveStatus } from "../../agent_ws";
-import { useTeamWorkspace } from "./team_workspace_context";
+import {
+  useTeamWorkbenchRuntime,
+  useTeamWorkspaceShell,
+} from "./team_workspace_context";
 
 type TeamWorkspaceHeaderProps = Parameters<typeof buildTeamWorkspaceHeaderProps>[0];
 type TeamRunsPanelProps = Parameters<typeof buildTeamRunsPanelProps>[0];
@@ -320,16 +325,14 @@ export type TeamWorkbenchRuntimeContext = {
 };
 
 export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer() {
+  const props = useTeamWorkbenchRuntime();
   const {
-    workbench: props,
     routeThreadRootMessageId,
+    routeSelectedMemberId,
     selectedConversationMatchesChannelLane,
     routeChannelId,
     navigateTeamRoute,
-  } = useTeamWorkspace();
-  if (!props) {
-    throw new Error("TeamWorkbenchContainer requires TeamWorkspaceContext.workbench");
-  }
+  } = useTeamWorkspaceShell();
   const {
     shell,
     header,
@@ -953,8 +956,8 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
     !isAgentWorkspace &&
     tab === "conversation" &&
     activeWorkspaceLens === "channels" &&
-    selectedMemberId.trim().length > 0
-      ? selectedMemberId.trim()
+    (routeSelectedMemberId.trim() || selectedMemberId.trim()).length > 0
+      ? routeSelectedMemberId.trim() || selectedMemberId.trim()
       : "";
   const profilePane =
     channelProfileMemberId && activeRunForSelectedTeam ? (
@@ -970,7 +973,7 @@ export const TeamWorkbenchContainer = React.memo(function TeamWorkbenchContainer
             setSelectedMemberId("");
             if (effectiveSelectedTeamId) {
               navigateTeamRoute(
-                buildTeamWorkspacePath(effectiveSelectedTeamId, "channels", routeChannelId)
+                buildTeamChannelProfileClosePath(effectiveSelectedTeamId, routeChannelId)
               );
             }
           }}

--- a/web/src/pages/team/team_route_boundary.test.ts
+++ b/web/src/pages/team/team_route_boundary.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+const TEAM_ROUTE_SYMBOLS = [
+  "buildCanonicalTeamWorkspaceSubpath",
+  "buildTeamDetailPath",
+  "buildTeamWorkspacePath",
+  "resolveTeamMemberRouteTab",
+  "resolveTeamRoute",
+  "resolveTeamWorkspacePathState",
+  "resolveWorkspaceLens",
+  "TeamMemberRouteTab",
+  "TeamRouteState",
+  "WorkspaceLens",
+] as const;
+
+const TEAM_ROUTE_SOURCE_ALLOWLIST = new Set([
+  "./team_route_helpers.ts",
+  "./team_route_helpers.test.ts",
+  "./team_route_boundary.test.ts",
+]);
+
+const sourceModules = import.meta.glob<string>(
+  [
+    "../**/*.{ts,tsx}",
+    "../../components/agent_nodes_workbench.tsx",
+    "../../../tests/e2e/**/*.{ts,tsx}",
+  ],
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+);
+
+const directNavigationModules = import.meta.glob<string>(
+  [
+    "../team_page.tsx",
+    "../team/**/*.{ts,tsx}",
+    "../../routes/use_workspace_route_state.ts",
+    "../../components/workbench_header_menu.tsx",
+    "../../components/agent_nodes_workbench.tsx",
+    "../../../tests/e2e/**/*.{ts,tsx}",
+  ],
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+);
+
+const productionNavigationModules = import.meta.glob<string>(
+  [
+    "../team_page.tsx",
+    "../team/**/*.{ts,tsx}",
+    "../../routes/use_workspace_route_state.ts",
+    "../../components/workbench_header_menu.tsx",
+    "../../components/agent_nodes_workbench.tsx",
+  ],
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+);
+
+const appModule = import.meta.glob<string>("../../app.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+function importedNamesFromAppRouteSelection(source: string): Set<string> {
+  const names = new Set<string>();
+  const importPattern = /import\s+(?:type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+["'][^"']*app_route_selection["']/g;
+  for (const match of source.matchAll(importPattern)) {
+    const imports = match.groups?.imports ?? "";
+    for (const segment of imports.split(",")) {
+      const imported = segment.trim().split(/\s+as\s+/)[0]?.trim();
+      if (imported) {
+        names.add(imported);
+      }
+    }
+  }
+  return names;
+}
+
+function exportedNamesFromAppRouteSelection(source: string): Set<string> {
+  const names = new Set<string>();
+  const exportPattern = /export\s+\{(?<exports>[\s\S]*?)\}\s+from\s+["'][^"']*app_route_selection["']/g;
+  for (const match of source.matchAll(exportPattern)) {
+    const exports = match.groups?.exports ?? "";
+    for (const segment of exports.split(",")) {
+      const exported = segment.trim().split(/\s+as\s+/)[0]?.trim();
+      if (exported) {
+        names.add(exported);
+      }
+    }
+  }
+  return names;
+}
+
+describe("Team route facade boundary", () => {
+  it("keeps global Team route symbols behind team_route_helpers", () => {
+    const violations = Object.entries(sourceModules).flatMap(([path, source]) => {
+      if (TEAM_ROUTE_SOURCE_ALLOWLIST.has(path)) {
+        return [];
+      }
+      const importedNames = importedNamesFromAppRouteSelection(source);
+      const routeImports = TEAM_ROUTE_SYMBOLS.filter((symbol) => importedNames.has(symbol));
+      return routeImports.length === 0
+        ? []
+        : [`${path}: ${routeImports.join(", ")}`];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps app-level exports from re-exposing Team route symbols", () => {
+    const violations = Object.entries(appModule).flatMap(([path, source]) => {
+      const exportedNames = exportedNamesFromAppRouteSelection(source);
+      const routeExports = TEAM_ROUTE_SYMBOLS.filter((symbol) => exportedNames.has(symbol));
+      return routeExports.length === 0
+        ? []
+        : [`${path}: ${routeExports.join(", ")}`];
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps Team navigation entrypoints behind named route helpers", () => {
+    const directTeamGotos = Object.entries(directNavigationModules).flatMap(([path, source]) => {
+      const matches = source.matchAll(
+        /(?:page\.goto|onNavigate|navigateWorkbenchRoute)\(\s*(["'`])\/(?:workspace\/)?teams(?:\/|\?|#|\1)/g
+      );
+      return Array.from(matches, (match) => `${path}: ${match[0]}`);
+    });
+
+    expect(directTeamGotos).toEqual([]);
+  });
+
+  it("keeps production Team links behind named route helpers", () => {
+    const directTeamLinks = Object.entries(productionNavigationModules).flatMap(([path, source]) => {
+      if (TEAM_ROUTE_SOURCE_ALLOWLIST.has(path)) {
+        return [];
+      }
+      const matches = source.matchAll(
+        /(?:href|to)=\{?\s*(["'`])\/(?:workspace\/)?teams(?:\/|\?|#|\1)/g
+      );
+      return Array.from(matches, (match) => `${path}: ${match[0]}`);
+    });
+
+    expect(directTeamLinks).toEqual([]);
+  });
+
+  it("keeps positional canonical Team subpath building inside the facade", () => {
+    const violations = Object.entries(productionNavigationModules).flatMap(([path, source]) => {
+      if (TEAM_ROUTE_SOURCE_ALLOWLIST.has(path)) {
+        return [];
+      }
+      const imports = source.matchAll(
+        /import\s+(?:type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+["'][^"']*team_route_helpers["']/g
+      );
+      const imported = Array.from(imports).some((match) =>
+        (match.groups?.imports ?? "")
+          .split(",")
+          .some((segment) => segment.trim().split(/\s+as\s+/)[0] === "buildCanonicalTeamSubpath")
+      );
+      return imported ? [`${path}: buildCanonicalTeamSubpath`] : [];
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/web/src/pages/team/team_route_helpers.test.ts
+++ b/web/src/pages/team/team_route_helpers.test.ts
@@ -101,6 +101,9 @@ describe("team route helpers", () => {
       "/workspace/teams/team-1/channels/review?tab=runs"
     );
     expect(
+      buildTeamTabCompatibilityPath("/workspace/teams/team-1/members/worker-1", "mailbox")
+    ).toBe("/workspace/teams/team-1/members/worker-1?tab=mailbox");
+    expect(
       buildTeamTabCompatibilityPath("/workspace/teams/team-1/members/worker-1", "agent_acp")
     ).toBe("/workspace/teams/team-1/members/worker-1?tab=thread");
   });
@@ -128,6 +131,10 @@ describe("team route helpers", () => {
     expect(buildTeamLensNavigationPath("team-1", "channels", "review", "task-9")).toBe(
       "/workspace/teams/team-1/channels/review/tasks/task-9"
     );
+    expect(buildTeamLensNavigationPath("team-1", "channels", "review")).toBe(
+      "/workspace/teams/team-1/channels/review"
+    );
+    expect(buildTeamLensNavigationPath("team-1", "channels")).toBe("/workspace/teams/team-1");
     expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
       "/workspace/teams/team-1?lens=members"
     );

--- a/web/src/pages/team/team_route_helpers.test.ts
+++ b/web/src/pages/team/team_route_helpers.test.ts
@@ -84,6 +84,9 @@ describe("team route helpers", () => {
     expect(buildTeamChannelProfilePath("team-1", "review", "worker-1")).toBe(
       "/workspace/teams/team-1/channels/review/members/worker-1"
     );
+    expect(buildTeamChannelProfilePath("team/1", "review/triage", "worker/1")).toBe(
+      "/workspace/teams/team%2F1/channels/review%2Ftriage/members/worker%2F1"
+    );
     expect(buildTeamChannelProfilePath("team-1", "all", "worker-1", "task-9")).toBe(
       "/workspace/teams/team-1/channels/all/tasks/task-9/members/worker-1"
     );
@@ -128,11 +131,17 @@ describe("team route helpers", () => {
     expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
       "/workspace/teams/team-1?lens=members"
     );
+    expect(buildTeamLensNavigationPath("team-1", "nodes", null, "task-9")).toBe(
+      "/workspace/teams/team-1?lens=nodes"
+    );
     expect(buildTeamWorkspaceLensPath("team-1", "search", "review")).toBe(
       "/workspace/teams/team-1/channels/review"
     );
     expect(buildTeamWorkspaceLensPath("team-1", "tasks", "review")).toBe(
       "/workspace/teams/team-1?lens=tasks"
+    );
+    expect(buildTeamWorkspaceLensPath("team-1", "members", "review")).toBe(
+      "/workspace/teams/team-1?lens=members"
     );
   });
 
@@ -153,6 +162,10 @@ describe("team route helpers", () => {
     expect(splitTeamRoutePath(buildTeamChannelPath("team-1", "review"))).toEqual({
       pathname: "/workspace/teams/team-1/channels/review",
       search: "",
+    });
+    expect(splitTeamRoutePath(buildTeamSearchCompatibilityPath("team-1"))).toEqual({
+      pathname: "/workspace/teams/team-1",
+      search: "?lens=search",
     });
   });
 
@@ -208,6 +221,9 @@ describe("team route helpers", () => {
       )
     ).toBe("mailbox");
     expect(resolveTeamWorkspaceTab("?tab=overview")).toBeNull();
+    expect(resolveTeamSelectedMemberId("", "/workspace/teams/team-1/members/%E0%A4%A")).toBe(
+      "%E0%A4%A"
+    );
   });
 
   it("maps route workspace lenses to Team tabs without promoting search to a content tab", () => {
@@ -278,6 +294,19 @@ describe("team route helpers", () => {
       selectedMemberId: "worker-2",
       selectedTaskId: "",
     });
+    expect(
+      resolveTeamRouteSelection(
+        "/workspace/teams/team-1/members/path-worker/member_console",
+        "?member=query-worker&tab=mailbox"
+      )
+    ).toEqual({
+      workspaceLens: "members",
+      workspaceTab: "mailbox",
+      channelId: "all",
+      threadRootMessageId: null,
+      selectedMemberId: "query-worker",
+      selectedTaskId: "",
+    });
   });
 
   it("resolves active Team workspace lenses from explicit routes before tab fallback", () => {
@@ -346,5 +375,11 @@ describe("team route helpers", () => {
         activeWorkspaceLens: "search",
       })
     ).toBe("channels");
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "mailbox",
+        activeWorkspaceLens: null,
+      })
+    ).toBe("agents");
   });
 });

--- a/web/src/pages/team/team_route_helpers.test.ts
+++ b/web/src/pages/team/team_route_helpers.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTeamChannelProfileClosePath,
+  buildTeamChannelProfilePath,
+  buildTeamChannelPath,
+  buildTeamChannelTaskPath,
+  buildTeamChannelThreadPath,
+  buildTeamDetailPath,
+  buildTeamLensNavigationPath,
+  buildTeamMemberWorkspacePath,
+  buildTeamSearchCompatibilityPath,
+  buildTeamSelectorPath,
+  buildTeamTaskPath,
+  buildTeamTabCompatibilityPath,
+  buildTeamWorkspaceLensPath,
+  buildTeamWorkspacePath,
+  normalizeTeamWorkspaceLensForHeader,
+  resolveActiveTeamWorkspaceLens,
+  resolveTeamChannelId,
+  resolveTeamSelectedMemberId,
+  resolveTeamSelectedTaskId,
+  resolveTeamRouteSelection,
+  resolveTeamSidebarSubjectPane,
+  resolveTeamTabForWorkspaceLens,
+  resolveTeamThreadRootMessageId,
+  resolveTeamWorkspaceLens,
+  resolveTeamWorkspaceTab,
+  resolveWorkspaceLensForTeamTab,
+  splitTeamRoutePath,
+} from "./team_route_helpers";
+
+describe("team route helpers", () => {
+  it("builds team detail paths with escaped identifiers", () => {
+    expect(buildTeamSelectorPath()).toBe("/workspace/teams");
+    expect(buildTeamDetailPath("team-1")).toBe("/workspace/teams/team-1");
+    expect(buildTeamDetailPath("team/1")).toBe("/workspace/teams/team%2F1");
+  });
+
+  it("keeps legacy team workspace query paths for compatibility-only state", () => {
+    expect(buildTeamWorkspacePath("team-1")).toBe("/workspace/teams/team-1");
+    expect(buildTeamWorkspacePath("team-1", "channels")).toBe("/workspace/teams/team-1");
+    expect(buildTeamWorkspacePath("team-1", "channels", "review")).toBe(
+      "/workspace/teams/team-1?channel=review"
+    );
+    expect(buildTeamWorkspacePath("team-1", "channels", "all", 42)).toBe(
+      "/workspace/teams/team-1?thread=42"
+    );
+    expect(buildTeamWorkspacePath("team-1", "channels", "review", -1)).toBe(
+      "/workspace/teams/team-1?channel=review"
+    );
+    expect(buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")).toBe(
+      "/workspace/teams/team-1?channel=review&task=task-9"
+    );
+    expect(buildTeamWorkspacePath("team-1", "channels", "all", 42, null, null, "task-9")).toBe(
+      "/workspace/teams/team-1?thread=42&task=task-9"
+    );
+    expect(
+      buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
+    ).toBe("/workspace/teams/team-1?lens=members&member=worker-1&tab=thread");
+    expect(
+      buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")
+    ).toBe("/workspace/teams/team-1?channel=review&task=task-9");
+    expect(buildTeamWorkspacePath("team-1", "members", null, null, " worker-2 ", null)).toBe(
+      "/workspace/teams/team-1?lens=members&member=worker-2"
+    );
+    expect(
+      buildTeamWorkspacePath("team-1", "members", null, null, "worker-3", "conversation" as never)
+    ).toBe("/workspace/teams/team-1?lens=members&member=worker-3");
+    expect(
+      buildTeamWorkspacePath(
+        "team-1",
+        "members",
+        null,
+        null,
+        "worker-3",
+        "conversation" as never,
+        "task-9"
+      )
+    ).toBe("/workspace/teams/team-1?lens=members&task=task-9&member=worker-3");
+  });
+
+  it("builds canonical channel-scoped profile panel paths", () => {
+    expect(buildTeamChannelProfilePath("team-1", "review", "worker-1")).toBe(
+      "/workspace/teams/team-1/channels/review/members/worker-1"
+    );
+    expect(buildTeamChannelProfilePath("team-1", "all", "worker-1", "task-9")).toBe(
+      "/workspace/teams/team-1/channels/all/tasks/task-9/members/worker-1"
+    );
+    expect(buildTeamChannelProfileClosePath("team-1", "review")).toBe(
+      "/workspace/teams/team-1/channels/review"
+    );
+    expect(buildTeamChannelProfileClosePath("team-1", "all")).toBe("/workspace/teams/team-1");
+    expect(buildTeamSearchCompatibilityPath("team-1")).toBe(
+      "/workspace/teams/team-1?lens=search"
+    );
+    expect(buildTeamTabCompatibilityPath("/workspace/teams/team-1/channels/review", "runs")).toBe(
+      "/workspace/teams/team-1/channels/review?tab=runs"
+    );
+    expect(
+      buildTeamTabCompatibilityPath("/workspace/teams/team-1/members/worker-1", "agent_acp")
+    ).toBe("/workspace/teams/team-1/members/worker-1?tab=thread");
+  });
+
+  it("builds canonical team lens navigation paths from the shared workspace route helper", () => {
+    expect(buildTeamChannelPath("team-1")).toBe("/workspace/teams/team-1");
+    expect(buildTeamChannelPath("team-1", "review")).toBe(
+      "/workspace/teams/team-1/channels/review"
+    );
+    expect(buildTeamChannelThreadPath("team-1", "all", 42, "task-9")).toBe(
+      "/workspace/teams/team-1/channels/all/threads/42"
+    );
+    expect(buildTeamChannelThreadPath("team-1", "review", 42)).toBe(
+      "/workspace/teams/team-1/channels/review/threads/42"
+    );
+    expect(buildTeamChannelTaskPath("team-1", "review", "task-9")).toBe(
+      "/workspace/teams/team-1/channels/review/tasks/task-9"
+    );
+    expect(buildTeamTaskPath("team-1", "task-9")).toBe(
+      "/workspace/teams/team-1/tasks/task-9"
+    );
+    expect(buildTeamLensNavigationPath("team-1", "channels", null, "task-9")).toBe(
+      "/workspace/teams/team-1/channels/all/tasks/task-9"
+    );
+    expect(buildTeamLensNavigationPath("team-1", "channels", "review", "task-9")).toBe(
+      "/workspace/teams/team-1/channels/review/tasks/task-9"
+    );
+    expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
+      "/workspace/teams/team-1?lens=members"
+    );
+    expect(buildTeamWorkspaceLensPath("team-1", "search", "review")).toBe(
+      "/workspace/teams/team-1/channels/review"
+    );
+    expect(buildTeamWorkspaceLensPath("team-1", "tasks", "review")).toBe(
+      "/workspace/teams/team-1?lens=tasks"
+    );
+  });
+
+  it("builds canonical Team member workspace paths", () => {
+    expect(buildTeamMemberWorkspacePath("team-1", "worker-1", "agent_acp")).toBe(
+      "/workspace/teams/team-1/members/worker-1/thread"
+    );
+    expect(buildTeamMemberWorkspacePath("team-1", "worker-1", "member_console")).toBe(
+      "/workspace/teams/team-1/members/worker-1/member_console"
+    );
+  });
+
+  it("splits facade-built paths for TeamPage pathname and search props", () => {
+    expect(splitTeamRoutePath(buildTeamTaskPath("team-1"))).toEqual({
+      pathname: "/workspace/teams/team-1",
+      search: "?lens=tasks",
+    });
+    expect(splitTeamRoutePath(buildTeamChannelPath("team-1", "review"))).toEqual({
+      pathname: "/workspace/teams/team-1/channels/review",
+      search: "",
+    });
+  });
+
+  it("parses team route query state before canonical path state", () => {
+    expect(resolveTeamChannelId("")).toBe("all");
+    expect(resolveTeamChannelId("?channel=all")).toBe("all");
+    expect(resolveTeamChannelId("?channel=research")).toBe("research");
+    expect(resolveTeamChannelId("?channel=%C4%B0nbox")).toBe("İnbox");
+    expect(resolveTeamChannelId("", "/workspace/teams/team-1/channels/Review")).toBe("review");
+    expect(resolveTeamChannelId("?channel=query", "/workspace/teams/team-1/channels/path")).toBe(
+      "query"
+    );
+    expect(resolveTeamThreadRootMessageId("")).toBeNull();
+    expect(resolveTeamThreadRootMessageId("?thread=17")).toBe(17);
+    expect(
+      resolveTeamThreadRootMessageId("", "/workspace/teams/team-1/channels/review/threads/17")
+    ).toBe(17);
+    expect(
+      resolveTeamThreadRootMessageId(
+        "?thread=23",
+        "/workspace/teams/team-1/channels/review/threads/17"
+      )
+    ).toBe(23);
+    expect(resolveTeamThreadRootMessageId("?thread=abc")).toBeNull();
+    expect(resolveTeamThreadRootMessageId("?thread=0")).toBeNull();
+    expect(resolveTeamThreadRootMessageId("?thread=-8")).toBeNull();
+    expect(resolveTeamThreadRootMessageId("?thread=7.5")).toBeNull();
+    expect(resolveTeamSelectedTaskId("")).toBe("");
+    expect(resolveTeamSelectedTaskId("?task=task-7")).toBe("task-7");
+    expect(resolveTeamSelectedTaskId("", "/workspace/teams/team-1/tasks/task-7")).toBe("task-7");
+    expect(
+      resolveTeamSelectedTaskId("?task=query-task", "/workspace/teams/team-1/tasks/path-task")
+    ).toBe("query-task");
+    expect(resolveTeamSelectedTaskId("?task=%20task-7%20")).toBe("task-7");
+    expect(resolveTeamSelectedMemberId("?member=worker-1")).toBe("worker-1");
+    expect(resolveTeamSelectedMemberId("", "/workspace/teams/team-1/members/worker-2")).toBe(
+      "worker-2"
+    );
+    expect(
+      resolveTeamSelectedMemberId("?member=query-worker", "/workspace/teams/team-1/members/path")
+    ).toBe("query-worker");
+    expect(resolveTeamWorkspaceTab("?tab=agent_acp")).toBe("agent_acp");
+    expect(resolveTeamWorkspaceTab("?tab=thread")).toBe("agent_acp");
+    expect(resolveTeamWorkspaceTab("?tab=mailbox")).toBe("mailbox");
+    expect(resolveTeamWorkspaceTab("?tab=member_console")).toBe("member_console");
+    expect(
+      resolveTeamWorkspaceTab("", "/workspace/teams/team-1/members/worker-1/member_console")
+    ).toBe("member_console");
+    expect(
+      resolveTeamWorkspaceTab(
+        "?tab=mailbox",
+        "/workspace/teams/team-1/members/worker-1/member_console"
+      )
+    ).toBe("mailbox");
+    expect(resolveTeamWorkspaceTab("?tab=overview")).toBeNull();
+  });
+
+  it("maps route workspace lenses to Team tabs without promoting search to a content tab", () => {
+    expect(resolveTeamTabForWorkspaceLens("channels")).toBe("conversation");
+    expect(resolveTeamTabForWorkspaceLens("tasks")).toBe("tasks");
+    expect(resolveTeamTabForWorkspaceLens("members")).toBe("overview");
+    expect(resolveTeamTabForWorkspaceLens("search")).toBeNull();
+    expect(resolveTeamTabForWorkspaceLens("teams")).toBe("conversation");
+  });
+
+  it("resolves Team workspace lenses through the Team-owned route facade", () => {
+    expect(resolveTeamWorkspaceLens("/workspace/teams/team-1", "")).toBe("channels");
+    expect(resolveTeamWorkspaceLens("/workspace/teams/team-1/tasks/task-1", "")).toBe("tasks");
+    expect(resolveTeamWorkspaceLens("/workspace/teams/team-1/members/worker-1", "")).toBe(
+      "members"
+    );
+    expect(resolveTeamWorkspaceLens("/workspace/teams/team-1", "?lens=search")).toBe("channels");
+  });
+
+  it("resolves the Team route selection snapshot through the Team-owned facade", () => {
+    expect(
+      resolveTeamRouteSelection(
+        "/workspace/teams/team-1/channels/path-channel/threads/17",
+        "?channel=query-channel&thread=23&task=task-9&member=worker-1&tab=mailbox"
+      )
+    ).toEqual({
+      workspaceLens: "channels",
+      workspaceTab: "mailbox",
+      channelId: "query-channel",
+      threadRootMessageId: 23,
+      selectedMemberId: "worker-1",
+      selectedTaskId: "task-9",
+    });
+
+    expect(
+      resolveTeamRouteSelection(
+        "/workspace/teams/team-1/channels/review/tasks/task-9/members/worker-2",
+        ""
+      )
+    ).toEqual({
+      workspaceLens: "channels",
+      workspaceTab: null,
+      channelId: "review",
+      threadRootMessageId: null,
+      selectedMemberId: "worker-2",
+      selectedTaskId: "task-9",
+    });
+
+    expect(
+      resolveTeamRouteSelection(
+        "/workspace/teams/team-1/channels/review/tasks/path-task/members/path-worker",
+        "?member=query-worker&task=query-task"
+      )
+    ).toEqual({
+      workspaceLens: "channels",
+      workspaceTab: null,
+      channelId: "review",
+      threadRootMessageId: null,
+      selectedMemberId: "query-worker",
+      selectedTaskId: "query-task",
+    });
+
+    expect(resolveTeamRouteSelection("/workspace/teams/team-1/members/worker-2/thread", "")).toEqual({
+      workspaceLens: "members",
+      workspaceTab: "agent_acp",
+      channelId: "all",
+      threadRootMessageId: null,
+      selectedMemberId: "worker-2",
+      selectedTaskId: "",
+    });
+  });
+
+  it("resolves active Team workspace lenses from explicit routes before tab fallback", () => {
+    expect(resolveWorkspaceLensForTeamTab("conversation")).toBe("channels");
+    expect(resolveWorkspaceLensForTeamTab("tasks")).toBe("tasks");
+    expect(resolveWorkspaceLensForTeamTab("overview")).toBe("members");
+    expect(
+      resolveActiveTeamWorkspaceLens({
+        routeWorkspaceLens: "members",
+        tab: "conversation",
+      })
+    ).toBe("members");
+    expect(
+      resolveActiveTeamWorkspaceLens({
+        routeWorkspaceLens: null,
+        tab: "overview",
+      })
+    ).toBe("members");
+    expect(
+      resolveActiveTeamWorkspaceLens({
+        routeWorkspaceLens: "search",
+        tab: "tasks",
+      })
+    ).toBe("tasks");
+    expect(
+      resolveActiveTeamWorkspaceLens({
+        routeWorkspaceLens: "search",
+        tab: "conversation",
+      })
+    ).toBe("channels");
+  });
+
+  it("normalizes deprecated search lens for Team workspace header decisions", () => {
+    expect(normalizeTeamWorkspaceLensForHeader("search")).toBe("channels");
+    expect(normalizeTeamWorkspaceLensForHeader("channels")).toBe("channels");
+  });
+
+  it("resolves Team sidebar subject panes from workspace lenses before tab fallback", () => {
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "conversation",
+        activeWorkspaceLens: "tasks",
+      })
+    ).toBe("tasks");
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "conversation",
+        activeWorkspaceLens: "members",
+      })
+    ).toBe("agents");
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "agent_acp",
+        activeWorkspaceLens: "channels",
+      })
+    ).toBe("agents");
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "tasks",
+        activeWorkspaceLens: "channels",
+      })
+    ).toBe("tasks");
+    expect(
+      resolveTeamSidebarSubjectPane({
+        tab: "conversation",
+        activeWorkspaceLens: "search",
+      })
+    ).toBe("channels");
+  });
+});

--- a/web/src/pages/team/team_route_helpers.ts
+++ b/web/src/pages/team/team_route_helpers.ts
@@ -1,0 +1,321 @@
+import {
+  buildCanonicalTeamWorkspaceSubpath,
+  buildTeamDetailPath as buildCanonicalTeamDetailPath,
+  buildTeamWorkspacePath as buildLegacyTeamWorkspacePath,
+  isTeamMemberRouteTab,
+  resolveTeamRoute as resolveCanonicalTeamRoute,
+  resolveWorkspaceLens,
+  resolveTeamMemberRouteTab,
+  resolveTeamWorkspacePathState,
+  type TeamRouteState,
+  type TeamMemberRouteTab,
+  type WorkspaceLens,
+} from "../../app_route_selection";
+import {
+  DEFAULT_TEAM_CHANNEL_ID,
+  type TeamChannelId,
+} from "./channel_metadata";
+import type { TeamTab } from "./state";
+
+export type { TeamMemberRouteTab, TeamRouteState, WorkspaceLens } from "../../app_route_selection";
+
+export type TeamSidebarSubjectPane = "channels" | "tasks" | "agents";
+export type TeamRouteSelection = {
+  workspaceLens: WorkspaceLens;
+  workspaceTab: TeamTab | null;
+  channelId: TeamChannelId;
+  threadRootMessageId: number | null;
+  selectedMemberId: string;
+  selectedTaskId: string;
+};
+export type TeamRouteLocation = {
+  pathname: string;
+  search: string;
+};
+
+function toAsciiLowercase(value: string): string {
+  return value.replace(/[A-Z]/g, (char) => char.toLowerCase());
+}
+
+export function resolveTeamChannelId(search: string, pathname?: string): TeamChannelId {
+  const params = new URLSearchParams(search);
+  const pathChannel = pathname ? resolveTeamWorkspacePathState(pathname).channelId : null;
+  const channel = (params.get("channel") ?? pathChannel ?? "").trim();
+  return channel.length === 0 ? DEFAULT_TEAM_CHANNEL_ID : toAsciiLowercase(channel);
+}
+
+export function resolveTeamThreadRootMessageId(search: string, pathname?: string): number | null {
+  const params = new URLSearchParams(search);
+  const raw = (params.get("thread") ?? "").trim();
+  if (raw) {
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+  return pathname ? resolveTeamWorkspacePathState(pathname).threadRootMessageId : null;
+}
+
+export function resolveTeamSelectedTaskId(search: string, pathname?: string): string {
+  const params = new URLSearchParams(search);
+  return (params.get("task") ?? resolveTeamWorkspacePathState(pathname ?? "").taskId ?? "").trim();
+}
+
+export function resolveTeamSelectedMemberId(search: string, pathname?: string): string {
+  const params = new URLSearchParams(search);
+  return (params.get("member") ?? resolveTeamWorkspacePathState(pathname ?? "").memberId ?? "").trim();
+}
+
+export function resolveTeamWorkspaceTab(search: string, pathname?: string): TeamTab | null {
+  return resolveTeamMemberRouteTab(search) ?? resolveTeamWorkspacePathState(pathname ?? "").tab;
+}
+
+export function resolveTeamTabForWorkspaceLens(lens: WorkspaceLens): TeamTab | null {
+  switch (lens) {
+    case "channels":
+      return "conversation";
+    case "tasks":
+      return "tasks";
+    case "members":
+      return "overview";
+    case "search":
+      return null;
+    default:
+      return "conversation";
+  }
+}
+
+export function resolveWorkspaceLensForTeamTab(tab: TeamTab): WorkspaceLens {
+  switch (tab) {
+    case "tasks":
+      return "tasks";
+    case "overview":
+      return "members";
+    default:
+      return "channels";
+  }
+}
+
+export function resolveActiveTeamWorkspaceLens({
+  routeWorkspaceLens,
+  tab,
+}: {
+  routeWorkspaceLens: WorkspaceLens | null;
+  tab: TeamTab;
+}): WorkspaceLens {
+  const tabWorkspaceLens = resolveWorkspaceLensForTeamTab(tab);
+  return routeWorkspaceLens === "search" ? tabWorkspaceLens : routeWorkspaceLens ?? tabWorkspaceLens;
+}
+
+export function normalizeTeamWorkspaceLensForHeader(
+  activeWorkspaceLens: WorkspaceLens
+): WorkspaceLens {
+  return activeWorkspaceLens === "search" ? "channels" : activeWorkspaceLens;
+}
+
+export function resolveTeamSidebarSubjectPane({
+  tab,
+  activeWorkspaceLens,
+}: {
+  tab: TeamTab;
+  activeWorkspaceLens?: WorkspaceLens | null;
+}): TeamSidebarSubjectPane {
+  if (activeWorkspaceLens === "tasks") {
+    return "tasks";
+  }
+  if (activeWorkspaceLens === "members") {
+    return "agents";
+  }
+  if (tab === "tasks") {
+    return "tasks";
+  }
+  if (tab === "agent_acp" || tab === "member_console" || tab === "mailbox") {
+    return "agents";
+  }
+  return "channels";
+}
+
+export function buildTeamDetailPath(teamId: string): string {
+  return buildCanonicalTeamDetailPath(teamId);
+}
+
+export function buildTeamSelectorPath(): string {
+  return buildCanonicalTeamDetailPath(null);
+}
+
+export function resolveTeamRoute(pathname: string): TeamRouteState | null {
+  return resolveCanonicalTeamRoute(pathname);
+}
+
+export function resolveTeamWorkspaceLens(pathname: string, search: string): WorkspaceLens {
+  return resolveWorkspaceLens(pathname, search);
+}
+
+export function resolveTeamRouteSelection(pathname: string, search: string): TeamRouteSelection {
+  return {
+    workspaceLens: resolveTeamWorkspaceLens(pathname, search),
+    workspaceTab: resolveTeamWorkspaceTab(search, pathname),
+    channelId: resolveTeamChannelId(search, pathname),
+    threadRootMessageId: resolveTeamThreadRootMessageId(search, pathname),
+    selectedMemberId: resolveTeamSelectedMemberId(search, pathname),
+    selectedTaskId: resolveTeamSelectedTaskId(search, pathname),
+  };
+}
+
+export function splitTeamRoutePath(path: string): TeamRouteLocation {
+  const url = new URL(path, "http://agenthub.local");
+  return {
+    pathname: url.pathname,
+    search: url.search,
+  };
+}
+
+export function buildTeamWorkspacePath(
+  teamId: string,
+  lens?: WorkspaceLens | null,
+  channelId?: TeamChannelId | null,
+  threadRootMessageId?: number | null,
+  memberId?: string | null,
+  tab?: TeamTab | null,
+  taskId?: string | null
+): string {
+  const normalizedTab: TeamMemberRouteTab | null = isTeamMemberRouteTab(tab) ? tab : null;
+  return buildLegacyTeamWorkspacePath(
+    teamId,
+    lens,
+    channelId,
+    threadRootMessageId,
+    memberId,
+    normalizedTab,
+    taskId
+  );
+}
+
+export function buildTeamChannelProfilePath(
+  teamId: string,
+  channelId: TeamChannelId | null,
+  memberId: string,
+  taskId?: string | null
+): string {
+  return buildCanonicalTeamSubpath(teamId, "channels", channelId, null, memberId, null, taskId);
+}
+
+export function buildTeamChannelProfileClosePath(
+  teamId: string,
+  channelId: TeamChannelId | null
+): string {
+  return buildTeamChannelPath(teamId, channelId);
+}
+
+export function buildTeamSearchCompatibilityPath(teamId: string): string {
+  return `${buildTeamChannelPath(teamId)}?lens=search`;
+}
+
+export function buildTeamTabCompatibilityPath(pathname: string, tab: TeamTab): string {
+  const params = new URLSearchParams();
+  if (isTeamMemberRouteTab(tab)) {
+    params.set("tab", tab === "agent_acp" ? "thread" : tab);
+  } else {
+    params.set("tab", tab);
+  }
+  return `${pathname}?${params.toString()}`;
+}
+
+export function buildTeamChannelPath(
+  teamId: string,
+  channelId?: TeamChannelId | null
+): string {
+  return buildCanonicalTeamSubpath(teamId, "channels", channelId);
+}
+
+export function buildTeamChannelThreadPath(
+  teamId: string,
+  channelId: TeamChannelId | null,
+  threadRootMessageId: number,
+  taskId?: string | null
+): string {
+  return buildCanonicalTeamSubpath(
+    teamId,
+    "channels",
+    channelId,
+    threadRootMessageId,
+    null,
+    null,
+    taskId
+  );
+}
+
+export function buildTeamChannelTaskPath(
+  teamId: string,
+  channelId: TeamChannelId | null,
+  taskId: string
+): string {
+  return buildCanonicalTeamSubpath(teamId, "channels", channelId, null, null, null, taskId);
+}
+
+export function buildTeamTaskPath(teamId: string, taskId?: string | null): string {
+  return buildCanonicalTeamSubpath(teamId, "tasks", null, null, null, null, taskId);
+}
+
+export function buildTeamMemberWorkspacePath(
+  teamId: string,
+  memberId: string,
+  tab: TeamTab
+): string {
+  return buildCanonicalTeamSubpath(teamId, "members", null, null, memberId, tab);
+}
+
+export function buildTeamLensNavigationPath(
+  teamId: string,
+  lens: WorkspaceLens,
+  channelId?: TeamChannelId | null,
+  taskId?: string | null
+): string {
+  if (lens === "channels") {
+    return taskId
+      ? buildTeamChannelTaskPath(teamId, channelId ?? DEFAULT_TEAM_CHANNEL_ID, taskId)
+      : buildTeamChannelPath(teamId, channelId ?? DEFAULT_TEAM_CHANNEL_ID);
+  }
+  if (lens === "tasks") {
+    return buildTeamTaskPath(teamId, taskId);
+  }
+  return buildCanonicalTeamSubpath(
+    teamId,
+    lens,
+    null,
+    null,
+    null,
+    null,
+    null
+  );
+}
+
+export function buildTeamWorkspaceLensPath(
+  teamId: string,
+  lens: WorkspaceLens,
+  channelId?: TeamChannelId | null
+): string {
+  if (lens === "channels" || lens === "search") {
+    return buildTeamChannelPath(teamId, channelId);
+  }
+  return buildTeamLensNavigationPath(teamId, lens);
+}
+
+export function buildCanonicalTeamSubpath(
+  teamId: string,
+  lens?: WorkspaceLens | null,
+  channelId?: TeamChannelId | null,
+  threadRootMessageId?: number | null,
+  memberId?: string | null,
+  tab?: TeamTab | null,
+  taskId?: string | null
+): string {
+  const normalizedTab: TeamMemberRouteTab | null = isTeamMemberRouteTab(tab) ? tab : null;
+  return buildCanonicalTeamWorkspaceSubpath(
+    teamId,
+    lens,
+    channelId,
+    threadRootMessageId,
+    memberId,
+    normalizedTab,
+    taskId
+  );
+}

--- a/web/src/pages/team/team_workbench_content.test.tsx
+++ b/web/src/pages/team/team_workbench_content.test.tsx
@@ -194,7 +194,7 @@ describe("team_workbench_content", () => {
     );
     expect(withoutThread).not.toContain("max-h-[40vh]");
     expect(withoutThread).not.toContain("lg:grid");
-    expect(withoutThread).not.toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(withoutThread).not.toContain("lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.9fr)]");
 
     const withThread = renderToStaticMarkup(
       <TeamWorkbenchContent
@@ -204,7 +204,7 @@ describe("team_workbench_content", () => {
     );
     expect(withThread).toContain("data-testid=\"thread-pane\"");
     expect(withThread).toContain("max-h-[40vh]");
-    expect(withThread).toContain("lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]");
+    expect(withThread).toContain("lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.9fr)]");
     expect(withThread).toContain("w-full");
     expect(withThread).toContain("lg:h-full");
     expect(withThread).toContain("lg:min-w-0");

--- a/web/src/pages/team/team_workbench_content.test.tsx
+++ b/web/src/pages/team/team_workbench_content.test.tsx
@@ -10,6 +10,7 @@ import {
   TeamPanelLoadingFallback,
   prefetchTeamSetupSurface,
   prefetchTeamWorkbenchTab,
+  shouldShowTeamWorkspaceHeader,
   type TeamWorkbenchContentProps,
 } from "./team_workbench_content";
 
@@ -158,6 +159,33 @@ describe("team_workbench_content", () => {
     });
   });
 
+  it("keeps the workspace header visibility rule explicit for shell reuse", () => {
+    expect(
+      shouldShowTeamWorkspaceHeader({
+        activeWorkspaceLens: "channels",
+        tab: "conversation",
+      })
+    ).toBe(true);
+    expect(
+      shouldShowTeamWorkspaceHeader({
+        activeWorkspaceLens: "search",
+        tab: "conversation",
+      })
+    ).toBe(true);
+    expect(
+      shouldShowTeamWorkspaceHeader({
+        activeWorkspaceLens: "tasks",
+        tab: "conversation",
+      })
+    ).toBe(false);
+    expect(
+      shouldShowTeamWorkspaceHeader({
+        activeWorkspaceLens: "channels",
+        tab: "tasks",
+      })
+    ).toBe(false);
+  });
+
   it("only renders the constrained thread wrapper when a thread pane is present", () => {
     const baseProps = createBaseWorkbenchContentProps();
 
@@ -181,6 +209,10 @@ describe("team_workbench_content", () => {
     expect(withThread).toContain("lg:h-full");
     expect(withThread).toContain("lg:min-w-0");
     expect(withThread).toContain("flex-col");
+    expect(withThread).toContain('data-workspace-split-pane-layout="true"');
+    expect(withThread).toContain('data-secondary-open="true"');
+    expect(withThread).toContain("team-channel-pane");
+    expect(withThread).toContain("team-thread-dock");
     expect(withThread).not.toContain("overflow-y-auto");
   });
 
@@ -226,9 +258,38 @@ describe("team_workbench_content", () => {
     );
 
     const headerShellMatch = html.match(
-      /<div class="([^"]*workspace-shell[^"]*)" data-team-workspace-header-shell="true">/
+      /<div class="([^"]*workspace-shell[^"]*)" data-workspace-section-shell="true" data-team-workspace-header-shell="true">/
     );
     expect(headerShellMatch?.[1]).toContain("workspace-shell");
+    expect(headerShellMatch?.[1]).toContain("rounded-xl");
     expect(headerShellMatch?.[1]).not.toContain("teams-panel-card");
+  });
+
+  it("uses compact shared shell chrome for agent workspaces", () => {
+    const html = renderToStaticMarkup(
+      <TeamWorkbenchContent
+        {...createBaseWorkbenchContentProps()}
+        isAgentWorkspace
+        teamWorkbenchWorkspaceShellClassName="workspace-shell"
+      />
+    );
+
+    const headerShellMatch = html.match(
+      /<div class="([^"]*workspace-shell[^"]*)" data-workspace-section-shell="true" data-team-workspace-header-shell="true">/
+    );
+    expect(headerShellMatch?.[1]).toContain("py-0.5");
+  });
+
+  it("uses shared content stacks for Team workspace body layout", () => {
+    const html = renderToStaticMarkup(
+      <TeamWorkbenchContent
+        {...createBaseWorkbenchContentProps()}
+        conversationPanel={<div data-testid="conversation-panel">Conversation</div>}
+      />
+    );
+
+    expect(html).toContain('data-workspace-content-stack="true"');
+    expect(html).toContain('data-team-workspace-body-stack="true"');
+    expect(html).toContain("gap-3");
   });
 });

--- a/web/src/pages/team/team_workbench_content.tsx
+++ b/web/src/pages/team/team_workbench_content.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import type { WorkspaceLens } from "../../app_route_selection";
 import type { TeamDefinitionRecord } from "../../api";
+import {
+  WorkspaceContentStack,
+  WorkspaceSectionShell,
+  WorkspaceSplitPaneLayout,
+} from "../../components/layout/workspace_section_shell";
 import { WorkspacePanelLoadingFallback } from "../../components/workspace_panel_loading_fallback";
 import { ActionButton, EmptyState } from "../../ui/primitives";
 import {
@@ -9,6 +13,10 @@ import {
 } from "../team_workspace_state_panel";
 import { TeamWorkspaceHeader } from "./team_workspace_header";
 import type { TeamTab } from "./state";
+import {
+  normalizeTeamWorkspaceLensForHeader,
+  type WorkspaceLens,
+} from "./team_route_helpers";
 
 const loadTeamEventsPanel = () => import("../team_events_panel");
 const loadTeamMailboxPanel = () => import("../team_mailbox_panel");
@@ -86,6 +94,17 @@ export function TeamPanelLoadingFallback() {
   return <WorkspacePanelLoadingFallback />;
 }
 
+export function shouldShowTeamWorkspaceHeader({
+  activeWorkspaceLens,
+  tab,
+}: {
+  activeWorkspaceLens: WorkspaceLens;
+  tab: TeamTab;
+}): boolean {
+  const effectiveWorkspaceLens = normalizeTeamWorkspaceLensForHeader(activeWorkspaceLens);
+  return effectiveWorkspaceLens !== "tasks" && tab !== "tasks";
+}
+
 export type TeamWorkbenchContentProps = {
   showTeamBootstrapLoading: boolean;
   showTeamUnavailable: boolean;
@@ -159,9 +178,7 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
   memberConsolePanelProps,
   debugPanel,
 }: TeamWorkbenchContentProps) {
-  const effectiveWorkspaceLens =
-    activeWorkspaceLens === "search" ? "channels" : activeWorkspaceLens;
-  const showWorkspaceHeader = effectiveWorkspaceLens !== "tasks" && tab !== "tasks";
+  const showWorkspaceHeader = shouldShowTeamWorkspaceHeader({ activeWorkspaceLens, tab });
 
   return (
     <div
@@ -173,20 +190,15 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
       {showTeamUnavailable && <TeamUnavailablePanel onBackToSelector={onBackToSelector} />}
 
       {selectedTeam && (
-        <div
-          className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
-            isAgentWorkspace ? "gap-2" : "gap-4"
-          }`}
-        >
+        <WorkspaceContentStack compact={isAgentWorkspace}>
           {showWorkspaceHeader && (
-            <div
-              className={`${teamWorkbenchWorkspaceShellClassName} ${
-                isAgentWorkspace ? "py-0.5" : ""
-              }`}
+            <WorkspaceSectionShell
+              className={teamWorkbenchWorkspaceShellClassName}
+              compact={isAgentWorkspace}
               data-team-workspace-header-shell="true"
             >
               <TeamWorkspaceHeader {...workspaceHeaderProps} />
-            </div>
+            </WorkspaceSectionShell>
           )}
 
           {!selectedTeamHasConfiguredMembers && (
@@ -235,36 +247,20 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
           )}
 
           {tab !== "runs" && !showRunContextLoading && !showNoActiveRunNotice && (
-            <div
-              className={`flex min-h-0 min-w-0 flex-1 flex-col ${
-                isAgentWorkspace ? "gap-2" : "gap-3"
-              }`}
+            <WorkspaceContentStack
+              compact={isAgentWorkspace}
+              gap={isAgentWorkspace ? "compact" : "tight"}
+              data-team-workspace-body-stack="true"
             >
               {tab === "conversation" && (
-                <div
-                  className={
-                    threadPane
-                      ? "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]"
-                      : "flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden"
-                  }
+                <WorkspaceSplitPaneLayout
                   data-team-surface="channel-thread-layout"
                   data-thread-open={threadPane ? "true" : "false"}
-                >
-                  <div
-                    className="min-h-0 min-w-0 flex-1 overflow-hidden"
-                    data-team-surface="channel-pane"
-                  >
-                    {conversationPanel}
-                  </div>
-                  {threadPane && (
-                    <div
-                      className="flex max-h-[40vh] min-h-0 w-full shrink-0 flex-col overflow-hidden lg:h-full lg:max-h-none lg:min-w-0"
-                      data-team-surface="thread-dock"
-                    >
-                      {threadPane}
-                    </div>
-                  )}
-                </div>
+                  primary={conversationPanel}
+                  primaryClassName="team-channel-pane"
+                  secondary={threadPane}
+                  secondaryClassName="team-thread-dock"
+                />
               )}
 
               {tab === "tasks" && tasksPanel}
@@ -321,9 +317,9 @@ export const TeamWorkbenchContent = React.memo(function TeamWorkbenchContent({
               )}
 
               {tab === "debug" && debugPanel}
-            </div>
+            </WorkspaceContentStack>
           )}
-        </div>
+        </WorkspaceContentStack>
       )}
     </div>
   );

--- a/web/src/pages/team/team_workspace_context.tsx
+++ b/web/src/pages/team/team_workspace_context.tsx
@@ -8,7 +8,7 @@ import type {
   TeamTaskDetailResponse,
   TeamTaskRecord,
 } from "../../api";
-import type { WorkspaceLens } from "../../app_route_selection";
+import type { WorkspaceLens } from "./team_route_helpers";
 import { TeamTasksPanel } from "../team_tasks_panel";
 import type { TeamChannelItem } from "./channel_metadata";
 import type { TeamMemberLiveState } from "./member_helpers";
@@ -17,7 +17,6 @@ import type { TeamWorkbenchRuntimeContext } from "./TeamWorkbenchContainer";
 type TeamTasksPanelProps = ComponentProps<typeof TeamTasksPanel>;
 
 export type TeamWorkspaceShellContextValue = {
-  workbench?: TeamWorkbenchRuntimeContext;
   developerMode: boolean;
   busy: string | null;
   snapshot: TeamRunSnapshotRecord | null;
@@ -25,6 +24,7 @@ export type TeamWorkspaceShellContextValue = {
   selectedTeamMemberLiveStates: TeamMemberLiveState[];
   selectedConversationMatchesChannelLane: boolean;
   routeThreadRootMessageId: number | null;
+  routeSelectedMemberId: string;
   effectiveSelectedTeamId: string | null;
   routeWorkspaceLens: WorkspaceLens | null;
   routeChannelId: string;
@@ -72,11 +72,13 @@ export type TeamTasksContextValue = {
 };
 
 export type TeamWorkspaceContextValue =
+  { workbench?: TeamWorkbenchRuntimeContext } &
   TeamWorkspaceShellContextValue &
   TeamConversationContextValue &
   TeamTasksContextValue;
 
 const TeamWorkspaceContext = React.createContext<TeamWorkspaceContextValue | null>(null);
+const TeamWorkbenchContext = React.createContext<TeamWorkbenchRuntimeContext | null>(null);
 const TeamWorkspaceShellContext = React.createContext<TeamWorkspaceShellContextValue | null>(null);
 const TeamConversationContext = React.createContext<TeamConversationContextValue | null>(null);
 const TeamTasksContext = React.createContext<TeamTasksContextValue | null>(null);
@@ -111,8 +113,8 @@ export function TeamWorkspaceProvider({
   value: TeamWorkspaceContextValue;
   children: React.ReactNode;
 }) {
+  const workbenchValue = value.workbench ?? null;
   const shellValue = useShallowStableObject<TeamWorkspaceShellContextValue>({
-    workbench: value.workbench,
     developerMode: value.developerMode,
     busy: value.busy,
     snapshot: value.snapshot,
@@ -120,6 +122,7 @@ export function TeamWorkspaceProvider({
     selectedTeamMemberLiveStates: value.selectedTeamMemberLiveStates,
     selectedConversationMatchesChannelLane: value.selectedConversationMatchesChannelLane,
     routeThreadRootMessageId: value.routeThreadRootMessageId,
+    routeSelectedMemberId: value.routeSelectedMemberId,
     effectiveSelectedTeamId: value.effectiveSelectedTeamId,
     routeWorkspaceLens: value.routeWorkspaceLens,
     routeChannelId: value.routeChannelId,
@@ -166,11 +169,13 @@ export function TeamWorkspaceProvider({
 
   return (
     <TeamWorkspaceContext.Provider value={value}>
-      <TeamWorkspaceShellContext.Provider value={shellValue}>
-        <TeamConversationContext.Provider value={conversationValue}>
-          <TeamTasksContext.Provider value={tasksValue}>{children}</TeamTasksContext.Provider>
-        </TeamConversationContext.Provider>
-      </TeamWorkspaceShellContext.Provider>
+      <TeamWorkbenchContext.Provider value={workbenchValue}>
+        <TeamWorkspaceShellContext.Provider value={shellValue}>
+          <TeamConversationContext.Provider value={conversationValue}>
+            <TeamTasksContext.Provider value={tasksValue}>{children}</TeamTasksContext.Provider>
+          </TeamConversationContext.Provider>
+        </TeamWorkspaceShellContext.Provider>
+      </TeamWorkbenchContext.Provider>
     </TeamWorkspaceContext.Provider>
   );
 }
@@ -187,6 +192,14 @@ export function useTeamWorkspaceShell(): TeamWorkspaceShellContextValue {
   const value = React.useContext(TeamWorkspaceShellContext);
   if (!value) {
     throw new Error("useTeamWorkspaceShell must be used within TeamWorkspaceProvider");
+  }
+  return value;
+}
+
+export function useTeamWorkbenchRuntime(): TeamWorkbenchRuntimeContext {
+  const value = React.useContext(TeamWorkbenchContext);
+  if (!value) {
+    throw new Error("useTeamWorkbenchRuntime must be used within TeamWorkspaceProvider");
   }
   return value;
 }

--- a/web/src/pages/team/use_team_workspace_view_model.test.tsx
+++ b/web/src/pages/team/use_team_workspace_view_model.test.tsx
@@ -161,7 +161,7 @@ describe("useTeamWorkspaceViewModel", () => {
         "Teams",
         "Channels",
         "Tasks",
-        "Agents",
+        "Members",
       ]);
       expect(snapshot?.workspaceTitle).toBe("# all");
       expect(snapshot?.workspaceDescription).toBe(

--- a/web/src/pages/team/use_team_workspace_view_model.ts
+++ b/web/src/pages/team/use_team_workspace_view_model.ts
@@ -6,8 +6,11 @@ import type {
   TeamRunRecord,
   TeamTaskRecord,
 } from "../../api";
-import type { WorkspaceLens } from "../../app_route_selection";
 import { buildStandardWorkspaceLensItems } from "../../components/workspace_lens_items";
+import {
+  resolveActiveTeamWorkspaceLens,
+  type WorkspaceLens,
+} from "./team_route_helpers";
 import { createDisplayNameLookup } from "./mailbox_helpers";
 import { describeTeamKanban } from "./channel_metadata";
 import type { TeamMemberLiveState, TeamMemberAgentStatusSummary } from "./member_helpers";
@@ -125,10 +128,10 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
   const isAgentWorkspace =
     hasSelectedAgentContext && (tab === "agent_acp" || tab === "mailbox" || tab === "member_console");
 
-  const activeWorkspaceLens =
-    routeWorkspaceLens === "search"
-      ? resolveWorkspaceLensForTab(tab)
-      : routeWorkspaceLens ?? resolveWorkspaceLensForTab(tab);
+  const activeWorkspaceLens = resolveActiveTeamWorkspaceLens({
+    routeWorkspaceLens,
+    tab,
+  });
   const selectedAgentLabelMemberId = useMemo(() => {
     const resolvedMemberId = selectedAgentWorkspaceMemberId.trim();
     if (resolvedMemberId) {
@@ -643,15 +646,4 @@ export function useTeamWorkspaceViewModel(options: UseTeamWorkspaceViewModelOpti
       showNoActiveRunNotice,
     ]
   );
-}
-
-function resolveWorkspaceLensForTab(tab: TeamTab): WorkspaceLens {
-  switch (tab) {
-    case "tasks":
-      return "tasks";
-    case "overview":
-      return "members";
-    default:
-      return "channels";
-  }
 }

--- a/web/src/pages/team_page.agent_loop.test.tsx
+++ b/web/src/pages/team_page.agent_loop.test.tsx
@@ -298,7 +298,11 @@ vi.mock("./team/TeamWorkbenchContainer", async () => {
 });
 
 import { TeamPage } from "./team_page";
-import { buildTeamWorkspacePath, resolveTeamRoute } from "../app_route_selection";
+import {
+  buildTeamDetailPath,
+  buildTeamMemberWorkspacePath,
+  resolveTeamRoute,
+} from "./team/team_route_helpers";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -449,7 +453,7 @@ describe("TeamPage agent loop profile flow", () => {
     useMediaQueryMock.mockReturnValue(false);
     teamPageFixture.teams = [];
     teamPageFixture.agents = [];
-    window.history.pushState({}, "", buildTeamWorkspacePath("team-1"));
+    window.history.pushState({}, "", buildTeamDetailPath("team-1"));
   });
 
   afterEach(() => {
@@ -558,7 +562,7 @@ describe("TeamPage agent loop profile flow", () => {
       window.history.pushState(
         {},
         "",
-        buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
+        buildTeamMemberWorkspacePath("team-1", "worker-1", "agent_acp")
       );
       await act(async () => {
         root.render(<TestTeamPageRouter />);
@@ -763,7 +767,7 @@ describe("TeamPage agent loop profile flow", () => {
       window.history.pushState(
         {},
         "",
-        buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
+        buildTeamMemberWorkspacePath("team-1", "worker-1", "agent_acp")
       );
       await act(async () => {
         root.render(<TestTeamPageRouter />);
@@ -880,7 +884,7 @@ describe("TeamPage agent loop profile flow", () => {
       window.history.pushState(
         {},
         "",
-        buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
+        buildTeamMemberWorkspacePath("team-1", "worker-1", "agent_acp")
       );
       await act(async () => {
         root.render(<TestTeamPageRouter />);

--- a/web/src/pages/team_page.helpers.test.ts
+++ b/web/src/pages/team_page.helpers.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildTeamLensNavigationPath,
-  buildTeamDetailPath,
-  buildTeamWorkspacePath,
   formatTeamRuntimeActionSummary,
   parseTeamAgentInputSessionMismatch,
   resolveNextSelectedAgentWorkspaceSessionOverride,
@@ -12,11 +9,6 @@ import {
   resolveRouteScopedConversationTaskSelection,
   resolveSelectedAgentWorkspaceSessionId,
   resolveThreadRootMessageIdFromPayload,
-  resolveTeamChannelId,
-  resolveTeamSelectedMemberId,
-  resolveTeamSelectedTaskId,
-  resolveTeamThreadRootMessageId,
-  resolveTeamWorkspaceTab,
   validateRunInputJson,
 } from "./team_page";
 import { isCurrentTeamScopedRequest } from "./team/page_helpers";
@@ -36,77 +28,6 @@ describe("team_page helpers", () => {
     expect(
       parseTeamAgentInputSessionMismatch("agent session mismatch: expected= running=session-b")
     ).toBeNull();
-  });
-
-  it("builds team detail paths with escaped identifiers", () => {
-    expect(buildTeamDetailPath("team-1")).toBe("/workspace/teams/team-1");
-    expect(buildTeamDetailPath("team/1")).toBe("/workspace/teams/team%2F1");
-  });
-
-  it("builds team workspace paths with optional lens, task, and thread query", () => {
-    expect(buildTeamWorkspacePath("team-1")).toBe("/workspace/teams/team-1");
-    expect(buildTeamWorkspacePath("team-1", "channels")).toBe("/workspace/teams/team-1");
-    expect(buildTeamWorkspacePath("team-1", "channels", "review")).toBe(
-      "/workspace/teams/team-1?channel=review"
-    );
-    expect(buildTeamWorkspacePath("team-1", "channels", "all", 42)).toBe(
-      "/workspace/teams/team-1?thread=42"
-    );
-    expect(buildTeamWorkspacePath("team-1", "channels", "review", -1)).toBe(
-      "/workspace/teams/team-1?channel=review"
-    );
-    expect(buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")).toBe(
-      "/workspace/teams/team-1?channel=review&task=task-9"
-    );
-    expect(buildTeamWorkspacePath("team-1", "channels", "all", 42, null, null, "task-9")).toBe(
-      "/workspace/teams/team-1?thread=42&task=task-9"
-    );
-    expect(
-      buildTeamWorkspacePath("team-1", "members", null, null, "worker-1", "agent_acp")
-    ).toBe("/workspace/teams/team-1?lens=members&member=worker-1&tab=thread");
-    expect(
-      buildTeamWorkspacePath("team-1", "channels", "review", null, null, null, "task-9")
-    ).toBe("/workspace/teams/team-1?channel=review&task=task-9");
-    expect(buildTeamWorkspacePath("team-1", "members", null, null, " worker-2 ", null)).toBe(
-      "/workspace/teams/team-1?lens=members&member=worker-2"
-    );
-    expect(
-      buildTeamWorkspacePath("team-1", "members", null, null, "worker-3", "conversation" as never)
-    ).toBe("/workspace/teams/team-1?lens=members&member=worker-3");
-    expect(buildTeamLensNavigationPath("team-1", "channels", null, "task-9")).toBe(
-      "/workspace/teams/team-1?task=task-9"
-    );
-    expect(buildTeamLensNavigationPath("team-1", "channels", "review", "task-9")).toBe(
-      "/workspace/teams/team-1?channel=review&task=task-9"
-    );
-    expect(buildTeamLensNavigationPath("team-1", "members", null, "task-9")).toBe(
-      "/workspace/teams/team-1?lens=members"
-    );
-    expect(
-      buildTeamWorkspacePath("team-1", "members", null, null, "worker-3", "conversation" as never, "task-9")
-    ).toBe("/workspace/teams/team-1?lens=members&task=task-9&member=worker-3");
-  });
-
-  it("parses team channel and thread query state", () => {
-    expect(resolveTeamChannelId("")).toBe("all");
-    expect(resolveTeamChannelId("?channel=all")).toBe("all");
-    expect(resolveTeamChannelId("?channel=research")).toBe("research");
-    expect(resolveTeamChannelId("?channel=%C4%B0nbox")).toBe("İnbox");
-    expect(resolveTeamThreadRootMessageId("")).toBeNull();
-    expect(resolveTeamThreadRootMessageId("?thread=17")).toBe(17);
-    expect(resolveTeamThreadRootMessageId("?thread=abc")).toBeNull();
-    expect(resolveTeamThreadRootMessageId("?thread=0")).toBeNull();
-    expect(resolveTeamThreadRootMessageId("?thread=-8")).toBeNull();
-    expect(resolveTeamThreadRootMessageId("?thread=7.5")).toBeNull();
-    expect(resolveTeamSelectedTaskId("")).toBe("");
-    expect(resolveTeamSelectedTaskId("?task=task-7")).toBe("task-7");
-    expect(resolveTeamSelectedTaskId("?task=%20task-7%20")).toBe("task-7");
-    expect(resolveTeamSelectedMemberId("?member=worker-1")).toBe("worker-1");
-    expect(resolveTeamWorkspaceTab("?tab=agent_acp")).toBe("agent_acp");
-    expect(resolveTeamWorkspaceTab("?tab=thread")).toBe("agent_acp");
-    expect(resolveTeamWorkspaceTab("?tab=mailbox")).toBe("mailbox");
-    expect(resolveTeamWorkspaceTab("?tab=member_console")).toBe("member_console");
-    expect(resolveTeamWorkspaceTab("?tab=overview")).toBeNull();
   });
 
   it("resolves route-scoped conversation task selection across task and channel lanes", () => {

--- a/web/src/pages/team_page.navigation.test.tsx
+++ b/web/src/pages/team_page.navigation.test.tsx
@@ -1,0 +1,498 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createTeamChannel,
+  deleteTeamChannel,
+  getRuntimeDefaults,
+  getTeamPromptDefaults,
+  getTeamRuntime,
+  getTeamSharedThread,
+  getTeamTask,
+  listTeamChannels,
+  listTeamTasks,
+  sidebarPropsSpy,
+  teamPageFixture,
+  useMediaQueryMock,
+} = vi.hoisted(() => ({
+  createTeamChannel: vi.fn(),
+  deleteTeamChannel: vi.fn().mockResolvedValue(undefined),
+  getRuntimeDefaults: vi.fn().mockResolvedValue({ default_worktree_root: "/tmp/worktrees" }),
+  getTeamPromptDefaults: vi.fn().mockResolvedValue({
+    coordinator_prompt: "coordinator-default-prompt",
+    worker_prompt: "worker-default-prompt",
+  }),
+  getTeamRuntime: vi.fn().mockResolvedValue({
+    team_id: "team-1",
+    team_name: "Team One",
+    status: "stopped",
+    members: [],
+  }),
+  getTeamSharedThread: vi.fn(),
+  getTeamTask: vi.fn(),
+  listTeamChannels: vi.fn().mockResolvedValue([]),
+  listTeamTasks: vi.fn().mockResolvedValue([]),
+  sidebarPropsSpy: vi.fn(),
+  teamPageFixture: {
+    teams: [] as Array<Record<string, unknown>>,
+    agents: [] as Array<Record<string, unknown>>,
+  },
+  useMediaQueryMock: vi.fn(() => false),
+}));
+
+vi.mock("@mantine/hooks", () => ({
+  useMediaQuery: useMediaQueryMock,
+}));
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      createTeamChannel,
+      deleteTeamChannel,
+      getRuntimeDefaults,
+      getTeamPromptDefaults,
+      getTeamRuntime,
+      getTeamSharedThread,
+      getTeamTask,
+      listTeamChannels,
+      listTeamTasks,
+    },
+  };
+});
+
+vi.mock("./team/use_team_actions", () => ({
+  useTeamActions: (options: {
+    setTeams: React.Dispatch<React.SetStateAction<Array<Record<string, unknown>>>>;
+    setAgents: React.Dispatch<React.SetStateAction<Array<Record<string, unknown>>>>;
+    onTeamsRefreshSettled?: () => void;
+  }) => {
+    const { setAgents, setTeams } = options;
+    const onTeamsRefreshSettled = options.onTeamsRefreshSettled;
+    React.useEffect(() => {
+      setTeams(teamPageFixture.teams);
+      setAgents(teamPageFixture.agents);
+      onTeamsRefreshSettled?.();
+    }, [onTeamsRefreshSettled, setAgents, setTeams]);
+    return {
+      refreshAgents: vi.fn().mockResolvedValue(undefined),
+      refreshTeams: vi.fn().mockResolvedValue(undefined),
+      refreshRun: vi.fn().mockResolvedValue(undefined),
+      refreshTeamRuns: vi.fn().mockResolvedValue(undefined),
+      refreshSteps: vi.fn().mockResolvedValue(undefined),
+      refreshEvents: vi.fn().mockResolvedValue(undefined),
+      refreshSnapshot: vi.fn().mockResolvedValue(undefined),
+      loadInbox: vi.fn().mockResolvedValue(undefined),
+      loadMemberEvents: vi.fn().mockResolvedValue(undefined),
+      onCreateRun: vi.fn().mockResolvedValue(undefined),
+      onLoadRunById: vi.fn().mockResolvedValue(undefined),
+      onRefreshRuns: vi.fn().mockResolvedValue(undefined),
+      onLoadMoreRuns: vi.fn().mockResolvedValue(undefined),
+      onCancelRun: vi.fn().mockResolvedValue(undefined),
+      onResumeRun: vi.fn().mockResolvedValue(undefined),
+      onRestartRun: vi.fn().mockResolvedValue(undefined),
+    };
+  },
+}));
+
+vi.mock("./team/use_team_step_actions", () => ({
+  useTeamStepActions: () => ({
+    onSubmitStep: vi.fn().mockResolvedValue(undefined),
+    onApplyStepAction: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("./team/use_team_mailbox_actions", () => ({
+  useTeamMailboxActions: () => ({
+    onSendChatMessage: vi.fn().mockResolvedValue(undefined),
+    onSendMessage: vi.fn().mockResolvedValue(undefined),
+    onRefreshInbox: vi.fn().mockResolvedValue(undefined),
+    onAcceptMessage: vi.fn().mockResolvedValue(undefined),
+    onAcceptVisibleMessages: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("./team/use_team_conversation_effects", () => ({
+  useTeamConversationEffects: () => undefined,
+}));
+
+vi.mock("./team/use_team_member_agent_backfill_effect", () => ({
+  useTeamMemberAgentBackfillEffect: () => undefined,
+}));
+
+vi.mock("./team/use_team_mailbox_lifecycle_effects", () => ({
+  useTeamMailboxLifecycleEffects: () => undefined,
+}));
+
+vi.mock("./team/use_team_run_lifecycle_effects", () => ({
+  useTeamRunLifecycleEffects: () => undefined,
+}));
+
+vi.mock("./team/use_team_runtime_effects", () => ({
+  useTeamRuntimeEffects: () => undefined,
+}));
+
+vi.mock("./team/use_team_conversation_actions", () => ({
+  useTeamConversationActions: () => ({
+    refreshTaskMessages: vi.fn().mockResolvedValue(undefined),
+    sendTaskMessage: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("./team/TeamWorkbenchContainer", () => ({
+  TeamWorkbenchContainer: () => <div data-testid="team-workbench" />,
+}));
+
+vi.mock("./team/TeamSidebarContainer", () => ({
+  TeamSidebarContainer: (props: Record<string, unknown>) => {
+    sidebarPropsSpy(props);
+    return (
+      <div data-testid="team-sidebar">
+        <button
+          type="button"
+          onClick={() =>
+            (props.onSelectAgentWorkspace as (memberId: string, tab: string) => void)(
+              "worker-1",
+              "mailbox"
+            )
+          }
+        >
+          Open member mailbox
+        </button>
+        <button
+          type="button"
+          onClick={() => (props.navigateToTeamDetail as (teamId: string) => void)("team-2")}
+        >
+          Switch team
+        </button>
+        <button
+          type="button"
+          onClick={() => (props.onSelectChannel as (channelId: string) => void)("review")}
+        >
+          Select review channel
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            void (props.onCreateChannel as (payload: {
+              channelId: string;
+              description: string;
+            }) => Promise<void>)({
+              channelId: "planning",
+              description: "Planning lane",
+            })
+          }
+        >
+          Create planning channel
+        </button>
+        <button
+          type="button"
+          onClick={() => void (props.onDeleteChannel as (channelId: string) => Promise<void>)("review")}
+        >
+          Delete review channel
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { TeamPage } from "./team_page";
+import {
+  buildTeamChannelPath,
+  buildTeamMemberWorkspacePath,
+  buildTeamWorkspaceLensPath,
+} from "./team/team_route_helpers";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+}
+
+if (typeof globalThis.ResizeObserver !== "function") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as typeof ResizeObserver;
+}
+
+function buildTeam(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: "Mission",
+    spec: {
+      spec_version: 1,
+      coordinator_member_id: "coordinator",
+      entrypoint: "coordinator_plan",
+      steps: [],
+      members: [
+        {
+          member_id: "coordinator",
+          role: "coordinator",
+          prompt: "Plan",
+        },
+        {
+          member_id: "worker-1",
+          role: "worker",
+          prompt: "Work",
+        },
+      ],
+    },
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+function buildSharedThreadDetail(teamId: string) {
+  return {
+    task: {
+      id: `task-${teamId}`,
+      team_id: teamId,
+      title: "all",
+      status: "in_progress",
+      created_by_actor_id: "coordinator",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "shared_thread" },
+      created_at: 1,
+      updated_at: 1,
+    },
+    conversation: {
+      id: `conv-${teamId}`,
+      team_id: teamId,
+      task_id: `task-${teamId}`,
+      mode: "group_chat",
+      topic: "all",
+      created_at: 1,
+      updated_at: 1,
+    },
+    latest_run: null,
+  };
+}
+
+function buildChannelTaskDetail(teamId: string, channelId: string, taskId: string) {
+  return {
+    task: {
+      id: taskId,
+      team_id: teamId,
+      title: channelId,
+      status: "open",
+      created_by_actor_id: "user:user-1",
+      assigned_member_id: null,
+      context: { bootstrap_kind: "team_channel", channel_id: channelId },
+      created_at: 1,
+      updated_at: 1,
+    },
+    conversation: {
+      id: `conv-${channelId}`,
+      team_id: teamId,
+      task_id: taskId,
+      mode: "group_chat",
+      topic: channelId,
+      created_at: 1,
+      updated_at: 1,
+    },
+    latest_run: null,
+  };
+}
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function renderTeamPage(routePathname = "/workspace/teams/team-1", routeSearch = "") {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  window.history.replaceState({}, "", `${routePathname}${routeSearch}`);
+  await act(async () => {
+    root.render(
+      <MantineProvider env="test">
+        <TeamPage
+          auth={{
+            token: "token",
+            userId: "user-1",
+            username: "root",
+            role: "root",
+          }}
+          token="token"
+          onLogout={() => {}}
+          developerMode={false}
+          routePathname={routePathname}
+          routeTeamId="team-1"
+          routeSearch={routeSearch}
+        />
+      </MantineProvider>
+    );
+    await flushEffects();
+  });
+  return {
+    container,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll("button")).find((node) =>
+    node.textContent?.includes(label)
+  ) as HTMLButtonElement | undefined;
+  if (!button) {
+    throw new Error(`button not found: ${label}`);
+  }
+  button.click();
+}
+
+describe("TeamPage navigation glue", () => {
+  beforeEach(() => {
+    createTeamChannel.mockReset();
+    createTeamChannel.mockResolvedValue({
+      team_id: "team-1",
+      channel_id: "planning",
+      task_id: "task-planning",
+      conversation_id: "conv-planning",
+      description: "Planning lane",
+      created_by_actor_id: "user:user-1",
+      created_at: 1,
+      updated_at: 1,
+    });
+    deleteTeamChannel.mockClear();
+    getRuntimeDefaults.mockClear();
+    getTeamPromptDefaults.mockClear();
+    getTeamRuntime.mockClear();
+    getTeamSharedThread.mockReset();
+    getTeamSharedThread.mockResolvedValue(buildSharedThreadDetail("team-1"));
+    getTeamTask.mockReset();
+    getTeamTask.mockImplementation((_token: string, teamId: string, taskId: string) => {
+      if (taskId === "task-review") {
+        return Promise.resolve(buildChannelTaskDetail(teamId, "review", taskId));
+      }
+      return Promise.reject({ status: 404, message: "missing task" });
+    });
+    listTeamChannels.mockReset();
+    listTeamChannels.mockResolvedValue([
+      {
+        team_id: "team-1",
+        channel_id: "review",
+        task_id: "task-review",
+        conversation_id: "conv-review",
+        description: "Review lane",
+        created_by_actor_id: "user:user-1",
+        created_at: 1,
+        updated_at: 1,
+      },
+    ]);
+    listTeamTasks.mockReset();
+    listTeamTasks.mockResolvedValue([]);
+    sidebarPropsSpy.mockClear();
+    teamPageFixture.teams = [buildTeam("team-1", "Team One"), buildTeam("team-2", "Team Two")];
+    teamPageFixture.agents = [];
+    useMediaQueryMock.mockReset();
+    useMediaQueryMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes sidebar member and team selections through canonical paths", async () => {
+    const rendered = await renderTeamPage();
+    try {
+      await act(async () => {
+        clickButton(rendered.container, "Open member mailbox");
+        await flushEffects();
+      });
+      expect(window.location.pathname).toBe(
+        buildTeamMemberWorkspacePath("team-1", "worker-1", "mailbox")
+      );
+
+      await act(async () => {
+        clickButton(rendered.container, "Switch team");
+        await flushEffects();
+      });
+      expect(window.location.pathname).toBe(
+        buildTeamWorkspaceLensPath("team-2", "channels", "all")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("routes sidebar channel selection, creation, and deletion through canonical paths", async () => {
+    const rendered = await renderTeamPage(buildTeamChannelPath("team-1", "review"));
+    try {
+      await act(async () => {
+        clickButton(rendered.container, "Select review channel");
+        await flushEffects();
+      });
+      expect(window.location.pathname).toBe(buildTeamChannelPath("team-1", "review"));
+
+      await act(async () => {
+        clickButton(rendered.container, "Create planning channel");
+        await flushEffects();
+      });
+      expect(createTeamChannel).toHaveBeenCalledWith("token", "team-1", {
+        channel_id: "planning",
+        description: "Planning lane",
+      });
+      expect(window.location.pathname).toBe(buildTeamChannelPath("team-1", "planning"));
+
+      await act(async () => {
+        clickButton(rendered.container, "Delete review channel");
+        await flushEffects();
+      });
+      expect(deleteTeamChannel).toHaveBeenCalledWith("token", "team-1", "review");
+      expect(window.location.pathname).toBe(buildTeamChannelPath("team-1"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("drops an unknown channel route after channels load successfully", async () => {
+    listTeamChannels.mockResolvedValue([]);
+    const rendered = await renderTeamPage(buildTeamChannelPath("team-1", "missing"));
+    try {
+      await act(async () => {
+        await flushEffects();
+      });
+      expect(window.location.pathname).toBe(buildTeamChannelPath("team-1"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("drops an unknown task from a channel route after task detail lookup misses", async () => {
+    const rendered = await renderTeamPage(buildTeamChannelPath("team-1", "review"), "?task=missing");
+    try {
+      await act(async () => {
+        await flushEffects();
+      });
+      expect(getTeamTask).toHaveBeenCalledWith("token", "team-1", "missing");
+      expect(window.location.pathname).toBe(buildTeamChannelPath("team-1", "review"));
+      expect(window.location.search).toBe("");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/web/src/pages/team_page.navigation.test.tsx
+++ b/web/src/pages/team_page.navigation.test.tsx
@@ -204,6 +204,7 @@ vi.mock("./team/TeamSidebarContainer", () => ({
 import { TeamPage } from "./team_page";
 import {
   buildTeamChannelPath,
+  buildTeamChannelThreadPath,
   buildTeamMemberWorkspacePath,
   buildTeamWorkspaceLensPath,
 } from "./team/team_route_helpers";
@@ -490,6 +491,20 @@ describe("TeamPage navigation glue", () => {
       });
       expect(getTeamTask).toHaveBeenCalledWith("token", "team-1", "missing");
       expect(window.location.pathname).toBe(buildTeamChannelPath("team-1", "review"));
+      expect(window.location.search).toBe("");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps thread context when canonicalizing a channel-scoped task route", async () => {
+    const rendered = await renderTeamPage(buildTeamChannelPath("team-1"), "?task=task-review&thread=17");
+    try {
+      await act(async () => {
+        await flushEffects();
+      });
+      expect(getTeamTask).toHaveBeenCalledWith("token", "team-1", "task-review");
+      expect(window.location.pathname).toBe(buildTeamChannelThreadPath("team-1", "review", 17));
       expect(window.location.search).toBe("");
     } finally {
       rendered.cleanup();

--- a/web/src/pages/team_page.smoke.test.tsx
+++ b/web/src/pages/team_page.smoke.test.tsx
@@ -172,6 +172,13 @@ vi.mock("../components/workbench_header_menu", () => ({
 }));
 
 import { TeamPage } from "./team_page";
+import {
+  buildTeamChannelPath,
+  buildTeamChannelTaskPath,
+  buildTeamChannelThreadPath,
+  buildTeamTaskPath,
+  splitTeamRoutePath,
+} from "./team/team_route_helpers";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -881,9 +888,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={buildTeamChannelPath("team-1", "review")}
               routeTeamId="team-1"
-              routeSearch="?channel=review"
+              routeSearch=""
             />
           </MantineProvider>
         );
@@ -978,9 +985,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={buildTeamChannelPath("team-1", "review")}
               routeTeamId="team-1"
-              routeSearch="?channel=review"
+              routeSearch=""
             />
           </MantineProvider>
         );
@@ -1198,9 +1205,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={buildTeamChannelThreadPath("team-1", "review", 17)}
               routeTeamId="team-1"
-              routeSearch="?channel=review&thread=17"
+              routeSearch=""
             />
           </MantineProvider>
         );
@@ -1217,8 +1224,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/review");
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -1318,8 +1325,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/review");
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -1400,9 +1407,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={buildTeamChannelThreadPath("team-1", "review", 17)}
               routeTeamId="team-1"
-              routeSearch="?channel=review&thread=17"
+              routeSearch=""
             />
           </MantineProvider>
         );
@@ -1419,8 +1426,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/review");
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -1520,8 +1527,10 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review&task=task-work");
+      expect(window.location.pathname).toBe(
+        "/workspace/teams/team-1/channels/review/tasks/task-work"
+      );
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -1816,8 +1825,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/review");
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -1917,8 +1926,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/review");
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -2018,8 +2027,10 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review&task=task-work");
+      expect(window.location.pathname).toBe(
+        "/workspace/teams/team-1/channels/review/tasks/task-work"
+      );
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();
@@ -2540,7 +2551,7 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={window.location.pathname}
               routeTeamId="team-1"
               routeSearch={window.location.search}
             />
@@ -2549,8 +2560,8 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?task=task-work");
+      expect(window.location.pathname).toBe("/workspace/teams/team-1/channels/all/tasks/task-work");
+      expect(window.location.search).toBe("");
 
       const lastOptions =
         teamConversationActionsOptionsSpy.mock.calls[
@@ -2653,9 +2664,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={buildTeamChannelTaskPath("team-1", "review", "task-work")}
               routeTeamId="team-1"
-              routeSearch="?channel=review&task=task-work"
+              routeSearch=""
             />
           </MantineProvider>
         );
@@ -2778,8 +2789,10 @@ describe("TeamPage smoke render", () => {
         await flushEffects();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review&task=task-work");
+      expect(window.location.pathname).toBe(
+        "/workspace/teams/team-1/channels/review/tasks/task-work"
+      );
+      expect(window.location.search).toBe("");
 
       const lastOptions =
         teamConversationActionsOptionsSpy.mock.calls[
@@ -2872,6 +2885,7 @@ describe("TeamPage smoke render", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root: Root = createRoot(container);
+    const tasksRoute = splitTeamRoutePath(buildTeamTaskPath("team-1"));
 
     try {
       await act(async () => {
@@ -2887,9 +2901,9 @@ describe("TeamPage smoke render", () => {
               token="token"
               onLogout={() => {}}
               developerMode={false}
-              routePathname="/workspace/teams/team-1"
+              routePathname={tasksRoute.pathname}
               routeTeamId="team-1"
-              routeSearch="?lens=tasks"
+              routeSearch={tasksRoute.search}
             />
           </MantineProvider>
         );
@@ -2919,8 +2933,10 @@ describe("TeamPage smoke render", () => {
         await Promise.resolve();
       });
 
-      expect(window.location.pathname).toBe("/workspace/teams/team-1");
-      expect(window.location.search).toBe("?channel=review&task=task-work");
+      expect(window.location.pathname).toBe(
+        "/workspace/teams/team-1/channels/review/tasks/task-work"
+      );
+      expect(window.location.search).toBe("");
     } finally {
       act(() => {
         root.unmount();

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -1793,11 +1793,10 @@ export function TeamPage(props: TeamPageProps) {
 
   useEffect(() => {
     const memberId = routeSelectedMemberId.trim();
-    if (!memberId) {
-      return;
-    }
     setSelectedMemberId(memberId);
-    setFocusedAgentMemberId(memberId);
+    if (memberId) {
+      setFocusedAgentMemberId(memberId);
+    }
   }, [
     activeRunIdForSelectedTeam,
     knownSelectedTeamMemberIds,

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -29,15 +29,8 @@ import {
   shouldHideErrorBannerMessage,
 } from "../connection_status";
 import {
-  buildTeamDetailPath as buildCanonicalTeamDetailPath,
-  buildTeamWorkspacePath as buildCanonicalTeamWorkspacePath,
   buildWorkspaceNodePath,
-  isTeamMemberRouteTab,
   navigateToPath,
-  resolveTeamMemberRouteTab,
-  resolveWorkspaceLens,
-  type TeamMemberRouteTab,
-  type WorkspaceLens,
 } from "../app_route_selection";
 import { AuthState } from "../types";
 import {
@@ -58,6 +51,19 @@ import {
   type TeamChannelId,
   type TeamChannelItem,
 } from "./team/channel_metadata";
+import {
+  buildTeamChannelPath,
+  buildTeamChannelTaskPath,
+  buildTeamChannelThreadPath,
+  buildTeamDetailPath,
+  buildTeamLensNavigationPath,
+  buildTeamMemberWorkspacePath,
+  buildTeamSelectorPath,
+  buildTeamWorkspaceLensPath,
+  resolveTeamRouteSelection,
+  resolveTeamTabForWorkspaceLens,
+  type WorkspaceLens,
+} from "./team/team_route_helpers";
 import { parseErrorMessage } from "./team/create_helpers";
 import {
   persistTeamCreateDraft,
@@ -264,31 +270,6 @@ type TeamPageProps = {
   defaultWorktreeRoot?: string | null;
 };
 
-function toAsciiLowercase(value: string): string {
-  return value.replace(/[A-Z]/g, (char) => char.toLowerCase());
-}
-
-export function resolveTeamChannelId(search: string): TeamChannelId {
-  const params = new URLSearchParams(search);
-  const channel = (params.get("channel") ?? "").trim();
-  return channel.length === 0 ? DEFAULT_TEAM_CHANNEL_ID : toAsciiLowercase(channel);
-}
-
-export function resolveTeamThreadRootMessageId(search: string): number | null {
-  const params = new URLSearchParams(search);
-  const raw = (params.get("thread") ?? "").trim();
-  if (!raw) {
-    return null;
-  }
-  const parsed = Number(raw);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-export function resolveTeamSelectedTaskId(search: string): string {
-  const params = new URLSearchParams(search);
-  return (params.get("task") ?? "").trim();
-}
-
 export function resolveRouteScopedConversationTaskSelection(options: {
   previousTaskId: string;
   routeSelectedTaskId: string;
@@ -346,15 +327,6 @@ export function resolveChannelRouteTaskId(options: {
     return null;
   }
   return normalizedRouteTaskId;
-}
-
-export function resolveTeamSelectedMemberId(search: string): string {
-  const params = new URLSearchParams(search);
-  return (params.get("member") ?? "").trim();
-}
-
-export function resolveTeamWorkspaceTab(search: string): TeamTab | null {
-  return resolveTeamMemberRouteTab(search);
 }
 
 export function parseTeamAgentInputSessionMismatch(
@@ -474,73 +446,12 @@ export function resolveNextSelectedAgentWorkspaceSessionOverride(
   return previous;
 }
 
-export function buildTeamDetailPath(teamId: string): string {
-  return buildCanonicalTeamDetailPath(teamId);
-}
-
 function navigateTeamRoute(pathname: string): void {
   if (`${location.pathname}${location.search}` === pathname) {
     return;
   }
   window.history.pushState({}, "", pathname);
   window.dispatchEvent(new PopStateEvent("popstate"));
-}
-
-function buildTeamSelectorPath(): string {
-  return "/workspace/teams";
-}
-
-export function buildTeamWorkspacePath(
-  teamId: string,
-  lens?: WorkspaceLens | null,
-  channelId?: TeamChannelId | null,
-  threadRootMessageId?: number | null,
-  memberId?: string | null,
-  tab?: TeamTab | null,
-  taskId?: string | null
-): string {
-  const normalizedTab: TeamMemberRouteTab | null = isTeamMemberRouteTab(tab) ? tab : null;
-  return buildCanonicalTeamWorkspacePath(
-    teamId,
-    lens,
-    channelId,
-    threadRootMessageId,
-    memberId,
-    normalizedTab,
-    taskId
-  );
-}
-
-export function buildTeamLensNavigationPath(
-  teamId: string,
-  lens: WorkspaceLens,
-  channelId?: TeamChannelId | null,
-  taskId?: string | null
-): string {
-  return buildTeamWorkspacePath(
-    teamId,
-    lens,
-    lens === "channels" ? (channelId ?? DEFAULT_TEAM_CHANNEL_ID) : null,
-    null,
-    null,
-    null,
-    lens === "channels" ? taskId : null
-  );
-}
-
-function resolveTeamTabForWorkspaceLens(lens: WorkspaceLens): TeamTab | null {
-  switch (lens) {
-    case "channels":
-      return "conversation";
-    case "tasks":
-      return "tasks";
-    case "members":
-      return "overview";
-    case "search":
-      return null;
-    default:
-      return "conversation";
-  }
 }
 
 const TEAM_AGENT_ADVANCED_TABS = new Set<TeamTab>([
@@ -640,30 +551,16 @@ const teamWorkbenchInfoStripLabelClassName = TEAM_WORKBENCH_INFO_STRIP_LABEL_CLA
 const teamWorkbenchInfoStripValueClassName = TEAM_WORKBENCH_INFO_STRIP_VALUE_CLASS;
 export function TeamPage(props: TeamPageProps) {
   const routeTeamId = props.routeTeamId?.trim() || null;
-  const routeWorkspaceLens = useMemo(
-    () => resolveWorkspaceLens(props.routePathname, props.routeSearch ?? ""),
+  const routeSelection = useMemo(
+    () => resolveTeamRouteSelection(props.routePathname, props.routeSearch ?? ""),
     [props.routePathname, props.routeSearch]
   );
-  const routeWorkspaceTab = useMemo(
-    () => resolveTeamWorkspaceTab(props.routeSearch ?? ""),
-    [props.routeSearch]
-  );
-  const routeChannelId = useMemo(
-    () => resolveTeamChannelId(props.routeSearch ?? ""),
-    [props.routeSearch]
-  );
-  const routeThreadRootMessageId = useMemo(
-    () => resolveTeamThreadRootMessageId(props.routeSearch ?? ""),
-    [props.routeSearch]
-  );
-  const routeSelectedMemberId = useMemo(
-    () => resolveTeamSelectedMemberId(props.routeSearch ?? ""),
-    [props.routeSearch]
-  );
-  const routeSelectedTaskId = useMemo(
-    () => resolveTeamSelectedTaskId(props.routeSearch ?? ""),
-    [props.routeSearch]
-  );
+  const routeWorkspaceLens = routeSelection.workspaceLens;
+  const routeWorkspaceTab = routeSelection.workspaceTab;
+  const routeChannelId = routeSelection.channelId;
+  const routeThreadRootMessageId = routeSelection.threadRootMessageId;
+  const routeSelectedMemberId = routeSelection.selectedMemberId;
+  const routeSelectedTaskId = routeSelection.selectedTaskId;
   const isSelectorRoute = routeTeamId == null;
   const routeDefaultWorktreeRoot = React.useMemo(() => {
     const normalized = normalizeWorkdirInput(props.defaultWorktreeRoot ?? "");
@@ -710,9 +607,7 @@ export function TeamPage(props: TeamPageProps) {
   }, []);
   const navigateToTeamMemberWorkspace = useCallback(
     (teamId: string, memberId: string, tab: TeamTab) => {
-      navigateTeamRoute(
-        buildTeamWorkspacePath(teamId, "members", null, null, memberId, tab)
-      );
+      navigateTeamRoute(buildTeamMemberWorkspacePath(teamId, memberId, tab));
     },
     []
   );
@@ -1103,7 +998,7 @@ export function TeamPage(props: TeamPageProps) {
       return;
     }
     if (teamChannelsSettled && teamChannelsLoadedSuccessfully) {
-      navigateTeamRoute(buildTeamWorkspacePath(effectiveSelectedTeamId, "channels"));
+      navigateTeamRoute(buildTeamChannelPath(effectiveSelectedTeamId));
     }
   }, [
     effectiveSelectedTeamId,
@@ -1115,14 +1010,6 @@ export function TeamPage(props: TeamPageProps) {
     teamChannelsLoadedSuccessfully,
     teamChannelsSettled,
   ]);
-  useEffect(() => {
-    const memberId = routeSelectedMemberId.trim();
-    if (!memberId) {
-      return;
-    }
-    setSelectedMemberId(memberId);
-    setFocusedAgentMemberId(memberId);
-  }, [routeSelectedMemberId, setSelectedMemberId]);
   const {
     teamSpecMemberIds,
     teamMemberSummaryByTeamId,
@@ -1904,6 +1791,20 @@ export function TeamPage(props: TeamPageProps) {
     setChatStickToBottom,
   });
 
+  useEffect(() => {
+    const memberId = routeSelectedMemberId.trim();
+    if (!memberId) {
+      return;
+    }
+    setSelectedMemberId(memberId);
+    setFocusedAgentMemberId(memberId);
+  }, [
+    activeRunIdForSelectedTeam,
+    knownSelectedTeamMemberIds,
+    routeSelectedMemberId,
+    setSelectedMemberId,
+  ]);
+
   useTeamMailboxLifecycleEffects({
     snapshot,
     selectedMemberId,
@@ -2022,15 +1923,18 @@ export function TeamPage(props: TeamPageProps) {
     // Canonicalize old task-only channel routes so channel-scoped conversations
     // regain their owning lane semantics, including thread-pane behavior.
     navigateTeamRoute(
-      buildTeamWorkspacePath(
-        effectiveSelectedTeamId,
-        "channels",
-        owningChannelId,
-        routeThreadRootMessageId,
-        null,
-        null,
-        routeSelectedTaskId
-      )
+      routeThreadRootMessageId
+        ? buildTeamChannelThreadPath(
+            effectiveSelectedTeamId,
+            owningChannelId,
+            routeThreadRootMessageId,
+            routeSelectedTaskId
+          )
+        : buildTeamChannelTaskPath(
+            effectiveSelectedTeamId,
+            owningChannelId,
+            routeSelectedTaskId
+          )
     );
   }, [
     effectiveSelectedTeamId,
@@ -2055,9 +1959,7 @@ export function TeamPage(props: TeamPageProps) {
     if (!shouldClearRouteTask) {
       return;
     }
-    navigateTeamRoute(
-      buildTeamWorkspacePath(effectiveSelectedTeamId, "channels", routeChannelId)
-    );
+    navigateTeamRoute(buildTeamChannelPath(effectiveSelectedTeamId, routeChannelId));
   }, [
     effectiveSelectedTeamId,
     routeChannelId,
@@ -2218,7 +2120,7 @@ export function TeamPage(props: TeamPageProps) {
   );
   const navigateToSidebarTeam = useCallback(
     (teamId: string) => {
-      navigateTeamRoute(buildTeamWorkspacePath(teamId, routeWorkspaceLens, routeChannelId));
+      navigateTeamRoute(buildTeamWorkspaceLensPath(teamId, routeWorkspaceLens, routeChannelId));
     },
     [routeChannelId, routeWorkspaceLens]
   );
@@ -2315,7 +2217,7 @@ export function TeamPage(props: TeamPageProps) {
       setSelectedConversationTaskId("");
       setTab("conversation");
       if (effectiveSelectedTeamId) {
-        navigateTeamRoute(buildTeamWorkspacePath(effectiveSelectedTeamId, "channels", channelId));
+        navigateTeamRoute(buildTeamChannelPath(effectiveSelectedTeamId, channelId));
       }
       if (isCompactWorkbench) {
         setTeamsSidebarCollapsed(true);
@@ -2348,9 +2250,7 @@ export function TeamPage(props: TeamPageProps) {
         setFocusedAgentMemberId("");
         setSelectedConversationTaskId(created.task_id);
         setTab("conversation");
-        navigateTeamRoute(
-          buildTeamWorkspacePath(effectiveSelectedTeamId, "channels", created.channel_id)
-        );
+        navigateTeamRoute(buildTeamChannelPath(effectiveSelectedTeamId, created.channel_id));
         if (isCompactWorkbench) {
           setTeamsSidebarCollapsed(true);
         }
@@ -2385,7 +2285,7 @@ export function TeamPage(props: TeamPageProps) {
         await refreshTeamChannels(effectiveSelectedTeamId);
         if (routeChannelId === channelId && routeWorkspaceLens === "channels") {
           setSelectedConversationTaskId("");
-          navigateTeamRoute(buildTeamWorkspacePath(effectiveSelectedTeamId, "channels"));
+          navigateTeamRoute(buildTeamChannelPath(effectiveSelectedTeamId));
         }
       } catch (err) {
         setError(parseErrorMessage(err));
@@ -3338,6 +3238,7 @@ export function TeamPage(props: TeamPageProps) {
     taskMessagesLoading,
     busy,
     routeThreadRootMessageId,
+    routeSelectedMemberId,
     channelFocusMessageId,
     setChannelFocusMessageId,
     effectiveSelectedTeamId,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3172,6 +3172,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: 1,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId,
       effectiveSelectedTeamId: "team-1",
@@ -3224,12 +3225,12 @@ describe("team panels interactions", () => {
     clickElement(findButtonByText(container, "View in channel"));
     expect(setChannelFocusMessageId).toHaveBeenCalledWith(1);
     expect(navigateTeamRoute).toHaveBeenCalledWith(
-      "/workspace/teams/team-1?task=task-1"
+      "/workspace/teams/team-1/channels/all/tasks/task-1"
     );
 
     clickElement(findButtonByText(container, "Close thread"));
     expect(navigateTeamRoute).toHaveBeenLastCalledWith(
-      "/workspace/teams/team-1?task=task-1"
+      "/workspace/teams/team-1/channels/all/tasks/task-1"
     );
   });
 
@@ -3265,6 +3266,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: null,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId: vi.fn(),
       effectiveSelectedTeamId: "team-1",
@@ -3324,6 +3326,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: 404,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId: vi.fn(),
       effectiveSelectedTeamId: "team-1",
@@ -3373,7 +3376,7 @@ describe("team panels interactions", () => {
           <TeamWorkbenchContainer />
         </TeamWorkspaceProvider>
       );
-    }).toThrow("TeamWorkbenchContainer requires TeamWorkspaceContext.workbench");
+    }).toThrow("useTeamWorkbenchRuntime must be used within TeamWorkspaceProvider");
 
     suppressReactError.mockRestore();
   });
@@ -3871,6 +3874,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: null,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId: vi.fn(),
       effectiveSelectedTeamId: "team-1",
@@ -3956,6 +3960,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: null,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId: vi.fn(),
       effectiveSelectedTeamId: "team-1",
@@ -3997,7 +4002,7 @@ describe("team panels interactions", () => {
     expect(mention).not.toBeNull();
     mention?.click();
     expect(navigateTeamRoute).toHaveBeenCalledWith(
-      "/workspace/teams/team-1?task=task-1&member=worker-agent"
+      "/workspace/teams/team-1/channels/all/tasks/task-1/members/worker-agent"
     );
   });
 
@@ -4035,6 +4040,7 @@ describe("team panels interactions", () => {
       taskMessagesLoading: false,
       busy: null,
       routeThreadRootMessageId: null,
+      routeSelectedMemberId: "",
       channelFocusMessageId: null,
       setChannelFocusMessageId: vi.fn(),
       effectiveSelectedTeamId: null,
@@ -4152,6 +4158,7 @@ describe("team panels interactions", () => {
         taskMessagesLoading: false,
         busy: null,
         routeThreadRootMessageId: null,
+        routeSelectedMemberId: selectedMemberId,
         channelFocusMessageId: null,
         setChannelFocusMessageId: vi.fn(),
         effectiveSelectedTeamId: "team-1",

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -3929,6 +3929,13 @@ describe("team panels interactions", () => {
 
   it("TeamConversationContainer routes clicked channel mentions to member overview", async () => {
     const navigateTeamRoute = vi.fn();
+    const setChannelFocusMessageId = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
     const workspaceContext: TeamWorkspaceContextValue = {
       selectedConversation: null,
       developerMode: false,
@@ -3962,8 +3969,8 @@ describe("team panels interactions", () => {
       busy: null,
       routeThreadRootMessageId: null,
       routeSelectedMemberId: "",
-      channelFocusMessageId: null,
-      setChannelFocusMessageId: vi.fn(),
+      channelFocusMessageId: 14,
+      setChannelFocusMessageId,
       effectiveSelectedTeamId: "team-1",
       routeWorkspaceLens: "channels",
       routeChannelId: "all",
@@ -3989,22 +3996,32 @@ describe("team panels interactions", () => {
       setThreadReplyDraft: vi.fn(),
     };
 
-    renderWithMantine(
-      root,
-      <TeamWorkspaceProvider value={workspaceContext}>
-        <TeamConversationContainer />
-      </TeamWorkspaceProvider>
-    );
+    try {
+      renderWithMantine(
+        root,
+        <TeamWorkspaceProvider value={workspaceContext}>
+          <TeamConversationContainer />
+        </TeamWorkspaceProvider>
+      );
 
-    await waitForCondition(() => container.textContent?.includes("@Worker Agent") ?? false);
-    const mention = container.querySelector(
-      '[data-team-agent-mention-id="worker-agent"]'
-    ) as HTMLButtonElement | null;
-    expect(mention).not.toBeNull();
-    mention?.click();
-    expect(navigateTeamRoute).toHaveBeenCalledWith(
-      "/workspace/teams/team-1/channels/all/tasks/task-1/members/worker-agent"
-    );
+      await waitForCondition(() => container.textContent?.includes("@Worker Agent") ?? false);
+      await waitForCondition(() => setChannelFocusMessageId.mock.calls.length > 0);
+      expect(setChannelFocusMessageId).toHaveBeenCalledWith(null);
+      const mention = container.querySelector(
+        '[data-team-agent-mention-id="worker-agent"]'
+      ) as HTMLButtonElement | null;
+      expect(mention).not.toBeNull();
+      mention?.click();
+      expect(navigateTeamRoute).toHaveBeenCalledWith(
+        "/workspace/teams/team-1/channels/all/tasks/task-1/members/worker-agent"
+      );
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        writable: true,
+        value: originalScrollIntoView,
+      });
+    }
   });
 
   it("TeamConversationContainer ignores clicked channel mentions without a selected team", async () => {

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -41,6 +41,7 @@ import {
   TeamWorkspaceProvider,
   type TeamWorkspaceContextValue,
 } from "./team/team_workspace_context";
+import { resolveTeamSelectedMemberId } from "./team/team_route_helpers";
 import {
   MAILBOX_ADVANCED_PANEL_TITLE_CLASS,
   MAILBOX_CHAT_HEADER_CLASS,
@@ -3912,7 +3913,7 @@ describe("team panels interactions", () => {
 
     await waitForCondition(() => container.textContent?.includes("Agent Profile") ?? false);
     const dock = required(
-      container.querySelector('[data-team-surface="thread-dock"]'),
+      container.querySelector(".team-thread-dock"),
       "profile dock missing"
     );
     expect(dock.textContent).toContain("Worker Agent");
@@ -4124,7 +4125,7 @@ describe("team panels interactions", () => {
       );
       const navigateTeamRoute = React.useCallback((path: string) => {
         const url = new URL(path, "http://localhost");
-        setSelectedMemberId(url.searchParams.get("member") ?? "");
+        setSelectedMemberId(resolveTeamSelectedMemberId(url.search, url.pathname));
       }, []);
       const workspaceContext: TeamWorkspaceContextValue = {
         selectedConversation: null,

--- a/web/src/pages/team_sidebar.tsx
+++ b/web/src/pages/team_sidebar.tsx
@@ -32,8 +32,12 @@ import {
 } from "./team/channel_metadata";
 import { TeamMemberLiveState } from "./team/member_helpers";
 import { normalizeTeamMemberLifecycle, normalizeTeamMemberWorkStatus } from "./team_member_status_strip";
-import type { WorkspaceLens } from "../app_route_selection";
 import type { TeamTab } from "./team/state";
+import {
+  resolveTeamSidebarSubjectPane,
+  type TeamSidebarSubjectPane,
+  type WorkspaceLens,
+} from "./team/team_route_helpers";
 
 type TeamMemberSummary = {
   active: number;
@@ -98,7 +102,6 @@ type TeamSidebarProps = {
 
 const AGENT_FOCUS_TABS = new Set<TeamTab>(["agent_acp", "member_console", "mailbox"]);
 type TeamSidebarSection = "teams" | "agents";
-type TeamSidebarSubjectPane = "channels" | "tasks" | "agents";
 const NO_ACTIVE_RUN_CONTEXT = "No active run context.";
 const DEBUG_CURRENT_WORK_PATTERN = /^(?:run_status|step_status)\s*=/i;
 type TeamSidebarSearchResult = {
@@ -204,25 +207,6 @@ const TEAM_SUBJECT_SWITCHER_ACTIVE_CLASS =
   "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-notion-hover text-[13px] text-notion-text";
 const TEAM_SUBJECT_SWITCHER_IDLE_CLASS =
   "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[13px] text-notion-text-muted transition hover:bg-notion-hover hover:text-notion-text";
-
-function resolveTeamSidebarSubjectPane(
-  tab: TeamTab,
-  activeWorkspaceLens?: WorkspaceLens
-): TeamSidebarSubjectPane {
-  if (activeWorkspaceLens === "tasks") {
-    return "tasks";
-  }
-  if (activeWorkspaceLens === "members") {
-    return "agents";
-  }
-  if (tab === "tasks") {
-    return "tasks";
-  }
-  if (AGENT_FOCUS_TABS.has(tab)) {
-    return "agents";
-  }
-  return "channels";
-}
 
 export function buildTeamSidebarSearchResults(options: {
   query: string;
@@ -377,10 +361,10 @@ function TeamSidebarImpl(props: TeamSidebarProps) {
     agents: true,
   });
   const [activeSubjectPane, setActiveSubjectPane] = React.useState<TeamSidebarSubjectPane>(() =>
-    resolveTeamSidebarSubjectPane(tab, activeWorkspaceLens)
+    resolveTeamSidebarSubjectPane({ tab, activeWorkspaceLens })
   );
   React.useEffect(() => {
-    setActiveSubjectPane(resolveTeamSidebarSubjectPane(tab, activeWorkspaceLens));
+    setActiveSubjectPane(resolveTeamSidebarSubjectPane({ tab, activeWorkspaceLens }));
   }, [activeWorkspaceLens, tab]);
   React.useEffect(() => {
     setShowCreateChannelForm(false);

--- a/web/src/routes/team_route_container.tsx
+++ b/web/src/routes/team_route_container.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useMemo } from "react";
-import { resolveTeamRoute } from "../app_route_selection";
+import { resolveTeamRoute } from "../pages/team/team_route_helpers";
 import type { AuthState } from "../types";
 import { APP_ROOT_CLASS } from "../ui/tailwind_classes";
 import { RouteFallback } from "./route_fallback";

--- a/web/src/routes/use_workspace_route_state.ts
+++ b/web/src/routes/use_workspace_route_state.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceLens,
 } from "../app_route_selection";
 import { buildStandardWorkspaceLensItems } from "../components/workspace_lens_items";
+import { buildTeamSelectorPath } from "../pages/team/team_route_helpers";
 import type { AuthState } from "../types";
 
 type UseWorkspaceRouteStateArgs = {
@@ -61,7 +62,7 @@ export function useWorkspaceRouteState({
     (value: string) => {
       const lens = value as WorkspaceLens;
       if (lens === "teams") {
-        navigateWorkbenchRoute("/workspace/teams");
+        navigateWorkbenchRoute(buildTeamSelectorPath());
         return;
       }
       if (lens === "nodes") {

--- a/web/src/workbench_header_menu.interaction.test.tsx
+++ b/web/src/workbench_header_menu.interaction.test.tsx
@@ -88,4 +88,32 @@ describe("WorkbenchHeaderMenu interactions", () => {
     expect(onNavigate).toHaveBeenNthCalledWith(2, "/workspace/nodes");
     expect(onNavigate).toHaveBeenNthCalledWith(3, "/admin");
   });
+
+  it("routes the Teams menu item through the canonical selector path", () => {
+    const onNavigate = vi.fn();
+
+    act(() => {
+      root.render(
+        <MantineProvider>
+          <WorkbenchHeaderMenu
+            active="workspace"
+            username="root"
+            isRoot={false}
+            onLogout={() => {}}
+            onNavigate={onNavigate}
+            buttonClassName="menu-button"
+            defaultOpened={true}
+          />
+        </MantineProvider>
+      );
+    });
+
+    act(() => {
+      findButtonByText(container, "Teams").dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith("/workspace/teams");
+  });
 });

--- a/web/tests/e2e/team_page_channels.e2e.ts
+++ b/web/tests/e2e/team_page_channels.e2e.ts
@@ -6,6 +6,10 @@ import {
   selectTeamChannelFromSidebar,
   teamChannelSidebarEntry,
 } from "./team_page_helpers";
+import {
+  buildTeamChannelProfilePath,
+  buildTeamChannelThreadPath,
+} from "../../src/pages/team/team_route_helpers";
 
 test("team channel sidebar helper does not select prefixed channel ids", async ({ page }) => {
   await page.setContent(`
@@ -95,7 +99,7 @@ test("team channels create, switch and delete custom channel", async ({ page }) 
   await expect(reviewChannel).toBeVisible();
 
   await selectTeamChannelFromSidebar(page, "review");
-  await expect(page).toHaveURL(/channel=review/);
+  await expect(page).toHaveURL(/\/channels\/review/);
 
   await selectTeamChannelFromSidebar(page, "all");
 
@@ -147,14 +151,86 @@ test("team channels navigates to channel via url and opens thread", async ({ pag
     },
   ]);
 
-  // Navigate directly to a channel + thread URL
-  await page.goto(`/workspace/teams/${teamId}?lens=channels&channel=all&thread=5`);
+  // Navigate directly to the canonical channel + thread URL.
+  await page.goto(buildTeamChannelThreadPath(teamId, "all", 5));
 
   // The page should load with the channels lens active
   await expect(page).toHaveURL(/workspace/);
-  await expect(page).toHaveURL(/thread=5/);
+  await expect(page).toHaveURL(/\/channels\/all\/threads\/5/);
   await expect(page.getByText("Root channel update")).toBeVisible();
   await expect(page.getByRole("textbox", { name: "Reply in thread" })).toBeVisible();
+});
+
+test("team channels opens member profile from canonical channel url", async ({ page }) => {
+  const fixture = await mockTeamPageApis(page);
+  const teamId = "team-ch-profile";
+  const teamCreatedAt = fixture.now + 90;
+  const taskId = `task-${teamId}-1`;
+  const runId = `${teamId}-working-1`;
+  fixture.teams.push({
+    id: teamId,
+    name: "Profile Route Team",
+    description: "profile route e2e",
+    spec: {
+      coordinator_member_id: "agent-coordinator-1",
+      members: [
+        { member_id: "agent-coordinator-1", role: "coordinator", model: "codex" },
+        {
+          member_id: "agent-worker-1",
+          role: "worker",
+          model: "gemini",
+          description: "Handles browser route validation",
+        },
+      ],
+      steps: [
+        { step_key: "coordinator_plan", member_id: "agent-coordinator-1" },
+        { step_key: "worker_execute", member_id: "agent-worker-1" },
+      ],
+    },
+    created_at: teamCreatedAt,
+    updated_at: teamCreatedAt,
+  });
+  fixture.seedRuns(teamId, [
+    {
+      id: runId,
+      team_id: teamId,
+      context_id: `ctx-${runId}`,
+      status: "working",
+      input: {},
+      created_at: fixture.now + 100,
+      started_at: fixture.now + 101,
+      ended_at: null,
+    },
+  ]);
+
+  const runsResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/teams/${teamId}/runs`) &&
+      response.request().method() === "GET"
+  );
+  const snapshotResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/teams/runs/${runId}/snapshot`) &&
+      response.request().method() === "GET"
+  );
+  await page.goto(buildTeamChannelProfilePath(teamId, "all", "agent-worker-1", taskId));
+  const runsResponse = await runsResponsePromise;
+  const runsPayload = (await runsResponse.json()) as unknown[];
+  expect(runsPayload).toHaveLength(1);
+  const snapshotResponse = await snapshotResponsePromise;
+  const snapshotPayload = (await snapshotResponse.json()) as { members: unknown[] };
+  expect(snapshotPayload.members).toHaveLength(2);
+
+  await expect(page).toHaveURL(
+    /\/channels\/all\/tasks\/task-team-ch-profile-1\/members\/agent-worker-1/
+  );
+  await expect(page.getByText("Agent Profile")).toBeVisible();
+  await expect(page.getByText("Worker Agent agent-worker-1")).toBeVisible();
+  await expect(page.getByText("Handles browser route validation")).toBeVisible();
+
+  await page.getByRole("button", { name: "Close agent profile" }).click();
+  await expect(page).toHaveURL(new RegExp(`/workspace/teams/${teamId}$`));
+  await expect(page.getByText("Agent Profile")).toBeHidden();
 });
 
 test("non-default channel delete requires confirmation", async ({ page }) => {

--- a/web/tests/e2e/team_page_fixture.ts
+++ b/web/tests/e2e/team_page_fixture.ts
@@ -198,6 +198,18 @@ export type TeamPageFixture = {
   getCreatePayload: () => CreateTeamPayload | null;
   getUpdateSpecPayloads: () => Array<{ teamId: string; payload: UpdateTeamSpecPayload }>;
   putTask: (task: TeamTaskRecord) => TeamTaskRecord;
+  seedTaskMessages: (
+    taskId: string,
+    messages: TeamConversationMessageRecord[]
+  ) => void;
+  seedMailboxMessages: (
+    runId: string,
+    messages: TeamActorMessageRecord[]
+  ) => void;
+  seedRuns: (
+    teamId: string,
+    runs: TeamRunRecord[]
+  ) => void;
 };
 
 export function jsonResponse(data: unknown, status = 200): {
@@ -312,6 +324,7 @@ export async function mockTeamPageApis(
   const tasksByTeamId = new Map<string, TeamTaskRecord[]>();
   const taskMessagesById = new Map<string, TeamConversationMessageRecord[]>();
   const taskCounterByTeamId = new Map<string, number>();
+  const runsByTeamId = new Map<string, TeamRunRecord[]>();
   const mailboxMessagesByRunId = new Map<string, TeamActorMessageRecord[]>();
   const runEventCounterByRunId = new Map<string, number>();
   let createTeamPayload: CreateTeamPayload | null = null;
@@ -368,6 +381,18 @@ export async function mockTeamPageApis(
     messages: TeamConversationMessageRecord[]
   ): void => {
     taskMessagesById.set(taskId, messages);
+  };
+  const seedMailboxMessages = (
+    runId: string,
+    messages: TeamActorMessageRecord[]
+  ): void => {
+    mailboxMessagesByRunId.set(runId, messages);
+  };
+  const seedRuns = (
+    teamId: string,
+    runs: TeamRunRecord[]
+  ): void => {
+    runsByTeamId.set(teamId, runs);
   };
 
   const inferRunStatusFromRunId = (runId: string): TeamRunRecord["status"] => {
@@ -993,7 +1018,8 @@ export async function mockTeamPageApis(
       await route.fallback();
       return;
     }
-    await route.fulfill(jsonResponse([]));
+    const teamId = request.url().match(/\/api\/teams\/([^/]+)\/runs/)?.[1] ?? "";
+    await route.fulfill(jsonResponse(runsByTeamId.get(teamId) ?? []));
   });
 
   await page.route(/\/api\/teams\/runs\/[^/]+$/, async (route, request) => {
@@ -1288,5 +1314,7 @@ export async function mockTeamPageApis(
     getUpdateSpecPayloads: () => updateSpecPayloads,
     putTask,
     seedTaskMessages,
+    seedMailboxMessages,
+    seedRuns,
   };
 }

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -1,4 +1,14 @@
 import { expect } from "./coverage";
+import {
+  buildTeamChannelPath,
+  buildTeamDetailPath,
+  buildTeamLensNavigationPath,
+  buildTeamSearchCompatibilityPath,
+  buildTeamSelectorPath,
+  buildTeamTabCompatibilityPath,
+  resolveTeamRoute,
+  type WorkspaceLens,
+} from "../../src/pages/team/team_route_helpers";
 import { UI_PREFS_STORAGE_KEY } from "../../src/ui/developer_mode";
 
 export {
@@ -267,7 +277,7 @@ export async function openTeamFromSelector(
     if ((await selectorButton.count()) > 0) {
       await selectorButton.first().click();
     } else {
-      await page.goto("/workspace/teams", { waitUntil: "domcontentloaded" });
+      await page.goto(buildTeamSelectorPath(), { waitUntil: "domcontentloaded" });
     }
   }
   await expect(page).toHaveURL(/\/(?:workspace\/)?teams(?:[/?#]|$)/);
@@ -283,18 +293,19 @@ export async function openTeamFromSelector(
   await expect(selectorTeamButton).toBeVisible();
   const selectorTeamId = await selectorTeamButton.getAttribute("data-team-id");
   expect(selectorTeamId).toBeTruthy();
+  const selectedTeamId = selectorTeamId ?? "";
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       await selectorTeamButton.click({ timeout: 1_500, force: attempt > 0 });
     } catch {
-      await page.goto(`/workspace/teams/${selectorTeamId}`, { waitUntil: "domcontentloaded" });
+      await page.goto(buildTeamDetailPath(selectedTeamId), { waitUntil: "domcontentloaded" });
     }
     await page.waitForTimeout(150);
     if (await isTeamDetailReady(page, teamName)) {
       return;
     }
   }
-  await page.goto(`/workspace/teams/${selectorTeamId}`, { waitUntil: "domcontentloaded" });
+  await page.goto(buildTeamDetailPath(selectedTeamId), { waitUntil: "domcontentloaded" });
   await expect
     .poll(() => isTeamDetailReady(page, teamName), {
       timeout: TEAM_DETAIL_READY_TIMEOUT_MS,
@@ -334,7 +345,7 @@ export async function isTeamDetailReady(
 }
 
 export async function gotoTeams(page: import("@playwright/test").Page): Promise<void> {
-  await page.goto("/teams", { waitUntil: "domcontentloaded" });
+  await page.goto(buildTeamSelectorPath(), { waitUntil: "domcontentloaded" });
   await expect(teamSelectorPanel(page)).toBeVisible();
 }
 
@@ -522,18 +533,17 @@ async function revealTeamSidebarSubject(
     return;
   }
 
-  await page.evaluate((nextLens) => {
-    const nextUrl = new URL(window.location.href);
-    if (nextLens === "channels") {
-      nextUrl.searchParams.delete("lens");
-    } else if (nextLens === "agents") {
-      nextUrl.searchParams.set("lens", "members");
-    } else {
-      nextUrl.searchParams.set("lens", nextLens);
-    }
-    window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }, subject);
+  const teamId = currentTeamId(page);
+  if (subject === "search") {
+    await pushTeamPath(page, buildTeamSearchCompatibilityPath(teamId));
+    return;
+  }
+  const lens: WorkspaceLens =
+    subject === "agents" ? "members" : subject === "tasks" ? "tasks" : "channels";
+  await pushTeamPath(
+    page,
+    lens === "channels" ? buildTeamChannelPath(teamId) : buildTeamLensNavigationPath(teamId, lens)
+  );
 }
 
 async function restoreTeamChannelWorkspace(
@@ -597,37 +607,37 @@ async function navigateToTeamChannelWorkspace(
   channelId: string
 ): Promise<void> {
   assertRawChannelId(channelId);
-  await page.evaluate((nextChannelId) => {
-    const nextUrl = new URL(window.location.href);
-    nextUrl.searchParams.delete("lens");
-    nextUrl.searchParams.delete("member");
-    nextUrl.searchParams.delete("tab");
-    nextUrl.searchParams.delete("thread");
-    nextUrl.searchParams.delete("task");
-    if (nextChannelId === "all") {
-      nextUrl.searchParams.delete("channel");
-    } else {
-      nextUrl.searchParams.set("channel", nextChannelId);
-    }
-    window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
+  await pushTeamPath(
+    page,
+    buildTeamChannelPath(currentTeamId(page), channelId)
+  );
+}
+
+function currentTeamId(page: import("@playwright/test").Page): string {
+  const currentUrl = new URL(page.url());
+  const route = resolveTeamRoute(currentUrl.pathname);
+  if (!route || route.mode !== "detail") {
+    throw new Error(`Expected a Team detail route, got ${currentUrl.pathname}`);
+  }
+  return route.teamId;
+}
+
+async function pushTeamPath(
+  page: import("@playwright/test").Page,
+  path: string
+): Promise<void> {
+  await page.evaluate((nextPath) => {
+    window.history.pushState({}, "", nextPath);
     window.dispatchEvent(new PopStateEvent("popstate"));
-  }, channelId);
+  }, path);
 }
 
 async function navigateToTeamTab(
   page: import("@playwright/test").Page,
-  tab: string
+  tab: Parameters<typeof buildTeamTabCompatibilityPath>[1]
 ): Promise<void> {
-  await page.evaluate((nextTab) => {
-    const nextUrl = new URL(window.location.href);
-    nextUrl.searchParams.delete("lens");
-    nextUrl.searchParams.delete("member");
-    nextUrl.searchParams.delete("thread");
-    nextUrl.searchParams.delete("task");
-    nextUrl.searchParams.set("tab", nextTab);
-    window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }, tab);
+  const currentUrl = new URL(page.url());
+  await pushTeamPath(page, buildTeamTabCompatibilityPath(currentUrl.pathname, tab));
 }
 
 export async function openMainTeamAction(

--- a/web/tests/e2e/team_page_layout.e2e.ts
+++ b/web/tests/e2e/team_page_layout.e2e.ts
@@ -225,10 +225,10 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
   expect(splitMetrics.overlaps).toBe(false);
   expect(splitMetrics.horizontalGap).toBeGreaterThanOrEqual(0);
   expect(splitMetrics.threadRightInset).toBeGreaterThanOrEqual(-1);
-  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.48);
-  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.58);
-  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.40);
-  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.50);
+  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.56);
+  expect(splitMetrics.channelWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.66);
+  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeGreaterThanOrEqual(0.32);
+  expect(splitMetrics.threadWidth / splitMetrics.layoutWidth).toBeLessThanOrEqual(0.42);
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.locator('[data-team-surface="thread-pane"]')).toBeVisible();

--- a/web/tests/e2e/team_page_layout.e2e.ts
+++ b/web/tests/e2e/team_page_layout.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "./coverage";
+import { buildTeamChannelThreadPath } from "../../src/pages/team/team_route_helpers";
 import {
   gotoTeams,
   mockTeamPageApis,
@@ -178,7 +179,7 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
   await expect(page.getByRole("button", { name: /Prepare layout release/ })).toBeVisible();
   await page.screenshot({ fullPage: false });
   await page.getByRole("button", { name: /Prepare layout release/ }).click();
-  await expect(page).toHaveURL(/task=task-team-layout-release/);
+  await expect(page).toHaveURL(/\/channels\/layout\/tasks\/task-team-layout-release/);
   await expect(page.getByText("Release task opened from search.")).toBeVisible();
 
   await page.getByRole("button", { name: "Search workspace", exact: true }).click();
@@ -188,17 +189,11 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
   await expect(searchInput).toBeHidden();
 
   await page.evaluate(
-    ({ nextTeamId, nextChannelId, nextTaskId }) => {
-      const nextUrl = new URL(window.location.href);
-      nextUrl.pathname = `/workspace/teams/${nextTeamId}`;
-      nextUrl.search = "";
-      nextUrl.searchParams.set("channel", nextChannelId);
-      nextUrl.searchParams.set("task", nextTaskId);
-      nextUrl.searchParams.set("thread", "101");
-      window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
+    (nextPath) => {
+      window.history.pushState({}, "", nextPath);
       window.dispatchEvent(new PopStateEvent("popstate"));
     },
-    { nextTeamId: teamId, nextChannelId: channelId, nextTaskId: channelTaskId }
+    buildTeamChannelThreadPath(teamId, channelId, 101)
   );
   await expect(page.locator('[data-team-surface="thread-pane"]')).toBeVisible();
   await expect(page.locator('[data-team-surface="channel-thread-layout"]')).toHaveAttribute(

--- a/web/tests/e2e/team_page_layout.e2e.ts
+++ b/web/tests/e2e/team_page_layout.e2e.ts
@@ -109,7 +109,7 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
     const channelThreadLayout = document.querySelector<HTMLElement>(
       '[data-team-surface="channel-thread-layout"]'
     );
-    const channelPane = document.querySelector<HTMLElement>('[data-team-surface="channel-pane"]');
+    const channelPane = document.querySelector<HTMLElement>(".team-channel-pane");
     const headerShell = document.querySelector<HTMLElement>(
       '[data-team-workspace-header-shell="true"]'
     );
@@ -205,8 +205,8 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
     const layout = document.querySelector<HTMLElement>(
       '[data-team-surface="channel-thread-layout"]'
     );
-    const channelPane = document.querySelector<HTMLElement>('[data-team-surface="channel-pane"]');
-    const threadDock = document.querySelector<HTMLElement>('[data-team-surface="thread-dock"]');
+    const channelPane = document.querySelector<HTMLElement>(".team-channel-pane");
+    const threadDock = document.querySelector<HTMLElement>(".team-thread-dock");
     if (!layout || !channelPane || !threadDock) {
       throw new Error("team workspace split nodes missing");
     }
@@ -235,7 +235,7 @@ test("team workspace keeps desktop layout proportions across shell, sidebar, hea
   const compactMetrics = await page.evaluate(() => {
     const visibleSurfaceRects = Array.from(
       document.querySelectorAll<HTMLElement>(
-        '[data-team-surface="sidebar"], [data-team-surface="workbench"], [data-team-surface="channel-pane"], [data-team-surface="thread-dock"]'
+        '[data-team-surface="sidebar"], [data-team-surface="workbench"], .team-channel-pane, .team-thread-dock'
       )
     )
       .filter((node) => {


### PR DESCRIPTION
chore(team): unify workspace route shell

## Summary

- Add a Team-owned route facade for canonical workspace subpaths, route snapshots, active lens fallback, member profile paths, and compatibility-only legacy query builders.
- Move Team page, sidebar, containers, Agent Nodes drill-down links, shell entrypoints, and E2E helpers onto named Team route helpers.
- Add shared workspace section/content/split-pane primitives and reuse them for Team workspace header/body/channel-thread layout.
- Update the unified workspace IA contract and route follow-up journal with the facade and shell reuse boundary.

## Purpose

This keeps Team route semantics behind a Team-owned boundary while the workspace shell converges on shared layout primitives. The route migration preserves query-first compatibility for old links and keeps `thread` subordinate to channel routes instead of introducing a top-level Team lens.

## Related Issues

- None.

## Tests

- `cd web && npm exec vitest -- run src/components/layout/workspace_section_shell.test.tsx src/components/layout/workspace_shell.test.tsx src/pages/team/team_workbench_content.test.tsx src/pages/team/team_route_boundary.test.ts src/pages/team/team_route_helpers.test.ts`
- `cd web && npm exec tsc -- --noEmit`
- `cd web && npm run lint`
- `cd web && PLAYWRIGHT_SYSTEM_CHROME=1 npx playwright test tests/e2e/team_page_channels.e2e.ts --project=system-chrome`

## Notes

- Validation above was rerun from a clean temporary worktree with only this staged patch applied.
- `npm run lint` exits successfully but still reports the existing `openReplyObligations` hook dependency warning in `web/src/pages/team_mailbox_panel.tsx`.
