### PR TITLE
fix(team): stabilize mailbox reply obligations

### DIFF
--- a/web/src/pages/team_mailbox_panel.tsx
+++ b/web/src/pages/team_mailbox_panel.tsx
@@ -97,6 +97,8 @@ type MailboxConversationRow = {
   canAccept: boolean;
 };
 
+const EMPTY_REPLY_OBLIGATIONS: TeamReplyObligationRecord[] = [];
+
 type TeamMailboxPanelProps = {
   developerMode: boolean;
   mode?: "full" | "advanced_only";
@@ -262,7 +264,8 @@ function TeamMailboxPanelImpl(props: TeamMailboxPanelProps) {
   const showAdvancedControls = mode === "advanced_only";
   const showDeveloperMailboxTools = developerMode && showAdvancedControls;
   const normalizedHumanActorId = humanActorId.trim();
-  const openReplyObligations = snapshot?.mailbox.open_reply_obligations ?? [];
+  const openReplyObligations =
+    snapshot?.mailbox.open_reply_obligations ?? EMPTY_REPLY_OBLIGATIONS;
   const mailboxMessagesById = React.useMemo(
     () => new Map(snapshot?.mailbox.recent_messages.map((message) => [message.message_id, message]) ?? []),
     [snapshot?.mailbox.recent_messages]


### PR DESCRIPTION
## Summary

- Stabilize the empty mailbox reply-obligation fallback so `useMemo` dependencies do not change on every render.
- Keep the existing obligation row memoization behavior unchanged when a snapshot provides real obligations.

## Purpose

This removes the React hook dependency warning emitted by the Web lint job for `TeamMailboxPanel`.

## Related Issues

- None.

## Testing

- `cd web && npm run lint`
- `cd web && npm exec vitest -- run src/pages/team_panels.test.tsx -t "TeamMailboxPanel"`
- `cd web && npm exec tsc -- --noEmit`
- `git diff --check`
