### PR TITLE
test(team): assert exact neutral bubble tokens

### DIFF
--- a/web/src/acp_conversation_render.test.tsx
+++ b/web/src/acp_conversation_render.test.tsx
@@ -316,8 +316,9 @@ describe("AcpConversation rendering", () => {
     expect(html).toContain('data-acp-message-bubble="user"');
     for (const role of ["agent", "user"] as const) {
       const className = bubbleClassName(html, role);
+      const classTokens = className.split(/\s+/);
       for (const token of CONVERSATION_MESSAGE_BUBBLE_NEUTRAL_CLASS.split(" ")) {
-        expect(className).toContain(token);
+        expect(classTokens).toContain(token);
       }
     }
   });


### PR DESCRIPTION
test(team): assert exact neutral bubble tokens

## Summary

- Assert neutral message-bubble styles as exact Tailwind class tokens.
- Prevent substring matches from masking a removed base `border` class.

## Purpose

Follow up on the suppressed review observation from PR #990 with a focused test-only correction.

## Related Issue

- Follow-up to #990

## Tests

- `cd web && npm run test -- acp_conversation_render.test.tsx`
- `cd web && npm run lint`
- `git diff --check`
