### PR TITLE
docs(storage): record S3 release artifact evidence

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,6 +35,7 @@ rust_library(
         "//crates/agenthub-object-store:Cargo.toml",
         ".github/workflows/release.yml",
         ".github/workflows/release-prebuild.yml",
+        "docs/journal/2026-08-08-object-store-s3-release-enablement.md",
         "docs/todo.md",
         "web/index.html",
     ] + glob(

--- a/docs/journal/2026-08-08-object-store-s3-release-enablement.md
+++ b/docs/journal/2026-08-08-object-store-s3-release-enablement.md
@@ -4,8 +4,11 @@
 
 Official release and prebuild matrices now enable S3-compatible object storage through the existing
 OpenDAL-backed `agenthub-object-store` abstraction. Runtime configuration still defaults to the
-local filesystem and must explicitly select `backend = "s3"`; successful published artifacts remain
-a separate rollout gate.
+local filesystem and must explicitly select `backend = "s3"`. Main prebuild run
+[`31259043337`](https://github.com/hawkingrei/agenthub/actions/runs/31259043337) closed the published
+artifact gate: every supported matrix row succeeded, and the published Linux x86_64 binary passed a
+MinIO smoke covering byte upload, hosted-image upload and public read, verification failure, and
+compensating delete.
 
 ## Background
 
@@ -18,7 +21,9 @@ or making remote object storage the default backend.
 - Add the root `object-store-s3` feature to every `agenthub` release and prebuild matrix row.
 - Keep root and object-store default features empty so local and Bazel builds remain unchanged.
 - Keep runtime backend selection explicit and preserve `fs` as the default.
-- Update the release feature regression test, canonical spec, and artifact-validation TODO.
+- Retain reviewed workflow and published-binary evidence for the release feature closure.
+- Track the independently discovered Linux runtime baseline issue as release packaging work rather
+  than treating it as an S3 backend failure.
 
 ## Key Decisions
 
@@ -30,6 +35,56 @@ or making remote object storage the default backend.
   production-certification evidence.
 - Compiling S3 into the binary does not configure credentials, select an endpoint, or change the
   runtime backend.
+
+## Published Artifact Evidence
+
+The successful `push` run used main commit `a71ebe0975eb8891460f1a9730ac18fd01a98b8c` and completed
+all supported rows:
+
+- Linux x86_64 job `93106856351`
+- Linux ARM64 job `93106856382`
+- macOS ARM64 job `93106856376`
+
+The Linux x86_64 log records this reviewed feature closure:
+
+```text
+cross build --locked --release --target x86_64-unknown-linux-gnu --bin agenthub \
+  --features release-vendored-openssl,release-lance-fp16,rocksdb,object-store-s3
+```
+
+The smoke used the following immutable artifact evidence:
+
+| Evidence | Value |
+| --- | --- |
+| Artifact ID | `9022659373` |
+| Artifact name | `release-prebuild-x86_64-unknown-linux-gnu` |
+| Artifact size | `337650437` bytes |
+| GitHub artifact digest | `sha256:4300bede3c1ff01a841120ba360c84e8b23aed35a7a0b645a387c0a8f7436297` |
+| Published archive | `agenthub-main-linux-amd64.tar.gz` |
+| Published archive SHA-256 | `4438513d8a4298c30697dcf1d3e50f869640cb9cfb66930543e73ed627b3ce24` |
+| Binary version | `agenthub 0.0.10` |
+| Artifact expiry | `2026-08-15T13:52:48Z` |
+
+The published binary ran in an Ubuntu 24.04 container with CA certificates against
+`minio/minio:RELEASE.2025-06-13T11-33-47Z` at image digest
+`sha256:064117214caceaa8d8a90ef7caa58f2b2aeb316b5156afe9ee8da5b4d83e12c8`.
+Disposable credentials and an isolated bucket were used; no production provider was contacted.
+
+| Runtime path | Evidence |
+| --- | --- |
+| Process health | `/health` returned `ok` |
+| Byte upload | S3 metadata and downloaded bytes agreed on `9160` bytes and SHA-256 `569b0e18fd54c270370e43da36a43cc1261debdc67875d438725ea1b11900daf` |
+| Hosted image | S3 metadata, the source image, and the public HTTP GET agreed on `10909` bytes and SHA-256 `7b645494cb372c3e67a823136d9a4eb907d9b6f9c47130ff9d0561796ec26a69` |
+| Verification failure | An intentionally incorrect expected digest returned HTTP `400` with failure class `verification` |
+| Compensating delete | `cleanup_attempts_total = 1`, `cleanup_successes_total = 1`, and `cleanup_failures_total = 0`; the failed object was absent from MinIO and its metadata row count was `0` |
+| Retained successes | SQLite and MinIO contained exactly the two successful S3 objects totaling `20069` bytes |
+
+This closes MinIO S3-compatibility evidence for the published Linux x86_64 artifact. It does not
+certify AWS S3, Cloudflare R2, or another production provider.
+
+The same artifact starts on Ubuntu 24.04 but does not start on Ubuntu 22.04 because it requires
+`GLIBC_2.38` and `GLIBC_2.39`. That packaging baseline is tracked separately in `docs/todo.md`; it
+does not invalidate the successful S3 path on a compatible runtime.
 
 ## Validation
 
@@ -44,12 +99,12 @@ git diff --check
 bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc \
   --test_arg=release_feature_tests::official_release_includes_opendal_s3_without_changing_defaults \
   //:agenthub_unit_tests
+gh run view 31259043337 --job 93106856351 --log
+gh api repos/hawkingrei/agenthub/actions/artifacts/9022659373
 ```
 
 ## Follow-Ups
 
-- Record one reviewed preview or semver release whose artifact matrix compiles the explicit S3
-  feature on every supported target.
-- Run the published Linux x86_64 binary against MinIO and retain byte, hosted-image, and delete
-  evidence.
 - Certify each documented production provider separately before making provider-specific claims.
+- Define and enforce the supported Linux glibc baseline, then add a published-binary startup smoke
+  on the oldest supported Linux distribution.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,6 +5,7 @@ Active backlog only. Keep this file small and current.
 ## Release And Packaging
 
 - [ ] `P1` Verify preview release partial-asset behavior: semver release run `29194967848` for `v0.0.11` proves Linux `x86_64` / `aarch64` release builds used `release-vendored-openssl`, avoided the stale cross-sysroot OpenSSL panic, and published canonical `agenthub` / `agenthub-acp` assets plus Debian packages. Remaining evidence is a preview release run showing successful binary assets publish when one release matrix target fails. Record the preview workflow run ID and release URL in [journal/2026-04-20-release-vendored-openssl-and-partial-assets.md](journal/2026-04-20-release-vendored-openssl-and-partial-assets.md).
+- [ ] `P1` Define and enforce the Linux runtime baseline for official artifacts: the x86_64 prebuild from workflow run `31259043337` starts on Ubuntu 24.04 but requires `GLIBC_2.38` / `GLIBC_2.39` and does not start on Ubuntu 22.04. Pin the supported glibc floor, build against a compatible sysroot, and add a published-binary startup smoke on the oldest supported Linux distribution. Evidence: [journal/2026-08-08-object-store-s3-release-enablement.md](journal/2026-08-08-object-store-s3-release-enablement.md).
 
 ## Team Workspace Browser Matrix
 
@@ -55,10 +56,6 @@ Stable contracts:
 
 - [x] `P1` Complete the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). SQLite authority rows now rebuild the conversation, actor mailbox, run-event, and agent-event projections; guarded ordered reads compare high-water marks and exact SQLite page IDs, fall back on any gap, and queue a startup worker for asynchronous repair. Orphan/prune helpers remain diagnostics and explicit maintenance only. Keep normal SQLite bodies readable until a later authority-cutover decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).
 - [ ] `P1` Stage SQLite retirement by responsibility, not by a flag flip: Phase 1 `cf_body` dual-write, durable SQLite outbox, startup drainer, and SQLite compatibility reads are landed; `cf_index` is now a rebuildable, guarded delivery projection. Before moving Team, Agent, run, mailbox, permission, or idempotency authority, complete dual-read comparison and full rebuild/backup-restore recovery evidence, then define a transactional `ControlStore` replacement with conditional updates, uniqueness, audit, and per-entity rollback. RocksDB indexes and LanceDB archives must not become control-plane authority by implication. Stable contract: [features/message-storage-tiering.md](features/message-storage-tiering.md).
-
-## Object Storage
-
-- [ ] `P1` Verify OpenDAL S3 release artifacts: official release and prebuild matrices now compile every `agenthub` target with the root `object-store-s3` feature while the runtime default remains `fs`. PR #890 and main push workflow run `29639782907` / job `88068255089` established the MinIO-backed bytes, hosted-image, and delete fixture. Remaining evidence is a reviewed preview or semver release whose published feature rows include `object-store-s3`, plus an x86_64 published-binary smoke against MinIO. Record the workflow run, artifact, and smoke evidence in [journal/2026-08-08-object-store-s3-release-enablement.md](journal/2026-08-08-object-store-s3-release-enablement.md). Provider-specific production certification remains separate.
 
 ## Observability, CI, And Docs
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ mod release_feature_tests {
     const RELEASE_PREBUILD_WORKFLOW: &str =
         include_str!("../.github/workflows/release-prebuild.yml");
     const TODO_MD: &str = include_str!("../docs/todo.md");
+    const S3_RELEASE_JOURNAL: &str =
+        include_str!("../docs/journal/2026-08-08-object-store-s3-release-enablement.md");
 
     #[test]
     fn official_release_includes_opendal_s3_without_changing_defaults() {
@@ -106,12 +108,21 @@ mod release_feature_tests {
             );
         }
         assert!(
-            TODO_MD.contains("- [ ] `P1` Verify OpenDAL S3 release artifacts"),
-            "keep the official artifact validation tail explicit"
+            !TODO_MD.contains("- [ ] `P1` Verify OpenDAL S3 release artifacts"),
+            "remove the S3 artifact gate after published-binary evidence lands"
         );
         assert!(
-            TODO_MD.contains("runtime default remains `fs`"),
-            "TODO should preserve the runtime default boundary"
+            S3_RELEASE_JOURNAL.contains("31259043337")
+                && S3_RELEASE_JOURNAL.contains("9022659373")
+                && S3_RELEASE_JOURNAL
+                    .contains("4438513d8a4298c30697dcf1d3e50f869640cb9cfb66930543e73ed627b3ce24"),
+            "journal must retain the official workflow, artifact, and archive evidence"
+        );
+        assert!(
+            S3_RELEASE_JOURNAL.contains("cleanup_attempts_total = 1")
+                && S3_RELEASE_JOURNAL.contains("cleanup_successes_total = 1")
+                && S3_RELEASE_JOURNAL.contains("runtime backend"),
+            "journal must retain the compensating-delete and runtime-default boundaries"
         );
     }
 


### PR DESCRIPTION
## Summary

- record the successful official prebuild run, matrix jobs, artifact identity, and immutable digests
- retain published Linux x86_64 MinIO smoke evidence for byte upload, hosted-image public read, verification failure, and compensating delete
- close the completed OpenDAL S3 release-artifact TODO and make the regression test require the journal evidence
- track the independently discovered Linux glibc runtime baseline as a separate release-packaging follow-up

## Why

The release workflows already compile the root `object-store-s3` feature into every official binary, but the rollout gate still required evidence from a published artifact. Main prebuild run `31259043337` succeeded across all supported targets, and its Linux x86_64 artifact passed the required MinIO smoke.

This change records that evidence and removes the completed gate without changing runtime selection: `fs` remains the default, and S3 still requires explicit configuration.

## User impact

The official Linux x86_64 prebuild is now evidenced to carry the OpenDAL S3 path and interoperate with the pinned MinIO compatibility fixture. This does not certify AWS S3, Cloudflare R2, or another production provider.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test official_release_includes_opendal_s3_without_changing_defaults --lib`
- `bazel test --action_env=PROTOC=/opt/homebrew/bin/protoc --test_arg=release_feature_tests::official_release_includes_opendal_s3_without_changing_defaults //:agenthub_unit_tests`
- official prebuild run `31259043337`, Linux x86_64 job `93106856351`, artifact `9022659373`
- isolated published-binary smoke against `minio/minio:RELEASE.2025-06-13T11-33-47Z`

## Follow-up

- define and enforce the supported Linux glibc floor; the current x86_64 artifact starts on Ubuntu 24.04 but requires `GLIBC_2.38` / `GLIBC_2.39` and does not start on Ubuntu 22.04
- certify production providers separately before making provider-specific claims

Related: #890
