### PR TITLE
feat(storage): add durable download ingestion metrics

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -21,11 +21,14 @@ pub mod message_body_outbox;
 pub mod object_uploads;
 
 pub use object_uploads::{
-    NewObjectUpload, NewObjectUploadSession, NewObjectUploadSessionPart, ObjectUploadRecord,
-    ObjectUploadSessionCleanupResult, ObjectUploadSessionPartRecord, ObjectUploadSessionRecord,
-    cancel_object_upload_session, cleanup_expired_object_upload_sessions, get_object_upload,
+    NewObjectUpload, NewObjectUploadSession, NewObjectUploadSessionPart,
+    ObjectDownloadCleanupOutcome, ObjectDownloadFailureMetricRecord, ObjectDownloadMetricDelta,
+    ObjectDownloadMetricsRecord, ObjectUploadRecord, ObjectUploadSessionCleanupResult,
+    ObjectUploadSessionPartRecord, ObjectUploadSessionRecord, cancel_object_upload_session,
+    cleanup_expired_object_upload_sessions, get_object_download_metrics, get_object_upload,
     get_object_upload_session, insert_object_upload, insert_object_upload_session,
-    list_object_upload_session_parts, publish_object_upload_session,
+    list_object_download_failure_metrics, list_object_upload_session_parts,
+    publish_object_upload_session, record_object_download_metric,
     upsert_object_upload_session_part,
 };
 
@@ -923,6 +926,43 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
             created_at INTEGER NOT NULL,
             published_at INTEGER,
             cleanup_after INTEGER
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS object_download_metrics (
+            backend TEXT PRIMARY KEY,
+            attempts_total INTEGER NOT NULL DEFAULT 0 CHECK(attempts_total >= 0),
+            successes_total INTEGER NOT NULL DEFAULT 0 CHECK(successes_total >= 0),
+            failures_total INTEGER NOT NULL DEFAULT 0 CHECK(failures_total >= 0),
+            downloaded_bytes_total INTEGER NOT NULL DEFAULT 0 CHECK(downloaded_bytes_total >= 0),
+            latency_ms_total INTEGER NOT NULL DEFAULT 0 CHECK(latency_ms_total >= 0),
+            latency_ms_max INTEGER NOT NULL DEFAULT 0 CHECK(latency_ms_max >= 0),
+            cleanup_attempts_total INTEGER NOT NULL DEFAULT 0 CHECK(cleanup_attempts_total >= 0),
+            cleanup_successes_total INTEGER NOT NULL DEFAULT 0 CHECK(cleanup_successes_total >= 0),
+            cleanup_failures_total INTEGER NOT NULL DEFAULT 0 CHECK(cleanup_failures_total >= 0),
+            updated_at INTEGER NOT NULL,
+            CHECK(attempts_total = successes_total + failures_total),
+            CHECK(cleanup_attempts_total = cleanup_successes_total + cleanup_failures_total)
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS object_download_failure_metrics (
+            backend TEXT NOT NULL,
+            failure_class TEXT NOT NULL,
+            failures_total INTEGER NOT NULL DEFAULT 0 CHECK(failures_total >= 0),
+            last_failure_at INTEGER NOT NULL,
+            PRIMARY KEY(backend, failure_class),
+            FOREIGN KEY(backend) REFERENCES object_download_metrics(backend) ON DELETE CASCADE
         );
         "#,
     )
@@ -3097,11 +3137,13 @@ async fn backfill_team_channel_message_replica_group_ids(pool: &SqlitePool) -> a
 mod tests {
     use super::{
         AgentEventDbRouter, AgentEventIdleGc, NewObjectUpload, NewObjectUploadSession,
-        NewObjectUploadSessionPart, cancel_object_upload_session, cleanup_agent_event_history,
-        cleanup_expired_object_upload_sessions, create_parent_dir, get_object_upload,
-        get_object_upload_session, init_db_at_path, insert_object_upload,
-        insert_object_upload_session, list_object_upload_session_parts,
-        publish_object_upload_session, try_connect, upsert_object_upload_session_part,
+        NewObjectUploadSessionPart, ObjectDownloadCleanupOutcome, ObjectDownloadMetricDelta,
+        cancel_object_upload_session, cleanup_agent_event_history,
+        cleanup_expired_object_upload_sessions, create_parent_dir, get_object_download_metrics,
+        get_object_upload, get_object_upload_session, init_db_at_path, insert_object_upload,
+        insert_object_upload_session, list_object_download_failure_metrics,
+        list_object_upload_session_parts, publish_object_upload_session,
+        record_object_download_metric, try_connect, upsert_object_upload_session_part,
     };
     use agenthub_config::path_utils::expand_tilde;
     use serde_json::json;
@@ -3143,6 +3185,8 @@ mod tests {
                 'team_context_artifacts',
                 'team_context_flush_checkpoint',
                 'object_uploads',
+                'object_download_metrics',
+                'object_download_failure_metrics',
                 'object_upload_sessions',
                 'object_upload_session_parts'
               )
@@ -3151,7 +3195,7 @@ mod tests {
         .fetch_one(&pool)
         .await
         .expect("count tables");
-        assert_eq!(table_count, 16);
+        assert_eq!(table_count, 18);
 
         let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
             .fetch_one(&pool)
@@ -3231,6 +3275,126 @@ mod tests {
         assert_eq!(upload.created_by_actor_id, "worker");
         assert_eq!(upload.publish_state, "published");
         assert_eq!(upload.published_at, Some(100));
+
+        pool.close().await;
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn object_download_metrics_accumulate_terminal_and_cleanup_outcomes() {
+        let dir = unique_temp_dir("object-download-metrics");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let db_path = dir.join("agenthub.db");
+        let pool = init_db_at_path(&db_path).await.expect("init db");
+
+        for metric in [
+            ObjectDownloadMetricDelta {
+                backend: "fs",
+                succeeded: true,
+                downloaded_bytes: 100,
+                latency_ms: 25,
+                failure_class: None,
+                cleanup_outcome: ObjectDownloadCleanupOutcome::NotAttempted,
+                recorded_at: 100,
+            },
+            ObjectDownloadMetricDelta {
+                backend: "fs",
+                succeeded: false,
+                downloaded_bytes: 100,
+                latency_ms: 40,
+                failure_class: Some("verification"),
+                cleanup_outcome: ObjectDownloadCleanupOutcome::Succeeded,
+                recorded_at: 110,
+            },
+            ObjectDownloadMetricDelta {
+                backend: "fs",
+                succeeded: false,
+                downloaded_bytes: 100,
+                latency_ms: 30,
+                failure_class: Some("metadata_publish"),
+                cleanup_outcome: ObjectDownloadCleanupOutcome::Failed,
+                recorded_at: 105,
+            },
+        ] {
+            record_object_download_metric(&pool, metric)
+                .await
+                .expect("record object download metric");
+        }
+
+        let metrics = get_object_download_metrics(&pool, "fs")
+            .await
+            .expect("load object download metrics")
+            .expect("fs object download metrics");
+        assert_eq!(metrics.attempts_total, 3);
+        assert_eq!(metrics.successes_total, 1);
+        assert_eq!(metrics.failures_total, 2);
+        assert_eq!(metrics.downloaded_bytes_total, 300);
+        assert_eq!(metrics.latency_ms_total, 95);
+        assert_eq!(metrics.latency_ms_max, 40);
+        assert_eq!(metrics.cleanup_attempts_total, 2);
+        assert_eq!(metrics.cleanup_successes_total, 1);
+        assert_eq!(metrics.cleanup_failures_total, 1);
+        assert_eq!(metrics.updated_at, 110);
+
+        let failures = list_object_download_failure_metrics(&pool, "fs")
+            .await
+            .expect("list object download failure metrics");
+        assert_eq!(failures.len(), 2);
+        assert_eq!(failures[0].failure_class, "metadata_publish");
+        assert_eq!(failures[0].failures_total, 1);
+        assert_eq!(failures[0].last_failure_at, 105);
+        assert_eq!(failures[1].failure_class, "verification");
+        assert_eq!(failures[1].failures_total, 1);
+        assert_eq!(failures[1].last_failure_at, 110);
+
+        let invalid = record_object_download_metric(
+            &pool,
+            ObjectDownloadMetricDelta {
+                backend: "fs",
+                succeeded: false,
+                downloaded_bytes: 0,
+                latency_ms: 1,
+                failure_class: None,
+                cleanup_outcome: ObjectDownloadCleanupOutcome::NotAttempted,
+                recorded_at: 120,
+            },
+        )
+        .await
+        .expect_err("failed metric must provide a failure class");
+        assert!(invalid.to_string().contains("failure class"));
+
+        let invalid = record_object_download_metric(
+            &pool,
+            ObjectDownloadMetricDelta {
+                backend: "fs",
+                succeeded: false,
+                downloaded_bytes: 0,
+                latency_ms: 1,
+                failure_class: Some("source-host.example.test"),
+                cleanup_outcome: ObjectDownloadCleanupOutcome::NotAttempted,
+                recorded_at: 120,
+            },
+        )
+        .await
+        .expect_err("failure classes must remain bounded");
+        assert!(invalid.to_string().contains("unsupported"));
+
+        let invalid = record_object_download_metric(
+            &pool,
+            ObjectDownloadMetricDelta {
+                backend: "source-host.example.test",
+                succeeded: true,
+                downloaded_bytes: 0,
+                latency_ms: 1,
+                failure_class: None,
+                cleanup_outcome: ObjectDownloadCleanupOutcome::NotAttempted,
+                recorded_at: 120,
+            },
+        )
+        .await
+        .expect_err("metric backends must remain bounded");
+        assert!(invalid.to_string().contains("unsupported"));
 
         pool.close().await;
         let _ = std::fs::remove_file(&db_path);

--- a/crates/agenthub-db/src/object_uploads.rs
+++ b/crates/agenthub-db/src/object_uploads.rs
@@ -104,6 +104,256 @@ pub struct ObjectUploadSessionCleanupResult {
     pub expire_batches: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectDownloadCleanupOutcome {
+    NotAttempted,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObjectDownloadMetricDelta<'a> {
+    pub backend: &'a str,
+    pub succeeded: bool,
+    pub downloaded_bytes: i64,
+    pub latency_ms: i64,
+    pub failure_class: Option<&'a str>,
+    pub cleanup_outcome: ObjectDownloadCleanupOutcome,
+    pub recorded_at: i64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct ObjectDownloadMetricsRecord {
+    pub backend: String,
+    pub attempts_total: i64,
+    pub successes_total: i64,
+    pub failures_total: i64,
+    pub downloaded_bytes_total: i64,
+    pub latency_ms_total: i64,
+    pub latency_ms_max: i64,
+    pub cleanup_attempts_total: i64,
+    pub cleanup_successes_total: i64,
+    pub cleanup_failures_total: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct ObjectDownloadFailureMetricRecord {
+    pub backend: String,
+    pub failure_class: String,
+    pub failures_total: i64,
+    pub last_failure_at: i64,
+}
+
+pub async fn record_object_download_metric(
+    pool: &SqlitePool,
+    metric: ObjectDownloadMetricDelta<'_>,
+) -> anyhow::Result<()> {
+    let backend = metric.backend.trim();
+    anyhow::ensure!(
+        !backend.is_empty(),
+        "object download metric backend is required"
+    );
+    anyhow::ensure!(
+        matches!(backend, "fs" | "s3"),
+        "unsupported object download metric backend"
+    );
+    anyhow::ensure!(
+        metric.downloaded_bytes >= 0,
+        "object download metric bytes must be non-negative"
+    );
+    anyhow::ensure!(
+        metric.latency_ms >= 0,
+        "object download metric latency must be non-negative"
+    );
+    let failure_class = metric
+        .failure_class
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    anyhow::ensure!(
+        metric.succeeded == failure_class.is_none(),
+        "successful object downloads must not have a failure class and failed downloads must have one"
+    );
+    anyhow::ensure!(
+        failure_class.is_none_or(is_object_download_failure_class),
+        "unsupported object download failure class"
+    );
+
+    let successes = i64::from(metric.succeeded);
+    let failures = i64::from(!metric.succeeded);
+    let (cleanup_attempts, cleanup_successes, cleanup_failures) = match metric.cleanup_outcome {
+        ObjectDownloadCleanupOutcome::NotAttempted => (0_i64, 0_i64, 0_i64),
+        ObjectDownloadCleanupOutcome::Succeeded => (1_i64, 1_i64, 0_i64),
+        ObjectDownloadCleanupOutcome::Failed => (1_i64, 0_i64, 1_i64),
+    };
+
+    let mut tx = pool
+        .begin()
+        .await
+        .context("begin object download metric update")?;
+    sqlx::query(
+        r#"
+        INSERT INTO object_download_metrics (
+            backend,
+            attempts_total,
+            successes_total,
+            failures_total,
+            downloaded_bytes_total,
+            latency_ms_total,
+            latency_ms_max,
+            cleanup_attempts_total,
+            cleanup_successes_total,
+            cleanup_failures_total,
+            updated_at
+        )
+        VALUES (?1, 1, ?2, ?3, ?4, ?5, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT(backend) DO UPDATE SET
+            attempts_total = attempts_total + 1,
+            successes_total = successes_total + excluded.successes_total,
+            failures_total = failures_total + excluded.failures_total,
+            downloaded_bytes_total = downloaded_bytes_total + excluded.downloaded_bytes_total,
+            latency_ms_total = latency_ms_total + excluded.latency_ms_total,
+            latency_ms_max = MAX(latency_ms_max, excluded.latency_ms_max),
+            cleanup_attempts_total = cleanup_attempts_total + excluded.cleanup_attempts_total,
+            cleanup_successes_total = cleanup_successes_total + excluded.cleanup_successes_total,
+            cleanup_failures_total = cleanup_failures_total + excluded.cleanup_failures_total,
+            updated_at = MAX(updated_at, excluded.updated_at)
+        "#,
+    )
+    .bind(backend)
+    .bind(successes)
+    .bind(failures)
+    .bind(metric.downloaded_bytes)
+    .bind(metric.latency_ms)
+    .bind(cleanup_attempts)
+    .bind(cleanup_successes)
+    .bind(cleanup_failures)
+    .bind(metric.recorded_at)
+    .execute(&mut *tx)
+    .await
+    .with_context(|| format!("update object download metrics for backend {backend:?}"))?;
+
+    if let Some(failure_class) = failure_class {
+        sqlx::query(
+            r#"
+            INSERT INTO object_download_failure_metrics (
+                backend,
+                failure_class,
+                failures_total,
+                last_failure_at
+            )
+            VALUES (?1, ?2, 1, ?3)
+            ON CONFLICT(backend, failure_class) DO UPDATE SET
+                failures_total = failures_total + 1,
+                last_failure_at = MAX(last_failure_at, excluded.last_failure_at)
+            "#,
+        )
+        .bind(backend)
+        .bind(failure_class)
+        .bind(metric.recorded_at)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| {
+            format!(
+                "update object download failure metric for backend {backend:?} class {failure_class:?}"
+            )
+        })?;
+    }
+
+    tx.commit()
+        .await
+        .context("commit object download metric update")?;
+    Ok(())
+}
+
+pub async fn get_object_download_metrics(
+    pool: &SqlitePool,
+    backend: &str,
+) -> anyhow::Result<Option<ObjectDownloadMetricsRecord>> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            backend,
+            attempts_total,
+            successes_total,
+            failures_total,
+            downloaded_bytes_total,
+            latency_ms_total,
+            latency_ms_max,
+            cleanup_attempts_total,
+            cleanup_successes_total,
+            cleanup_failures_total,
+            updated_at
+        FROM object_download_metrics
+        WHERE backend = ?1
+        "#,
+    )
+    .bind(backend.trim())
+    .fetch_optional(pool)
+    .await
+    .with_context(|| format!("load object download metrics for backend {backend:?}"))?;
+
+    Ok(row.map(|row| ObjectDownloadMetricsRecord {
+        backend: row.get("backend"),
+        attempts_total: row.get("attempts_total"),
+        successes_total: row.get("successes_total"),
+        failures_total: row.get("failures_total"),
+        downloaded_bytes_total: row.get("downloaded_bytes_total"),
+        latency_ms_total: row.get("latency_ms_total"),
+        latency_ms_max: row.get("latency_ms_max"),
+        cleanup_attempts_total: row.get("cleanup_attempts_total"),
+        cleanup_successes_total: row.get("cleanup_successes_total"),
+        cleanup_failures_total: row.get("cleanup_failures_total"),
+        updated_at: row.get("updated_at"),
+    }))
+}
+
+pub async fn list_object_download_failure_metrics(
+    pool: &SqlitePool,
+    backend: &str,
+) -> anyhow::Result<Vec<ObjectDownloadFailureMetricRecord>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT backend, failure_class, failures_total, last_failure_at
+        FROM object_download_failure_metrics
+        WHERE backend = ?1
+        ORDER BY failure_class ASC
+        "#,
+    )
+    .bind(backend.trim())
+    .fetch_all(pool)
+    .await
+    .with_context(|| format!("list object download failure metrics for backend {backend:?}"))?;
+
+    Ok(rows
+        .iter()
+        .map(|row| ObjectDownloadFailureMetricRecord {
+            backend: row.get("backend"),
+            failure_class: row.get("failure_class"),
+            failures_total: row.get("failures_total"),
+            last_failure_at: row.get("last_failure_at"),
+        })
+        .collect())
+}
+
+fn is_object_download_failure_class(value: &str) -> bool {
+    matches!(
+        value,
+        "request_validation"
+            | "transient_status"
+            | "server_status"
+            | "size_limit"
+            | "source_policy"
+            | "redirect"
+            | "dns"
+            | "source_stream"
+            | "object_store"
+            | "request"
+            | "verification"
+            | "metadata_publish"
+    )
+}
+
 pub async fn insert_object_upload(
     pool: &SqlitePool,
     upload: &NewObjectUpload<'_>,

--- a/docs/features/object-storage-opendal.md
+++ b/docs/features/object-storage-opendal.md
@@ -115,8 +115,10 @@ The request names a source URL, file name, content type, optional expected size,
 SHA-256. AgentHub authorizes the route resource, derives the owner scope, downloads the source on
 the server, streams bytes into the object store, verifies the final size/checksum, and publishes
 SQLite metadata only after successful verification. The first implementation is synchronous at the
-API boundary and returns the published `ObjectUploadRecord`; a future async intent table can add
-queued/canceled/expired terminal states without changing the owner-scope authority.
+API boundary and returns the published `ObjectUploadRecord`. Terminal outcomes also update durable,
+backend-scoped SQLite counters after request validation, verification, and metadata publication. A
+future async intent table can add queued/canceled/expired terminal states without changing the
+owner-scope authority when a product flow actually requires those states.
 
 Download ingestion must be fail-closed:
 
@@ -180,6 +182,10 @@ operations must still authorize against the Team-owned metadata row.
   expiry, status, and error class.
 - Download completion must verify final size and SHA-256 before inserting a `published` metadata
   row. Failed, canceled, expired, or oversized downloads must not publish object metadata.
+- Download success means both object verification and metadata publication completed. Durable
+  counters use fixed failure classes and never persist source URL, source host, actor, owner-scope,
+  or credential labels. Metric persistence failure must not reverse an already-published object or
+  create a retryable ambiguous result.
 - Public image URLs must be issued only after the owner scope is validated and the metadata row is
   published. A CDN URL is not proof that a user may create, replace, or delete an image.
 - Writes must record size and SHA-256 so repair and migration jobs can verify object integrity.
@@ -201,7 +207,7 @@ operations must still authorize against the Team-owned metadata row.
 | Agent upload entry | Parser, owner-scope, and DB tests cover `agenthub actor upload`, required scope/file flags, image mode, and published metadata persistence. |
 | Team upload API | Handler and router tests cover authorization, owner-scope derivation, base64 upload publication, raster-image allowlist, and size/checksum mismatch rejection without publishing metadata. |
 | Task and agent upload APIs | Focused API tests cover parent Team authorization before task-scope publication, agent existence checks before agent-scope publication, object/image key prefixes, and OpenAPI fixture coverage for every new route. |
-| Large download ingestion | Service and API tests cover route-derived owner scopes, URL scheme rejection, private/loopback address rejection, operator source-host allow/deny policy, configurable private-network allowance for controlled tests, final size/SHA-256 verification, OpenAPI coverage, and successful metadata publication after a streamed server-side download. Object-store tests cover chunked writes with size/hash calculation. |
+| Large download ingestion | Service and API tests cover route-derived owner scopes, URL scheme rejection, private/loopback address rejection, operator source-host allow/deny policy, configurable private-network allowance for controlled tests, final size/SHA-256 verification, OpenAPI coverage, and successful metadata publication after a streamed server-side download. Terminal-metric tests cover cumulative success/failure, bytes, latency, bounded failure classes, verification and metadata-publication compensation, and the no-publish-on-failure invariant. Object-store tests cover chunked writes with size/hash calculation. |
 | Graph-bed UX | Frontend tests cover raster MIME allowlisting, browser SHA-256/base64 request preparation, Team image endpoint wiring, and Markdown image insertion in the Team channel composer. |
 | Config contract | `agenthub-config` tests confirm defaults and secret-free S3 env reference trimming. |
 | Bazel coverage | `//crates/agenthub-object-store:agenthub_object_store_tests` is listed in Bazel test and coverage targets. |
@@ -231,8 +237,11 @@ operations must still authorize against the Team-owned metadata row.
   held until the object-store byte stream finishes so one hot source cannot monopolize download
   workers with large objects.
 - Download ingestion emits structured logs for retry attempts and terminal success/failure with
-  source host, owner scope, upload id, latency, byte count on success, and failure class. S3/R2/MinIO
-  production use should add durable counters before large user-facing uploads become default-on.
+  source host, owner scope, upload id, latency, completed byte count, and failure class. Terminal
+  success is emitted only after metadata publication. `object_download_metrics` retains cumulative
+  backend-scoped attempts, outcomes, bytes, latency sum/max, and cleanup totals;
+  `object_download_failure_metrics` retains fixed failure-class totals. These writes are best-effort
+  observability and warn on persistence failure without changing the primary request result.
 - Existing local Team context artifacts remain compatible until their metadata schema is explicitly
   migrated to record backend/key instead of only absolute local paths.
 
@@ -240,9 +249,8 @@ operations must still authorize against the Team-owned metadata row.
 
 - Existing artifact tables store local filesystem paths; moving those rows to object storage needs a
   schema migration and read-compatibility plan.
-- Download ingestion has first-pass SSRF guardrails, operator source-host policy, bounded pre-stream
-  retry, per-host concurrency limits, structured logs, and streaming object-store writer support,
-  but still needs durable metrics counters before broad untrusted production exposure.
+- Download ingestion remains synchronous. A queued/cancelable product flow must add a durable
+  intent state machine with expiry and error-class semantics before exposing asynchronous behavior.
 - S3-compatible providers differ in multipart, path-style, and checksum behavior; MinIO is the first
   CI fixture, but each documented production provider still needs compatibility evidence before it
   is described as production-ready.
@@ -253,4 +261,6 @@ operations must still authorize against the Team-owned metadata row.
 
 - [2026-07-16-object-storage-opendal.md](../journal/2026-07-16-object-storage-opendal.md)
 - [2026-07-22-object-storage-download-ingest.md](../journal/2026-07-22-object-storage-download-ingest.md)
+- [2026-07-23-object-storage-download-ingest-implementation.md](../journal/2026-07-23-object-storage-download-ingest-implementation.md)
 - [2026-08-08-object-store-s3-release-enablement.md](../journal/2026-08-08-object-store-s3-release-enablement.md)
+- [2026-08-08-object-storage-download-observability.md](../journal/2026-08-08-object-storage-download-observability.md)

--- a/docs/journal/2026-07-22-object-storage-download-ingest.md
+++ b/docs/journal/2026-07-22-object-storage-download-ingest.md
@@ -56,7 +56,8 @@ git diff --check
 
 ## Follow-Ups
 
-- Add source host allow/deny lists, retry policy, per-host concurrency limits,
-  and download observability before broad untrusted production exposure.
-- Add an async intent table if product flows need queued/cancelable downloads
-  or durable failed ingest state.
+- Source host policy, retry, per-host concurrency, structured logs, and durable terminal metrics
+  landed in the implementation checkpoints linked above and in
+  [Object Storage Download Observability](2026-08-08-object-storage-download-observability.md).
+- Add an async intent table only if product flows require queued/cancelable downloads or durable
+  in-progress state.

--- a/docs/journal/2026-07-23-object-storage-download-ingest-implementation.md
+++ b/docs/journal/2026-07-23-object-storage-download-ingest-implementation.md
@@ -46,10 +46,11 @@ cargo test -p agenthub-config object_store -- --nocapture
 
 ## Follow-Ups
 
-- Add retry policy, per-host concurrency limits, and download observability before broad untrusted
-  production exposure.
-- Add an async intent table if product flows need queued/cancelable downloads or durable failed
-  ingest state.
+- Retry, per-host concurrency, structured logs, and durable terminal counters landed in the dated
+  checkpoints below and in
+  [Object Storage Download Observability](2026-08-08-object-storage-download-observability.md).
+- Add an async intent table only if product flows require queued/cancelable downloads or durable
+  in-progress state.
 
 ## 2026-07-28 Host Policy Hardening
 
@@ -76,9 +77,10 @@ cargo test -p agenthub download_ -- --nocapture
 
 ### Follow-Ups
 
-- Add durable download counters before broad untrusted production exposure.
-- Add an async intent table if product flows need queued/cancelable downloads or durable failed
-  ingest state.
+- Durable terminal counters landed in
+  [Object Storage Download Observability](2026-08-08-object-storage-download-observability.md).
+- Add an async intent table only if product flows require queued/cancelable downloads or durable
+  in-progress state.
 
 ## 2026-07-29 Retry And Observability
 
@@ -102,8 +104,8 @@ streaming starts and emits structured logs for retry attempts plus terminal succ
 
 - Do not retry after object-store streaming starts. That keeps partial writer semantics explicit
   until download ingestion has durable intents and cleanup accounting.
-- Keep logs as the first observability surface; durable counters remain separate production
-  hardening.
+- Keep structured logs as the request-level observability surface. Durable low-cardinality counters
+  later landed without persisting source or owner labels.
 
 ### Validation
 
@@ -115,9 +117,10 @@ cargo check -p agenthub
 
 ### Follow-Ups
 
-- Add durable latency/byte/failure/cleanup counters before broad untrusted production exposure.
-- Add an async intent table if product flows need queued/cancelable downloads or durable failed
-  ingest state.
+- Durable latency, byte, failure, and cleanup counters landed in
+  [Object Storage Download Observability](2026-08-08-object-storage-download-observability.md).
+- Add an async intent table only if product flows require queued/cancelable downloads or durable
+  in-progress state.
 
 ## 2026-07-29 Per-Host Concurrency
 
@@ -150,6 +153,7 @@ cargo check -p agenthub
 
 ### Follow-Ups
 
-- Add durable latency/byte/failure/cleanup counters before broad untrusted production exposure.
-- Add an async intent table if product flows need queued/cancelable downloads or durable failed
-  ingest state.
+- Durable latency, byte, failure, and cleanup counters landed in
+  [Object Storage Download Observability](2026-08-08-object-storage-download-observability.md).
+- Add an async intent table only if product flows require queued/cancelable downloads or durable
+  in-progress state.

--- a/docs/journal/2026-08-08-object-storage-download-observability.md
+++ b/docs/journal/2026-08-08-object-storage-download-observability.md
@@ -1,0 +1,69 @@
+# Object Storage Download Observability
+
+## Summary
+
+Server-side download ingestion now records durable, low-cardinality terminal metrics in SQLite.
+The counters survive process restarts and distinguish successful publication, bounded failure
+classes, downloaded bytes, latency, and compensation cleanup outcomes.
+
+## Background
+
+Download ingestion already enforced source policy, bounded pre-stream retries, per-host
+concurrency, streaming size limits, checksum verification, and structured logs. Those logs were
+not durable, and the success log was emitted after the object write but before checksum
+verification and metadata publication. A later verification or SQLite failure could therefore be
+reported as both a success and a failure.
+
+## Scope
+
+- Add backend-scoped cumulative counters in `object_download_metrics`.
+- Add bounded failure-class counters in `object_download_failure_metrics`.
+- Record attempts, successes, failures, downloaded bytes, latency sum/max, and cleanup
+  attempt/success/failure totals.
+- Count request validation, source/request, verification, and metadata publication terminal
+  failures without persisting source hosts, URLs, owner scopes, or credentials.
+- Emit the terminal success log only after final verification and `object_uploads` publication.
+- Keep metric persistence observational: a metric write failure emits a warning but does not turn
+  an already-published object into an ambiguous client-visible failure.
+
+## Key Decisions
+
+- Use monotonic SQLite aggregates rather than process-local atomics so restart does not reset the
+  evidence.
+- Use fixed failure classes rather than arbitrary error text or per-source labels, preserving
+  bounded cardinality and avoiding sensitive metadata in the metric tables.
+- Count bytes once the object-store stream returns a complete object, including objects later
+  rejected by verification or metadata publication. Preflight and pre-stream failures contribute
+  zero downloaded bytes.
+- Track compensation cleanup separately from the primary failure class. Cleanup failure must not
+  hide whether the primary failure came from verification or metadata publication.
+- Do not add a queued intent table until a product flow requires queued, cancelable, expiring, or
+  durably inspectable in-progress downloads.
+
+## Validation
+
+```bash
+cargo test -p agenthub-db object_download_metrics_accumulate_terminal_and_cleanup_outcomes -- --nocapture
+cargo test -p agenthub team_download_api_streams_remote_object_and_publishes_metadata -- --nocapture
+cargo test -p agenthub download_ -- --nocapture
+cargo fmt --all --check
+cargo clippy --locked -p agenthub-db -p agenthub --all-targets -- -D warnings
+bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc \
+  --test_arg=object_download_metrics_accumulate_terminal_and_cleanup_outcomes \
+  //crates/agenthub-db:agenthub_db_tests
+bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc \
+  --test_arg=team_download_api_streams_remote_object_and_publishes_metadata \
+  //:agenthub_unit_tests
+git diff --check
+```
+
+The focused service regression covers successful publication, checksum rejection, request
+validation rejection, forced metadata publication failure, cleanup accounting, bounded failure
+classes, and the invariant that failed downloads do not publish additional metadata rows.
+
+## Follow-Ups
+
+- Add a durable async intent table only if a product surface introduces queued/cancelable downloads
+  or needs durable in-progress and terminal failure state.
+- Any future operator-facing metrics exporter should read these aggregates without adding
+  source-host, URL, actor, or owner-scope labels.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -182,6 +182,8 @@ Main shape:
   return immutable results to the parent Task evidence stream.
 - Official release matrices now enable the OpenDAL S3 backend explicitly while keeping the local
   filesystem as the runtime default and artifact/provider evidence as separate gates.
+- Server-side download ingestion now records durable terminal outcome, latency, byte, failure-class,
+  and compensation-cleanup aggregates without introducing high-cardinality source labels.
 
 Start with:
 
@@ -189,6 +191,7 @@ Start with:
 - `2026-08-06-teamspace-control-plane.md`
 - `2026-08-07-team-goal-lease-foundation.md`
 - `2026-08-08-object-store-s3-release-enablement.md`
+- `2026-08-08-object-storage-download-observability.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -59,7 +59,6 @@ Stable contracts:
 ## Object Storage
 
 - [ ] `P1` Verify OpenDAL S3 release artifacts: official release and prebuild matrices now compile every `agenthub` target with the root `object-store-s3` feature while the runtime default remains `fs`. PR #890 and main push workflow run `29639782907` / job `88068255089` established the MinIO-backed bytes, hosted-image, and delete fixture. Remaining evidence is a reviewed preview or semver release whose published feature rows include `object-store-s3`, plus an x86_64 published-binary smoke against MinIO. Record the workflow run, artifact, and smoke evidence in [journal/2026-08-08-object-store-s3-release-enablement.md](journal/2026-08-08-object-store-s3-release-enablement.md). Provider-specific production certification remains separate.
-- [ ] `P2` Harden server-side download ingestion for broad untrusted production exposure: source host allow/deny lists, bounded pre-stream retry, per-host concurrency limits, and structured success/failure logs are implemented; remaining hardening is durable latency/bytes/failure/cleanup counters and an async intent table if product flows need queued, cancelable, or durable failed downloads. Stable contract: [features/object-storage-opendal.md](features/object-storage-opendal.md); notes: [journal/2026-07-22-object-storage-download-ingest.md](journal/2026-07-22-object-storage-download-ingest.md), [journal/2026-07-23-object-storage-download-ingest-implementation.md](journal/2026-07-23-object-storage-download-ingest-implementation.md).
 
 ## Observability, CI, And Docs
 

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -564,6 +564,43 @@ async fn init_test_schema(db: &SqlitePool) {
 
     sqlx::query(
         r#"
+        CREATE TABLE object_download_metrics (
+            backend TEXT PRIMARY KEY,
+            attempts_total INTEGER NOT NULL DEFAULT 0,
+            successes_total INTEGER NOT NULL DEFAULT 0,
+            failures_total INTEGER NOT NULL DEFAULT 0,
+            downloaded_bytes_total INTEGER NOT NULL DEFAULT 0,
+            latency_ms_total INTEGER NOT NULL DEFAULT 0,
+            latency_ms_max INTEGER NOT NULL DEFAULT 0,
+            cleanup_attempts_total INTEGER NOT NULL DEFAULT 0,
+            cleanup_successes_total INTEGER NOT NULL DEFAULT 0,
+            cleanup_failures_total INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create object_download_metrics");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE object_download_failure_metrics (
+            backend TEXT NOT NULL,
+            failure_class TEXT NOT NULL,
+            failures_total INTEGER NOT NULL DEFAULT 0,
+            last_failure_at INTEGER NOT NULL,
+            PRIMARY KEY(backend, failure_class),
+            FOREIGN KEY(backend) REFERENCES object_download_metrics(backend) ON DELETE CASCADE
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create object_download_failure_metrics");
+
+    sqlx::query(
+        r#"
         CREATE TABLE object_upload_sessions (
             id TEXT PRIMARY KEY,
             owner_scope TEXT NOT NULL,

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -184,8 +184,24 @@ async fn team_upload_api_requires_team_access_and_publishes_metadata() {
 
 #[tokio::test]
 async fn team_download_api_streams_remote_object_and_publishes_metadata() {
-    let state = build_test_state().await;
+    let state = build_test_state_without_seeded_team_member_agents().await;
     let headers = auth_headers(&state).await;
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO agents (
+            id, name, workdir, command, args, worktree_mode, worktree_repo, worktree_ref,
+            code_mode, status, created_at, updated_at
+        )
+        VALUES ('planner', 'planner-agent', '/tmp', '/usr/bin/true', '[]', 'use_existing',
+                NULL, NULL, 0, 'created', ?1, ?2)
+        "#,
+    )
+    .bind(now)
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .expect("insert download test planner agent");
 
     let Json(created) = create_team(
         State(state.clone()),
@@ -203,7 +219,7 @@ async fn team_download_api_streams_remote_object_and_publishes_metadata() {
     let sha256 = hex_encode(&Sha256::digest(bytes));
     let source_url = spawn_download_source(bytes.to_vec()).await;
     let request = TeamDownloadRequest {
-        source_url,
+        source_url: source_url.clone(),
         file_name: " evidence.txt ".to_string(),
         content_type: " Text/Plain ".to_string(),
         expected_size_bytes: Some(bytes.len() as u64),
@@ -212,7 +228,7 @@ async fn team_download_api_streams_remote_object_and_publishes_metadata() {
 
     let Json(upload) = download_team_object(
         State(state.clone()),
-        headers,
+        headers.clone(),
         Path(created.id.clone()),
         Json(request),
     )
@@ -235,6 +251,110 @@ async fn team_download_api_streams_remote_object_and_publishes_metadata() {
         .await
         .expect("load persisted download");
     assert_eq!(persisted, upload);
+
+    let successful_metrics = agenthub_db::get_object_download_metrics(&state.db, "fs")
+        .await
+        .expect("load successful download metrics")
+        .expect("fs download metrics");
+    assert_eq!(successful_metrics.attempts_total, 1);
+    assert_eq!(successful_metrics.successes_total, 1);
+    assert_eq!(successful_metrics.failures_total, 0);
+    assert_eq!(
+        successful_metrics.downloaded_bytes_total,
+        bytes.len() as i64
+    );
+
+    download_team_object(
+        State(state.clone()),
+        headers.clone(),
+        Path(created.id.clone()),
+        Json(TeamDownloadRequest {
+            source_url: source_url.clone(),
+            file_name: "rejected.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            expected_size_bytes: Some(bytes.len() as u64),
+            expected_sha256: Some("0".repeat(64)),
+        }),
+    )
+    .await
+    .expect_err("checksum mismatch should reject the downloaded object");
+
+    download_team_object(
+        State(state.clone()),
+        headers.clone(),
+        Path(created.id.clone()),
+        Json(TeamDownloadRequest {
+            source_url: "file:///tmp/rejected.txt".to_string(),
+            file_name: "rejected.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            expected_size_bytes: None,
+            expected_sha256: None,
+        }),
+    )
+    .await
+    .expect_err("unsupported source URL should reject before download");
+
+    sqlx::query(
+        r#"
+        CREATE TRIGGER reject_object_download_metadata
+        BEFORE INSERT ON object_uploads
+        BEGIN
+            SELECT RAISE(FAIL, 'forced object upload metadata failure');
+        END;
+        "#,
+    )
+    .execute(&state.db)
+    .await
+    .expect("create metadata failure trigger");
+    download_team_object(
+        State(state.clone()),
+        headers,
+        Path(created.id.clone()),
+        Json(TeamDownloadRequest {
+            source_url,
+            file_name: "metadata-failure.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            expected_size_bytes: Some(bytes.len() as u64),
+            expected_sha256: Some(sha256),
+        }),
+    )
+    .await
+    .expect_err("metadata insert failure should reject the downloaded object");
+
+    let terminal_metrics = agenthub_db::get_object_download_metrics(&state.db, "fs")
+        .await
+        .expect("load terminal download metrics")
+        .expect("fs download metrics");
+    assert_eq!(terminal_metrics.attempts_total, 4);
+    assert_eq!(terminal_metrics.successes_total, 1);
+    assert_eq!(terminal_metrics.failures_total, 3);
+    assert_eq!(
+        terminal_metrics.downloaded_bytes_total,
+        (bytes.len() * 3) as i64
+    );
+    assert_eq!(terminal_metrics.cleanup_attempts_total, 2);
+    assert_eq!(terminal_metrics.cleanup_successes_total, 2);
+    assert_eq!(terminal_metrics.cleanup_failures_total, 0);
+
+    let failures = agenthub_db::list_object_download_failure_metrics(&state.db, "fs")
+        .await
+        .expect("load download failure metrics");
+    assert_eq!(failures.len(), 3);
+    assert_eq!(failures[0].failure_class, "metadata_publish");
+    assert_eq!(failures[0].failures_total, 1);
+    assert_eq!(failures[1].failure_class, "request_validation");
+    assert_eq!(failures[1].failures_total, 1);
+    assert_eq!(failures[2].failure_class, "verification");
+    assert_eq!(failures[2].failures_total, 1);
+
+    let published_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM object_uploads WHERE owner_scope = ?1",
+    )
+    .bind(format!("teams/{}", created.id))
+    .fetch_one(&state.db)
+    .await
+    .expect("count published team downloads");
+    assert_eq!(published_count, 1);
 }
 
 #[tokio::test]

--- a/src/object_upload.rs
+++ b/src/object_upload.rs
@@ -213,16 +213,11 @@ impl ObjectUploadService {
         if let Err(err) =
             verify_stored_object(&object, expected_size_bytes, expected_sha256.as_deref())
         {
-            if let Err(cleanup_err) = self.store.delete_stored_object(&object).await {
-                tracing::warn!(
-                    object_key = %object.key,
-                    error = %cleanup_err,
-                    "failed to delete object after upload verification failure"
-                );
-            }
+            self.cleanup_failed_object(&object, "upload_verification")
+                .await;
             return Err(err);
         }
-        self.publish_verified_object(VerifiedObjectPublication {
+        let publication = VerifiedObjectPublication {
             upload_id,
             owner_scope,
             file_name,
@@ -230,51 +225,86 @@ impl ObjectUploadService {
             object,
             public_url,
             actor_id: request.actor_id,
-        })
-        .await
+        };
+        match self.publish_verified_object(&publication).await {
+            Ok(record) => Ok(record),
+            Err(err) => {
+                self.cleanup_failed_object(&publication.object, "upload_metadata_publish")
+                    .await;
+                Err(err)
+            }
+        }
     }
 
     pub async fn download(
         &self,
         request: ObjectDownloadRequest,
     ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
-        let file_name = normalize_upload_file_name(&request.file_name)?;
-        let expected_size_bytes = request.expected_size_bytes;
-        let expected_sha256 = normalize_expected_sha256(request.expected_sha256.as_deref())?;
-        if let Some(expected_size_bytes) = expected_size_bytes {
-            anyhow::ensure!(
-                expected_size_bytes <= self.download_settings.max_bytes,
-                "download expected_size_bytes exceeds configured max_bytes"
-            );
-        }
-        let source_url = parse_download_url(&request.source_url)?;
+        let started_at = Instant::now();
+        let upload_id = Uuid::now_v7().to_string();
+        let owner_scope = request.owner_scope.to_string();
+        let source_host_hint = Url::parse(request.source_url.trim())
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_string))
+            .unwrap_or_else(|| "<invalid>".to_string());
+        let prepared = (|| {
+            let file_name = normalize_upload_file_name(&request.file_name)?;
+            let expected_size_bytes = request.expected_size_bytes;
+            let expected_sha256 = normalize_expected_sha256(request.expected_sha256.as_deref())?;
+            if let Some(expected_size_bytes) = expected_size_bytes {
+                anyhow::ensure!(
+                    expected_size_bytes <= self.download_settings.max_bytes,
+                    "download expected_size_bytes exceeds configured max_bytes"
+                );
+            }
+            let source_url = parse_download_url(&request.source_url)?;
+            Ok::<_, anyhow::Error>((file_name, expected_size_bytes, expected_sha256, source_url))
+        })();
+        let (file_name, expected_size_bytes, expected_sha256, source_url) = match prepared {
+            Ok(prepared) => prepared,
+            Err(err) => {
+                self.record_download_metric(
+                    false,
+                    Some("request_validation"),
+                    0,
+                    started_at,
+                    agenthub_db::ObjectDownloadCleanupOutcome::NotAttempted,
+                )
+                .await;
+                tracing::warn!(
+                    upload_id = %upload_id,
+                    owner_scope = %owner_scope,
+                    source_host = %source_host_hint,
+                    failure_class = "request_validation",
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    error = %err,
+                    "object download ingestion failed"
+                );
+                return Err(err);
+            }
+        };
         let source_host = source_url
             .host_str()
             .expect("host checked by parse_download_url")
             .to_string();
-        let started_at = Instant::now();
-        let upload_id = Uuid::now_v7().to_string();
-        let owner_scope = request.owner_scope.to_string();
         let key = format!("uploads/{owner_scope}/{upload_id}/{file_name}");
         let object = match self.download_to_object(&key, source_url).await {
-            Ok(object) => {
-                tracing::info!(
-                    upload_id = %upload_id,
-                    owner_scope = %owner_scope,
-                    source_host = %source_host,
-                    object_key = %object.key,
-                    size_bytes = object.size_bytes,
-                    elapsed_ms = started_at.elapsed().as_millis() as u64,
-                    "object download ingestion completed"
-                );
-                object
-            }
+            Ok(object) => object,
             Err(err) => {
+                let failure_class = classify_download_error(&err);
+                self.record_download_metric(
+                    false,
+                    Some(failure_class),
+                    0,
+                    started_at,
+                    agenthub_db::ObjectDownloadCleanupOutcome::NotAttempted,
+                )
+                .await;
                 tracing::warn!(
                     upload_id = %upload_id,
                     owner_scope = %owner_scope,
                     source_host = %source_host,
-                    failure_class = classify_download_error(&err),
+                    failure_class,
                     elapsed_ms = started_at.elapsed().as_millis() as u64,
                     error = %err,
                     "object download ingestion failed"
@@ -285,16 +315,31 @@ impl ObjectUploadService {
         if let Err(err) =
             verify_stored_object(&object, expected_size_bytes, expected_sha256.as_deref())
         {
-            if let Err(cleanup_err) = self.store.delete_stored_object(&object).await {
-                tracing::warn!(
-                    object_key = %object.key,
-                    error = %cleanup_err,
-                    "failed to delete object after download verification failure"
-                );
-            }
+            let cleanup = self
+                .cleanup_failed_object(&object, "download_verification")
+                .await;
+            self.record_download_metric(
+                false,
+                Some("verification"),
+                object.size_bytes,
+                started_at,
+                cleanup,
+            )
+            .await;
+            tracing::warn!(
+                upload_id = %upload_id,
+                owner_scope = %owner_scope,
+                source_host = %source_host,
+                object_key = %object.key,
+                size_bytes = object.size_bytes,
+                failure_class = "verification",
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                error = %err,
+                "object download ingestion failed"
+            );
             return Err(err);
         }
-        self.publish_verified_object(VerifiedObjectPublication {
+        let publication = VerifiedObjectPublication {
             upload_id,
             owner_scope,
             file_name,
@@ -302,8 +347,53 @@ impl ObjectUploadService {
             object,
             public_url: None,
             actor_id: request.actor_id,
-        })
-        .await
+        };
+        let record = match self.publish_verified_object(&publication).await {
+            Ok(record) => record,
+            Err(err) => {
+                let cleanup = self
+                    .cleanup_failed_object(&publication.object, "download_metadata_publish")
+                    .await;
+                self.record_download_metric(
+                    false,
+                    Some("metadata_publish"),
+                    publication.object.size_bytes,
+                    started_at,
+                    cleanup,
+                )
+                .await;
+                tracing::warn!(
+                    upload_id = %publication.upload_id,
+                    owner_scope = %publication.owner_scope,
+                    source_host = %source_host,
+                    object_key = %publication.object.key,
+                    size_bytes = publication.object.size_bytes,
+                    failure_class = "metadata_publish",
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    error = %err,
+                    "object download ingestion failed"
+                );
+                return Err(err);
+            }
+        };
+        self.record_download_metric(
+            true,
+            None,
+            publication.object.size_bytes,
+            started_at,
+            agenthub_db::ObjectDownloadCleanupOutcome::NotAttempted,
+        )
+        .await;
+        tracing::info!(
+            upload_id = %publication.upload_id,
+            owner_scope = %publication.owner_scope,
+            source_host = %source_host,
+            object_key = %publication.object.key,
+            size_bytes = publication.object.size_bytes,
+            elapsed_ms = started_at.elapsed().as_millis() as u64,
+            "object download ingestion completed"
+        );
+        Ok(record)
     }
 
     async fn store_upload_bytes(
@@ -468,9 +558,9 @@ impl ObjectUploadService {
 
     async fn publish_verified_object(
         &self,
-        publication: VerifiedObjectPublication,
+        publication: &VerifiedObjectPublication,
     ) -> anyhow::Result<agenthub_db::ObjectUploadRecord> {
-        let object = publication.object;
+        let object = &publication.object;
         let now = Utc::now().timestamp();
         let size_bytes = i64::try_from(object.size_bytes)
             .context("uploaded object is too large for SQLite metadata size_bytes")?;
@@ -490,18 +580,56 @@ impl ObjectUploadService {
             published_at: Some(now),
             cleanup_after: None,
         };
-        match agenthub_db::insert_object_upload(&self.db, &upload).await {
-            Ok(record) => Ok(record),
+        agenthub_db::insert_object_upload(&self.db, &upload)
+            .await
+            .context("failed to publish upload metadata")
+    }
+
+    async fn cleanup_failed_object(
+        &self,
+        object: &StoredObject,
+        cleanup_reason: &'static str,
+    ) -> agenthub_db::ObjectDownloadCleanupOutcome {
+        match self.store.delete_stored_object(object).await {
+            Ok(()) => agenthub_db::ObjectDownloadCleanupOutcome::Succeeded,
             Err(err) => {
-                if let Err(cleanup_err) = self.store.delete_stored_object(&object).await {
-                    tracing::warn!(
-                        object_key = %object.key,
-                        error = %cleanup_err,
-                        "failed to delete object after upload metadata insert failure"
-                    );
-                }
-                Err(err).context("failed to publish upload metadata")
+                tracing::warn!(
+                    object_key = %object.key,
+                    cleanup_reason,
+                    error = %err,
+                    "failed to delete object after object ingestion failure"
+                );
+                agenthub_db::ObjectDownloadCleanupOutcome::Failed
             }
+        }
+    }
+
+    async fn record_download_metric(
+        &self,
+        succeeded: bool,
+        failure_class: Option<&str>,
+        downloaded_bytes: u64,
+        started_at: Instant,
+        cleanup_outcome: agenthub_db::ObjectDownloadCleanupOutcome,
+    ) {
+        let backend = object_store_backend_name(self.store.backend());
+        let metric = agenthub_db::ObjectDownloadMetricDelta {
+            backend,
+            succeeded,
+            downloaded_bytes: saturating_metric_i64(downloaded_bytes.into()),
+            latency_ms: saturating_metric_i64(started_at.elapsed().as_millis()),
+            failure_class,
+            cleanup_outcome,
+            recorded_at: Utc::now().timestamp(),
+        };
+        if let Err(err) = agenthub_db::record_object_download_metric(&self.db, metric).await {
+            tracing::warn!(
+                backend,
+                succeeded,
+                failure_class,
+                error = %err,
+                "failed to persist object download metric"
+            );
         }
     }
 }
@@ -587,7 +715,7 @@ fn is_retryable_download_request_error(err: &reqwest::Error) -> bool {
 }
 
 fn classify_download_error(err: &anyhow::Error) -> &'static str {
-    let message = err.to_string();
+    let message = format!("{err:#}");
     if message.contains("HTTP 408") || message.contains("HTTP 429") {
         return "transient_status";
     }
@@ -608,6 +736,15 @@ fn classify_download_error(err: &anyhow::Error) -> &'static str {
     }
     if message.contains("resolve download source host") {
         return "dns";
+    }
+    if message.contains("read object chunk") {
+        return "source_stream";
+    }
+    if message.contains("create object writer")
+        || message.contains("write object chunk")
+        || message.contains("close object writer")
+    {
+        return "object_store";
     }
     "request"
 }
@@ -763,6 +900,10 @@ fn object_store_backend_name(backend: ObjectStoreBackend) -> &'static str {
     }
 }
 
+fn saturating_metric_i64(value: u128) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
 fn normalize_upload_file_name(file_name: &str) -> anyhow::Result<String> {
     let file_name = file_name.trim();
     if file_name.is_empty() || file_name == "." || file_name == ".." {
@@ -896,6 +1037,16 @@ mod tests {
         assert_eq!(
             classify_download_error(&anyhow!("download exceeded max redirects")),
             "redirect"
+        );
+        assert_eq!(
+            classify_download_error(
+                &anyhow!("download exceeded configured max_bytes").context("read object chunk")
+            ),
+            "size_limit"
+        );
+        assert_eq!(
+            classify_download_error(&anyhow!("disk full").context("write object chunk")),
+            "object_store"
         );
     }
 


### PR DESCRIPTION
feat(storage): add durable download ingestion metrics

## Summary

- Persist backend-scoped download attempts, terminal outcomes, downloaded bytes, latency, and cleanup totals in SQLite.
- Persist bounded failure-class totals without source URL, host, owner, actor, or other high-cardinality labels.
- Emit terminal success only after object verification and metadata publication.
- Track compensation cleanup independently when verification or metadata publication fails.
- Close the durable-observability TODO and align the canonical spec and rollout journals.

## Why

Server-side download ingestion already emitted structured logs, but process-local logs do not provide durable cumulative evidence. The previous success log also occurred after the object write but before final verification and metadata publication, so a later checksum or publication failure could appear successful before being rejected.

## Behavior and safety

- Success means a verified object with published metadata.
- Metric writes are best-effort observability and do not convert an already-published success into an ambiguous client failure.
- Backend and failure-class dimensions are bounded.
- Sensitive and high-cardinality labels are not persisted.
- Failed verification or publication does not leave an additional metadata row.
- An asynchronous intent table remains out of scope until a queued or cancelable product flow exists.

## Related issues

None. This closes the Object Storage P2 durable-observability item in `docs/todo.md`. Official S3 artifact validation remains open as a separate P1 item.

## Test coverage and recommended validation

Focused tests cover:

- cumulative success, failure, byte, latency, and cleanup accounting;
- bounded backend and failure-class validation;
- successful ingestion, checksum rejection, request validation failure, and forced metadata publication failure;
- compensation cleanup totals and the absence of an extra metadata row after failure.

Recommended commands:

```console
cargo test -p agenthub-db
cargo test -p agenthub download_ -- --nocapture
cargo fmt --all --check
cargo clippy --locked -p agenthub-db -p agenthub --all-targets -- -D warnings
bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc --test_arg=object_download_metrics_accumulate_terminal_and_cleanup_outcomes //crates/agenthub-db:agenthub_db_tests
bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc --test_arg=team_download_api_streams_remote_object_and_publishes_metadata //:agenthub_unit_tests
```

## Out of scope

- Asynchronous download intent persistence.
- Metrics HTTP or exporter surfaces.
- Official release artifact and provider compatibility validation.
