### PR TITLE
feat(team): add workspace adoption copy

### DIFF
--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
+use std::path::{Path as StdPath, PathBuf};
 
 mod errors;
 
@@ -33,7 +35,7 @@ use uuid::Uuid;
 
 use agenthub_auth_domain::UserCapability;
 
-use crate::agent::AgentStatus;
+use crate::agent::{AgentConfig, AgentStatus, WorktreeMode};
 use crate::api::authz::require_capability;
 use crate::api::error::ApiError;
 use crate::api::uploads::{
@@ -75,6 +77,7 @@ const TEAM_MESSAGE_SUMMARY_MAX_CHARS: usize = 240;
 const TEAM_MEMORY_FLUSH_TRIGGER_VALUES: [&str; 3] = ["manual", "soft_threshold", "hard_error"];
 const TEAM_TASK_COMPILE_MAX_TEXT_LEN: usize = 280;
 const TEAM_TASK_COMPILE_MAX_DEADLINE_LEN: usize = 40;
+const ADOPTED_MEMBER_ID_PLACEHOLDER: &str = "__agenthub_adopted_member__";
 
 fn team_owner_matches_user(team: &TeamDefinitionRecord, user: &UserRecord) -> bool {
     match team.owner_user_id.as_deref() {
@@ -166,6 +169,22 @@ pub struct MoveExistingAgentRequest {
     pub agent_id: String,
     pub spec: Value,
     pub expected_updated_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AdoptExistingAgentRequest {
+    pub source_agent_id: String,
+    pub name: String,
+    pub spec: Value,
+    pub expected_updated_at: i64,
+    pub workspace_copy_destination: Option<String>,
+    pub memory_seed: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdoptExistingAgentResponse {
+    pub agent: crate::agent::AgentRecord,
+    pub team: TeamDefinitionRecord,
 }
 
 #[derive(Debug, Deserialize)]
@@ -519,6 +538,7 @@ pub fn router(state: AppState) -> Router {
         .route("/prompt_defaults", get(get_team_prompt_defaults))
         .route("/{id}", get(get_team).delete(delete_team))
         .route("/{id}/spec", put(update_team_spec))
+        .route("/{id}/members/adopt", post(adopt_existing_agent_to_team))
         .route("/{id}/members/move", post(move_existing_agent_to_team))
         .route("/{id}/runtime", get(get_team_runtime))
         .route(
@@ -771,6 +791,212 @@ async fn move_existing_agent_to_team(
             .map_err(map_runtime_start_error)?;
     }
     Ok(Json(sanitize_team_definition_for_response(updated)))
+}
+
+async fn adopt_existing_agent_to_team(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(team_id): Path<String>,
+    Json(payload): Json<AdoptExistingAgentRequest>,
+) -> Result<Json<AdoptExistingAgentResponse>, ApiError> {
+    let _user = require_capability(&headers, &state, UserCapability::TeamsManage).await?;
+    let current = load_team_for_user(&state, &team_id, &_user).await?;
+    let source_id = payload.source_agent_id.trim();
+    if source_id.is_empty() || payload.name.trim().is_empty() {
+        return Err(ApiError::bad_request(
+            "source_agent_id and name are required",
+        ));
+    }
+    let source = state
+        .agents
+        .get_agent(source_id)
+        .await
+        .map_err(|err| map_not_found_error(err, "agent not found"))?;
+    if !state
+        .teams
+        .list_teams_referencing_member(source_id)
+        .await
+        .map_err(map_team_internal_error)?
+        .is_empty()
+    {
+        return Err(ApiError::conflict("agent already belongs to a team"));
+    }
+    if source.target_node_id.is_some() && payload.workspace_copy_destination.is_some() {
+        return Err(ApiError::bad_request(
+            "workspace-content copy is only available for local agents",
+        ));
+    }
+    let destination = payload
+        .workspace_copy_destination
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let seed = payload
+        .memory_seed
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if seed.is_some() && destination.is_none() {
+        return Err(ApiError::bad_request(
+            "memory seed requires a copied workspace destination",
+        ));
+    }
+    let workdir = destination.unwrap_or(&source.workdir).to_string();
+    let mut spec = payload.spec;
+    let member_id = Uuid::new_v4().to_string();
+    replace_adopted_member_placeholder(&mut spec, &member_id);
+    normalize_team_spec(&mut spec)?;
+    validate_team_spec(&spec)?;
+    let previous_member_ids = parse_member_ids(current.spec.get("members"))?;
+    let next_member_ids = parse_member_ids(spec.get("members"))?;
+    if !previous_member_ids.is_subset(&next_member_ids)
+        || next_member_ids
+            .difference(&previous_member_ids)
+            .collect::<Vec<_>>()
+            != vec![&member_id]
+    {
+        return Err(ApiError::bad_request(
+            "adoption must add exactly one new member",
+        ));
+    }
+    if let Some(destination) = destination {
+        copy_adoption_workspace(&source.workdir, destination, &source.id, &current.id, seed)?;
+    }
+    let agent_result = state
+        .agents
+        .create_agent_with_source(
+            AgentConfig {
+                name: payload.name.trim().to_string(),
+                workdir,
+                command: source.command.clone(),
+                args: source.args.clone(),
+                target_node_id: source.target_node_id.clone(),
+                worktree_mode: WorktreeMode::UseExisting,
+                worktree_repo: None,
+                worktree_ref: None,
+                code_mode: source.code_mode,
+                codex_acp_default_mode: source.codex_acp_default_mode.clone(),
+                runtime_model: source.runtime_model.clone(),
+                thinking_level: source.thinking_level.clone(),
+                agent_loop_enabled: false,
+                agent_loop_idle_seconds: None,
+                agent_loop_prompt: None,
+            },
+            "team_forge",
+        )
+        .await;
+    let agent = match agent_result {
+        Ok(agent) => agent,
+        Err(err) => {
+            if let Some(destination) = destination {
+                let _ = fs::remove_dir_all(destination);
+            }
+            return Err(map_team_internal_error(err));
+        }
+    };
+    let updated = match state
+        .teams
+        .update_team_spec_if_unchanged(&current.id, payload.expected_updated_at, spec)
+        .await
+        .map_err(map_team_internal_error)?
+    {
+        Some(team) => team,
+        None => {
+            let _ = state.agents.delete_agent(&agent.id).await;
+            if let Some(destination) = destination {
+                let _ = fs::remove_dir_all(destination);
+            }
+            return Err(ApiError::conflict(
+                "team definition changed concurrently; reload and retry",
+            ));
+        }
+    };
+    if let Err(err) = ensure_team_runtime_started(state.agents.as_ref(), &updated).await {
+        let _ = state.agents.stop_agent(&agent.id).await;
+        return Err(map_runtime_start_error(err));
+    }
+    Ok(Json(AdoptExistingAgentResponse {
+        agent,
+        team: sanitize_team_definition_for_response(updated),
+    }))
+}
+
+fn replace_adopted_member_placeholder(value: &mut Value, member_id: &str) {
+    match value {
+        Value::String(current) if current == ADOPTED_MEMBER_ID_PLACEHOLDER => {
+            *current = member_id.to_string()
+        }
+        Value::Array(values) => values
+            .iter_mut()
+            .for_each(|value| replace_adopted_member_placeholder(value, member_id)),
+        Value::Object(values) => values
+            .values_mut()
+            .for_each(|value| replace_adopted_member_placeholder(value, member_id)),
+        _ => {}
+    }
+}
+
+fn copy_adoption_workspace(
+    source: &str,
+    destination: &str,
+    source_agent_id: &str,
+    team_id: &str,
+    seed: Option<&str>,
+) -> Result<(), ApiError> {
+    let source = fs::canonicalize(source)
+        .map_err(|_| ApiError::bad_request("source workspace must exist"))?;
+    let destination = PathBuf::from(destination);
+    if destination.exists() {
+        return Err(ApiError::conflict(
+            "workspace copy destination must not already exist",
+        ));
+    }
+    let parent = destination.parent().ok_or_else(|| {
+        ApiError::bad_request("workspace copy destination must have a parent directory")
+    })?;
+    fs::create_dir_all(parent).map_err(ApiError::from)?;
+    let temporary = parent.join(format!(".agenthub-adoption-{}", Uuid::new_v4()));
+    let result = (|| {
+        copy_adoption_directory(&source, &temporary)?;
+        let manifest = serde_json::json!({"source_agent_id": source_agent_id, "team_id": team_id, "source": source, "destination": destination, "excluded": [".git", ".agenthub", ".agenthubmemory", ".cache", ".env", "*.sock", "*.lock"]});
+        fs::write(
+            temporary.join(".agenthub-adoption-manifest.json"),
+            serde_json::to_vec_pretty(&manifest).map_err(ApiError::from)?,
+        )
+        .map_err(ApiError::from)?;
+        if let Some(seed) = seed {
+            fs::write(temporary.join(".agenthub-team-seed.json"), serde_json::to_vec_pretty(&serde_json::json!({"source_agent_id": source_agent_id, "team_id": team_id, "seed": seed})).map_err(ApiError::from)?).map_err(ApiError::from)?;
+        }
+        fs::rename(&temporary, &destination).map_err(ApiError::from)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&temporary);
+    }
+    result
+}
+
+fn copy_adoption_directory(source: &StdPath, destination: &StdPath) -> Result<(), ApiError> {
+    fs::create_dir_all(destination).map_err(ApiError::from)?;
+    for entry in fs::read_dir(source).map_err(ApiError::from)? {
+        let entry = entry.map_err(ApiError::from)?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if [".git", ".agenthub", ".agenthubmemory", ".cache", ".env"].contains(&name.as_ref())
+            || name.ends_with(".sock")
+            || name.ends_with(".lock")
+        {
+            continue;
+        }
+        let target = destination.join(entry.file_name());
+        let file_type = entry.file_type().map_err(ApiError::from)?;
+        if file_type.is_dir() {
+            copy_adoption_directory(&path, &target)?;
+        } else if file_type.is_file() {
+            fs::copy(&path, target).map_err(ApiError::from)?;
+        }
+    }
+    Ok(())
 }
 
 async fn start_team(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -967,6 +967,15 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
+  adoptExistingAgentToTeam: (
+    token: string,
+    id: string,
+    payload: { source_agent_id: string; name: string; spec: unknown; expected_updated_at: number; workspace_copy_destination?: string | null; memory_seed?: string | null }
+  ) =>
+    apiFetch<{ agent: AgentRecord; team: TeamDefinitionRecord }>(
+      `/api/teams/${encodePathSegment(id)}/members/adopt`, token,
+      { method: "POST", body: JSON.stringify(payload) }
+    ),
   moveExistingAgentToTeam: (
     token: string,
     id: string,

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -445,18 +445,22 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
   busy: boolean;
   selectedTeamHasCoordinator: boolean;
   candidateAgents: AgentRecord[];
-  onCopy: (agentId: string) => void;
+  onCopy: (agentId: string, options: { workspaceCopyDestination: string; memorySeed: string }) => void;
   onMove?: (agentId: string) => void;
   onClose: () => void;
   chrome: TeamModalChrome;
 }) {
   const [filter, setFilter] = React.useState("");
   const [selectedAgentId, setSelectedAgentId] = React.useState("");
+  const [workspaceCopyDestination, setWorkspaceCopyDestination] = React.useState("");
+  const [memorySeed, setMemorySeed] = React.useState("");
 
   React.useEffect(() => {
     if (!open) {
       setFilter("");
       setSelectedAgentId("");
+      setWorkspaceCopyDestination("");
+      setMemorySeed("");
     }
   }, [open]);
 
@@ -607,6 +611,10 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
             sessions, or workspace-local memory/context. Those must remain explicit opt-in
             follow-ups.
           </Alert>
+          <SurfaceCard className={TEAM_CREATE_PANEL_CARD_CLASS}>
+            <TextInput label="Copy workspace contents to" placeholder="Optional new local directory" value={workspaceCopyDestination} onChange={(event) => setWorkspaceCopyDestination(event.currentTarget.value)} />
+            <Textarea className="mt-3" label="Seed memory/context" placeholder="Optional operator-provided seed. Stored with source-agent provenance in the new workspace." value={memorySeed} onChange={(event) => setMemorySeed(event.currentTarget.value)} disabled={!workspaceCopyDestination.trim()} />
+          </SurfaceCard>
           <Alert
             radius="md"
             color="yellow"
@@ -633,8 +641,8 @@ export const TeamCopyExistingAgentDialog = React.memo(function TeamCopyExistingA
           </ActionButton>
           <ActionButton
             className={chrome.accentButtonClassName}
-            onClick={() => onCopy(selectedAgentId)}
-            disabled={busy || !selectedAgentId}
+            onClick={() => onCopy(selectedAgentId, { workspaceCopyDestination, memorySeed })}
+            disabled={busy || !selectedAgentId || (memorySeed.trim().length > 0 && !workspaceCopyDestination.trim())}
             size="md"
             tone="primary"
             type="button"

--- a/web/src/pages/team/use_team_management_actions.test.tsx
+++ b/web/src/pages/team/use_team_management_actions.test.tsx
@@ -17,6 +17,31 @@ vi.mock("../../api", async () => {
       createTeam: vi.fn(),
       createAgent: vi.fn(),
       deleteAgent: vi.fn(),
+      adoptExistingAgentToTeam: vi.fn(async (token, teamId, payload) => {
+        const agent = await api.createAgent(token, {
+          name: payload.name,
+          workdir: "/repo/source",
+          command: "agenthub-codex-acp",
+          args: [],
+          target_node_id: null,
+          source: "team_forge",
+          worktree_mode: "use_existing",
+          worktree_repo: null,
+          worktree_ref: null,
+          code_mode: true,
+          codex_acp_default_mode: "full-access",
+        });
+        const spec = JSON.parse(
+          JSON.stringify(payload.spec)
+            .split("__agenthub_adopted_member__")
+            .join(agent.id)
+        );
+        const team = await api.updateTeamSpec(token, teamId, {
+          spec,
+          expected_updated_at: payload.expected_updated_at,
+        });
+        return { agent, team };
+      }),
       setAgentCodexAcpDefaultMode: vi.fn(),
       setAgentRuntimeProfile: vi.fn(),
       setAgentLoop: vi.fn(),
@@ -758,7 +783,7 @@ describe("useTeamManagementActions", () => {
     }
   });
 
-  it("cleans up a copied agent when the team spec update conflicts", async () => {
+  it("surfaces adoption conflicts without client-side cleanup", async () => {
     mockedApi.createAgent.mockResolvedValueOnce({
       id: "agent-copy-conflict",
       name: "source-agent-worker-1",
@@ -785,7 +810,7 @@ describe("useTeamManagementActions", () => {
         await mounted.getSnapshot()?.onCopyExistingTeamAgent("agent-source-1");
       });
 
-      expect(mockedApi.deleteAgent).toHaveBeenCalledWith("token-1", "agent-copy-conflict");
+      expect(mockedApi.deleteAgent).not.toHaveBeenCalled();
       expect(params.setError).toHaveBeenCalledWith("team spec changed");
       expect(params.setShowCopyExistingAgentModal).not.toHaveBeenCalledWith(false);
     } finally {
@@ -793,7 +818,7 @@ describe("useTeamManagementActions", () => {
     }
   });
 
-  it("keeps the original copy conflict error when cleanup deletion fails", async () => {
+  it("keeps the original adoption conflict error", async () => {
     mockedApi.createAgent.mockResolvedValueOnce({
       id: "agent-copy-delete-fails",
       name: "source-agent-worker-1",
@@ -811,7 +836,6 @@ describe("useTeamManagementActions", () => {
     mockedApi.updateTeamSpec.mockRejectedValueOnce(
       Object.assign(new Error("team spec changed"), { status: 409 })
     );
-    mockedApi.deleteAgent.mockRejectedValueOnce(new Error("delete failed"));
 
     const params = createParams();
     const mounted = await mountHook(params);
@@ -820,14 +844,14 @@ describe("useTeamManagementActions", () => {
         await mounted.getSnapshot()?.onCopyExistingTeamAgent("agent-source-1");
       });
 
-      expect(mockedApi.deleteAgent).toHaveBeenCalledWith("token-1", "agent-copy-delete-fails");
+      expect(mockedApi.deleteAgent).not.toHaveBeenCalled();
       expect(params.setError).toHaveBeenCalledWith("team spec changed");
     } finally {
       mounted.cleanup();
     }
   });
 
-  it("does not clean up a copied agent for non-conflict team spec failures", async () => {
+  it("does not clean up locally for adoption failures", async () => {
     mockedApi.createAgent.mockResolvedValueOnce({
       id: "agent-copy-server-error",
       name: "source-agent-worker-1",

--- a/web/src/pages/team/use_team_management_actions.ts
+++ b/web/src/pages/team/use_team_management_actions.ts
@@ -540,7 +540,13 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
     refreshTeamRuntime,
   ]);
 
-  const onCopyExistingTeamAgent = useCallback(async (sourceAgentId: string) => {
+  const onCopyExistingTeamAgent = useCallback(async (
+    sourceAgentId: string,
+    options: { workspaceCopyDestination: string; memorySeed: string } = {
+      workspaceCopyDestination: "",
+      memorySeed: "",
+    }
+  ) => {
     if (busy === "copy-team-agent") {
       return;
     }
@@ -580,48 +586,24 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       thinking_level: sourceAgent.thinking_level ?? "",
     };
 
-    const copiedWorktreeMode = role === "coordinator" ? "use_existing" : sourceAgent.worktree_mode;
-    const copiedWorktreeRepo = role === "coordinator" ? null : sourceAgent.worktree_repo ?? null;
-    const copiedWorktreeRef = role === "coordinator" ? null : sourceAgent.worktree_ref ?? null;
-    const copiedCodexAcpDefaultMode =
-      resolveAcpProviderForAgent(sourceAgent.command, sourceAgent.args) === "codex"
-        ? normalizeCodexAcpModeId(sourceAgent.codex_acp_default_mode)
-        : null;
-
     setBusy("copy-team-agent");
     setError(null);
     setWarning(null);
-    let createdAgentId: string | null = null;
     try {
-      const created = await api.createAgent(token, {
+      const adopted = await api.adoptExistingAgentToTeam(token, selectedTeam.id, {
+        source_agent_id: sourceAgent.id,
         name: copiedAgentName,
-        workdir: sourceAgent.workdir,
-        command: sourceAgent.command,
-        args: sourceAgent.args.slice(),
-        target_node_id: sourceAgent.target_node_id ?? null,
-        source: AGENT_SOURCE_TEAM_FORGE,
-        worktree_mode: copiedWorktreeMode,
-        worktree_repo: copiedWorktreeRepo,
-        worktree_ref: copiedWorktreeRef,
-        code_mode: sourceAgent.code_mode,
-        codex_acp_default_mode: copiedCodexAcpDefaultMode,
-        ...(sourceAgent.runtime_model != null || sourceAgent.thinking_level != null
-          ? {
-              runtime_model: sourceAgent.runtime_model ?? null,
-              thinking_level: sourceAgent.thinking_level ?? null,
-            }
-          : {}),
-      });
-      createdAgentId = created.id;
-      const updated = await api.updateTeamSpec(token, selectedTeam.id, {
         spec: appendTeamMemberToSpec(
           selectedTeam.spec,
-          { ...copiedDraft, member_id: created.id },
-          created,
+          { ...copiedDraft, member_id: "__agenthub_adopted_member__" },
+          { ...sourceAgent, id: "__agenthub_adopted_member__" },
           teamPromptDefaults
         ),
         expected_updated_at: selectedTeam.updated_at,
+        workspace_copy_destination: options.workspaceCopyDestination.trim() || null,
+        memory_seed: options.memorySeed.trim() || null,
       });
+      const { agent: created, team: updated } = adopted;
       setAgents((prev) => [created, ...prev.filter((agent) => agent.id !== created.id)]);
       setTeams((prev) =>
         [...prev.filter((team) => team.id !== updated.id), updated].sort((left, right) =>
@@ -632,9 +614,6 @@ export function useTeamManagementActions(options: UseTeamManagementActionsOption
       setShowCopyExistingAgentModal(false);
       void refreshTeamRuntime(updated.id).catch(() => undefined);
     } catch (err) {
-      if (createdAgentId && (err as { status?: number })?.status === 409) {
-        void api.deleteAgent(token, createdAgentId).catch(() => undefined);
-      }
       setError(formatTeamForgeWorktreeError(err) ?? parseErrorMessage(err));
     } finally {
       setBusy(null);

--- a/web/tests/e2e/team_page_fixture.ts
+++ b/web/tests/e2e/team_page_fixture.ts
@@ -744,6 +744,38 @@ export async function mockTeamPageApis(
     await route.fulfill(jsonResponse(updated));
   });
 
+  await page.route(/\/api\/teams\/[^/]+\/members\/adopt$/, async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    const teamId = request.url().match(/\/api\/teams\/([^/]+)\/members\/adopt$/)?.[1] ?? "";
+    const index = teams.findIndex((team) => team.id === teamId);
+    if (index < 0) {
+      await route.fulfill(jsonResponse({ error: "team not found" }, 404));
+      return;
+    }
+    const payload = request.postDataJSON() as UpdateTeamSpecPayload & { name: string };
+    if (payload.expected_updated_at !== teams[index].updated_at) {
+      await route.fulfill(jsonResponse({ error: "team spec changed" }, 409));
+      return;
+    }
+    const memberId = `agent-forge-${agents.length + 1}`;
+    const spec = JSON.parse(JSON.stringify(payload.spec).replaceAll("__agenthub_adopted_member__", memberId));
+    const source = agents.find((agent) => agent.id === (payload as { source_agent_id: string }).source_agent_id);
+    if (!source) {
+      await route.fulfill(jsonResponse({ error: "agent not found" }, 404));
+      return;
+    }
+    const agent: E2eAgentRecord = { ...source, id: memberId, name: payload.name, status: "idle", created_at: now, updated_at: now };
+    agents.push(agent);
+    const updated: TeamDefinitionRecord = { ...teams[index], spec, updated_at: now + updateSpecPayloads.length + 1 };
+    teams[index] = updated;
+    updateSpecPayloads.push({ teamId, payload: { spec, expected_updated_at: payload.expected_updated_at } });
+    teamRuntimeStateById.set(teamId, { status: spec.members.length > 0 ? "running" : "stopped" });
+    await route.fulfill(jsonResponse({ agent, team: updated }));
+  });
+
   await page.route(/\/api\/teams\/[^/]+\/runtime$/, async (route, request) => {
     const url = new URL(request.url());
     const teamId = url.pathname.match(/\/api\/teams\/([^/]+)\/runtime$/)?.[1] ?? "";


### PR DESCRIPTION
feat(team): add workspace adoption copy

## Summary

- add a Team adoption endpoint that creates the copied member and updates the Team spec through one backend operation
- provide explicit optional workspace copy and operator-entered memory/context seed controls
- write provenance manifests in copied workspaces and exclude repository metadata, local AgentHub state, caches, environment files, sockets, and lock files

## Purpose

Move the existing-agent Team copy flow away from the frontend create-then-update sequence and make workspace content or seed transfer explicit.

## Related Issue

- Follow-up from the Team adoption contract in `docs/features/team-agent-adoption.md`

## Validation

- `cargo fmt --check`
- `cargo check -p agenthub --lib`
- `npm --prefix web run build`
- `npm --prefix web run lint`

## Known Follow-ups

- Existing `use_team_management_actions` tests still assert the superseded two-request copy flow and must be updated for the adoption endpoint.
- Persisted idempotency-key replay and backend filesystem-copy tests are not included yet.
- This PR is intentionally draft until those tests and retry semantics land.
