### PR TITLE
fix(agent): remove execution path allowlist

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -53,7 +53,7 @@ use crate::internal::p2p::{
     MembershipView, ResolvedNodeEndpoint, derive_cluster_id,
     resolved_node_endpoint_from_agent_node_record,
 };
-use crate::path_utils::{expand_tilde, is_path_allowed, normalize_path};
+use crate::path_utils::expand_tilde;
 use crate::push::PushService;
 use agenthub_config::{
     normalize_codex_acp_mode_id, normalize_optional_codex_acp_mode_id,
@@ -1249,9 +1249,6 @@ impl AgentManager {
                 path.trim().to_string()
             }
         });
-        if is_local_target {
-            self.ensure_safe_path(&workdir).await?;
-        }
         let id = Uuid::new_v4().to_string();
         let now = Utc::now().timestamp();
         let args_json = serde_json::to_string(&config.args)?;
@@ -1326,8 +1323,6 @@ impl AgentManager {
 
         let workdir = expand_tilde(&config.workdir);
         let worktree_repo = config.worktree_repo.as_deref().map(expand_tilde);
-        self.ensure_safe_path(&workdir).await?;
-
         let args_json = serde_json::to_string(&config.args)?;
         let now = Utc::now().timestamp();
         let existing = self.get_agent(agent_id).await.ok();
@@ -2022,33 +2017,6 @@ impl AgentManager {
             workdir,
             stderr
         );
-    }
-
-    async fn ensure_safe_path(&self, workdir: &str) -> anyhow::Result<()> {
-        let allow = sqlx::query(
-            r#"
-            SELECT path
-            FROM safe_paths
-            ORDER BY id ASC
-            "#,
-        )
-        .fetch_all(&self.db)
-        .await?;
-
-        if allow.is_empty() {
-            anyhow::bail!("no safe paths configured");
-        }
-
-        let target = normalize_path(workdir);
-        for row in allow {
-            let path: String = row.get("path");
-            let allowed = normalize_path(&expand_tilde(&path));
-            if is_path_allowed(&target, &allowed) {
-                return Ok(());
-            }
-        }
-
-        anyhow::bail!("workdir not allowed")
     }
 
     pub async fn subscribe_output(

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -91,50 +91,6 @@ impl AgentManager {
                 let repo =
                     worktree_repo.ok_or_else(|| anyhow::anyhow!("worktree_repo required"))?;
                 let ref_name = agent.worktree_ref.as_deref().unwrap_or("HEAD");
-                if let Err(err) = self.ensure_safe_path(repo).await {
-                    let detail = serde_json::json!({
-                        "agent_id": agent.id,
-                        "mode": "create_worktree",
-                        "repo": repo,
-                        "workdir": workdir,
-                        "error": err.to_string(),
-                    })
-                    .to_string();
-                    let _ = self
-                        .auth
-                        .record_audit(
-                            None,
-                            None,
-                            "worktree_create_failed",
-                            Some(&detail),
-                            None,
-                            None,
-                        )
-                        .await;
-                    return Err(err);
-                }
-                if let Err(err) = self.ensure_safe_path(workdir).await {
-                    let detail = serde_json::json!({
-                        "agent_id": agent.id,
-                        "mode": "create_worktree",
-                        "repo": repo,
-                        "workdir": workdir,
-                        "error": err.to_string(),
-                    })
-                    .to_string();
-                    let _ = self
-                        .auth
-                        .record_audit(
-                            None,
-                            None,
-                            "worktree_create_failed",
-                            Some(&detail),
-                            None,
-                            None,
-                        )
-                        .await;
-                    return Err(err);
-                }
                 let workdir_path = Path::new(workdir);
                 if workdir_path.exists() && !is_dir_empty(workdir_path)? {
                     let existing_worktree = match repo_find_worktree_entry(repo, workdir).await {
@@ -487,10 +443,6 @@ impl AgentManager {
     ) -> anyhow::Result<()> {
         let normalized_workdir = expand_tilde(workdir);
         let normalized_worktree_repo = worktree_repo.map(expand_tilde);
-        self.ensure_safe_path(&normalized_workdir).await?;
-        if let Some(repo) = normalized_worktree_repo.as_deref() {
-            self.ensure_safe_path(repo).await?;
-        }
         let now = Utc::now().timestamp();
         sqlx::query(
             r#"

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -488,31 +488,6 @@ impl AgentManager {
             }
             return Err(err);
         }
-        if let Err(err) = self.ensure_safe_path(&start_policy.workdir).await {
-            if let Err(record_err) = self
-                .record_failed_session(&agent.id, &session_id, &err.to_string())
-                .await
-            {
-                tracing::error!(
-                    agent_id = %agent.id,
-                    session_id = %session_id,
-                    error = %record_err,
-                    "failed to record safe-path startup failure"
-                );
-            }
-            if let Err(status_err) = self
-                .update_agent_status(&agent.id, AgentStatus::Failed)
-                .await
-            {
-                tracing::error!(
-                    agent_id = %agent.id,
-                    session_id = %session_id,
-                    error = %status_err,
-                    "failed to update agent status after safe-path failure"
-                );
-            }
-            return Err(err);
-        }
         if let Err(err) =
             ensure_team_runtime_workspace_layout(actor_context.as_ref(), &start_policy.workdir)
                 .await

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -2719,18 +2719,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_agent_treats_main_target_node_as_local() {
+    async fn create_agent_treats_main_target_node_as_local_without_safe_path() {
         let db = create_test_db().await;
         init_test_schema(&db).await;
         add_agent_node_support(&db).await;
         let state = build_test_state_with_db(db).await;
-        let now = chrono::Utc::now().timestamp();
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind("/tmp/main-target-normalizes-local")
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert safe path");
 
         let agent = state
             .agents
@@ -4148,7 +4141,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_route_accepts_empty_body_with_json_content_type() {
+    async fn start_route_accepts_empty_body_without_safe_path() {
         let state = build_test_state().await;
         let token = create_auth_token(&state).await;
         let app = router(state.clone());
@@ -4156,13 +4149,6 @@ mod tests {
         let workdir =
             std::env::temp_dir().join(format!("agenthub-start-empty-json-{}", Uuid::new_v4()));
         std::fs::create_dir_all(&workdir).expect("create workdir");
-        let now = chrono::Utc::now().timestamp();
-        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
-            .bind(workdir.to_string_lossy().to_string())
-            .bind(now)
-            .execute(&state.db)
-            .await
-            .expect("insert safe path");
 
         let create_resp = app
             .clone()

--- a/src/team/runtime/repair.rs
+++ b/src/team/runtime/repair.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use sqlx::Error as SqlxError;
 
 use crate::agent::{AgentManager, AgentRecord, WorktreeMode, normalize_target_node_id};
-use crate::path_utils::{expand_tilde, is_path_allowed, normalize_path};
+use crate::path_utils::expand_tilde;
 
 use super::spec::{TeamRuntimeMemberRuntimeHint, TeamRuntimeMemberSpec, trimmed_opt};
 use super::types::TeamRuntimeStartError;
@@ -80,51 +80,6 @@ fn collect_repo_candidates(safe_paths: &[String]) -> Vec<String> {
     candidates
 }
 
-fn safe_paths_allow(safe_paths: &[String], target: &str) -> bool {
-    let expanded_target = expand_tilde(target);
-    safe_paths.iter().any(|allowed| {
-        let expanded_allowed = expand_tilde(allowed);
-        is_path_allowed(&expanded_target, &expanded_allowed)
-    })
-}
-
-pub(super) fn adjust_worker_runtime_workdir_for_safe_paths(
-    mut config: WorkerRuntimeRepairConfig,
-    safe_paths: &[String],
-) -> anyhow::Result<WorkerRuntimeRepairConfig> {
-    let derived_root = Path::new(&config.workdir)
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .map(|parent| parent.to_string_lossy().to_string())
-        .unwrap_or_else(|| config.workdir.clone());
-    if safe_paths_allow(safe_paths, &derived_root) {
-        return Ok(config);
-    }
-
-    if safe_paths_allow(safe_paths, &config.workdir) {
-        let normalized_repo = normalize_path(&expand_tilde(&config.worktree_repo));
-        let normalized_workdir = normalize_path(&expand_tilde(&config.workdir));
-        if is_path_allowed(&normalized_workdir, &normalized_repo) {
-            return Err(TeamRuntimeStartError::InvalidConfig(format!(
-                "legacy worker runtime workdir '{}' is inside repo '{}' and cannot derive a safe worktree root",
-                config.workdir, config.worktree_repo
-            ))
-            .into());
-        }
-        config.workdir = Path::new(&config.workdir)
-            .join(".agenthub-worker-root")
-            .to_string_lossy()
-            .to_string();
-        return Ok(config);
-    }
-
-    Err(TeamRuntimeStartError::InvalidConfig(format!(
-        "legacy worker runtime workdir '{}' is outside safe paths and cannot derive a safe worktree root",
-        config.workdir
-    ))
-    .into())
-}
-
 fn infer_repo_from_member_text(
     candidates: &[String],
     member: &TeamRuntimeMemberSpec,
@@ -165,27 +120,24 @@ async fn resolve_worker_runtime_repair(
     member: &TeamRuntimeMemberSpec,
     agent: &AgentRecord,
 ) -> anyhow::Result<Option<WorkerRuntimeRepairConfig>> {
-    let safe_paths = agents.list_safe_paths().await?;
     if let Some(hint) = member.runtime.as_ref()
         && let Some(config) = build_worker_runtime_hint_config(agent, hint)
     {
-        let config = adjust_worker_runtime_workdir_for_safe_paths(config, &safe_paths)?;
         return Ok(Some(config));
     }
     if let Some(config) = build_worker_runtime_agent_config(agent) {
-        let config = adjust_worker_runtime_workdir_for_safe_paths(config, &safe_paths)?;
         return Ok(Some(config));
     }
+    let safe_paths = agents.list_safe_paths().await?;
     let candidates = collect_repo_candidates(&safe_paths);
     let inferred_repo = infer_repo_from_member_text(&candidates, member, agent);
-    inferred_repo
-        .map(|worktree_repo| WorkerRuntimeRepairConfig {
+    Ok(
+        inferred_repo.map(|worktree_repo| WorkerRuntimeRepairConfig {
             workdir: agent.workdir.clone(),
             worktree_repo,
             worktree_ref: Some("HEAD".to_string()),
-        })
-        .map(|config| adjust_worker_runtime_workdir_for_safe_paths(config, &safe_paths))
-        .transpose()
+        }),
+    )
 }
 
 pub(super) async fn reconcile_team_member_runtime(

--- a/src/team/runtime/tests.rs
+++ b/src/team/runtime/tests.rs
@@ -1,7 +1,4 @@
-use super::repair::{
-    WorkerRuntimeRepairConfig, adjust_worker_runtime_workdir_for_safe_paths,
-    map_member_agent_lookup_error, runtime_target_node_hint_is_present,
-};
+use super::repair::{map_member_agent_lookup_error, runtime_target_node_hint_is_present};
 use super::types::TeamRuntimeStartError;
 use crate::path_utils::expand_tilde;
 use core::assert_matches;
@@ -17,23 +14,6 @@ fn expand_tilde_uses_path_join_for_home_relative_paths() {
             .to_string_lossy()
             .to_string()
     );
-}
-
-#[test]
-fn worker_runtime_adjust_rejects_workdir_outside_safe_paths() {
-    let err = adjust_worker_runtime_workdir_for_safe_paths(
-        WorkerRuntimeRepairConfig {
-            workdir: "/tmp/agenthub-worker".to_string(),
-            worktree_repo: "/repo".to_string(),
-            worktree_ref: Some("HEAD".to_string()),
-        },
-        &[String::from("/safe/root")],
-    )
-    .expect_err("workdir outside safe paths should fail");
-    let typed = err
-        .downcast_ref::<TeamRuntimeStartError>()
-        .expect("typed runtime error");
-    assert_matches!(typed, TeamRuntimeStartError::InvalidConfig(_));
 }
 
 #[test]

--- a/web/tests/e2e/team_page_helpers.ts
+++ b/web/tests/e2e/team_page_helpers.ts
@@ -51,6 +51,7 @@ const TEAM_MEMBER_WORKSPACE_LABEL_PATTERN =
 const TEAM_SELECTOR_ROUTE_PATTERN = /^\/(?:workspace\/)?teams\/?$/;
 const TEAM_DETAIL_ROUTE_PATTERN = /^\/(?:workspace\/)?teams\/[^/]+$/;
 const TEAM_DETAIL_READY_TIMEOUT_MS = 15_000;
+const TEAM_SELECTOR_NAVIGATION_TIMEOUT_MS = 2_000;
 
 function isTeamSelectorPath(pathname: string): boolean {
   return TEAM_SELECTOR_ROUTE_PATTERN.test(pathname);
@@ -58,6 +59,14 @@ function isTeamSelectorPath(pathname: string): boolean {
 
 function isTeamDetailPath(pathname: string): boolean {
   return TEAM_DETAIL_ROUTE_PATTERN.test(pathname);
+}
+
+function isTeamDetailUrl(url: URL, teamId: string): boolean {
+  return url.pathname === buildTeamDetailPath(teamId);
+}
+
+function hasTeamDetailPath(page: import("@playwright/test").Page, teamId: string): boolean {
+  return isTeamDetailUrl(new URL(page.url()), teamId);
 }
 export async function createTeamFromModal(
   page: import("@playwright/test").Page,
@@ -289,24 +298,25 @@ export async function openTeamFromSelector(
     await filterInput.fill(teamName);
   }
   const selectorTeamButton = selectorPanel
-    .locator('[data-team-selector-entry="true"]', { hasText: teamName })
+    .locator(`[data-team-selector-entry="true"][data-team-name="${escapeCssAttributeValue(teamName)}"]`)
     .first();
   await expect(selectorTeamButton).toBeVisible();
   const selectorTeamId = await selectorTeamButton.getAttribute("data-team-id");
   expect(selectorTeamId).toBeTruthy();
   const selectedTeamId = selectorTeamId ?? "";
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      await selectorTeamButton.click({ timeout: 1_500, force: attempt > 0 });
-    } catch {
+  try {
+    await Promise.all([
+      page.waitForURL(
+        (url) => isTeamDetailUrl(url, selectedTeamId),
+        { timeout: TEAM_SELECTOR_NAVIGATION_TIMEOUT_MS }
+      ),
+      selectorTeamButton.click(),
+    ]);
+  } catch {
+    if (!hasTeamDetailPath(page, selectedTeamId)) {
       await page.goto(buildTeamDetailPath(selectedTeamId), { waitUntil: "domcontentloaded" });
     }
-    await page.waitForTimeout(150);
-    if (await isTeamDetailReady(page, teamName)) {
-      return;
-    }
   }
-  await page.goto(buildTeamDetailPath(selectedTeamId), { waitUntil: "domcontentloaded" });
   await expect
     .poll(() => isTeamDetailReady(page, teamName), {
       timeout: TEAM_DETAIL_READY_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- remove `safe_paths` checks from local Agent creation, startup, worktree preparation, and Team worker runtime repair
- retain `safe_paths` only for ACP skill discovery and optional repository inference when legacy worker runtime data lacks a repository
- cover local Agent creation and startup with an empty `safe_paths` table

## Purpose

Agent execution should accept the configured workspace path without requiring an administrator-managed execution allowlist.

## Testing

- `cargo fmt --check`
- `cargo check -p agenthub`
- `cargo test -p agenthub create_agent_treats_main_target_node_as_local_without_safe_path`
- `cargo test -p agenthub start_route_accepts_empty_body_without_safe_path`
- `cargo test -p agenthub team::runtime::tests`

## Related Issue

None.
