### PR TITLE
fix(storage): gate download source hosts

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -163,6 +163,8 @@ pub struct ObjectStoreConfig {
     pub download_max_redirects: Option<u8>,
     pub download_timeout_seconds: Option<u64>,
     pub download_allow_private_networks: Option<bool>,
+    pub download_allowed_hosts: Option<Vec<String>>,
+    pub download_denied_hosts: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -595,6 +597,22 @@ impl AppConfig {
             .unwrap_or(false)
     }
 
+    pub fn object_store_download_allowed_hosts(&self) -> Vec<String> {
+        normalized_object_store_host_list(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.download_allowed_hosts.as_deref()),
+        )
+    }
+
+    pub fn object_store_download_denied_hosts(&self) -> Vec<String> {
+        normalized_object_store_host_list(
+            self.object_store
+                .as_ref()
+                .and_then(|config| config.download_denied_hosts.as_deref()),
+        )
+    }
+
     pub fn history_event_retention_days(&self) -> Option<u32> {
         let days = self
             .history
@@ -750,6 +768,19 @@ fn trimmed_object_store_value(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn normalized_object_store_host_list(values: Option<&[String]>) -> Vec<String> {
+    let Some(values) = values else {
+        return Vec::new();
+    };
+    let mut seen = HashSet::new();
+    values
+        .iter()
+        .map(|value| value.trim().trim_end_matches('.').to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .filter(|value| seen.insert(value.clone()))
+        .collect()
 }
 
 pub fn normalize_codex_acp_mode_id(mode_id: &str) -> String {
@@ -975,6 +1006,8 @@ mod tests {
         assert_eq!(config.object_store_download_max_redirects(), 5);
         assert_eq!(config.object_store_download_timeout_seconds(), 120);
         assert!(!config.object_store_download_allow_private_networks());
+        assert!(config.object_store_download_allowed_hosts().is_empty());
+        assert!(config.object_store_download_denied_hosts().is_empty());
     }
 
     #[test]
@@ -996,6 +1029,16 @@ mod tests {
                 download_max_redirects: Some(2),
                 download_timeout_seconds: Some(9),
                 download_allow_private_networks: Some(true),
+                download_allowed_hosts: Some(vec![
+                    " Downloads.Example.Test. ".to_string(),
+                    "*.CDN.Example.Test".to_string(),
+                    "downloads.example.test".to_string(),
+                    " ".to_string(),
+                ]),
+                download_denied_hosts: Some(vec![
+                    " Metadata.Google.Internal ".to_string(),
+                    "169.254.169.254".to_string(),
+                ]),
             }),
             ..Default::default()
         };
@@ -1031,6 +1074,14 @@ mod tests {
         assert_eq!(config.object_store_download_max_redirects(), 2);
         assert_eq!(config.object_store_download_timeout_seconds(), 9);
         assert!(config.object_store_download_allow_private_networks());
+        assert_eq!(
+            config.object_store_download_allowed_hosts(),
+            vec!["downloads.example.test", "*.cdn.example.test"]
+        );
+        assert_eq!(
+            config.object_store_download_denied_hosts(),
+            vec!["metadata.google.internal", "169.254.169.254"]
+        );
     }
 
     #[test]

--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -50,6 +50,8 @@ Configuration lives under `[object_store]`:
 backend = "fs"
 root = "~/.agenthub/objects"
 prefix = "agenthub/local"
+download_allowed_hosts = ["downloads.example.com", "*.cdn.example.com"]
+download_denied_hosts = ["metadata.google.internal", "169.254.169.254"]
 ```
 
 S3-compatible deployments use the same logical surface and keep credentials indirect:
@@ -194,7 +196,7 @@ operations must still authorize against the Team-owned metadata row.
 | Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
 | Team upload API | Handler and router tests cover authorization, owner-scope derivation, base64 upload publication, raster-image allowlist, and size/checksum mismatch rejection without publishing metadata. |
 | Task and agent upload APIs | Focused API tests cover parent Team authorization before task-scope publication, agent existence checks before agent-scope publication, object/image key prefixes, and OpenAPI fixture coverage for every new route. |
-| Large download ingestion | Service and API tests cover route-derived owner scopes, URL scheme rejection, private/loopback address rejection, configurable private-network allowance for controlled tests, final size/SHA-256 verification, OpenAPI coverage, and successful metadata publication after a streamed server-side download. Object-store tests cover chunked writes with size/hash calculation. |
+| Large download ingestion | Service and API tests cover route-derived owner scopes, URL scheme rejection, private/loopback address rejection, operator source-host allow/deny policy, configurable private-network allowance for controlled tests, final size/SHA-256 verification, OpenAPI coverage, and successful metadata publication after a streamed server-side download. Object-store tests cover chunked writes with size/hash calculation. |
 | Graph-bed UX | Frontend tests cover raster MIME allowlisting, browser SHA-256/base64 request preparation, Team image endpoint wiring, and Markdown image insertion in the Team channel composer. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
@@ -213,9 +215,11 @@ operations must still authorize against the Team-owned metadata row.
   is older than the grace period and no published row references the same object key.
 - Download ingestion should stream through a bounded buffer into the object store and compute
   SHA-256 while streaming. It must not materialize the full remote object in memory.
-- Operators can configure maximum download bytes, redirect limits, timeout limits, and whether
-  private networks are allowed for controlled deployments/tests. Source host allow/deny lists,
-  retry policy, and per-host concurrency remain future hardening before broad untrusted rollout.
+- Operators can configure maximum download bytes, redirect limits, timeout limits, whether private
+  networks are allowed for controlled deployments/tests, and source-host allow/deny lists. Host
+  policy defaults to allow all non-private HTTP(S) sources, denies exact or wildcard-denied hosts
+  first, and requires an exact or wildcard allow match when `download_allowed_hosts` is non-empty.
+  Retry policy and per-host concurrency remain future hardening before broad untrusted rollout.
 - S3/R2/MinIO production use should add operation latency, byte count, error-class, and cleanup
   counters before large user-facing uploads become default-on.
 - Existing local Team context artifacts remain compatible until their metadata schema is explicitly
@@ -225,9 +229,9 @@ operations must still authorize against the Team-owned metadata row.
 
 - Existing artifact tables store local filesystem paths; moving those rows to object storage needs a
   schema migration and read-compatibility plan.
-- Download ingestion has first-pass SSRF guardrails and streaming object-store writer support, but
-  still needs reviewed source allow/deny policy, per-host concurrency limits, and observability
-  before broad untrusted production exposure.
+- Download ingestion has first-pass SSRF guardrails, operator source-host policy, and streaming
+  object-store writer support, but still needs retry policy, per-host concurrency limits, and
+  observability before broad untrusted production exposure.
 - S3-compatible providers differ in multipart, path-style, and checksum behavior; MinIO is the first
   CI fixture, but each documented production provider still needs compatibility evidence before it
   is described as production-ready.

--- a/docs/journal/2026-07-23-object-storage-download-ingest-implementation.md
+++ b/docs/journal/2026-07-23-object-storage-download-ingest-implementation.md
@@ -46,7 +46,37 @@ cargo test -p agenthub-config object_store -- --nocapture
 
 ## Follow-Ups
 
-- Add source host allow/deny lists, retry policy, per-host concurrency limits, and download
-  observability before broad untrusted production exposure.
+- Add retry policy, per-host concurrency limits, and download observability before broad untrusted
+  production exposure.
+- Add an async intent table if product flows need queued/cancelable downloads or durable failed
+  ingest state.
+
+## 2026-07-28 Host Policy Hardening
+
+### Summary
+
+Server-side download ingestion now accepts operator-controlled source-host policy through
+`[object_store].download_allowed_hosts` and `[object_store].download_denied_hosts`.
+
+### Scope
+
+- Added config parsing that trims, lowercases, de-duplicates, and ignores empty source-host policy
+  entries.
+- Added host validation before DNS/network access on the initial URL and every redirect hop.
+- Kept the default behavior compatible: an empty allow list permits any otherwise-valid public
+  HTTP(S) host, while deny entries always win.
+- Supported exact host patterns and `*.example.com` wildcard subdomain patterns.
+
+### Validation
+
+```bash
+cargo test -p agenthub-config object_store -- --nocapture
+cargo test -p agenthub download_ -- --nocapture
+```
+
+### Follow-Ups
+
+- Add retry policy, per-host concurrency limits, and download observability before broad untrusted
+  production exposure.
 - Add an async intent table if product flows need queued/cancelable downloads or durable failed
   ingest state.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,7 +47,7 @@ Stable contracts:
 ## Object Storage
 
 - [ ] `P1` Keep `agenthub-object-store/s3` out of release feature sets until a reviewed release build intentionally includes it. PR #890 merged with `Rust (Object Store S3 MinIO)` green, and main push Rust workflow run `29639782907` / job `88068255089` passed the MinIO-backed S3 fixture.
-- [ ] `P2` Harden server-side download ingestion for broad untrusted production exposure: add source host allow/deny lists, retry policy, per-host concurrency limits, observability for latency/bytes/failure class/cleanup compensation, and an async intent table if product flows need queued, cancelable, or durable failed downloads. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-22-object-storage-download-ingest.md](journal/2026-07-22-object-storage-download-ingest.md), [journal/2026-07-23-object-storage-download-ingest-implementation.md](journal/2026-07-23-object-storage-download-ingest-implementation.md).
+- [ ] `P2` Harden server-side download ingestion for broad untrusted production exposure: source host allow/deny lists are implemented; remaining hardening is retry policy, per-host concurrency limits, observability for latency/bytes/failure class/cleanup compensation, and an async intent table if product flows need queued, cancelable, or durable failed downloads. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-22-object-storage-download-ingest.md](journal/2026-07-22-object-storage-download-ingest.md), [journal/2026-07-23-object-storage-download-ingest-implementation.md](journal/2026-07-23-object-storage-download-ingest-implementation.md).
 
 ## Observability, CI, And Docs
 

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1969,6 +1969,8 @@ mod tests {
                 download_max_redirects: Some(3),
                 download_timeout_seconds: Some(10),
                 download_allow_private_networks: Some(true),
+                download_allowed_hosts: None,
+                download_denied_hosts: None,
             }),
             ..Default::default()
         };

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -336,6 +336,8 @@ fn test_object_upload_service(db: SqlitePool) -> ObjectUploadService {
             download_max_redirects: Some(3),
             download_timeout_seconds: Some(10),
             download_allow_private_networks: Some(true),
+            download_allowed_hosts: None,
+            download_denied_hosts: None,
         }),
         ..Default::default()
     };

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -104,6 +104,8 @@ pub struct ObjectDownloadSettings {
     pub max_redirects: u8,
     pub timeout: Duration,
     pub allow_private_networks: bool,
+    pub allowed_hosts: Vec<String>,
+    pub denied_hosts: Vec<String>,
 }
 
 impl Default for ObjectDownloadSettings {
@@ -113,6 +115,8 @@ impl Default for ObjectDownloadSettings {
             max_redirects: 5,
             timeout: Duration::from_secs(120),
             allow_private_networks: false,
+            allowed_hosts: Vec::new(),
+            denied_hosts: Vec::new(),
         }
     }
 }
@@ -158,6 +162,8 @@ impl ObjectUploadService {
             max_redirects: config.object_store_download_max_redirects(),
             timeout: Duration::from_secs(config.object_store_download_timeout_seconds()),
             allow_private_networks: config.object_store_download_allow_private_networks(),
+            allowed_hosts: config.object_store_download_allowed_hosts(),
+            denied_hosts: config.object_store_download_denied_hosts(),
         };
         Ok(Self::new_with_download_settings(
             db,
@@ -282,7 +288,7 @@ impl ObjectUploadService {
     async fn download_to_object(&self, key: &str, source_url: Url) -> anyhow::Result<StoredObject> {
         let mut current = source_url;
         for redirect_count in 0..=self.download_settings.max_redirects {
-            validate_download_url(&current, self.download_settings.allow_private_networks).await?;
+            validate_download_url(&current, &self.download_settings).await?;
             let response = self
                 .download_http
                 .get(current.clone())
@@ -442,10 +448,11 @@ fn validate_download_url_shape(url: &Url) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn validate_download_url(url: &Url, allow_private_networks: bool) -> anyhow::Result<()> {
+async fn validate_download_url(url: &Url, settings: &ObjectDownloadSettings) -> anyhow::Result<()> {
     validate_download_url_shape(url)?;
     let host = url.host_str().expect("host checked above");
-    if !allow_private_networks && host.eq_ignore_ascii_case("localhost") {
+    validate_download_host_policy(host, &settings.allowed_hosts, &settings.denied_hosts)?;
+    if !settings.allow_private_networks && host.eq_ignore_ascii_case("localhost") {
         anyhow::bail!("source_url host resolves to a private or local address");
     }
     let port = url
@@ -459,7 +466,7 @@ async fn validate_download_url(url: &Url, allow_private_networks: bool) -> anyho
         !addresses.is_empty(),
         "source_url host did not resolve to any address"
     );
-    if !allow_private_networks {
+    if !settings.allow_private_networks {
         for address in addresses {
             anyhow::ensure!(
                 is_public_download_ip(address.ip()),
@@ -468,6 +475,46 @@ async fn validate_download_url(url: &Url, allow_private_networks: bool) -> anyho
         }
     }
     Ok(())
+}
+
+fn validate_download_host_policy(
+    host: &str,
+    allowed_hosts: &[String],
+    denied_hosts: &[String],
+) -> anyhow::Result<()> {
+    let host = normalize_download_host_pattern(host)?;
+    if denied_hosts
+        .iter()
+        .any(|pattern| download_host_pattern_matches(pattern, &host))
+    {
+        anyhow::bail!("source_url host is denied by object_store.download_denied_hosts");
+    }
+    if !allowed_hosts.is_empty()
+        && !allowed_hosts
+            .iter()
+            .any(|pattern| download_host_pattern_matches(pattern, &host))
+    {
+        anyhow::bail!("source_url host is not allowed by object_store.download_allowed_hosts");
+    }
+    Ok(())
+}
+
+fn normalize_download_host_pattern(value: &str) -> anyhow::Result<String> {
+    let value = value.trim().trim_end_matches('.').to_ascii_lowercase();
+    anyhow::ensure!(!value.is_empty(), "download host pattern must not be empty");
+    Ok(value)
+}
+
+fn download_host_pattern_matches(pattern: &str, host: &str) -> bool {
+    let Ok(pattern) = normalize_download_host_pattern(pattern) else {
+        return false;
+    };
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        return host
+            .strip_suffix(suffix)
+            .is_some_and(|prefix| prefix.ends_with('.') && prefix.len() > 1);
+    }
+    pattern == host
 }
 
 fn is_public_download_ip(ip: IpAddr) -> bool {
@@ -702,14 +749,49 @@ mod tests {
     #[tokio::test]
     async fn download_url_guard_rejects_private_sources_by_default() {
         let url = parse_download_url("http://127.0.0.1:8080/file.txt").unwrap();
-        let err = validate_download_url(&url, false)
+        let err = validate_download_url(&url, &ObjectDownloadSettings::default())
             .await
             .expect_err("private download sources should be rejected");
         assert!(err.to_string().contains("private or local"));
 
-        validate_download_url(&url, true)
-            .await
-            .expect("private download sources can be explicitly enabled");
+        validate_download_url(
+            &url,
+            &ObjectDownloadSettings {
+                allow_private_networks: true,
+                ..ObjectDownloadSettings::default()
+            },
+        )
+        .await
+        .expect("private download sources can be explicitly enabled");
+    }
+
+    #[test]
+    fn download_host_policy_denies_blocked_hosts_before_allow_list() {
+        let allowed_hosts = vec!["*.example.test".to_string()];
+        let denied_hosts = vec!["blocked.example.test".to_string()];
+
+        validate_download_host_policy("files.example.test", &allowed_hosts, &denied_hosts)
+            .expect("matching wildcard host should be allowed");
+
+        let err =
+            validate_download_host_policy("blocked.example.test", &allowed_hosts, &denied_hosts)
+                .expect_err("denied host should win over allow list");
+        assert!(err.to_string().contains("denied"));
+
+        let err = validate_download_host_policy("example.test", &allowed_hosts, &denied_hosts)
+            .expect_err("wildcard should not match apex host");
+        assert!(err.to_string().contains("not allowed"));
+    }
+
+    #[test]
+    fn download_host_policy_normalizes_case_and_trailing_dot() {
+        let allowed_hosts = vec!["Downloads.Example.Test.".to_string()];
+        let denied_hosts = vec!["*.internal.example.test".to_string()];
+
+        validate_download_host_policy("downloads.example.test.", &allowed_hosts, &denied_hosts)
+            .expect("exact host should normalize");
+        validate_download_host_policy("Sub.Internal.Example.Test", &[], &denied_hosts)
+            .expect_err("wildcard deny should normalize");
     }
 
     #[test]

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1315,6 +1315,8 @@ mod tests {
                 download_max_redirects: Some(3),
                 download_timeout_seconds: Some(10),
                 download_allow_private_networks: Some(true),
+                download_allowed_hosts: None,
+                download_denied_hosts: None,
             }),
             ..Default::default()
         };


### PR DESCRIPTION
## Summary

- add `[object_store].download_allowed_hosts` and `download_denied_hosts` config for server-side download ingestion
- validate exact and wildcard source-host policy before DNS/network access on the initial URL and every redirect hop
- update object-storage docs, journal evidence, and TODO state for the completed host-policy slice

## Purpose

Server-side download ingestion already rejects unsafe schemes, credentials, private/local resolved addresses, oversized sources, and unchecked redirects. Broad untrusted exposure still needed an operator-controlled host policy so deployments can pin downloads to reviewed source hosts or block known-sensitive endpoints even when private-network downloads are enabled for controlled environments.

## Related Issues

- None

## Tests

```bash
cargo fmt
cargo test -p agenthub-config object_store -- --nocapture
cargo test -p agenthub download_ -- --nocapture
cargo check -p agenthub
git diff --check
```
