### PR TITLE
feat(auth): gate agent node routes by capability

### DIFF
--- a/docs/journal/2026-07-21-agent-node-capability-gate.md
+++ b/docs/journal/2026-07-21-agent-node-capability-gate.md
@@ -1,0 +1,44 @@
+# Agent Node Capability Gate
+
+## Summary
+
+Agent node management routes now use the `nodes:manage` capability instead of the root-only
+compatibility gate, while bootstrap join information remains root-only.
+
+## Background
+
+The access-control contract allows `root` and `admin` users to manage node records, but not
+`operator`, `viewer`, or `device` users. The agent-node routes still used `require_root`, which kept
+normal node operations tied to instance-configuration authority.
+
+## Scope
+
+- Switched agent node create, list, get, update, and delete authorization to
+  `require_capability(..., NodesManage)`.
+- Kept `/api/agent_nodes/bootstrap` on `require_root` because it exposes bootstrap join material.
+- Added route coverage proving `operator` is denied, `admin` can list nodes, and `admin` still
+  cannot read bootstrap join information.
+
+## Key Decisions
+
+- Treat node registry CRUD as `nodes:manage`, matching the stable capability matrix.
+- Keep bootstrap join info as root-only because it is closer to instance/node credential bootstrap
+  than routine node operation.
+- Reuse the canonical authz helper instead of adding route-local role checks.
+
+## Validation
+
+```bash
+cargo test -p agenthub api::agent_nodes::tests::agent_node_routes_require_nodes_manage_capability -- --nocapture
+cargo test -p agenthub api::agent_nodes::tests::get_agent_node_bootstrap_requires_root -- --nocapture
+cargo test -p agenthub api::agent_nodes::tests -- --nocapture
+cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture
+cargo fmt -p agenthub -- --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Continue migrating normal operator route clusters from root-only gates to capability gates.
+- Keep bootstrap token, root lifecycle, safe path, and passkey configuration routes root-only unless
+  the stable access-control contract changes.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,7 +47,7 @@ Stable contract:
 
 - [features/access-control-and-roles.md](features/access-control-and-roles.md)
 
-- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, remote-node create-agent gate, debug diagnostics `diagnostics:read` route gate, and `push:subscribe` route gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract. Latest notes: [journal/2026-07-20-diagnostics-capability-gate.md](journal/2026-07-20-diagnostics-capability-gate.md) and [journal/2026-07-20-push-subscribe-capability-gate.md](journal/2026-07-20-push-subscribe-capability-gate.md).
+- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, remote-node create-agent gate, debug diagnostics `diagnostics:read` route gate, `push:subscribe` route gate, and agent-node CRUD/list/get `nodes:manage` gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract. Latest notes: [journal/2026-07-20-diagnostics-capability-gate.md](journal/2026-07-20-diagnostics-capability-gate.md), [journal/2026-07-20-push-subscribe-capability-gate.md](journal/2026-07-20-push-subscribe-capability-gate.md), and [journal/2026-07-21-agent-node-capability-gate.md](journal/2026-07-21-agent-node-capability-gate.md).
 
 ## Message Storage
 

--- a/src/api/agent_nodes.rs
+++ b/src/api/agent_nodes.rs
@@ -1,3 +1,4 @@
+use agenthub_auth_domain::UserCapability;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -6,7 +7,7 @@ use axum::{
 };
 
 use crate::agent::{AgentNodeConfig, AgentNodeJoinBootstrapInfo, AgentNodeRecord, AgentNodeUpdate};
-use crate::api::authz::require_root;
+use crate::api::authz::{require_capability, require_root};
 use crate::api::error::ApiError;
 use crate::api::ok_response;
 use crate::state::AppState;
@@ -50,7 +51,7 @@ async fn create_agent_node(
     headers: HeaderMap,
     Json(payload): Json<AgentNodeConfig>,
 ) -> Result<Json<AgentNodeRecord>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::NodesManage).await?;
     let node = state
         .agents
         .create_agent_node(payload)
@@ -63,7 +64,7 @@ async fn list_agent_nodes(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<AgentNodeRecord>>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::NodesManage).await?;
     let nodes = state.agents.list_agent_nodes().await?;
     Ok(Json(nodes))
 }
@@ -73,7 +74,7 @@ async fn get_agent_node(
     headers: HeaderMap,
     Path(node_id): Path<String>,
 ) -> Result<Json<AgentNodeRecord>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::NodesManage).await?;
     let node = state
         .agents
         .get_agent_node(&node_id)
@@ -96,7 +97,7 @@ async fn update_agent_node(
     Path(node_id): Path<String>,
     Json(payload): Json<AgentNodeUpdate>,
 ) -> Result<Json<AgentNodeRecord>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::NodesManage).await?;
     let node = state
         .agents
         .update_agent_node(&node_id, payload)
@@ -110,7 +111,7 @@ async fn delete_agent_node(
     headers: HeaderMap,
     Path(node_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::NodesManage).await?;
     state
         .agents
         .delete_agent_node(&node_id)
@@ -121,6 +122,7 @@ async fn delete_agent_node(
 
 #[cfg(test)]
 mod tests {
+    use agenthub_auth_domain::UserRole;
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode, header};
     use serde_json::{Value, json};
@@ -130,27 +132,29 @@ mod tests {
     use super::router;
     use crate::api::team_tests::{build_test_state, create_auth_token};
 
-    async fn create_non_root_auth_token(state: &crate::state::AppState) -> String {
+    async fn create_role_auth_token(state: &crate::state::AppState, role: UserRole) -> String {
         let user_id = Uuid::new_v4().to_string();
         let now = chrono::Utc::now().timestamp();
+        let role_str = role.as_str();
         sqlx::query(
             r#"
             INSERT INTO users (id, username, display_name, role, password_hash, created_at)
-            VALUES (?1, ?2, ?3, 'user', NULL, ?4)
+            VALUES (?1, ?2, ?3, ?4, NULL, ?5)
             "#,
         )
         .bind(&user_id)
-        .bind(format!("user-{}", Uuid::new_v4()))
-        .bind("User")
+        .bind(format!("{role_str}-{}", Uuid::new_v4()))
+        .bind(role_str)
+        .bind(role_str)
         .bind(now)
         .execute(&state.db)
         .await
-        .expect("insert non-root user");
+        .expect("insert role user");
         state
             .auth
             .create_session(&user_id)
             .await
-            .expect("create non-root session")
+            .expect("create role session")
     }
 
     fn build_json_request(
@@ -180,35 +184,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn agent_node_routes_require_root() {
+    async fn agent_node_routes_require_nodes_manage_capability() {
         let state = build_test_state().await;
-        let token = create_non_root_auth_token(&state).await;
-        let app = router(state);
+        let operator_token = create_role_auth_token(&state, UserRole::Operator).await;
+        let admin_token = create_role_auth_token(&state, UserRole::Admin).await;
+        let app = router(state.clone());
 
         let response = app
-            .oneshot(build_json_request(Method::GET, "/", Some(&token), None))
+            .clone()
+            .oneshot(build_json_request(
+                Method::GET,
+                "/",
+                Some(&operator_token),
+                None,
+            ))
             .await
-            .expect("run non-root list agent nodes request");
+            .expect("run operator list agent nodes request");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let body = decode_json_body(response).await;
-        assert_eq!(body["error"], json!("root required"));
+        assert_eq!(body["error"], json!("nodes:manage required"));
+
+        let response = app
+            .oneshot(build_json_request(
+                Method::GET,
+                "/",
+                Some(&admin_token),
+                None,
+            ))
+            .await
+            .expect("run admin list agent nodes request");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn get_agent_node_bootstrap_requires_root() {
         let state = build_test_state().await;
-        let token = create_non_root_auth_token(&state).await;
+        let admin_token = create_role_auth_token(&state, UserRole::Admin).await;
         let app = router(state);
 
         let response = app
             .oneshot(build_json_request(
                 Method::GET,
                 "/bootstrap",
-                Some(&token),
+                Some(&admin_token),
                 None,
             ))
             .await
-            .expect("run non-root get agent node bootstrap request");
+            .expect("run admin get agent node bootstrap request");
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         let body = decode_json_body(response).await;
         assert_eq!(body["error"], json!("root required"));


### PR DESCRIPTION
## Summary

- move agent node create/list/get/update/delete routes from the root-only gate to `nodes:manage`
- keep agent node bootstrap join information root-only
- add route coverage for operator denial, admin node-list access, and admin bootstrap denial
- record the rollout checkpoint in the active TODO and journal

## Related issue

- None

## Testing

- `cargo test -p agenthub api::agent_nodes::tests::agent_node_routes_require_nodes_manage_capability -- --nocapture`
- `cargo test -p agenthub api::agent_nodes::tests::get_agent_node_bootstrap_requires_root -- --nocapture`
- `cargo test -p agenthub api::agent_nodes::tests -- --nocapture`
- `cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture`
- `cargo fmt -p agenthub -- --check`
- `git diff --check`
