### PR TITLE
feat(storage): add message index projection

### DIFF
--- a/crates/agenthub-message-store/src/index_store.rs
+++ b/crates/agenthub-message-store/src/index_store.rs
@@ -1,0 +1,264 @@
+//! Body-free delivery-index projection.
+//!
+//! `cf_index` is derived from SQLite authority metadata and stores compact [`MessageRef`] rows for
+//! hot ordered delivery scans. Full bodies stay in `cf_body`; this module only handles refs.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use thiserror::Error;
+
+use crate::ids::DeliveryMessageId;
+use crate::keys;
+use crate::reference::MessageRef;
+
+pub type MessageIndexEntry = (Vec<u8>, Vec<u8>);
+
+#[derive(Debug, Error)]
+pub enum MessageIndexError {
+    #[error("failed to encode message ref: {0}")]
+    Encode(#[from] serde_json::Error),
+    #[error("message index backend error: {0}")]
+    Backend(String),
+}
+
+/// One authority-derived delivery projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageIndexProjection {
+    pub sort_id: u64,
+    pub reference: MessageRef,
+    pub channel: Option<ChannelProjection>,
+    pub agent_id: Option<String>,
+    pub run_id: Option<String>,
+    pub inbox_actor_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelProjection {
+    pub group_id: String,
+    pub channel_id: String,
+}
+
+impl ChannelProjection {
+    pub fn new(group_id: impl Into<String>, channel_id: impl Into<String>) -> Self {
+        Self {
+            group_id: group_id.into(),
+            channel_id: channel_id.into(),
+        }
+    }
+}
+
+impl MessageIndexProjection {
+    pub fn new(sort_id: u64, reference: MessageRef) -> Self {
+        Self {
+            sort_id,
+            reference,
+            channel: None,
+            agent_id: None,
+            run_id: None,
+            inbox_actor_id: None,
+        }
+    }
+
+    pub fn for_channel(
+        mut self,
+        group_id: impl Into<String>,
+        channel_id: impl Into<String>,
+    ) -> Self {
+        self.channel = Some(ChannelProjection::new(group_id, channel_id));
+        self
+    }
+
+    pub fn for_agent(mut self, agent_id: impl Into<String>) -> Self {
+        self.agent_id = Some(agent_id.into());
+        self
+    }
+
+    pub fn for_run(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+
+    pub fn for_inbox_actor(mut self, actor_id: impl Into<String>) -> Self {
+        self.inbox_actor_id = Some(actor_id.into());
+        self
+    }
+
+    pub fn entries(&self) -> Result<Vec<MessageIndexEntry>, MessageIndexError> {
+        let encoded = self.reference.to_bytes()?;
+        let mut entries = Vec::new();
+        entries.push((keys::by_id_key(&self.reference.message_id), encoded.clone()));
+        if let Some(channel) = &self.channel {
+            entries.push((
+                keys::channel_key(&channel.group_id, &channel.channel_id, self.sort_id),
+                encoded.clone(),
+            ));
+        }
+        if let Some(agent_id) = &self.agent_id {
+            entries.push((keys::agent_key(agent_id, self.sort_id), encoded.clone()));
+        }
+        if let Some(run_id) = &self.run_id {
+            entries.push((keys::run_key(run_id, self.sort_id), encoded.clone()));
+        }
+        if let Some(actor_id) = &self.inbox_actor_id {
+            entries.push((keys::inbox_key(actor_id, self.sort_id), encoded));
+        }
+        Ok(entries)
+    }
+}
+
+/// Body-free delivery-index API.
+pub trait MessageIndex {
+    fn put_message(&self, projection: &MessageIndexProjection) -> Result<(), MessageIndexError>;
+
+    fn get_by_id(
+        &self,
+        message_id: &DeliveryMessageId,
+    ) -> Result<Option<MessageRef>, MessageIndexError>;
+
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError>;
+
+    fn scan_channel(
+        &self,
+        group_id: &str,
+        channel_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError> {
+        self.scan_prefix(&keys::channel_prefix(group_id, channel_id), limit)
+    }
+
+    fn scan_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError> {
+        self.scan_prefix(&keys::agent_prefix(agent_id), limit)
+    }
+
+    fn scan_run(&self, run_id: &str, limit: usize) -> Result<Vec<MessageRef>, MessageIndexError> {
+        self.scan_prefix(&keys::run_prefix(run_id), limit)
+    }
+
+    fn scan_inbox(
+        &self,
+        actor_id: &str,
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError> {
+        self.scan_prefix(&keys::inbox_prefix(actor_id), limit)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct InMemoryMessageIndex {
+    entries: Arc<Mutex<BTreeMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl InMemoryMessageIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn decode(bytes: &[u8]) -> Result<MessageRef, MessageIndexError> {
+        MessageRef::from_bytes(bytes).map_err(MessageIndexError::Encode)
+    }
+}
+
+impl MessageIndex for InMemoryMessageIndex {
+    fn put_message(&self, projection: &MessageIndexProjection) -> Result<(), MessageIndexError> {
+        let mut entries = self
+            .entries
+            .lock()
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))?;
+        for (key, value) in projection.entries()? {
+            entries.insert(key, value);
+        }
+        Ok(())
+    }
+
+    fn get_by_id(
+        &self,
+        message_id: &DeliveryMessageId,
+    ) -> Result<Option<MessageRef>, MessageIndexError> {
+        let entries = self
+            .entries
+            .lock()
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))?;
+        entries
+            .get(&keys::by_id_key(message_id))
+            .map(|bytes| Self::decode(bytes))
+            .transpose()
+    }
+
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError> {
+        let entries = self
+            .entries
+            .lock()
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))?;
+        entries
+            .range(prefix.to_vec()..)
+            .take_while(|(key, _)| key.starts_with(prefix))
+            .take(limit)
+            .map(|(_, bytes)| Self::decode(bytes))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::{AuthorityMessageId, MessageKind};
+
+    fn sample_ref(seq: u64) -> MessageRef {
+        MessageRef {
+            message_id: DeliveryMessageId::new(format!("delivery-{seq}")),
+            authority_message_id: AuthorityMessageId::new(format!("auth-{seq}")),
+            archive_document_id: Some(format!("doc-{seq}")),
+            created_at: 1_700_000_000 + seq as i64,
+            source_kind: "team_conversation_messages".to_string(),
+            message_kind: MessageKind::Text,
+            correlation_id: Some(format!("corr-{seq}")),
+            group_id: Some("group-a".to_string()),
+            run_id: Some("run-a".to_string()),
+            conversation_id: Some("channel-a".to_string()),
+            agent_id: Some("agent-a".to_string()),
+        }
+    }
+
+    #[test]
+    fn in_memory_index_projects_ordered_body_free_refs() {
+        let index = InMemoryMessageIndex::new();
+        for seq in [2, 0, 1] {
+            let reference = sample_ref(seq);
+            let projection = MessageIndexProjection::new(seq, reference)
+                .for_channel("group-a", "channel-a")
+                .for_agent("agent-a")
+                .for_run("run-a")
+                .for_inbox_actor("actor-a");
+            index.put_message(&projection).unwrap();
+        }
+
+        let channel = index.scan_channel("group-a", "channel-a", 10).unwrap();
+        let ids: Vec<_> = channel.iter().map(|row| row.message_id.as_str()).collect();
+        assert_eq!(ids, ["delivery-0", "delivery-1", "delivery-2"]);
+        assert_eq!(
+            index
+                .get_by_id(&DeliveryMessageId::new("delivery-1"))
+                .unwrap()
+                .unwrap()
+                .authority_message_id
+                .as_str(),
+            "auth-1"
+        );
+        assert_eq!(index.scan_agent("agent-a", 2).unwrap().len(), 2);
+        assert_eq!(index.scan_run("run-a", 10).unwrap().len(), 3);
+        assert_eq!(index.scan_inbox("actor-a", 10).unwrap().len(), 3);
+    }
+}

--- a/crates/agenthub-message-store/src/keys.rs
+++ b/crates/agenthub-message-store/src/keys.rs
@@ -37,40 +37,59 @@ fn join(parts: &[&[u8]], sort_id: Option<[u8; 8]>) -> Vec<u8> {
     key
 }
 
-/// `msg/by_channel/<group_id>/<channel_id>/<sort_id>`
-pub fn channel_key(group_id: &str, channel_id: &str, seq: u64) -> Vec<u8> {
+/// `msg/by_channel/<group_id>/<channel_id>`
+pub fn channel_prefix(group_id: &str, channel_id: &str) -> Vec<u8> {
     join(
         &[
             b"msg/by_channel",
             group_id.as_bytes(),
             channel_id.as_bytes(),
         ],
+        None,
+    )
+}
+
+/// `msg/by_channel/<group_id>/<channel_id>/<sort_id>`
+pub fn channel_key(group_id: &str, channel_id: &str, seq: u64) -> Vec<u8> {
+    join(
+        &[&channel_prefix(group_id, channel_id)],
         Some(encode_sort_id(seq)),
     )
+}
+
+/// `msg/by_agent/<agent_id>`
+pub fn agent_prefix(agent_id: &str) -> Vec<u8> {
+    join(&[b"msg/by_agent", agent_id.as_bytes()], None)
 }
 
 /// `msg/by_agent/<agent_id>/<sort_id>`
 pub fn agent_key(agent_id: &str, seq: u64) -> Vec<u8> {
-    join(
-        &[b"msg/by_agent", agent_id.as_bytes()],
-        Some(encode_sort_id(seq)),
-    )
+    join(&[&agent_prefix(agent_id)], Some(encode_sort_id(seq)))
+}
+
+/// `msg/by_run/<run_id>`
+pub fn run_prefix(run_id: &str) -> Vec<u8> {
+    join(&[b"msg/by_run", run_id.as_bytes()], None)
 }
 
 /// `msg/by_run/<run_id>/<sort_id>`
 pub fn run_key(run_id: &str, seq: u64) -> Vec<u8> {
-    join(
-        &[b"msg/by_run", run_id.as_bytes()],
-        Some(encode_sort_id(seq)),
-    )
+    join(&[&run_prefix(run_id)], Some(encode_sort_id(seq)))
+}
+
+/// `msg/by_id/<message_id>`
+pub fn by_id_key(message_id: &crate::ids::DeliveryMessageId) -> Vec<u8> {
+    join(&[b"msg/by_id", message_id.as_str().as_bytes()], None)
+}
+
+/// `inbox/by_actor/<actor_id>` — unified chronological inbox across runs.
+pub fn inbox_prefix(actor_id: &str) -> Vec<u8> {
+    join(&[b"inbox/by_actor", actor_id.as_bytes()], None)
 }
 
 /// `inbox/by_actor/<actor_id>/<sort_id>` — unified chronological inbox across runs.
 pub fn inbox_key(actor_id: &str, seq: u64) -> Vec<u8> {
-    join(
-        &[b"inbox/by_actor", actor_id.as_bytes()],
-        Some(encode_sort_id(seq)),
-    )
+    join(&[&inbox_prefix(actor_id)], Some(encode_sort_id(seq)))
 }
 
 /// `body/by_message/<authority_message_id>` — the body key. One body per logical message.

--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod body_store;
 pub mod ids;
+pub mod index_store;
 pub mod keys;
 pub mod outbox;
 pub mod reference;
@@ -21,6 +22,10 @@ pub mod rocksdb_store;
 
 pub use body_store::{BodyStoreError, InMemoryBodyStore, MessageBodyStore};
 pub use ids::{AuthorityMessageId, DeliveryMessageId, MessageKind};
+pub use index_store::{
+    ChannelProjection, InMemoryMessageIndex, MessageIndex, MessageIndexError,
+    MessageIndexProjection,
+};
 pub use outbox::BodyOutbox;
 pub use reference::MessageRef;
 #[cfg(feature = "rocksdb")]

--- a/crates/agenthub-message-store/src/rocksdb_store.rs
+++ b/crates/agenthub-message-store/src/rocksdb_store.rs
@@ -9,14 +9,23 @@
 
 use std::path::Path;
 
-use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options};
+use rocksdb::{
+    ColumnFamilyDescriptor, DB, DBCompressionType, Direction, IteratorMode, Options, WriteBatch,
+};
 
 use crate::body_store::{BodyStoreError, MessageBodyStore};
 use crate::ids::AuthorityMessageId;
 use crate::keys::body_key;
+use crate::{
+    DeliveryMessageId, MessageRef,
+    index_store::{MessageIndex, MessageIndexError, MessageIndexProjection},
+    keys,
+};
 
 /// Column family holding compressed message bodies.
 pub const CF_BODY: &str = "cf_body";
+/// Column family holding body-free delivery index rows.
+pub const CF_INDEX: &str = "cf_index";
 
 fn backend_err(err: impl ToString) -> BodyStoreError {
     BodyStoreError::Backend(err.to_string())
@@ -60,6 +69,7 @@ impl RocksdbBodyStore {
         let cfs = vec![
             ColumnFamilyDescriptor::new("default", Options::default()),
             ColumnFamilyDescriptor::new(CF_BODY, body_cf_options(compression)),
+            ColumnFamilyDescriptor::new(CF_INDEX, Options::default()),
         ];
         let db = DB::open_cf_descriptors(&db_opts, path, cfs).map_err(backend_err)?;
         Ok(Self { db })
@@ -71,6 +81,33 @@ impl RocksdbBodyStore {
             .ok_or_else(|| BodyStoreError::Backend(format!("missing column family {CF_BODY}")))
     }
 
+    fn index_cf(&self) -> Result<&rocksdb::ColumnFamily, MessageIndexError> {
+        self.db
+            .cf_handle(CF_INDEX)
+            .ok_or_else(|| MessageIndexError::Backend(format!("missing column family {CF_INDEX}")))
+    }
+
+    /// Put the body and all derived delivery-index refs in one RocksDB batch.
+    pub fn put_body_and_index(
+        &self,
+        id: &AuthorityMessageId,
+        body: &[u8],
+        projection: &MessageIndexProjection,
+    ) -> Result<(), MessageIndexError> {
+        let body_cf = self
+            .body_cf()
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))?;
+        let index_cf = self.index_cf()?;
+        let mut batch = WriteBatch::default();
+        batch.put_cf(body_cf, body_key(id), body);
+        for (key, value) in projection.entries()? {
+            batch.put_cf(index_cf, key, value);
+        }
+        self.db
+            .write(batch)
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))
+    }
+
     /// Flush memtables and compact `cf_body` so compression is applied to SST files. Test-only:
     /// it forces a full compaction and is only needed by the on-disk size test.
     #[cfg(test)]
@@ -79,6 +116,57 @@ impl RocksdbBodyStore {
         self.db.flush_cf(cf).map_err(backend_err)?;
         self.db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
         Ok(())
+    }
+}
+
+impl RocksdbBodyStore {
+    fn decode_index_ref(bytes: &[u8]) -> Result<MessageRef, MessageIndexError> {
+        MessageRef::from_bytes(bytes).map_err(MessageIndexError::Encode)
+    }
+}
+
+impl MessageIndex for RocksdbBodyStore {
+    fn put_message(&self, projection: &MessageIndexProjection) -> Result<(), MessageIndexError> {
+        let cf = self.index_cf()?;
+        let mut batch = WriteBatch::default();
+        for (key, value) in projection.entries()? {
+            batch.put_cf(cf, key, value);
+        }
+        self.db
+            .write(batch)
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))
+    }
+
+    fn get_by_id(
+        &self,
+        message_id: &DeliveryMessageId,
+    ) -> Result<Option<MessageRef>, MessageIndexError> {
+        let cf = self.index_cf()?;
+        self.db
+            .get_cf(cf, keys::by_id_key(message_id))
+            .map_err(|err| MessageIndexError::Backend(err.to_string()))?
+            .map(|bytes| Self::decode_index_ref(&bytes))
+            .transpose()
+    }
+
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+        limit: usize,
+    ) -> Result<Vec<MessageRef>, MessageIndexError> {
+        let cf = self.index_cf()?;
+        let iter = self
+            .db
+            .iterator_cf(cf, IteratorMode::From(prefix, Direction::Forward));
+        let mut refs = Vec::new();
+        for item in iter {
+            let (key, value) = item.map_err(|err| MessageIndexError::Backend(err.to_string()))?;
+            if !key.starts_with(prefix) || refs.len() >= limit {
+                break;
+            }
+            refs.push(Self::decode_index_ref(&value)?);
+        }
+        Ok(refs)
     }
 }
 
@@ -125,6 +213,7 @@ impl MessageBodyStore for RocksdbBodyStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DeliveryMessageId, MessageIndex, MessageIndexProjection, MessageKind, MessageRef};
 
     fn corpus(repeat: usize) -> Vec<(AuthorityMessageId, String)> {
         let speakers = ["alice", "bob", "agent-claude", "agent-codex"];
@@ -143,6 +232,22 @@ mod tests {
             out.push((AuthorityMessageId::new(format!("auth-{i}")), body));
         }
         out
+    }
+
+    fn sample_ref(seq: u64) -> MessageRef {
+        MessageRef {
+            message_id: DeliveryMessageId::new(format!("delivery-{seq}")),
+            authority_message_id: AuthorityMessageId::new(format!("auth-{seq}")),
+            archive_document_id: Some(format!("doc-{seq}")),
+            created_at: 1_700_000_000 + seq as i64,
+            source_kind: "team_conversation_messages".to_string(),
+            message_kind: MessageKind::Text,
+            correlation_id: Some(format!("corr-{seq}")),
+            group_id: Some("group-a".to_string()),
+            run_id: Some("run-a".to_string()),
+            conversation_id: Some("channel-a".to_string()),
+            agent_id: Some("agent-a".to_string()),
+        }
     }
 
     /// Total size of the SST data files (`.sst`/`.ldb`) under `path`. Only these are subject to SST
@@ -201,6 +306,58 @@ mod tests {
         let missing = AuthorityMessageId::new("auth-missing");
         assert_eq!(store.get_body(&missing).unwrap(), None);
         assert!(!store.contains(&missing));
+    }
+
+    #[test]
+    fn cf_index_scans_ordered_body_free_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RocksdbBodyStore::open(dir.path()).unwrap();
+        for seq in [2, 0, 1] {
+            let reference = sample_ref(seq);
+            let projection = MessageIndexProjection::new(seq, reference)
+                .for_channel("group-a", "channel-a")
+                .for_agent("agent-a")
+                .for_run("run-a")
+                .for_inbox_actor("actor-a");
+            store.put_message(&projection).unwrap();
+        }
+
+        let channel = store.scan_channel("group-a", "channel-a", 10).unwrap();
+        let ids: Vec<_> = channel.iter().map(|row| row.message_id.as_str()).collect();
+        assert_eq!(ids, ["delivery-0", "delivery-1", "delivery-2"]);
+        assert_eq!(
+            store
+                .get_by_id(&DeliveryMessageId::new("delivery-2"))
+                .unwrap()
+                .unwrap()
+                .authority_message_id
+                .as_str(),
+            "auth-2"
+        );
+        assert_eq!(store.scan_agent("agent-a", 10).unwrap().len(), 3);
+        assert_eq!(store.scan_run("run-a", 10).unwrap().len(), 3);
+        assert_eq!(store.scan_inbox("actor-a", 1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn body_and_index_write_share_one_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let reference = sample_ref(7);
+        let authority = reference.authority_message_id.clone();
+        let projection = MessageIndexProjection::new(7, reference).for_channel("group-a", "chan-a");
+        store
+            .put_body_and_index(&authority, b"body in the same batch", &projection)
+            .unwrap();
+
+        assert_eq!(
+            store.get_body(&authority).unwrap().as_deref(),
+            Some(&b"body in the same batch"[..])
+        );
+        assert_eq!(
+            store.scan_channel("group-a", "chan-a", 10).unwrap().len(),
+            1
+        );
     }
 
     #[test]

--- a/docs/features/message-storage-tiering.md
+++ b/docs/features/message-storage-tiering.md
@@ -100,7 +100,14 @@ Delivery index column family (`cf_index`)
   - `authority_message_id`;
   - `correlation_id`;
   - optional `group_id`, `run_id`, `conversation_id`, `agent_id`;
-  - compact delivery state when the key is ack/cursor scoped.
+- compact delivery state when the key is ack/cursor scoped.
+
+The message-store foundation exposes `MessageIndexProjection` as the typed boundary for writing these
+body-free refs. A projection always writes the direct `msg/by_id/<message_id>` lookup and may write
+channel, agent, run, and actor-inbox ordered prefixes for the same `MessageRef`. This API is the
+storage boundary only: callers must still derive projections from SQLite authority metadata, and
+authority-derived rebuild/repair remains the correctness boundary before ordered reads can become
+production-facing.
 
 Body column family (`cf_body`)
 

--- a/docs/journal/2026-06-10-message-store-foundation-crate.md
+++ b/docs/journal/2026-06-10-message-store-foundation-crate.md
@@ -56,3 +56,40 @@ spec requires isolating it behind a backend boundary. This crate establishes tha
 - Implement the RocksDB backend of `MessageBodyStore` (`cf_body` + `cf_index`) behind a feature flag,
   with SST zstd + bottommost zstd, plus the dual-body migration write path. Tracked in
   [todo.md](../todo.md) under Message Storage.
+
+# 2026-07-29 Follow-Up: Delivery Index Projection Foundation
+
+## Summary
+
+Added the first `cf_index` delivery-projection foundation to `agenthub-message-store`. The crate now
+has a backend-agnostic `MessageIndex` API, an in-memory implementation, and a RocksDB implementation
+behind the existing opt-in `rocksdb` feature.
+
+## Scope
+
+- Added typed `MessageIndexProjection` writes for body-free `MessageRef` rows.
+- Added direct `msg/by_id/<message_id>` lookup plus ordered channel, agent, run, and actor inbox scan
+  prefixes.
+- Opened RocksDB with both `cf_body` and `cf_index`.
+- Added a RocksDB batch helper that writes one body plus its derived index refs in one `WriteBatch`.
+
+## Key Decisions
+
+- Keep `cf_index` strictly derived: the new API stores `MessageRef` rows only and never inlines body
+  bytes.
+- Keep normal application reads on the existing SQLite path; this slice only provides the index
+  backend boundary and tests.
+- Leave authority-derived rebuild/repair for a later slice, because that must integrate with SQLite
+  authority tables rather than crate-local fixtures.
+
+## Validation
+
+- `cargo test -p agenthub-message-store`
+- `cargo test -p agenthub-message-store --features rocksdb cf_index -- --nocapture`
+- `cargo test -p agenthub-message-store --features rocksdb body_and_index_write_share_one_batch -- --nocapture`
+
+## Follow-Ups
+
+- Wire projection derivation from SQLite authority rows.
+- Add rebuild/repair and integrity checks that rebuild `cf_index` from SQLite metadata alone.
+- Keep normal reads on SQLite until ordered index reads and backup/restore evidence are reviewed.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -40,7 +40,7 @@ Stable contracts:
 
 ## Message Storage
 
-- [ ] `P1` Implement the RocksDB `cf_index` delivery projection and its authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill is complete; keep normal reads on SQLite until ordered index reads, integrity checks, and backup validation are in place. Do not drop SQLite bodies before the Phase 2 rollout decision.
+- [ ] `P1` Implement the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill and a `cf_index` projection backend foundation are complete; remaining work is deriving projections from SQLite authority rows, rebuild/repair, ordered index reads, integrity checks, and backup validation. Keep normal reads on SQLite and do not drop SQLite bodies before the Phase 2 rollout decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).
 
 ## Object Storage
 


### PR DESCRIPTION
## Summary

- add a backend-agnostic `MessageIndex` projection API for body-free `MessageRef` rows
- add ordered channel, agent, run, inbox, and direct `msg/by_id` index keys
- open RocksDB with `cf_index` and write index refs, including a body+index single `WriteBatch` helper
- update the message storage spec, journal, and TODO to narrow the remaining `cf_index` work to authority-derived repair/read integration

## Purpose

This advances the Message Storage P1 TODO by landing the `cf_index` backend foundation without switching production reads away from SQLite. The index remains derived, body-free, and opt-in behind the existing `rocksdb` feature.

## Related Issues

- None

## Testing

- `cargo test -p agenthub-message-store`
- `cargo test -p agenthub-message-store --features rocksdb`
- `cargo clippy -p agenthub-message-store --all-targets --features rocksdb -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
