### PR TITLE
chore(acp): bump codex crates to rust-v0.144.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,8 +2793,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2804,8 +2804,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2823,8 +2823,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2843,8 +2843,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2874,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "axum",
@@ -2950,8 +2950,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -2976,8 +2976,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -3002,8 +3002,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "axum",
@@ -3040,8 +3040,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3056,8 +3056,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3076,8 +3076,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3085,8 +3085,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3099,8 +3099,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3116,8 +3116,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "serde",
  "serde_json",
@@ -3126,8 +3126,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -3144,8 +3144,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -3157,8 +3157,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3179,8 +3179,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -3195,8 +3195,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "serde",
@@ -3207,13 +3207,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 
 [[package]]
 name = "codex-config"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3257,8 +3257,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -3273,8 +3273,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -3286,8 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3295,8 +3295,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3398,8 +3398,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3442,8 +3442,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -3475,8 +3475,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3514,8 +3514,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3529,8 +3529,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -3545,8 +3545,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,8 +3555,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3568,8 +3568,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -3579,8 +3579,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-hooks",
  "serde_json",
@@ -3590,8 +3590,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-sessions"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-protocol",
@@ -3603,8 +3603,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3616,8 +3616,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -3630,8 +3630,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -3645,8 +3645,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3658,8 +3658,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "notify",
  "tokio",
@@ -3668,8 +3668,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3693,8 +3693,8 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-analytics",
  "codex-core",
@@ -3712,8 +3712,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3722,8 +3722,8 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3732,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3754,8 +3754,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -3780,8 +3780,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3806,8 +3806,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3815,8 +3815,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "keyring",
  "tracing",
@@ -3824,8 +3824,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3846,8 +3846,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3879,8 +3879,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3912,8 +3912,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-config",
  "codex-connectors-extension",
@@ -3935,8 +3935,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -3962,8 +3962,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3982,8 +3982,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3992,8 +3992,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4024,8 +4024,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4045,8 +4045,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -4057,8 +4057,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -4076,8 +4076,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4111,8 +4111,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4142,8 +4142,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4155,16 +4155,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4177,8 +4177,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4216,8 +4216,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4227,8 +4227,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "axum",
@@ -4264,8 +4264,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4288,8 +4288,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4303,8 +4303,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -4323,8 +4323,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "age",
  "anyhow",
@@ -4342,8 +4342,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4362,8 +4362,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -4381,8 +4381,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -4391,8 +4391,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-core-skills",
  "codex-exec-server",
@@ -4412,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4435,16 +4435,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -4463,8 +4463,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -4487,8 +4487,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "async-io",
  "tokio",
@@ -4498,8 +4498,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "dirs",
  "dunce",
@@ -4510,16 +4510,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4528,8 +4528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4540,8 +4540,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4549,8 +4549,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4562,8 +4562,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4571,8 +4571,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4580,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4590,8 +4590,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4605,8 +4605,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -4617,8 +4617,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4633,21 +4633,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4656,13 +4656,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4681,8 +4681,8 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -4695,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5221,7 +5221,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6319,7 +6319,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6688,7 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8742,7 +8742,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8837,7 +8837,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9301,7 +9301,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11206,7 +11206,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11350,7 +11350,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -12790,7 +12790,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12828,9 +12828,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13946,7 +13946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14005,7 +14005,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15734,7 +15734,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15787,7 +15787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17309,7 +17309,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,24 +26,24 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-app-server-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-feedback = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
 heck = "0.5.0"
 itertools = "0.15.0"
 libc = "0.2"

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp-runtime = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]


### PR DESCRIPTION
## Summary

- bump the ACP Codex runtime git dependencies from `rust-v0.144.1` to `rust-v0.144.4`
- keep the adapter-side `codex-utils-cli` dependency on the same upstream tag
- regenerate `Cargo.lock` so Codex protocol and shell-command types come from one version

## Purpose

Dependabot PRs #869, #870, and #872 each update one tightly coupled Codex crate. Updating them independently leaves multiple `codex-protocol` versions in the dependency graph and fails with `ParsedCommand` type mismatches. This replacement PR updates the ACP Codex dependency set together.

Related PRs: #869, #870, #872

## Testing

- `cargo check -p agenthub-codex-acp-runtime`
- `cargo check -p agenthub-acp-adapter`
- `cargo test -p agenthub-codex-acp-runtime --lib`
- `git diff --check`
