### PR TITLE
feat(auth): gate linker routes by capability

### DIFF
--- a/docs/features/access-control-and-roles.md
+++ b/docs/features/access-control-and-roles.md
@@ -197,3 +197,4 @@ result.
 ## Source Journals
 
 - [2026-07-16 Access Control Roles](../journal/2026-07-16-access-control-roles.md)
+- [2026-07-21 Linker Capability Gate](../journal/2026-07-21-linker-capability-gate.md)

--- a/docs/journal/2026-07-21-linker-capability-gate.md
+++ b/docs/journal/2026-07-21-linker-capability-gate.md
@@ -1,0 +1,47 @@
+# Linker Capability Gate
+
+## Summary
+
+The admin linker routes now use the `linkers:manage` user capability instead of the root-only
+compatibility gate. Root and admin users can manage linker configuration and linked-resource reads;
+operators and lower roles are denied by the capability matrix.
+
+## Background
+
+The access-control rollout is migrating normal operator routes by capability cluster. Node
+management already moved to `nodes:manage`; linker configuration and resource reads are the next
+cluster in the stable access-control contract.
+
+## Scope
+
+- Converted `/admin/linkers` and `/admin/linkers/slock*` routes to `linkers:manage`.
+- Kept instance security and break-glass admin routes on the root-only compatibility gate.
+- Updated the Slock linker route test to prove `operator` is denied and `admin` can configure and
+  list linkers without exposing stored secrets.
+
+## Key Decisions
+
+- Treat linker configuration and linked Slock resource reads as one `linkers:manage` route cluster.
+- Preserve existing resource-contract behavior for unimplemented Slock channel reads; authorization
+  now reaches that contract only after the caller has `linkers:manage`.
+- Keep safe paths, passkey settings, device revocation, join challenges, audit export, and archive
+  migration outside this slice because they remain instance-security or root-owned maintenance
+  actions.
+
+## Validation
+
+```bash
+cargo test -p agenthub api::admin::tests::slock_linker_routes_require_linkers_manage_and_do_not_expose_secrets -- --nocapture
+cargo test -p agenthub api::admin::tests::slock_link_attempt_requires_config_and_persists_state -- --nocapture
+cargo test -p agenthub api::admin::tests::slock_channel_routes_report_missing_resource_contract -- --nocapture
+cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture
+cargo fmt -p agenthub -- --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Continue the route-cluster migration with the remaining normal agent and Team routes that still
+  use authentication-only checks.
+- Add audit records that include the capability name once the audit schema grows a stable field for
+  capability evidence.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,7 +47,7 @@ Stable contract:
 
 - [features/access-control-and-roles.md](features/access-control-and-roles.md)
 
-- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, remote-node create-agent gate, debug diagnostics `diagnostics:read` route gate, `push:subscribe` route gate, and agent-node CRUD/list/get `nodes:manage` gate, migrate normal operator routes from root-only auth to capability auth in the order defined by the stable contract. Latest notes: [journal/2026-07-20-diagnostics-capability-gate.md](journal/2026-07-20-diagnostics-capability-gate.md), [journal/2026-07-20-push-subscribe-capability-gate.md](journal/2026-07-20-push-subscribe-capability-gate.md), and [journal/2026-07-21-agent-node-capability-gate.md](journal/2026-07-21-agent-node-capability-gate.md).
+- [ ] `P1` Continue user role/capability migration by route cluster: after the first domain matrix, capability helper, bypass guard, remote-node create-agent gate, debug diagnostics `diagnostics:read` route gate, `push:subscribe` route gate, agent-node CRUD/list/get `nodes:manage` gate, and admin linker `linkers:manage` gate, migrate normal operator routes from authentication-only auth to capability auth in the order defined by the stable contract. Latest notes: [journal/2026-07-20-diagnostics-capability-gate.md](journal/2026-07-20-diagnostics-capability-gate.md), [journal/2026-07-20-push-subscribe-capability-gate.md](journal/2026-07-20-push-subscribe-capability-gate.md), [journal/2026-07-21-agent-node-capability-gate.md](journal/2026-07-21-agent-node-capability-gate.md), and [journal/2026-07-21-linker-capability-gate.md](journal/2026-07-21-linker-capability-gate.md).
 
 ## Message Storage
 

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -10,7 +10,9 @@ use rand::Rng;
 use sqlx::Row;
 use uuid::Uuid;
 
-use crate::api::authz::require_root;
+use agenthub_auth_domain::UserCapability;
+
+use crate::api::authz::{require_capability, require_root};
 use crate::api::error::{ApiError, map_linker_error};
 use crate::api::{extract_ip, extract_ua, ok_response};
 use crate::linkers::{self, AppLinkerRecord, AppLinkerService, SlockConfigInput};
@@ -375,7 +377,7 @@ async fn list_linkers(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<AppLinkerRecord>>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .list_linkers()
         .await
@@ -388,7 +390,7 @@ async fn upsert_slock_linker(
     headers: HeaderMap,
     Json(payload): Json<UpsertSlockLinkerRequest>,
 ) -> Result<Json<AppLinkerRecord>, ApiError> {
-    let user = require_root(&headers, &state).await?;
+    let user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     let record = AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .upsert_slock_config(
             &user.id,
@@ -421,7 +423,7 @@ async fn create_slock_link_attempt(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<SlockLinkAttemptResponse>, ApiError> {
-    let user = require_root(&headers, &state).await?;
+    let user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     let attempt = AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .create_slock_link_attempt(&user.id)
         .await
@@ -454,7 +456,7 @@ async fn exchange_slock_code(
     headers: HeaderMap,
     Json(payload): Json<ExchangeSlockCodeRequest>,
 ) -> Result<Json<AppLinkerRecord>, ApiError> {
-    let user = require_root(&headers, &state).await?;
+    let user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     let code = linkers::parse_slock_exchange_code(
         payload.code.as_deref(),
         payload.callback_url.as_deref(),
@@ -492,7 +494,7 @@ async fn get_slock_userinfo(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<AppLinkerRecord>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     let record = AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .get_slock_linker()
         .await
@@ -505,7 +507,7 @@ async fn list_slock_channels(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .list_slock_channels()
         .await
@@ -518,7 +520,7 @@ async fn list_slock_channel_messages(
     headers: HeaderMap,
     Path(channel_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let _user = require_root(&headers, &state).await?;
+    let _user = require_capability(&headers, &state, UserCapability::LinkersManage).await?;
     AppLinkerService::new(state.db.clone(), state.linker_http.clone())
         .list_slock_channel_messages(&channel_id)
         .await
@@ -656,6 +658,8 @@ mod tests {
     use tower::util::ServiceExt;
     use uuid::Uuid;
 
+    use agenthub_auth_domain::UserRole;
+
     use crate::api::teams::tests::{
         build_test_state, build_test_state_with_message_archive, create_auth_token,
     };
@@ -729,28 +733,29 @@ mod tests {
         serde_json::from_slice(&bytes).expect("decode response body")
     }
 
-    async fn create_non_root_auth_token(state: &crate::state::AppState) -> String {
+    async fn create_role_auth_token(state: &crate::state::AppState, role: UserRole) -> String {
         let user_id = Uuid::new_v4().to_string();
         let now = Utc::now().timestamp();
         sqlx::query(
             r#"
             INSERT INTO users (id, username, display_name, role, password_hash, created_at)
-            VALUES (?1, ?2, ?3, 'user', NULL, ?4)
+            VALUES (?1, ?2, ?3, ?4, NULL, ?5)
             "#,
         )
         .bind(&user_id)
         .bind(format!("user-{}", Uuid::new_v4()))
         .bind("User")
+        .bind(role.as_str())
         .bind(now)
         .execute(&state.db)
         .await
-        .expect("insert non-root user");
+        .expect("insert role user");
 
         state
             .auth
             .create_session(&user_id)
             .await
-            .expect("create non-root token")
+            .expect("create role token")
     }
 
     fn slock_config_payload() -> Value {
@@ -898,10 +903,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slock_linker_routes_require_root_and_do_not_expose_secrets() {
+    async fn slock_linker_routes_require_linkers_manage_and_do_not_expose_secrets() {
         let state = build_test_state().await;
-        let root_token = create_auth_token(&state).await;
-        let non_root_token = create_non_root_auth_token(&state).await;
+        let admin_token = create_role_auth_token(&state, UserRole::Admin).await;
+        let operator_token = create_role_auth_token(&state, UserRole::Operator).await;
         let app = super::router(state.clone());
 
         let unauthorized = app
@@ -909,20 +914,20 @@ mod tests {
             .oneshot(build_empty_request(
                 Method::GET,
                 "/linkers",
-                Some(&non_root_token),
+                Some(&operator_token),
             ))
             .await
             .expect("execute non-root list linkers request");
         assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
         let unauthorized_body = decode_json_body(unauthorized).await;
-        assert_eq!(unauthorized_body["error"], json!("root required"));
+        assert_eq!(unauthorized_body["error"], json!("linkers:manage required"));
 
         let response = app
             .clone()
             .oneshot(build_method_json_request(
                 Method::PUT,
                 "/linkers/slock",
-                Some(&root_token),
+                Some(&admin_token),
                 slock_config_payload(),
             ))
             .await
@@ -943,7 +948,7 @@ mod tests {
             .oneshot(build_empty_request(
                 Method::GET,
                 "/linkers",
-                Some(&root_token),
+                Some(&admin_token),
             ))
             .await
             .expect("execute list linkers request");


### PR DESCRIPTION
## Summary

- Move admin linker and Slock linker routes from root-only authorization to the `linkers:manage` capability.
- Keep root-only gates for instance security and maintenance routes outside the linker cluster.
- Record the rollout checkpoint in the access-control journal and update the active TODO state.

## Purpose

Continue the route-cluster access-control migration so admin users can manage linker configuration
without requiring break-glass root authority, while operators and lower roles remain denied by the
capability matrix.

## Related Issues

- None

## Testing

- `cargo test -p agenthub api::admin::tests::slock_linker_routes_require_linkers_manage_and_do_not_expose_secrets -- --nocapture`
- `cargo test -p agenthub api::admin::tests::slock_link_attempt_requires_config_and_persists_state -- --nocapture`
- `cargo test -p agenthub api::admin::tests::slock_channel_routes_report_missing_resource_contract -- --nocapture`
- `cargo test -p agenthub api::admin::tests -- --nocapture`
- `cargo test -p agenthub api::authz::tests::api_code_does_not_bypass_capability_authz_for_human_roles -- --nocapture`
- `cargo fmt -p agenthub -- --check`
- `git diff --check`
