### PR TITLE
fix(auth): gate diagnostics trace by capability

### DIFF
--- a/docs/journal/2026-07-20-diagnostics-capability-gate.md
+++ b/docs/journal/2026-07-20-diagnostics-capability-gate.md
@@ -1,0 +1,41 @@
+# Diagnostics Capability Gate
+
+## Summary
+
+The debug-only `/api/diagnostics/agent_trace` route now uses the `diagnostics:read`
+capability instead of the root-only compatibility gate.
+
+## Background
+
+The access-control contract allows `root` and `admin` users to read diagnostics while
+denying `operator`, `viewer`, and `device` users. The route still used the root-only
+helper, which kept this read-only diagnostics surface stricter than the capability
+matrix and blocked the route-cluster migration.
+
+## Scope
+
+- Switched the diagnostics route authz call to `require_capability(..., DiagnosticsRead)`.
+- Added router coverage proving a `viewer` is denied and an `admin` passes authz.
+- Kept the route debug-only and left trace target/resource validation unchanged.
+
+## Key Decisions
+
+- Treat diagnostics trace collection as `diagnostics:read`, not `instance:configure`.
+- Use the existing capability matrix and authz helper rather than adding a route-local
+  role check.
+- Keep the test independent of live runtime trace fixtures by using a missing target
+  after authz succeeds.
+
+## Validation
+
+```bash
+cargo test -p agenthub api::diagnostics::tests::agent_trace_requires_diagnostics_read_capability -- --nocapture
+cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture
+cargo fmt -p agenthub -- --check
+```
+
+## Follow-Ups
+
+- Continue migrating the next route cluster from root-only gates to capability gates.
+- Keep security-critical instance settings on root-only authorization unless the stable
+  access-control contract changes.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -48,7 +48,7 @@ Stable contract:
 
 - [features/access-control-and-roles.md](features/access-control-and-roles.md)
 
-- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, and remote-node create-agent gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract.
+- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, remote-node create-agent gate, and debug diagnostics `diagnostics:read` route gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract. Latest notes: [journal/2026-07-20-diagnostics-capability-gate.md](journal/2026-07-20-diagnostics-capability-gate.md).
 
 ## Message Storage
 

--- a/src/api/diagnostics.rs
+++ b/src/api/diagnostics.rs
@@ -67,6 +67,7 @@ async fn agent_trace(
 
 #[cfg(all(test, debug_assertions))]
 mod tests {
+    use agenthub_auth_domain::UserRole;
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode, header};
     use serde_json::{Value, json};
@@ -77,19 +78,20 @@ mod tests {
     use crate::api::team_tests::build_test_state;
     use crate::state::AppState;
 
-    async fn create_role_token(state: &AppState, role: &str) -> String {
+    async fn create_role_token(state: &AppState, role: UserRole) -> String {
         let user_id = Uuid::new_v4().to_string();
         let now = chrono::Utc::now().timestamp();
+        let role_str = role.as_str();
         sqlx::query(
             r#"
             INSERT INTO users (id, username, display_name, role, password_hash, created_at)
-            VALUES (?1, ?2, ?3, ?4, NULL, ?5)
+            VALUES (?, ?, ?, ?, NULL, ?)
             "#,
         )
         .bind(&user_id)
-        .bind(format!("{role}-{}", Uuid::new_v4()))
-        .bind(role)
-        .bind(role)
+        .bind(format!("{role_str}-{}", Uuid::new_v4()))
+        .bind(role_str)
+        .bind(role_str)
         .bind(now)
         .execute(&state.db)
         .await
@@ -120,8 +122,8 @@ mod tests {
     #[tokio::test]
     async fn agent_trace_requires_diagnostics_read_capability() {
         let state = build_test_state().await;
-        let viewer_token = create_role_token(&state, "viewer").await;
-        let admin_token = create_role_token(&state, "admin").await;
+        let viewer_token = create_role_token(&state, UserRole::Viewer).await;
+        let admin_token = create_role_token(&state, UserRole::Admin).await;
         let app = router(state);
 
         let denied = app

--- a/src/api/diagnostics.rs
+++ b/src/api/diagnostics.rs
@@ -1,4 +1,6 @@
 #[cfg(debug_assertions)]
+use agenthub_auth_domain::UserCapability;
+#[cfg(debug_assertions)]
 use axum::{
     Json, Router,
     extract::{Query, State},
@@ -40,7 +42,7 @@ async fn agent_trace(
     headers: HeaderMap,
     Query(query): Query<AgentTraceQuery>,
 ) -> Result<Json<AgentTraceReport>, ApiError> {
-    authz::require_root(&headers, &state).await?;
+    authz::require_capability(&headers, &state, UserCapability::DiagnosticsRead).await?;
     let request = AgentTraceRequest {
         agent_id: query.agent_id,
         team_id: query.team_id,
@@ -61,4 +63,86 @@ async fn agent_trace(
         .await;
     apply_live_overlay(&mut report, overlay);
     Ok(Json(report))
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, StatusCode, header};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::router;
+    use crate::api::team_tests::build_test_state;
+    use crate::state::AppState;
+
+    async fn create_role_token(state: &AppState, role: &str) -> String {
+        let user_id = Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT INTO users (id, username, display_name, role, password_hash, created_at)
+            VALUES (?1, ?2, ?3, ?4, NULL, ?5)
+            "#,
+        )
+        .bind(&user_id)
+        .bind(format!("{role}-{}", Uuid::new_v4()))
+        .bind(role)
+        .bind(role)
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert role user");
+
+        state
+            .auth
+            .create_session(&user_id)
+            .await
+            .expect("create role session")
+    }
+
+    fn build_request(path: &str, token: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().method(Method::GET).uri(path);
+        if let Some(token) = token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        builder.body(Body::empty()).expect("build request")
+    }
+
+    async fn decode_json_body(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        serde_json::from_slice(&bytes).expect("decode response json")
+    }
+
+    #[tokio::test]
+    async fn agent_trace_requires_diagnostics_read_capability() {
+        let state = build_test_state().await;
+        let viewer_token = create_role_token(&state, "viewer").await;
+        let admin_token = create_role_token(&state, "admin").await;
+        let app = router(state);
+
+        let denied = app
+            .clone()
+            .oneshot(build_request(
+                "/agent_trace?agent_id=missing",
+                Some(&viewer_token),
+            ))
+            .await
+            .expect("run viewer agent trace request");
+        assert_eq!(denied.status(), StatusCode::UNAUTHORIZED);
+        let denied_body = decode_json_body(denied).await;
+        assert_eq!(denied_body["error"], json!("diagnostics:read required"));
+
+        let allowed = app
+            .oneshot(build_request(
+                "/agent_trace?agent_id=missing",
+                Some(&admin_token),
+            ))
+            .await
+            .expect("run admin agent trace request");
+        assert_ne!(allowed.status(), StatusCode::UNAUTHORIZED);
+    }
 }


### PR DESCRIPTION
## Summary

- Gate the debug-only diagnostics agent trace route with `diagnostics:read` instead of root-only auth.
- Add route coverage proving viewers are denied while admins pass authorization.
- Record the rollout checkpoint in `docs/journal` and update `docs/todo.md`.

## Motivation

The access-control contract already maps diagnostics read access to the capability matrix. This route was still using the root-only compatibility helper, which kept a read-only diagnostics surface outside the route-cluster migration.

## Related Issues

- None.

## Tests

- `cargo fmt -p agenthub -- --check`
- `cargo test -p agenthub api::diagnostics::tests::agent_trace_requires_diagnostics_read_capability -- --nocapture`
- `cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture`
