### PR TITLE
feat(storage): add message index repair report

### DIFF
--- a/crates/agenthub-message-store/src/lib.rs
+++ b/crates/agenthub-message-store/src/lib.rs
@@ -17,6 +17,7 @@ pub mod index_store;
 pub mod keys;
 pub mod outbox;
 pub mod reference;
+pub mod repair;
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb_store;
 
@@ -28,6 +29,10 @@ pub use index_store::{
 };
 pub use outbox::BodyOutbox;
 pub use reference::MessageRef;
+pub use repair::{
+    MessageIndexIntegrityReport, MessageIndexNamespace, MissingIndexRef,
+    check_authority_projection_integrity, repair_authority_projection_index,
+};
 #[cfg(feature = "rocksdb")]
 pub use rocksdb_store::RocksdbBodyStore;
 

--- a/crates/agenthub-message-store/src/repair.rs
+++ b/crates/agenthub-message-store/src/repair.rs
@@ -1,0 +1,268 @@
+//! Authority-derived index integrity and repair helpers.
+//!
+//! The delivery index is derived state. Callers own deriving [`MessageIndexProjection`] rows from
+//! SQLite authority metadata; this module checks whether an index contains those expected refs and
+//! replays them idempotently when it does not. Body checks are integrity-only: a missing `cf_body`
+//! entry is reported, never rebuilt from index data.
+
+use crate::{
+    AuthorityMessageId, DeliveryMessageId, MessageBodyStore, MessageIndex, MessageIndexError,
+    MessageIndexProjection, MessageRef,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MessageIndexNamespace {
+    ById,
+    Channel {
+        group_id: String,
+        channel_id: String,
+    },
+    Agent {
+        agent_id: String,
+    },
+    Run {
+        run_id: String,
+    },
+    Inbox {
+        actor_id: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MissingIndexRef {
+    pub namespace: MessageIndexNamespace,
+    pub message_id: DeliveryMessageId,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MessageIndexIntegrityReport {
+    pub expected_projections: usize,
+    pub missing_index_refs: Vec<MissingIndexRef>,
+    pub missing_bodies: Vec<AuthorityMessageId>,
+}
+
+impl MessageIndexIntegrityReport {
+    pub fn is_clean(&self) -> bool {
+        self.missing_index_refs.is_empty() && self.missing_bodies.is_empty()
+    }
+}
+
+pub fn check_authority_projection_integrity<I, B>(
+    index: &I,
+    body_store: &B,
+    expected: &[MessageIndexProjection],
+) -> Result<MessageIndexIntegrityReport, MessageIndexError>
+where
+    I: MessageIndex,
+    B: MessageBodyStore,
+{
+    let mut report = MessageIndexIntegrityReport {
+        expected_projections: expected.len(),
+        ..MessageIndexIntegrityReport::default()
+    };
+
+    for projection in expected {
+        let message_id = projection.reference.message_id.clone();
+        if !matches_index_ref(index.get_by_id(&message_id)?, &projection.reference) {
+            report.missing_index_refs.push(MissingIndexRef {
+                namespace: MessageIndexNamespace::ById,
+                message_id: message_id.clone(),
+            });
+        }
+
+        if let Some(channel) = &projection.channel {
+            let refs = index.scan_channel(&channel.group_id, &channel.channel_id, usize::MAX)?;
+            if !contains_ref(&refs, &projection.reference) {
+                report.missing_index_refs.push(MissingIndexRef {
+                    namespace: MessageIndexNamespace::Channel {
+                        group_id: channel.group_id.clone(),
+                        channel_id: channel.channel_id.clone(),
+                    },
+                    message_id: message_id.clone(),
+                });
+            }
+        }
+
+        if let Some(agent_id) = &projection.agent_id {
+            let refs = index.scan_agent(agent_id, usize::MAX)?;
+            if !contains_ref(&refs, &projection.reference) {
+                report.missing_index_refs.push(MissingIndexRef {
+                    namespace: MessageIndexNamespace::Agent {
+                        agent_id: agent_id.clone(),
+                    },
+                    message_id: message_id.clone(),
+                });
+            }
+        }
+
+        if let Some(run_id) = &projection.run_id {
+            let refs = index.scan_run(run_id, usize::MAX)?;
+            if !contains_ref(&refs, &projection.reference) {
+                report.missing_index_refs.push(MissingIndexRef {
+                    namespace: MessageIndexNamespace::Run {
+                        run_id: run_id.clone(),
+                    },
+                    message_id: message_id.clone(),
+                });
+            }
+        }
+
+        if let Some(actor_id) = &projection.inbox_actor_id {
+            let refs = index.scan_inbox(actor_id, usize::MAX)?;
+            if !contains_ref(&refs, &projection.reference) {
+                report.missing_index_refs.push(MissingIndexRef {
+                    namespace: MessageIndexNamespace::Inbox {
+                        actor_id: actor_id.clone(),
+                    },
+                    message_id: message_id.clone(),
+                });
+            }
+        }
+
+        if !body_store.contains(&projection.reference.authority_message_id) {
+            report
+                .missing_bodies
+                .push(projection.reference.authority_message_id.clone());
+        }
+    }
+
+    report.missing_bodies.sort();
+    report.missing_bodies.dedup();
+    Ok(report)
+}
+
+pub fn repair_authority_projection_index<I>(
+    index: &I,
+    expected: &[MessageIndexProjection],
+) -> Result<usize, MessageIndexError>
+where
+    I: MessageIndex,
+{
+    for projection in expected {
+        index.put_message(projection)?;
+    }
+    Ok(expected.len())
+}
+
+fn matches_index_ref(actual: Option<MessageRef>, expected: &MessageRef) -> bool {
+    actual.as_ref() == Some(expected)
+}
+
+fn contains_ref(refs: &[MessageRef], expected: &MessageRef) -> bool {
+    refs.iter().any(|actual| actual == expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AuthorityMessageId, InMemoryBodyStore, InMemoryMessageIndex, MessageKind, MessageRef,
+    };
+
+    fn sample_ref(seq: u64) -> MessageRef {
+        MessageRef {
+            message_id: DeliveryMessageId::new(format!("delivery-{seq}")),
+            authority_message_id: AuthorityMessageId::new(format!("auth-{seq}")),
+            archive_document_id: Some(format!("doc-{seq}")),
+            created_at: 1_700_000_000 + seq as i64,
+            source_kind: "team_conversation_messages".to_string(),
+            message_kind: MessageKind::Text,
+            correlation_id: Some(format!("corr-{seq}")),
+            group_id: Some("group-a".to_string()),
+            run_id: Some("run-a".to_string()),
+            conversation_id: Some("channel-a".to_string()),
+            agent_id: Some("agent-a".to_string()),
+        }
+    }
+
+    fn sample_projection(seq: u64) -> MessageIndexProjection {
+        MessageIndexProjection::new(seq, sample_ref(seq))
+            .for_channel("group-a", "channel-a")
+            .for_agent("agent-a")
+            .for_run("run-a")
+            .for_inbox_actor("actor-a")
+    }
+
+    #[test]
+    fn integrity_reports_missing_index_refs_and_bodies() {
+        let index = InMemoryMessageIndex::new();
+        let body_store = InMemoryBodyStore::new();
+        let expected = vec![sample_projection(1)];
+
+        let report = check_authority_projection_integrity(&index, &body_store, &expected).unwrap();
+
+        assert_eq!(report.expected_projections, 1);
+        assert_eq!(
+            report.missing_index_refs,
+            vec![
+                MissingIndexRef {
+                    namespace: MessageIndexNamespace::ById,
+                    message_id: DeliveryMessageId::new("delivery-1"),
+                },
+                MissingIndexRef {
+                    namespace: MessageIndexNamespace::Channel {
+                        group_id: "group-a".to_string(),
+                        channel_id: "channel-a".to_string(),
+                    },
+                    message_id: DeliveryMessageId::new("delivery-1"),
+                },
+                MissingIndexRef {
+                    namespace: MessageIndexNamespace::Agent {
+                        agent_id: "agent-a".to_string(),
+                    },
+                    message_id: DeliveryMessageId::new("delivery-1"),
+                },
+                MissingIndexRef {
+                    namespace: MessageIndexNamespace::Run {
+                        run_id: "run-a".to_string(),
+                    },
+                    message_id: DeliveryMessageId::new("delivery-1"),
+                },
+                MissingIndexRef {
+                    namespace: MessageIndexNamespace::Inbox {
+                        actor_id: "actor-a".to_string(),
+                    },
+                    message_id: DeliveryMessageId::new("delivery-1"),
+                },
+            ]
+        );
+        assert_eq!(
+            report.missing_bodies,
+            vec![AuthorityMessageId::new("auth-1")]
+        );
+    }
+
+    #[test]
+    fn repair_replays_index_without_rebuilding_missing_bodies() {
+        let index = InMemoryMessageIndex::new();
+        let body_store = InMemoryBodyStore::new();
+        let expected = vec![sample_projection(1), sample_projection(2)];
+
+        let repaired = repair_authority_projection_index(&index, &expected).unwrap();
+        assert_eq!(repaired, 2);
+
+        let report = check_authority_projection_integrity(&index, &body_store, &expected).unwrap();
+        assert!(report.missing_index_refs.is_empty());
+        assert_eq!(
+            report.missing_bodies,
+            vec![
+                AuthorityMessageId::new("auth-1"),
+                AuthorityMessageId::new("auth-2")
+            ]
+        );
+    }
+
+    #[test]
+    fn integrity_is_clean_after_index_and_body_are_present() {
+        let index = InMemoryMessageIndex::new();
+        let body_store = InMemoryBodyStore::new();
+        let expected = vec![sample_projection(1)];
+        repair_authority_projection_index(&index, &expected).unwrap();
+        body_store
+            .put_body(&AuthorityMessageId::new("auth-1"), b"body")
+            .unwrap();
+
+        let report = check_authority_projection_integrity(&index, &body_store, &expected).unwrap();
+        assert!(report.is_clean());
+    }
+}

--- a/crates/agenthub-message-store/src/rocksdb_store.rs
+++ b/crates/agenthub-message-store/src/rocksdb_store.rs
@@ -361,6 +361,35 @@ mod tests {
     }
 
     #[test]
+    fn repair_report_checks_cf_index_and_cf_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RocksdbBodyStore::open(dir.path()).unwrap();
+        let reference = sample_ref(8);
+        let authority = reference.authority_message_id.clone();
+        let projection = MessageIndexProjection::new(8, reference)
+            .for_channel("group-a", "chan-a")
+            .for_agent("agent-a")
+            .for_run("run-a")
+            .for_inbox_actor("actor-a");
+        let expected = vec![projection];
+
+        let missing =
+            crate::check_authority_projection_integrity(&store, &store, &expected).unwrap();
+        assert_eq!(missing.missing_index_refs.len(), 5);
+        assert_eq!(missing.missing_bodies, vec![authority.clone()]);
+
+        crate::repair_authority_projection_index(&store, &expected).unwrap();
+        let still_missing_body =
+            crate::check_authority_projection_integrity(&store, &store, &expected).unwrap();
+        assert!(still_missing_body.missing_index_refs.is_empty());
+        assert_eq!(still_missing_body.missing_bodies, vec![authority.clone()]);
+
+        store.put_body(&authority, b"body").unwrap();
+        let clean = crate::check_authority_projection_integrity(&store, &store, &expected).unwrap();
+        assert!(clean.is_clean());
+    }
+
+    #[test]
     fn fan_out_stores_one_body_per_authority_message() {
         let dir = tempfile::tempdir().unwrap();
         let store = RocksdbBodyStore::open(dir.path()).unwrap();

--- a/docs/features/message-storage-tiering.md
+++ b/docs/features/message-storage-tiering.md
@@ -109,6 +109,11 @@ storage boundary only: callers must still derive projections from SQLite authori
 authority-derived rebuild/repair remains the correctness boundary before ordered reads can become
 production-facing.
 
+The repair foundation accepts those authority-derived projections as input and can verify/replay the
+expected index refs idempotently. Its body check is intentionally report-only: `cf_body` is primary
+data after migration, so missing bodies are surfaced as durability failures and are never rebuilt from
+index rows.
+
 Body column family (`cf_body`)
 
 - maps `authority_message_id` to the full body payload (text, tool output, JSON);
@@ -258,10 +263,11 @@ Index rebuild inputs:
 Required operations:
 
 - dry-run index scan that reports expected key counts per namespace;
+- replay expected projections derived from SQLite metadata into the index idempotently;
 - rebuild index namespace for one team, channel, agent, run, or actor from SQLite metadata;
 - rebuild all delivery indexes from SQLite metadata;
-- integrity check (not rebuild): verify each index ref has a matching `cf_body` entry and, when archive
-  is enabled, an existing archive document id;
+- integrity check (not rebuild): verify each expected index ref has a matching `cf_body` entry and,
+  when archive is enabled, an existing archive document id;
 - detect and report orphan index refs, with an explicit prune mode that deletes refs not backed by
   authority rows;
 - detect index refs whose `cf_body` entry is missing (a body-loss signal that the SQLite body outbox or
@@ -395,6 +401,8 @@ it must not authorize or redefine message authority.
   - SQLite authority write still succeeds when a RocksDB write fails after commit;
   - read-repair / high-water-mark guard surfaces a freshly written message rather than dropping it;
   - repair job rebuilds missing index keys from SQLite metadata alone (no `cf_body` dependency).
+  - missing `cf_body` entries are reported as body durability failures rather than rebuilt from index
+    rows.
 - Body durability tests:
   - the body is committed to `message_body_outbox` inside the authority transaction;
   - a `cf_body` write failure after the authority commit leaves the body recoverable from the outbox,

--- a/docs/journal/2026-06-10-message-store-foundation-crate.md
+++ b/docs/journal/2026-06-10-message-store-foundation-crate.md
@@ -93,3 +93,38 @@ behind the existing opt-in `rocksdb` feature.
 - Wire projection derivation from SQLite authority rows.
 - Add rebuild/repair and integrity checks that rebuild `cf_index` from SQLite metadata alone.
 - Keep normal reads on SQLite until ordered index reads and backup/restore evidence are reviewed.
+
+# 2026-07-29 Follow-Up: Projection Integrity And Replay
+
+## Summary
+
+Added crate-local integrity and repair helpers for authority-derived `cf_index` projections. Callers
+still own deriving `MessageIndexProjection` values from SQLite authority rows; the new helpers verify
+that those expected refs exist in the index, report missing `cf_body` entries, and replay expected
+index refs idempotently.
+
+## Scope
+
+- Added `MessageIndexIntegrityReport`, `MissingIndexRef`, and namespace-specific missing-ref records.
+- Added `check_authority_projection_integrity(...)` for expected projection vs index/body checks.
+- Added `repair_authority_projection_index(...)` to replay expected projections into the index.
+- Covered both the in-memory index and the RocksDB `cf_index`/`cf_body` backend.
+
+## Key Decisions
+
+- Treat `cf_index` as derived and rebuildable by replaying expected projections.
+- Treat missing bodies as report-only durability failures. The helper never rebuilds `cf_body` from
+  index rows.
+- Keep real SQLite authority derivation, orphan/prune handling, ordered read-path enablement, and
+  backup validation as follow-up work.
+
+## Validation
+
+- `cargo test -p agenthub-message-store repair -- --nocapture`
+- `cargo test -p agenthub-message-store --features rocksdb repair_report_checks_cf_index_and_cf_body -- --nocapture`
+
+## Follow-Ups
+
+- Derive `MessageIndexProjection` rows from SQLite authority tables.
+- Add orphan detection and explicit prune mode for refs not backed by authority rows.
+- Keep production reads on SQLite until high-water-mark/read-repair and backup/restore evidence land.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -40,7 +40,7 @@ Stable contracts:
 
 ## Message Storage
 
-- [ ] `P1` Implement the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill and a `cf_index` projection backend foundation are complete; remaining work is deriving projections from SQLite authority rows, rebuild/repair, ordered index reads, integrity checks, and backup validation. Keep normal reads on SQLite and do not drop SQLite bodies before the Phase 2 rollout decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).
+- [ ] `P1` Implement the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). The opt-in Phase 1 `cf_body` dual-write/backfill, `cf_index` projection backend foundation, and projection integrity/replay helpers are complete; remaining work is deriving projections from SQLite authority rows, orphan/prune handling, ordered index reads, high-water-mark/read-repair, and backup validation. Keep normal reads on SQLite and do not drop SQLite bodies before the Phase 2 rollout decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).
 
 ## Object Storage
 


### PR DESCRIPTION
## Summary

- add authority-projection integrity reports for the message delivery index
- add an idempotent helper to replay expected `cf_index` projections
- report missing `cf_body` entries as durability failures instead of rebuilding bodies from index rows
- update the message storage spec, journal, and TODO with the narrowed remaining repair/read-path work

## Purpose

This advances the Message Storage P1 TODO after the `cf_index` projection foundation. The new helper layer gives the future SQLite authority-derived repair job a focused API to verify and replay expected projections while preserving the boundary that `cf_body` is primary body data.

## Related Issues

- None

## Testing

- `cargo test -p agenthub-message-store`
- `cargo test -p agenthub-message-store --features rocksdb`
- `cargo clippy -p agenthub-message-store --all-targets --features rocksdb -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
