### PR TITLE
docs(userdocs): align guides with release behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,50 +46,42 @@ workbench than to a thin prompt UI.
 
 ## Install AgentHub
 
-### Homebrew
-
-AgentHub publishes Homebrew release binaries through the
-`linkerdog/homebrew-tap` tap.
-
-```bash
-brew tap linkerdog/homebrew-tap
-brew install linkerdog/homebrew-tap/agenthub
-```
-
-Installed binaries:
-
-- `agenthub`
-- `agenthub-codex-acp`
-- `agenthub-acp`
-
-To run AgentHub in the background:
-
-```bash
-brew services start linkerdog/homebrew-tap/agenthub
-```
-
-AgentHub reads config from `~/.agenthub/config.toml`.
-
-To create that file interactively:
-
-```bash
-agenthub init
-```
-
-Minimal example:
-
-```toml
-[server]
-listen = "127.0.0.1:8080"
-```
-
-Then open `http://localhost:8080`.
-
-Current release binaries are available for:
+Official release binaries are available for:
 
 - macOS Apple Silicon (`darwin-arm64`)
 - Linux `x86_64`
 - Linux `aarch64`
+
+Windows and macOS Intel binaries are not currently published.
+
+Recommended installation paths:
+
+- Ubuntu/Debian: install the matching `.deb` from the
+  [latest release](https://github.com/hawkingrei/agenthub/releases/latest). It
+  includes `agenthub`, `agenthub-acp`, and a systemd service.
+- macOS or portable Linux: install the matching `agenthub` and `agenthub-acp`
+  archives from the same release and verify them with `SHA256SUMS.txt`.
+- npm: `npm install -g @linkerdog/agenthub` installs only the `agenthub`
+  control-plane binary; install the matching `agenthub-acp` release archive
+  separately before running the default Codex or Claude adapters.
+
+The Homebrew tap currently trails the primary release channel and installs a
+legacy ACP helper. Use release archives for a new complete installation until
+the formula is brought back into version and adapter parity.
+
+After installing both binaries:
+
+```bash
+agenthub --version
+agenthub-acp --version
+agenthub init
+agenthub
+```
+
+Then open `http://localhost:8080`. For package-specific commands, checksum
+verification, upgrades, uninstall behavior, platform limitations, and the
+current Linux runtime caveat, see
+[Installation and Startup](https://doc.agenthub.hawkingrei.com/docs/getting-started/installation).
 
 For local source development, contributor setup, repository layout, and common
 commands, see [docs/developer-setup.md](docs/developer-setup.md).
@@ -176,34 +168,33 @@ Core concepts:
 
 ## Remote Agent Nodes
 
-If you want remote execution, run the same `agenthub` binary on the remote
-machine and enable internal gRPC on both the main node and the remote node.
+If you want remote execution, run the same `agenthub` release on every machine.
+Keep the main process in its default `main` role, enable internal gRPC on both
+sides, and configure each remote process with `role = "node"` plus a unique
+`node_id`.
 
 ```toml
+[server]
+role = "node"
+node_id = "node-east"
+
 [internal_grpc]
 enabled = true
 listen = "0.0.0.0:50051"
 
-[internal_grpc.security]
-mode = "mtls" # mtls | tls | disabled
-cert_dir = "~/.agenthub/internal-grpc"
-
 [internal_grpc.auth]
-shared_secret = "replace-me"
+shared_secret = "<shared-secret-from-your-secret-store>"
 issuer = "agenthub"
 audience = "agenthub-internal"
+
+[internal_grpc.bootstrap]
+token = "<node-bootstrap-token>"
 ```
 
-Then register the remote node from the `Agents` page or the `agent_nodes` API
-with:
-
-- `id`
-- `grpc_target`
-- `tls_server_name`
-- `default_worktree_root` (optional)
-
-For the current contract, see
-[docs/features/agent-nodes.md](docs/features/agent-nodes.md).
+Use TLS or mTLS on a private network, then register the reachable gRPC target
+from the root-only node controls on the **Agents** page. See the
+[Agent Nodes user guide](https://doc.agenthub.hawkingrei.com/docs/core/agent-nodes)
+for onboarding and the current transport boundary.
 
 ## Documentation
 

--- a/docs/journal/2026-08-13-user-documentation-release-readiness.md
+++ b/docs/journal/2026-08-13-user-documentation-release-readiness.md
@@ -1,0 +1,71 @@
+# User Documentation Release Readiness
+
+## Summary
+
+The README and published user documentation now describe the current product and release behavior
+instead of mixing intended features, developer workflows, and stale endpoint examples. The refresh
+covers installation, first-run onboarding, agents, worktrees, replay and recovery, OpenAPI,
+notifications, Agent Nodes, security, deployment, operations, and storage boundaries.
+
+## Background
+
+The existing site had accumulated implementation drift across several user-critical paths. Examples
+included obsolete authentication and push routes, environment overrides that the server actually
+ignores, monitoring and orchestration contracts that are not implemented, unsafe worktree cleanup,
+an incomplete backup set, and installation channels whose published artifacts no longer matched the
+guide.
+
+A live distribution audit also found that GitHub release archives and Debian packages publish the
+current `agenthub` plus `agenthub-acp` pair, npm publishes only `agenthub`, and the Homebrew formula
+still points to `v0.0.7` with the legacy `agenthub-codex-acp` helper. The Linux glibc compatibility
+floor remains open and must not be inferred from the workflow runner label.
+
+## Scope
+
+- Make Debian packages and paired GitHub archives the complete-runtime installation paths.
+- Document npm's main-binary-only boundary and mark Homebrew as lagging until it reaches release and
+  adapter parity.
+- Align first-run root setup, agent creation, status, worktree, replay, and recovery guidance with
+  the current UI and backend routes.
+- Separate REST history from SSE live delivery and describe the bounded reconnect behavior.
+- Describe the incremental OpenAPI surface without implying that every HTTP route is published.
+- Correct role, passkey, notification, Agent Node, safe-path, and internal gRPC security boundaries.
+- Document the complete SQLite, event database, archive, message-body, object, and VAPID backup set.
+- Keep future monitoring, webhook, Kubernetes, and high-availability work out of current user
+  procedures.
+
+## Key Decisions
+
+- User documentation follows shipped behavior and exact artifact shape, not intended channel shape.
+- `agenthub` and `agenthub-acp` should come from the same release whenever installed separately.
+- The public OpenAPI document is an incremental automation contract, not a mirror of every internal
+  UI route.
+- `safe_paths` is an input-validation guardrail, not an operating-system sandbox.
+- Agent event replay uses persisted per-agent SQLite databases; SSE is the bounded live transport.
+- Official release artifacts include the OpenDAL S3 backend, while default source builds remain
+  feature-gated and runtime storage remains `fs` until explicitly configured.
+- Shipping S3 support is distinct from certifying every S3-compatible provider.
+- Normal server settings come from `config.toml`; detected `AGENTHUB_*` config overrides are logged
+  as ignored.
+- Backup and restore procedures operate on a consistent complete data set rather than individual
+  database or storage files.
+
+## Validation
+
+```bash
+npm --prefix userdocs ci
+npm --prefix userdocs run build
+git diff --check
+rg -n "/api/(login|register|admin/push|agents/stream|events/stream)" userdocs/docs README.md
+gh release view v0.0.11 --repo hawkingrei/agenthub --json assets,tagName,url
+npm view @linkerdog/agenthub version dist-tags bin optionalDependencies engines --json
+gh api repos/linkerdog/homebrew-tap/contents/Formula/agenthub.rb
+```
+
+## Follow-Ups
+
+- Restore Homebrew release and adapter parity before advertising it as a current complete install.
+- Freeze and enforce the minimum Linux glibc baseline, then replace the compatibility caution with a
+  tested support matrix.
+- Keep deployed-browser behavior and public API examples in the release verification loop so the
+  user guide does not drift back toward implementation intent.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -188,6 +188,8 @@ Main shape:
   contracts in canonical specs while retaining dated journals only for rollout evidence.
 - Dependabot remediation now removes all 16 open alert versions from the Rust ACP, web, and
   userdocs dependency graphs while retaining explicit upstream dependency migration follow-ups.
+- User documentation now follows current release artifacts and runtime behavior across installation,
+  onboarding, agent lifecycle, streaming, API automation, nodes, security, storage, and operations.
 
 Start with:
 
@@ -198,6 +200,7 @@ Start with:
 - `2026-08-08-object-storage-download-observability.md`
 - `2026-08-09-feature-docs-compaction-wave2-closeout.md`
 - `2026-08-12-dependabot-security-remediation.md`
+- `2026-08-13-user-documentation-release-readiness.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,6 +4,12 @@ Active backlog only. Keep this file small and current.
 
 ## Release And Packaging
 
+- [ ] `P0` Restore Homebrew channel parity before advertising it as a current complete install. The
+  `linkerdog/homebrew-tap` formula still points to `v0.0.7` and installs the legacy
+  `agenthub-codex-acp` helper, while current GitHub artifacts publish `agenthub-acp`. Update and
+  validate the formula against the intended formal release, including both binary versions and
+  `brew services` startup. Evidence:
+  [journal/2026-08-13-user-documentation-release-readiness.md](journal/2026-08-13-user-documentation-release-readiness.md).
 - [ ] `P1` Replace the temporary security pins for
   `hawkingrei/codex@6ca61345ceb09d76edc3db8c4eb55df18a10888a` and
   `hawkingrei/symposium-acp@c731bb045d1375af48b0446af728aea52503b30b` with upstream stable

--- a/userdocs/docs/advanced/connection-status-and-recovery.md
+++ b/userdocs/docs/advanced/connection-status-and-recovery.md
@@ -4,417 +4,109 @@ sidebar_position: 3
 
 # Connection Status and Recovery
 
-AgentHub uses Server-Sent Events (SSE) for real-time updates. This guide explains the connection lifecycle, recovery mechanisms, and troubleshooting techniques.
+AgentHub uses two complementary paths for session output:
 
-## Architecture Overview
+- authenticated REST requests load persisted event history;
+- Server-Sent Events (SSE) deliver new output while an agent is running.
 
-```
-┌──────────────┐      HTTP/SSE       ┌──────────────────┐
-│   Browser    │ ◄──────────────────► │  AgentHub Server │
-│   (UI)       │   Event Stream      │                  │
-└──────────────┘                     └────────┬─────────┘
-                                              │
-                    ┌─────────────────────────┼─────────────────────────┐
-                    │                         │                         │
-                    ▼                         ▼                         ▼
-            ┌──────────────┐         ┌──────────────┐         ┌──────────────┐
-            │ Agent Process│         │ Agent Process│         │ Agent Process│
-            │  (running)   │         │  (running)   │         │  (running)   │
-            └──────────────┘         └──────────────┘         └──────────────┘
-```
-
-**Key Points**:
-- Each agent session has its own SSE stream
-- Server pushes events as they occur
-- Client automatically reconnects on interruption
-- Events are persisted server-side for replay
+The persisted event API is the recovery source of truth. A temporary stream
+failure should delay live rendering, not erase completed output.
 
 ## Connection Badge States
 
-The connection badge in the UI header shows stream health:
+| Badge | Meaning | Recommended action |
+|-------|---------|--------------------|
+| `Online · SSE connected` | Browser and live stream are healthy. | None. |
+| `Online · SSE connecting` | A stream target exists and the first connection is opening. | Wait briefly. |
+| `Online · SSE reconnecting` | The prior stream failed or became stale. | Check proxy/server health if it persists. |
+| `Online · SSE idle` | Network is online but no running agent needs a stream. | Start or select a running agent if expected. |
+| `Offline · SSE disconnected` | The browser reports that the network is offline. | Restore connectivity. |
 
-| State | Badge | Meaning | Action Needed |
-|-------|-------|---------|---------------|
-| Connected | `Online · SSE connected` | Stream healthy | None |
-| Connecting | `Online · SSE connecting` | Opening connection | Wait |
-| Reconnecting | `Online · SSE reconnecting` | Retry after interruption | Wait |
-| Idle | `Online · SSE idle` | No agent selected | Select agent |
-| Disconnected | `Offline · SSE disconnected` | Network offline | Check network |
+## Current Endpoints
 
-### State Transitions
+The web UI opens the multi-agent stream:
 
-```
-         ┌─────────────┐
-         │    Idle     │
-         └──────┬──────┘
-                │ Select Agent
-                ▼
-         ┌─────────────┐
-         │  Connecting │
-         └──────┬──────┘
-           ┌────┴────┐
-           │         │
-           ▼         │
-    ┌─────────────┐  │
-    │  Connected  │  │ Error
-    └──────┬──────┘  │
-           │         │
-    Network│         │
-    Issue  │         │
-           ▼         │
-    ┌─────────────┐  │
-    │ Reconnecting│◄─┘
-    └──────┬──────┘
-           │ Success
-           ▼
-    ┌─────────────┐
-    │  Connected  │
-    └─────────────┘
+```text
+GET /sse/agents?ids=<comma-separated-agent-ids>&token=<session-token>
 ```
 
-## Server-Sent Events (SSE) Deep Dive
+A single-agent stream also exists:
 
-### How SSE Works
-
-```javascript
-// Browser connects to SSE endpoint
-const eventSource = new EventSource('/api/agents/{agent_id}/events')
-
-eventSource.onmessage = (event) => {
-  const data = JSON.parse(event.data)
-  // Handle agent output, status changes, etc.
-}
-
-eventSource.onerror = (error) => {
-  // Connection interrupted, auto-reconnect triggered
-}
+```text
+GET /sse/agents/<agent-id>?token=<session-token>
 ```
 
-### Event Types
+SSE uses a query token because the browser `EventSource` API cannot attach the
+normal bearer header. Treat browser history, proxy logs, and copied URLs as
+sensitive. Do not paste a live stream URL into tickets or chat.
 
-| Event Type | Description |
-|------------|-------------|
-| `output` | New agent output (stdout/stderr) |
-| `status` | Agent status change (running → completed) |
-| `acp_event` | Structured ACP protocol event |
-| `error` | Agent or transport error |
-| `heartbeat` | Keepalive ping (every 30s) |
+Persisted history uses the authenticated REST route:
 
-### Heartbeat Mechanism
-
-```
-Server sends:  {"type": "heartbeat", "ts": 1710000000}
-Every 30 seconds
+```text
+GET /api/agents/<agent-id>/events?limit=20&before_id=<event-id>
 ```
 
-**Purpose**:
-- Detect half-open connections
-- Keep proxy timeouts at bay
-- Validate client is still listening
+Optional `session_id` filters history to one session. This REST endpoint
+returns JSON; it is not the SSE stream.
 
-## Automatic Recovery
+## Stream Behavior
 
-### Reconnection Strategy
+- The server emits a heartbeat data message every 15 seconds.
+- Output may arrive as one `output` or `acp` message, or as a `batch`.
+- The server bounds each browser stream. Sustained backpressure or receiver lag
+  closes the connection so replay can recover without unbounded buffering.
+- The web UI reconnects with exponential delays capped at 30 seconds.
+- While the stream is unavailable or stale, the UI polls persisted events and
+  merges unseen records by event identity.
 
-AgentHub implements exponential backoff for reconnection:
+Reverse proxies must preserve `text/event-stream`, avoid response buffering,
+and allow connections to remain open beyond the heartbeat interval. The server
+sets `Cache-Control: no-cache` and `X-Accel-Buffering: no` on SSE responses.
 
-```
-Attempt 1: Wait 1 second
-Attempt 2: Wait 2 seconds
-Attempt 3: Wait 4 seconds
-Attempt 4: Wait 8 seconds
-Attempt 5+: Wait 30 seconds (max)
-```
+## Recovery Checklist
 
-### Event Replay on Reconnect
+1. Read the exact connection badge; `idle` is not a failure.
+2. Confirm the server health endpoint:
 
-When reconnecting, the server:
+   ```bash
+   curl --fail http://127.0.0.1:8080/health
+   ```
 
-1. Accepts new SSE connection
-2. Sends missed events since last known sequence
-3. Continues with live events
+3. In browser developer tools, inspect the request to `/sse/agents`:
+   - `401` means the session expired; sign in again.
+   - `404` means none of the requested agents is currently running.
+   - a gateway HTML response indicates proxy/upstream failure.
+4. Confirm normal authenticated REST requests still work. If history loads but
+   SSE does not, focus on proxy buffering, idle timeouts, and routing.
+5. Refresh the page. The backend task continues and history replay should fill
+   the gap.
+6. Inspect service logs for `backpressure timeout`, `broadcast lagged`, or an
+   ACP process failure.
 
-```javascript
-// Client tracks last received event
-const lastEventId = event.lastEventId
+## Manual SSE Check
 
-// On reconnect, server sends:
-// Events with id > lastEventId
-```
-
-### Recovery Checklist
-
-1. **Wait briefly** (up to 30 seconds)
-2. **Check badge state** - should show `reconnecting`
-3. **Observe output** - missed events appear when connected
-4. **Manual refresh** if stuck in `reconnecting` > 60s
-
-## Common Scenarios
-
-### Scenario 1: Brief Network Interruption
-
-**Symptoms**:
-- Badge shows `reconnecting` for 5-10 seconds
-- Output resumes automatically
-- No data loss
-
-**Recovery**:
-1. Wait for automatic reconnection
-2. Verify output resumes
-3. No action needed
-
-### Scenario 2: Extended Network Outage
-
-**Symptoms**:
-- Badge shows `disconnected`
-- UI becomes unresponsive
-- Network icon shows offline
-
-**Recovery**:
-1. Restore network connection
-2. Refresh browser page
-3. Reconnect to session
-4. History replay shows all missed events
-
-### Scenario 3: Server Restart
-
-**Symptoms**:
-- All agents show `reconnecting` simultaneously
-- Badge stuck in connecting state
-- Cannot access other UI features
-
-**Recovery**:
-1. Wait for server to restart
-2. Refresh page after server is back
-3. All sessions recoverable from history
-
-### Scenario 4: Agent Process Crash
-
-**Symptoms**:
-- Status changes to `failed`
-- SSE connection remains active
-- No new output
-
-**Recovery**:
-1. Check agent logs in `Debug / Raw` tab
-2. Restart agent if needed
-3. Create new session if unrecoverable
-
-## Manual Recovery Steps
-
-### Step 1: Check Connection Badge
-
-```
-Online · SSE connected    → Stream healthy
-Online · SSE reconnecting → Wait for auto-recovery
-Offline · SSE disconnected → Check network
-```
-
-### Step 2: Verify Network
+Copy a short-lived session token from an authenticated development environment
+only. Avoid shell history when possible.
 
 ```bash
-# Test connectivity
-curl -I http://localhost:8080/
-
-# Check SSE endpoint
-curl -N http://localhost:8080/api/agents/{agent_id}/events \
-  -H "Authorization: Bearer $TOKEN"
+curl -N \
+  "http://127.0.0.1:8080/sse/agents/<agent-id>?token=<session-token>"
 ```
 
-### Step 3: Refresh Session View
+You should see `heartbeat` messages and JSON output while the agent runs. Stop
+the command after diagnosis and revoke the session if the URL was exposed.
 
-1. Navigate away from agent view
-2. Return to agent view
-3. New SSE connection established
-4. History replay begins
+## What Not to Do
 
-### Step 4: Clear Browser Cache (Last Resort)
+- Do not delete per-agent databases to repair a live stream.
+- Do not clear all browser storage before checking the status code and server
+  logs; that destroys useful session evidence.
+- Do not build alerts around undocumented `/metrics` endpoints. AgentHub does
+  not currently expose a Prometheus contract.
+- Do not assume an SSE disconnect stopped the agent process.
 
-```
-1. Open DevTools (F12)
-2. Application → Clear Storage
-3. Clear site data
-4. Refresh page
-5. Login again
-```
+## Escalation Evidence
 
-## Debug Output
-
-### Raw Event Stream
-
-Access raw SSE stream for debugging:
-
-```bash
-# Terminal 1: Start agent
-curl -X POST http://localhost:8080/api/agents/{id}/start \
-  -H "Authorization: Bearer $TOKEN"
-
-# Terminal 2: Monitor events
-curl -N http://localhost:8080/api/agents/{id}/events \
-  -H "Authorization: Bearer $TOKEN" | jq .
-```
-
-### Browser DevTools
-
-**Network Tab**:
-```
-1. Open DevTools (F12)
-2. Network tab
-3. Filter by "events"
-4. Observe SSE connection
-```
-
-**Console Tab**:
-```javascript
-// Check EventSource state
-console.log(eventSource.readyState)
-// 0 = CONNECTING, 1 = OPEN, 2 = CLOSED
-
-// Manual reconnect
-eventSource.close()
-location.reload()
-```
-
-### Server Logs
-
-```bash
-# Follow server logs
-journalctl -u agenthub -f
-
-# Or if running directly
-agenthub 2>&1 | grep -i sse
-```
-
-## Advanced Recovery Techniques
-
-### Forcing Reconnect
-
-```javascript
-// In browser console
-window.location.reload()
-
-// Or more targeted
-const agentId = 'your-agent-id'
-fetch(`/api/agents/${agentId}/events`, {method: 'HEAD'})
-  .then(() => console.log('Server reachable'))
-  .catch(() => console.log('Server unreachable'))
-```
-
-### Event Sequence Debugging
-
-```bash
-# Check event sequence in database
-sqlite3 ~/.agenthub/agent-events/{agent_id}.db \
-  "SELECT seq, ts, stream FROM agent_events ORDER BY id DESC LIMIT 20;"
-```
-
-### Proxy Timeout Issues
-
-If behind a reverse proxy:
-
-```nginx
-# nginx.conf
-location /api/agents/ {
-    proxy_pass http://agenthub;
-    proxy_http_version 1.1;
-    
-    # Critical for SSE
-    proxy_set_header Connection '';
-    proxy_set_header Cache-Control 'no-cache';
-    
-    # Extend timeouts
-    proxy_read_timeout 86400s;
-    proxy_send_timeout 86400s;
-}
-```
-
-## Monitoring and Alerting
-
-### Key Metrics
-
-| Metric | Good | Warning | Critical |
-|--------|------|---------|----------|
-| SSE connection rate | > 95% | 90-95% | < 90% |
-| Reconnection count | 0-1/min | 2-5/min | > 5/min |
-| Event latency | < 100ms | 100-500ms | > 500ms |
-| Error rate | < 0.1% | 0.1-1% | > 1% |
-
-### Prometheus Metrics
-
-```python
-from prometheus_client import Counter, Gauge
-
-sse_connections_total = Counter('agenthub_sse_connections_total', 'Total SSE connections')
-sse_active_connections = Gauge('agenthub_sse_active_connections', 'Active SSE connections')
-sse_reconnections_total = Counter('agenthub_sse_reconnections_total', 'Total reconnections')
-```
-
-### Alerting Rules
-
-```yaml
-# Example alerting
-rules:
-  - alert: HighReconnectionRate
-    expr: rate(agenthub_sse_reconnections_total[5m]) > 0.1
-    for: 5m
-    labels:
-      severity: warning
-    annotations:
-      summary: "High SSE reconnection rate"
-      
-  - alert: NoActiveConnections
-    expr: agenthub_sse_active_connections == 0
-    for: 1m
-    labels:
-      severity: critical
-```
-
-## Troubleshooting Matrix
-
-| Symptom | Likely Cause | Solution |
-|---------|-------------|----------|
-| Constant reconnecting | Proxy timeout | Increase proxy timeouts |
-| No output after reconnect | Event ordering issue | Refresh page |
-| SSE 401 errors | Token expired | Re-login |
-| SSE 404 errors | Agent deleted | Check agent exists |
-| Slow event delivery | Server overload | Check server resources |
-| Connection drops every 30s | Load balancer timeout | Configure LB for long connections |
-
-## Best Practices
-
-### For Users
-
-1. **Don't panic on brief disconnections** - Auto-recovery works
-2. **Keep sessions open during important runs** - For visual monitoring
-3. **Refresh if stuck reconnecting > 60s** - Forces fresh connection
-4. **Check Debug/Raw for details** - When issues persist
-
-### For Operators
-
-1. **Configure proper timeouts** - On all proxies/load balancers
-2. **Monitor reconnection rates** - Early warning of issues
-3. **Scale horizontally** - If SSE connections overwhelm server
-4. **Use HTTP/2** - Better connection handling
-
-### For Developers
-
-1. **Implement proper error handling** - In custom clients
-2. **Handle reconnect gracefully** - Replay from last known event
-3. **Test network interruptions** - During development
-4. **Log connection events** - For debugging
-
-## When to Escalate
-
-Escalate to backend/runtime investigation when:
-
-- Badge oscillates between `connecting` and `reconnecting` for > 5 minutes
-- Session status advances but no new output arrives (possible event loss)
-- Multiple agents show stale stream behavior simultaneously
-- Server logs show SSE errors or panics
-- Event replay shows gaps in sequence numbers
-
-## Related Pages
-
-- [Troubleshooting](../operations/troubleshooting.md)
-- [View Execution Output](../core/view-output.md)
-- [Session Lifecycle](../core/session-lifecycle.md)
+Capture the AgentHub version, browser, proxy, agent ID, badge state, HTTP status
+for `/sse/agents`, whether REST history still loads, and the matching server log
+window. Redact query tokens and credentials.

--- a/userdocs/docs/advanced/openapi-and-automation.md
+++ b/userdocs/docs/advanced/openapi-and-automation.md
@@ -4,706 +4,141 @@ sidebar_position: 2
 
 # OpenAPI and Automation
 
-AgentHub exposes authenticated OpenAPI endpoints for integration and automation workflows. This guide covers API usage, client generation, and real-world automation patterns.
+AgentHub publishes a generated OpenAPI document for the HTTP operations that
+currently have a stable automation contract. The document is intentionally
+incremental; it does not yet describe every route used by the web UI.
 
-## Endpoints
+## Discovery Endpoints
 
-| Endpoint | Description | Auth Required |
-|----------|-------------|---------------|
-| `/api/openapi.json` | Full OpenAPI specification | Yes |
-| `/api/openapi/docs` | Interactive documentation | Yes |
+| Endpoint | Authentication | Purpose |
+|----------|----------------|---------|
+| `GET /api/openapi/docs` | None | Interactive API reference. |
+| `GET /api/openapi.json` | Bearer session with runtime-inspect capability | OpenAPI 3.0.3 document. |
 
-## Quick Start
+Open `http://localhost:8080/api/openapi/docs` in a browser to inspect the
+contract shipped by the running binary. Treat that generated document as the
+source for request and response schemas.
 
-### Authentication
+## Authentication
 
-All API endpoints require Bearer token authentication:
+Authenticated HTTP routes expect:
 
-```bash
-# Login to get token
-TOKEN=$(curl -X POST http://localhost:8080/api/login \
-  -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"secret"}' \
-  | jq -r '.token')
-
-# Use token in requests
-curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8080/api/agents
+```http
+Authorization: Bearer <session-token>
 ```
 
-### Fetch OpenAPI Spec
+The normal password flow starts at `POST /api/auth/login/start`. When passkeys
+are disabled, a valid password login returns a token directly. When passkeys
+are enabled, the response may require a WebAuthn finish step instead, so do not
+assume that password-only scripts work in every deployment.
+
+AgentHub does not currently expose a separate long-lived service-account token
+contract. For unattended automation, keep the session creation and renewal
+policy explicit, store tokens in a secrets manager, and expect a session to
+expire after 12 hours.
+
+## Fetch the Current Contract
+
+With an authenticated token in `AGENTHUB_TOKEN`:
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8080/api/openapi.json \
-  > agenthub-openapi.json
+curl --fail \
+  -H "Authorization: Bearer ${AGENTHUB_TOKEN}" \
+  http://127.0.0.1:8080/api/openapi.json \
+  -o agenthub-openapi.json
 ```
 
-## Client Generation
-
-### TypeScript/JavaScript
-
-Using `openapi-typescript`:
+Inspect the path set before generating a client:
 
 ```bash
-# Install
-npm install -g openapi-typescript
-
-# Generate types
-openapi-typescript agenthub-openapi.json -o agenthub-api.ts
-
-# Usage
-import { components } from './agenthub-api.ts'
-type Agent = components['schemas']['Agent']
+jq -r '.paths | keys[]' agenthub-openapi.json
 ```
 
-Using `openapi-generator-cli`:
+The current schema focuses on Team workbench operations plus scoped object and
+image uploads. General agent lifecycle routes may exist in the HTTP server
+without appearing in the published OpenAPI document yet.
+
+## Generate a Client
+
+Pin both the AgentHub release and a copy or digest of its OpenAPI document. Do
+not generate from a moving server during a release build.
+
+### TypeScript
 
 ```bash
-# Install
-npm install -g @openapitools/openapi-generator-cli
-
-# Generate TypeScript client
-openapi-generator-cli generate \
-  -i agenthub-openapi.json \
-  -g typescript-fetch \
-  -o ./agenthub-client
-
-# Usage
-import { AgentsApi, Configuration } from './agenthub-client'
-
-const api = new AgentsApi(new Configuration({
-  basePath: 'http://localhost:8080',
-  accessToken: 'your-token'
-}))
-
-const agents = await api.listAgents()
+npx openapi-typescript agenthub-openapi.json -o src/agenthub-api.d.ts
 ```
 
 ### Python
 
-Using `openapi-generator-cli`:
-
 ```bash
-# Generate Python client
 openapi-generator-cli generate \
   -i agenthub-openapi.json \
   -g python \
-  -o ./agenthub-python-client
-
-# Install
-pip install ./agenthub-python-client
-
-# Usage
-from agenthub_client import AgentsApi, Configuration
-
-config = Configuration(
-    host="http://localhost:8080",
-    access_token="your-token"
-)
-api = AgentsApi(config)
-
-agents = api.list_agents()
+  -o generated/agenthub_client
 ```
 
-Using `httpx` directly:
+Generated clients still need the bearer session:
 
 ```python
-import httpx
-from typing import Optional, Dict, Any
+from agenthub_client import ApiClient, Configuration
 
-class AgentHubClient:
-    def __init__(self, base_url: str, token: str):
-        self.base_url = base_url.rstrip('/')
-        self.headers = {"Authorization": f"Bearer {token}"}
-    
-    async def list_agents(self) -> list:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.base_url}/api/agents",
-                headers=self.headers
-            )
-            resp.raise_for_status()
-            return resp.json()
-    
-    async def create_agent(self, name: str, workdir: str, command: str) -> dict:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.base_url}/api/agents",
-                headers=self.headers,
-                json={
-                    "name": name,
-                    "workdir": workdir,
-                    "command": command,
-                    "worktree_mode": "use_existing"
-                }
-            )
-            resp.raise_for_status()
-            return resp.json()
-    
-    async def start_agent(self, agent_id: str) -> None:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.base_url}/api/agents/{agent_id}/start",
-                headers=self.headers
-            )
-            resp.raise_for_status()
+config = Configuration(host="https://agenthub.example.com")
+config.access_token = token
 
-# Usage
-import asyncio
-
-async def main():
-    client = AgentHubClient("http://localhost:8080", "your-token")
-    
-    # List agents
-    agents = await client.list_agents()
-    print(f"Found {len(agents)} agents")
-    
-    # Create and start agent
-    agent = await client.create_agent(
-        name="api-test",
-        workdir="/home/user/project",
-        command="echo 'Hello from API'"
-    )
-    await client.start_agent(agent['id'])
-
-asyncio.run(main())
+with ApiClient(config) as client:
+    pass
 ```
 
-### Go
+## Direct HTTP Example
 
-```go
-package main
-
-import (
-    "bytes"
-    "encoding/json"
-    "fmt"
-    "net/http"
-)
-
-type AgentHubClient struct {
-    BaseURL string
-    Token   string
-}
-
-func (c *AgentHubClient) request(method, path string, body interface{}) (*http.Response, error) {
-    var bodyReader *bytes.Reader
-    if body != nil {
-        bodyBytes, _ := json.Marshal(body)
-        bodyReader = bytes.NewReader(bodyBytes)
-    } else {
-        bodyReader = bytes.NewReader([]byte{})
-    }
-    
-    req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
-    if err != nil {
-        return nil, err
-    }
-    
-    req.Header.Set("Authorization", "Bearer "+c.Token)
-    req.Header.Set("Content-Type", "application/json")
-    
-    return http.DefaultClient.Do(req)
-}
-
-func (c *AgentHubClient) ListAgents() ([]map[string]interface{}, error) {
-    resp, err := c.request("GET", "/api/agents", nil)
-    if err != nil {
-        return nil, err
-    }
-    defer resp.Body.Close()
-    
-    var agents []map[string]interface{}
-    err = json.NewDecoder(resp.Body).Decode(&agents)
-    return agents, err
-}
-
-func main() {
-    client := &AgentHubClient{
-        BaseURL: "http://localhost:8080",
-        Token:   "your-token",
-    }
-    
-    agents, err := client.ListAgents()
-    if err != nil {
-        panic(err)
-    }
-    
-    fmt.Printf("Found %d agents\n", len(agents))
-}
-```
-
-### Rust
-
-Using `reqwest`:
-
-```rust
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
-use anyhow::Result;
-
-#[derive(Debug, Deserialize)]
-struct Agent {
-    id: String,
-    name: String,
-    status: String,
-}
-
-#[derive(Debug, Serialize)]
-struct CreateAgentRequest {
-    name: String,
-    workdir: String,
-    command: String,
-    worktree_mode: String,
-}
-
-struct AgentHubClient {
-    client: Client,
-    base_url: String,
-    token: String,
-}
-
-impl AgentHubClient {
-    fn new(base_url: &str, token: &str) -> Self {
-        Self {
-            client: Client::new(),
-            base_url: base_url.to_string(),
-            token: token.to_string(),
-        }
-    }
-    
-    async fn list_agents(&self) -> Result<Vec<Agent>> {
-        let resp = self.client
-            .get(format!("{}/api/agents", self.base_url))
-            .bearer_auth(&self.token)
-            .send()
-            .await?;
-        
-        Ok(resp.json().await?)
-    }
-    
-    async fn create_agent(&self, name: &str, workdir: &str, command: &str) -> Result<Agent> {
-        let req = CreateAgentRequest {
-            name: name.to_string(),
-            workdir: workdir.to_string(),
-            command: command.to_string(),
-            worktree_mode: "use_existing".to_string(),
-        };
-        
-        let resp = self.client
-            .post(format!("{}/api/agents", self.base_url))
-            .bearer_auth(&self.token)
-            .json(&req)
-            .send()
-            .await?;
-        
-        Ok(resp.json().await?)
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let client = AgentHubClient::new("http://localhost:8080", "your-token");
-    
-    let agents = client.list_agents().await?;
-    println!("Found {} agents", agents.len());
-    
-    Ok(())
-}
-```
-
-## Common Automation Patterns
-
-### Pattern 1: CI/CD Integration
-
-Trigger agent runs from CI pipeline:
-
-```yaml
-# .github/workflows/agent-run.yml
-name: Agent Run
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  run-agent:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Trigger AgentHub Task
-        run: |
-          # Login
-          TOKEN=$(curl -X POST ${{ secrets.AGENTHUB_URL }}/api/login \
-            -H "Content-Type: application/json" \
-            -d '{"username":"ci-bot","password":"'"${{ secrets.AGENTHUB_PASSWORD }}"'"}' \
-            | jq -r '.token')
-          
-          # Create agent
-          AGENT_ID=$(curl -X POST ${{ secrets.AGENTHUB_URL }}/api/agents \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "name": "ci-'"$GITHUB_RUN_ID"'",
-              "workdir": "/github/workspace",
-              "command": "run-tests-and-build",
-              "worktree_mode": "use_existing"
-            }' | jq -r '.id')
-          
-          # Start agent
-          curl -X POST ${{ secrets.AGENTHUB_URL }}/api/agents/$AGENT_ID/start \
-            -H "Authorization: Bearer $TOKEN"
-          
-          # Wait for completion (poll loop)
-          while true; do
-            STATUS=$(curl -s ${{ secrets.AGENTHUB_URL }}/api/agents/$AGENT_ID \
-              -H "Authorization: Bearer $TOKEN" | jq -r '.status')
-            echo "Status: $STATUS"
-            if [[ "$STATUS" =~ ^(completed|failed|cancelled)$ ]]; then
-              break
-            fi
-            sleep 10
-          done
-          
-          # Check result
-          if [ "$STATUS" != "completed" ]; then
-            echo "Agent run failed"
-            exit 1
-          fi
-```
-
-### Pattern 2: Scheduled Tasks
-
-```python
-#!/usr/bin/env python3
-"""Daily maintenance agent runner"""
-
-import schedule
-import time
-import httpx
-import os
-
-AGENTHUB_URL = os.environ["AGENTHUB_URL"]
-AGENTHUB_TOKEN = os.environ["AGENTHUB_TOKEN"]
-
-def run_maintenance():
-    """Run daily maintenance agent"""
-    with httpx.Client() as client:
-        # Create maintenance agent
-        resp = client.post(
-            f"{AGENTHUB_URL}/api/agents",
-            headers={"Authorization": f"Bearer {AGENTHUB_TOKEN}"},
-            json={
-                "name": f"maintenance-{time.strftime('%Y-%m-%d')}",
-                "workdir": "/data/maintenance",
-                "command": "daily-cleanup-and-report",
-                "worktree_mode": "create_worktree",
-                "worktree_repo": "/data/repos/maintenance"
-            }
-        )
-        agent = resp.json()
-        
-        # Start it
-        client.post(
-            f"{AGENTHUB_URL}/api/agents/{agent['id']}/start",
-            headers={"Authorization": f"Bearer {AGENTHUB_TOKEN}"}
-        )
-        
-        print(f"Started maintenance agent: {agent['id']}")
-
-# Schedule daily at 2 AM
-schedule.every().day.at("02:00").do(run_maintenance)
-
-while True:
-    schedule.run_pending()
-    time.sleep(60)
-```
-
-### Pattern 3: Team Automation
-
-```python
-async def create_and_run_team(client: AgentHubClient, team_spec: dict, input_data: dict):
-    """Create team definition and start a run"""
-    
-    # Create team
-    team = await client.post("/api/teams", team_spec)
-    team_id = team["id"]
-    print(f"Created team: {team_id}")
-    
-    # Start run
-    run = await client.post(f"/api/teams/{team_id}/runs", {
-        "input": input_data
-    })
-    run_id = run["id"]
-    print(f"Started run: {run_id}")
-    
-    # Poll for completion
-    while True:
-        run = await client.get(f"/api/teams/{team_id}/runs/{run_id}")
-        status = run["status"]
-        print(f"Run status: {status}")
-        
-        if status in ["completed", "failed", "cancelled"]:
-            break
-            
-        await asyncio.sleep(10)
-    
-    # Get results
-    steps = await client.get(f"/api/teams/{team_id}/runs/{run_id}/steps")
-    return steps
-
-# Usage
-team_spec = {
-    "name": "feature-implementation",
-    "spec": {
-        "spec_version": 1,
-        "entrypoint": {"type": "task"},
-        "members": [
-            {"member_id": "coordinator", "description": "Tech lead", "skills": ["planning"]},
-            {"member_id": "developer", "description": "Developer", "skills": ["coding"]}
-        ],
-        "coordinator_member_id": "coordinator"
-    }
-}
-
-results = await create_and_run_team(client, team_spec, {"goal": "Implement feature X"})
-```
-
-### Pattern 4: Actor Mailbox Automation
-
-```python
-async def send_command_to_team(client: AgentHubClient, run_id: str, command: str):
-    """Send a command to a running team via actor mailbox"""
-    
-    # Get team members
-    members = await client.get(f"/api/teams/runs/{run_id}/members")
-    coordinator_id = members["coordinator"]["actor_id"]
-    
-    # Send message to coordinator
-    await client.post("/api/actor/mailbox/send", {
-        "from_actor_id": "automation-bot",
-        "to_actor_id": coordinator_id,
-        "run_id": run_id,
-        "payload": {
-            "type": "command",
-            "text": command
-        }
-    })
-
-async def check_team_messages(client: AgentHubClient, actor_id: str, run_id: str):
-    """Check inbox for team responses"""
-    
-    messages = await client.get(
-        f"/api/actor/{actor_id}/mailbox",
-        params={"run_id": run_id, "limit": 10}
-    )
-    
-    for msg in messages:
-        print(f"From {msg['from_actor_id']}: {msg['payload']}")
-        # Acknowledge receipt
-        await client.post(f"/api/actor/mailbox/{msg['id']}/ack")
-```
-
-## Testing and Contract Verification
-
-### API Contract Tests
-
-```python
-# test_agenthub_contract.py
-import pytest
-import httpx
-from jsonschema import validate
-
-class TestAgentHubContract:
-    @pytest.fixture
-    def client(self):
-        return httpx.Client(
-            base_url="http://localhost:8080",
-            headers={"Authorization": "Bearer test-token"}
-        )
-    
-    def test_list_agents_returns_valid_schema(self, client):
-        """Verify /api/agents returns expected schema"""
-        resp = client.get("/api/agents")
-        assert resp.status_code == 200
-        
-        agents = resp.json()
-        assert isinstance(agents, list)
-        
-        # Validate schema
-        agent_schema = {
-            "type": "object",
-            "required": ["id", "name", "status"],
-            "properties": {
-                "id": {"type": "string"},
-                "name": {"type": "string"},
-                "status": {"type": "string", "enum": ["created", "running", "completed", "failed"]}
-            }
-        }
-        
-        for agent in agents:
-            validate(instance=agent, schema=agent_schema)
-    
-    def test_create_agent_requires_name(self, client):
-        """Verify validation error for missing name"""
-        resp = client.post("/api/agents", json={"workdir": "/tmp"})
-        assert resp.status_code == 400
-        assert "name" in resp.json()["error"].lower()
-```
-
-### Spec Version Pinning
+Listing Teams is part of the published contract:
 
 ```bash
-# Pin spec version in CI
-SPEC_VERSION=$(curl -s http://localhost:8080/api/openapi.json | jq -r '.info.version')
-echo "Testing against API spec version: $SPEC_VERSION"
-
-# Store in artifacts for traceability
-echo "$SPEC_VERSION" > .spec-version
+curl --fail \
+  -H "Authorization: Bearer ${AGENTHUB_TOKEN}" \
+  https://agenthub.example.com/api/teams
 ```
 
-## Reliability Best Practices
+For create, run, step, mailbox, channel, goal-fork, and scoped-upload request
+bodies, use the schemas embedded in `/api/openapi.json`. This avoids copying
+large example payloads that drift as the contract evolves.
 
-### 1. Idempotency
+## Reliability Rules
 
-Design automation to be idempotent:
+- Set connection and request timeouts in every client.
+- Retry transport failures and selected `5xx` responses with bounded backoff.
+- Do not retry `400`, `401`, `403`, or `404` without changing the request or
+  credentials.
+- Treat `409` as a state/concurrency conflict and reload current state before
+  deciding whether to retry.
+- Supply the documented idempotency key on message operations that accept one;
+  do not assume every POST is idempotent.
+- Follow only pagination parameters declared by the operation. Agent history
+  uses `before_id`; Team operations may use different shapes.
 
-```python
-async def ensure_agent_exists(client, name: str, config: dict) -> str:
-    """Create agent if it doesn't exist, return ID"""
-    
-    # Check if agent exists
-    agents = await client.get("/api/agents")
-    for agent in agents:
-        if agent["name"] == name:
-            print(f"Agent {name} already exists: {agent['id']}")
-            return agent["id"]
-    
-    # Create new
-    agent = await client.post("/api/agents", {**config, "name": name})
-    print(f"Created agent {name}: {agent['id']}")
-    return agent["id"]
-```
+## Contract Verification
 
-### 2. Exponential Backoff
+At deployment time:
 
-```python
-import random
+1. Download `/api/openapi.json` from the exact candidate binary.
+2. Compare its digest and path set with the reviewed contract.
+3. Generate or compile the client against that file.
+4. Run a read-only authenticated smoke request.
+5. Exercise each mutating operation in staging with an isolated Team or agent.
 
-async def retry_with_backoff(func, max_retries=5):
-    """Retry with exponential backoff"""
-    for attempt in range(max_retries):
-        try:
-            return await func()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code in [429, 502, 503, 504]:
-                delay = (2 ** attempt) + random.uniform(0, 1)
-                print(f"Retry {attempt + 1}/{max_retries} after {delay:.1f}s")
-                await asyncio.sleep(delay)
-            else:
-                raise
-    raise Exception("Max retries exceeded")
-```
+The repository tests verify that documented OpenAPI paths are registered by the
+HTTP router. They do not prove that routes omitted from the spec are stable for
+external automation.
 
-### 3. Pagination Handling
+## Security
 
-```python
-async def list_all_agents(client) -> list:
-    """List all agents handling pagination"""
-    all_agents = []
-    cursor = None
-    
-    while True:
-        params = {"limit": 100}
-        if cursor:
-            params["cursor"] = cursor
-            
-        resp = await client.get("/api/agents", params=params)
-        data = resp.json()
-        
-        all_agents.extend(data["items"])
-        
-        cursor = data.get("next_cursor")
-        if not cursor:
-            break
-    
-    return all_agents
-```
+- Prefer HTTPS and private ingress for non-local deployments.
+- Never put bearer tokens in committed files, command examples with real
+  values, URLs, or CI logs.
+- Grant automation only the role/capabilities it needs.
+- Redact object source URLs and uploaded content from failure reports.
 
-### 4. Token Refresh
-
-```python
-class AgentHubClient:
-    def __init__(self, base_url: str, username: str, password: str):
-        self.base_url = base_url
-        self.username = username
-        self.password = password
-        self.token = None
-        self.token_expires = 0
-    
-    async def ensure_token(self):
-        """Refresh token if expired"""
-        if time.time() < self.token_expires - 60:  # 60s buffer
-            return
-            
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.base_url}/api/login",
-                json={"username": self.username, "password": self.password}
-            )
-            data = resp.json()
-            self.token = data["token"]
-            self.token_expires = time.time() + data.get("expires_in", 3600)
-```
-
-## Monitoring Integration
-
-### Prometheus Metrics Example
-
-```python
-from prometheus_client import Counter, Histogram
-
-api_calls_total = Counter(
-    'agenthub_api_calls_total',
-    'Total API calls',
-    ['method', 'endpoint', 'status']
-)
-
-api_latency = Histogram(
-    'agenthub_api_latency_seconds',
-    'API call latency',
-    ['method', 'endpoint']
-)
-
-async def instrumented_request(client, method: str, path: str, **kwargs):
-    """Make request with metrics"""
-    start = time.time()
-    
-    try:
-        resp = await client.request(method, path, **kwargs)
-        status = resp.status_code
-        return resp
-    except Exception as e:
-        status = "error"
-        raise
-    finally:
-        duration = time.time() - start
-        api_calls_total.labels(method=method, endpoint=path, status=status).inc()
-        api_latency.labels(method=method, endpoint=path).observe(duration)
-```
-
-## Security Considerations
-
-1. **Token Storage**: Store tokens in secrets management (not in code)
-2. **HTTPS Only**: Use TLS in production
-3. **Token Rotation**: Implement automatic token refresh
-4. **Least Privilege**: Use dedicated service accounts
-5. **Audit Logging**: Log all API actions for compliance
-
-## Related Pages
-
-- [Team Workbench](./team-workbench.md)
-- [Deployment Overview and Topology](../deployment/overview-and-topology.md)
-- [API Error Reference](../operations/api-error-reference.md)
+SSE uses a separate query-token transport for browser compatibility. See
+[Connection Status and Recovery](./connection-status-and-recovery.md) before
+building a streaming client.

--- a/userdocs/docs/advanced/team-workbench.md
+++ b/userdocs/docs/advanced/team-workbench.md
@@ -25,17 +25,6 @@ Use the header toggle to move between them.
 The important distinction is that Team `Execution Runs` and `steps` are
 execution and debug artifacts. They are not the primary planning surface.
 
-## Recent Updates
-
-Recent Team workbench updates changed the operator-facing shape in a few useful
-ways:
-
-- the shell is now more clearly `Channels`-first
-- run history is consistently labeled `Execution Runs`
-- the left rail carries most Team switching and workspace navigation
-- the shared `# all` lane stays the default place for human goals and team-wide
-  coordination
-
 ## Main UI Areas
 
 - **Channels**:
@@ -173,34 +162,6 @@ prompt:
   to a human-visible review card
 - resolved or timed-out review cards collapse to compact status cards so the
   shared channel keeps more space for active content
-
-## Managed Runtime Vs Local Development
-
-Managed Team sessions already receive the role indexes and actor runtime
-environment they need.
-
-If you run Team actors manually in a local Codex environment outside the normal
-managed runtime, bootstrap the Team skills first:
-
-```bash
-scripts/setup_team_skills.sh
-```
-
-Managed Team runtime actor commands are now auto-approved by the ACP
-permission layer when `agenthub actor ...` resolves to the managed runtime
-binary.
-
-If you also run `agenthub actor ...` manually in a local Codex shell and want
-those manual commands to stop prompting repeatedly, allow the human-typed
-prefix:
-
-```text
-prefix_rule(pattern=["agenthub", "actor"], decision="allow")
-```
-
-Recommended location:
-
-- `~/.codex/rules/default.rules`
 
 ## Related Pages
 

--- a/userdocs/docs/core/agent-nodes.md
+++ b/userdocs/docs/core/agent-nodes.md
@@ -4,652 +4,178 @@ sidebar_position: 2
 
 # Agent Nodes and Remote Execution
 
-AgentHub can bind an agent to either the local `Main Node` or a registered remote Agent Node. This enables distributed execution while keeping a single control plane.
+Agent Nodes let the main AgentHub control plane start and supervise an agent on
+another machine. Users keep one web UI while repositories, credentials, and
+compute remain on the selected execution host.
 
-## Why Agent Nodes Matter
+## Topology
 
-Agent Nodes are not just a deployment detail. They let AgentHub keep one control plane while moving execution closer to:
-
-- **Data**: Large datasets that shouldn't move over network
-- **Compute**: GPU/TPU resources or specialized hardware
-- **Network**: Required network boundaries or VPN segments
-- **Ownership**: Machines that should own local worktrees
-
-This is also where the actor p2p model matters: mailbox and control traffic can stay consistent even when the process runs remotely.
-
-## Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Main Control Plane                       │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │   Web UI     │  │   API        │  │   Registry   │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-│                                                              │
-│  ┌────────────────────────────────────────────────────┐    │
-│  │         Internal gRPC Control Plane                │    │
-│  │   (mTLS/TLS encrypted, authenticated)             │    │
-│  └────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────┘
-                            │
-            ┌───────────────┼───────────────┐
-            │               │               │
-            ▼               ▼               ▼
-    ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
-    │  Agent Node  │ │  Agent Node  │ │  Agent Node  │
-    │  (node-gpu)  │ │  (node-east) │ │  (node-west) │
-    └──────────────┘ └──────────────┘ └──────────────┘
+```text
+Browser
+   |
+   | HTTPS + SSE
+   v
+Main AgentHub control plane
+   |
+   | authenticated TLS/mTLS gRPC
+   v
+Remote AgentHub node -> local workdir -> ACP subprocess
 ```
 
-## What Agent Nodes Control
-
-Each registered node stores:
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `id` | Yes | Stable unique identifier (e.g., `node-gpu-01`) |
-| `name` | Yes | Human-readable name |
-| `grpc_target` | Yes | gRPC endpoint (e.g., `https://node1.internal:50051`) |
-| `tls_server_name` | No | TLS SNI override for certificate validation |
-| `default_worktree_root` | No | Default base for `create_worktree` mode |
-
-The node registry is a control-plane view. Runtime state still lives on the selected execution node.
-
-## Deployment Prerequisites
-
-Before registering remote nodes, ensure:
-
-### Main Control Plane
-
-```toml
-[internal_grpc]
-enabled = true
-listen = "0.0.0.0:50051"
-
-[internal_grpc.security]
-mode = "tls"  # or "mtls" for mutual TLS
-cert_dir = "/etc/agenthub/certs"
-
-[internal_grpc.auth]
-shared_secret = "your-256-bit-secret-here"
-issuer = "agenthub"
-audience = "agenthub-internal"
-
-[internal_grpc.bootstrap]
-token = "bootstrap-token-for-remote-nodes"
-```
-
-Root operators can copy the bootstrap token from `Agents -> Join node with token`.
-Agent Node onboarding is token-based; QR is not part of the node join path.
-
-### Remote Node
-
-```toml
-[server]
-role = "node"
-node_id = "node-01"
-
-[internal_grpc]
-enabled = true
-listen = "0.0.0.0:50051"
-
-[internal_grpc.security]
-mode = "tls"
-cert_dir = "/etc/agenthub/certs"
-
-[internal_grpc.auth]
-shared_secret = "same-secret-as-main"  # Must match!
-issuer = "agenthub"
-audience = "agenthub-internal"
-
-[internal_grpc.bootstrap]
-token = "bootstrap-token-from-main-control-plane"
-```
-
-`node_id` must match the node you register on the main control plane. In node
-mode, AgentHub only starts the internal gRPC execution/control surface; it does
-not serve the public web UI or HTTP API.
-
-The bootstrap token is only the join handshake. TLS material, JWT issuer/audience,
-and the shared secret must still match the main control plane configuration today.
-
-### Network Requirements
-
-- Main control plane can reach remote node on gRPC port
-- Firewalls allow bidirectional gRPC traffic
-- DNS resolution (or IP addresses) configured
-
-## TLS Configuration
-
-### Mode: `tls` (Server Authentication)
-
-Remote node presents certificate; main control plane verifies.
-
-**Generate certificates**:
-
-```bash
-# On main control plane
-cd /etc/agenthub/certs
-
-# Generate CA
-openssl req -x509 -newkey rsa:4096 -keyout ca-key.pem -out ca-cert.pem \
-  -days 365 -nodes -subj "/CN=agenthub-ca"
-
-# Generate server cert for remote node
-openssl req -newkey rsa:4096 -keyout node-key.pem -out node-csr.pem \
-  -nodes -subj "/CN=node1.internal"
-
-openssl x509 -req -in node-csr.pem -CA ca-cert.pem -CAkey ca-key.pem \
-  -out node-cert.pem -days 365 -CAcreateserial
-
-# Copy to remote node
-scp ca-cert.pem node-cert.pem node-key.pem node1.internal:/etc/agenthub/certs/
-```
-
-**Register node**:
-
-```
-ID: node-01
-Name: GPU Node 01
-gRPC Target: https://node1.internal:50051
-TLS Server Name: node1.internal
-Default Worktree Root: /data/agenthub/worktrees
-```
-
-### Mode: `mtls` (Mutual Authentication)
-
-Both sides present and verify certificates. More secure but complex.
-
-**Benefits**:
-- Node cannot be impersonated
-- Main control plane identity verified by nodes
-- No shared secret needed (certificates only)
-
-**Setup**:
-
-1. Generate client certificates for main control plane
-2. Distribute CA to all nodes
-3. Configure `mode = "mtls"` on both sides
-
-## Deployment Examples
-
-### Example 1: Single Remote GPU Node
-
-**Scenario**: Machine learning workloads on GPU server.
-
-**Main Control Plane** (`hub.example.com`):
-```toml
-[server]
-listen = "0.0.0.0:8080"
-
-[internal_grpc]
-enabled = true
-listen = "0.0.0.0:50051"
-
-[internal_grpc.security]
-mode = "tls"
-cert_dir = "/etc/agenthub/certs"
-
-[internal_grpc.auth]
-shared_secret = "CHANGE-ME-256-BIT-SECRET"
-```
-
-**GPU Node** (`gpu01.internal`):
-```toml
-[server]
-role = "node"
-node_id = "gpu-01"
-
-[internal_grpc]
-enabled = true
-listen = "0.0.0.0:50051"
-
-[internal_grpc.security]
-mode = "tls"
-cert_dir = "/etc/agenthub/certs"
-
-[internal_grpc.auth]
-shared_secret = "CHANGE-ME-256-BIT-SECRET"
-
-[worktree]
-default_root = "/data/agenthub/worktrees"
-```
-
-**Bootstrap and registration**:
-```bash
-# 1. Copy the bootstrap token from Agents -> Join node with token.
-# 2. Start the remote node with the matching [internal_grpc] config above.
-# 3. Register the reachable node route via UI or API.
-curl -X POST http://hub.example.com:8080/api/admin/agent-nodes \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "gpu-01",
-    "name": "GPU Server 01",
-    "grpc_target": "https://gpu01.internal:50051",
-    "tls_server_name": "gpu01.internal",
-    "default_worktree_root": "/data/agenthub/worktrees"
-  }'
-```
-
-**Test**:
-```bash
-# Create agent targeting GPU node
-# UI: Agents → Create → Execution Node: "GPU Server 01"
-```
-
-### Example 2: Multi-Region Deployment
-
-**Scenario**: Teams in US and EU with local execution.
-
-```
-┌─────────────────┐         ┌─────────────────┐
-│  Main Control   │◄───────►│  Main Control   │
-│  (us-central)   │         │  (eu-west)      │
-│  (passive)      │   sync  │  (active)       │
-└────────┬────────┘         └────────┬────────┘
-         │                           │
-    ┌────┴────┐                 ┌────┴────┐
-    ▼         ▼                 ▼         ▼
-┌──────┐  ┌──────┐          ┌──────┐  ┌──────┐
-│us-01 │  │us-02 │          │eu-01 │  │eu-02 │
-└──────┘  └──────┘          └──────┘  └──────┘
-```
-
-### Example 3: Kubernetes Deployment
-
-**Main Control Plane** (Deployment + Service):
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: agenthub-control
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: agenthub-control
-  template:
-    metadata:
-      labels:
-        app: agenthub-control
-    spec:
-      containers:
-      - name: agenthub
-        image: agenthub:latest
-        ports:
-        - containerPort: 8080
-          name: http
-        - containerPort: 50051
-          name: grpc
-        volumeMounts:
-        - name: config
-          mountPath: /etc/agenthub
-        - name: data
-          mountPath: /data
-      volumes:
-      - name: config
-        configMap:
-          name: agenthub-config
-      - name: data
-        persistentVolumeClaim:
-          claimName: agenthub-data
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: agenthub-control
-spec:
-  selector:
-    app: agenthub-control
-  ports:
-  - port: 8080
-    name: http
-  - port: 50051
-    name: grpc
-```
-
-**Agent Node** (DaemonSet for node-local execution):
-
-```yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: agenthub-node
-spec:
-  selector:
-    matchLabels:
-      app: agenthub-node
-  template:
-    metadata:
-      labels:
-        app: agenthub-node
-    spec:
-      hostNetwork: true
-      containers:
-      - name: agenthub
-        image: agenthub:latest
-        command: ["agenthub", "-c", "/etc/agenthub/config.toml"]
-        ports:
-        - containerPort: 50051
-        volumeMounts:
-        - name: config
-          mountPath: /etc/agenthub
-        - name: workdir
-          mountPath: /workdirs
-      volumes:
-      - name: config
-        configMap:
-          name: agenthub-node-config
-      - name: workdir
-        hostPath:
-          path: /var/agenthub/workdirs
-```
-
-The node config should set `server.role = "node"`, a non-`main`
-`server.node_id`, `internal_grpc.enabled = true`, and the bootstrap token copied
-from `Agents -> Join node with token`. Node mode is config-driven; QR onboarding
-and a separate `--node-mode` flag are not part of the Agent Node join path.
-
-## Internal gRPC Also Powers `agenthub actor ...`
-
-The same internal gRPC control plane is used by the actor CLI:
-
-```bash
-# These commands require internal gRPC:
-agenthub actor team-members --actor-id <id>
-agenthub actor inbox --actor-id <id> --run-id <run_id>
-agenthub actor ack --actor-id <id> --message-id <msg_id>
-agenthub actor send --actor-id <id> --to <recipient> --payload '{}'
-agenthub actor time-trigger-list --actor-id <id>
-agenthub actor permission-review-respond --request-id <id> --decision allow
-```
-
-**Important**: `internal_grpc.enabled = true` is required even on single-machine setups for actor CLI to work.
-
-### Local Loopback Configuration
-
-For local actor CLI usage:
+The main process serves login, UI, API, Teams, and SSE. A process configured
+with `server.role = "node"` serves internal gRPC only and does not expose the
+public UI or `/health` HTTP endpoint.
+
+## Registry Fields
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Stable unique node identity; must match the remote `server.node_id`. |
+| `name` | Operator-facing label. |
+| `grpc_target` | Reachable private `https://` internal gRPC endpoint. |
+| `tls_server_name` | Optional expected certificate server name. |
+| `default_worktree_root` | Optional base for generated remote worktrees. |
+
+The registry stores routing metadata only. Bootstrap tokens, JWT shared
+secrets, and TLS private keys remain deployment secrets.
+
+## Main Control Plane
+
+Enable internal gRPC when the main process operates remote agents or serves the
+actor CLI:
 
 ```toml
 [internal_grpc]
 enabled = true
 listen = "127.0.0.1:50051"
 
+[internal_grpc.security]
+mode = "tls"
+cert_dir = "/etc/agenthub/internal-grpc"
+
 [internal_grpc.auth]
-shared_secret = "local-dev-secret"
+shared_secret = "<deployment-secret>"
+issuer = "agenthub"
+audience = "agenthub-internal"
+
+[internal_grpc.bootstrap]
+token = "<bootstrap-token>"
 ```
 
-The CLI reads `shared_secret` from config to mint tokens. Auto-generated secrets (stored in `cert_dir/auth_secret.txt`) are **not** automatically used by CLI.
+Bind to a private reachable address rather than loopback when remote nodes must
+connect. Use firewall policy to restrict the listener to expected peers.
 
-## Actor CLI Batch Operations
+## Remote Node
 
-The authority-side actor CLI also supports small client-side batch workflows for
-high-frequency operator actions:
+Install the same AgentHub release and configure a unique identity:
 
-- `agenthub actor ack --message-id 101 --message-id 102`
-- `agenthub actor permission-review-respond --permission-id req-1 --permission-id req-2 --option-id approved`
+```toml
+[server]
+role = "node"
+node_id = "node-east"
 
-Batch handling is still sequential on the client side. AgentHub does not expose
-a separate batch internal gRPC protocol for these operations.
+[internal_grpc]
+enabled = true
+listen = "0.0.0.0:50051"
 
-Single-item calls keep their original JSON object output. Multi-item calls
-return a JSON array of per-item responses.
+[internal_grpc.security]
+mode = "tls"
+cert_dir = "/etc/agenthub/internal-grpc"
 
-For permission review responses, any session or persistent approval path must
-use the request-provided `--option-id` value. `--outcome` currently supports
-only `cancelled`.
+[internal_grpc.auth]
+shared_secret = "<same-deployment-secret>"
+issuer = "agenthub"
+audience = "agenthub-internal"
 
-## Register and Edit Nodes
+[internal_grpc.bootstrap]
+token = "<bootstrap-token-from-main>"
 
-### Via Web UI
-
-1. Go to the `Agents` page as a root operator.
-2. Open `Join node with token` and copy the bootstrap token/details into the
-   remote node config.
-3. Start the remote node with `server.role = "node"` and the matching
-   `server.node_id`.
-4. Register the node route from the same `Agents` page.
-5. Fill in routing details and test connection.
-
-The bootstrap token is not stored in the node registry. Registered node records
-store routing metadata such as `grpc_target`, `tls_server_name`, and
-`default_worktree_root`.
-
-### Via API
-
-**Register node**:
-```bash
-curl -X POST http://localhost:8080/api/admin/agent-nodes \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "node-01",
-    "name": "Production Node 01",
-    "grpc_target": "https://node01.prod.internal:50051",
-    "tls_server_name": "node01.prod.internal",
-    "default_worktree_root": "/data/agenthub/worktrees"
-  }'
+safe_paths = [
+  "/srv/agenthub/repositories",
+  "/srv/agenthub/worktrees",
+]
 ```
 
-**List nodes**:
-```bash
-curl http://localhost:8080/api/admin/agent-nodes \
-  -H "Authorization: Bearer $TOKEN"
-```
+The bootstrap token authenticates onboarding. Runtime calls still depend on
+the configured TLS and JWT auth contract. Keep clocks synchronized and restart
+processes after changing security material.
 
-**Update node**:
-```bash
-curl -X PUT http://localhost:8080/api/admin/agent-nodes/node-01 \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Updated Name",
-    "default_worktree_root": "/new/path"
-  }'
-```
+## Register and Validate a Node
 
-**Delete node**:
-```bash
-curl -X DELETE http://localhost:8080/api/admin/agent-nodes/node-01 \
-  -H "Authorization: Bearer $TOKEN"
-```
+1. On the main UI, sign in as root and open **Nodes** or
+   **Agents → Join node with token**.
+2. Copy the displayed bootstrap/security details through a secure channel.
+3. Configure TLS material, auth values, the unique node ID, paths, and provider
+   credentials on the remote host.
+4. Start the remote node and confirm its internal gRPC port is listening.
+5. Register its `https://` target, TLS server name, and optional default
+   worktree root in the main UI.
+6. Create an agent, select the remote node, and use a repository path that
+   exists on that host.
+7. Start a bounded task and verify live output, history replay, stop, and a
+   second start.
 
-**Note**: Nodes with active agents cannot be deleted.
+The UI reserves node management for root operators. The backend protects node
+routes with the `nodes:manage` capability, while bootstrap detail remains
+root-only.
 
-## Default Worktree Root
+## Worktree Behavior
 
-`Default worktree root` is optional and applies to remote `create_worktree` agents.
+- Paths are resolved on the remote node; a main-host path has no meaning unless
+  the remote filesystem exposes the same location.
+- `use_existing` requires an existing allowed directory on the node.
+- `create_worktree` requires a repository path/ref on the node and either an
+  explicit workdir or the registered default worktree root.
+- `reuse_worktree` requires a pre-existing Git worktree on the node.
+- The remote service account needs Git, filesystem permissions, ACP provider
+  binaries, and provider credentials.
 
-**With default root**:
-- Leaving `Workdir` blank in `create_worktree` mode is allowed
-- AgentHub derives workdir under node root
-- Example: `/data/worktrees/myproject-goal-abc123/`
+## Actor and Mailbox Traffic
 
-**Without default root**:
-- Must provide explicit `Workdir`
-- Full path must exist on remote node
-- Must be within node's safe_paths
+The same internal gRPC control plane carries remote lifecycle and actor mailbox
+operations. Mailbox relay is at-least-once and uses message identity plus a
+timestamp window for deduplication/staleness checks. Preserve message IDs and
+timestamps when diagnosing delivery, and keep node clocks synchronized.
 
-### Per-Node Worktree Strategy
+`agenthub actor ...` also requires internal gRPC on the authority process. For
+local CLI use, keep `shared_secret` explicitly available through the effective
+configuration; the CLI cannot assume a separately generated secret file.
 
-| Node Type | Recommended Default Root | Use Case |
-|-----------|------------------------|----------|
-| GPU nodes | `/data/agenthub/worktrees` | ML workloads with large datasets |
-| Build nodes | `/var/lib/agenthub/builds` | CI/CD compilation |
-| Dev nodes | `/home/agenthub/worktrees` | Development environments |
+## TLS Modes
 
-## Execution Behavior
+- `tls` verifies the server certificate and still uses the internal JWT auth
+  contract.
+- `mtls` additionally requires client-certificate verification; it does not
+  remove the need to keep the runtime auth configuration aligned.
+- `disabled` is only for isolated local testing.
 
-### Main Node
-
-- Local safe-path and worktree policies apply directly
-- No network overhead
-- Filesystem access is direct
-
-### Remote Node
-
-- AgentHub proxies lifecycle control over encrypted gRPC
-- Execution data stays on remote node
-- UI/Control stays on main control plane
-- Output streamed via gRPC to main plane, then to UI
-
-### Network Flow
-
-```
-User → Main Control Plane → Remote Node
-                ↓                ↓
-              gRPC call    Process spawned
-                ↓                ↓
-           Status check   Output captured
-                ↓                ↓
-           Stream to UI ← Output via gRPC
-```
-
-## Actor P2P And Mailbox Delivery
-
-Remote execution preserves the actor model:
-
-- **Actor control**: Relayed over internal gRPC
-- **Mailbox delivery**: Targets remote recipients through same path
-- **Local state**: Remote nodes keep execution data
-- **Central view**: Main node is primary control plane
-
-This ensures remote execution feels like `AgentHub`, not a different product.
-
-For deployment-level transport rules, timestamp-window policy, and the mTLS
-identity roadmap, see [Remote Node Transport](../deployment/remote-node-transport.md).
-
-## Health Checking
-
-### Manual Health Check
+Before registration, inspect the certificate without bypassing verification:
 
 ```bash
-# Check gRPC endpoint
-curl -v telnet://node01.internal:50051
-
-# Check TLS
-echo | openssl s_client -connect node01.internal:50051 2>/dev/null | openssl x509 -noout -text
-
-# Check via AgentHub API
-curl http://main-hub:8080/api/admin/agent-nodes/node-01/health \
-  -H "Authorization: Bearer $TOKEN"
+openssl s_client \
+  -connect node-east.internal:50051 \
+  -servername node-east.internal \
+  -CAfile /path/to/ca-cert.pem </dev/null
 ```
 
-### Automated Monitoring
-
-Monitor these metrics:
-
-| Metric | Warning Threshold | Critical Threshold |
-|--------|------------------|-------------------|
-| gRPC latency | > 100ms | > 500ms |
-| Connection failures | > 1% | > 10% |
-| Agent start time | > 30s | > 60s |
-| Disk usage (node) | > 80% | > 95% |
+Do not use `grpcurl -insecure` as production evidence.
 
 ## Troubleshooting
 
-### "failed to connect to remote node"
+| Symptom | Check |
+|---------|-------|
+| Connection failure | Node process/role, private routing, firewall, target host/port. |
+| Certificate failure | CA trust, SAN, expiry, and registered `tls_server_name`. |
+| Unauthorized | Bootstrap token during onboarding; shared secret, issuer, audience, and clock during runtime. |
+| Agent starts locally instead | Selected execution node and persisted `target_node_id`. |
+| Worktree failure | Repository/ref, effective safe paths, default root, and permissions on the remote host. |
+| Stale node signal | Process health, network path, and last-seen timestamp before editing registry state. |
+| Node cannot be deleted | Stop or migrate agents that still reference it. |
 
-**Causes**:
-- Network unreachable
-- Firewall blocking
-- Node not running
-- TLS certificate mismatch
+Keep browser/API diagnostics on the main control plane and service/gRPC/process
+diagnostics on the remote host. Do not expose the node listener publicly or
+weaken TLS to compensate for a routing error.
 
-**Diagnostic**:
-```bash
-# From main control plane
-grpcurl -insecure node01.internal:50051 list
-
-# Check certificates
-echo | openssl s_client -connect node01.internal:50051 -servername node01.internal
-```
-
-### "certificate verify failed"
-
-**Solutions**:
-- Verify `tls_server_name` matches certificate CN/SAN
-- Check CA certificate is in trust store
-- Regenerate certificates if expired
-
-### "unauthorized"
-
-**Causes**:
-- `shared_secret` mismatch
-- Token expired
-- Clock skew between nodes
-
-**Solutions**:
-- Ensure same `shared_secret` on all nodes
-- Check system clocks are synchronized (NTP)
-- Restart nodes after secret changes
-
-### Slow Agent Start on Remote Node
-
-**Possible causes**:
-- Network latency to node
-- Slow worktree creation
-- Resource constraints on node
-
-**Solutions**:
-- Use `use_existing` mode for faster starts
-- Pre-warm worktree directories
-- Monitor node resource usage
-
-## Operator Rollout Flow
-
-### New Node Onboarding
-
-1. **Prepare node**:
-   ```bash
-   # Install AgentHub on remote machine
-   # Copy TLS certificates
-   # Create config file
-   ```
-
-2. **Start node**:
-   ```bash
-   agenthub
-   # Verify gRPC port listening
-   ss -tlnp | grep 50051
-   ```
-
-3. **Verify connectivity**:
-   ```bash
-   # From main control plane
-   curl http://main-hub:8080/api/admin/agent-nodes \
-     -H "Authorization: Bearer $TOKEN"
-   ```
-
-4. **Register node** (via UI or API)
-
-5. **Set default worktree root** (optional)
-
-6. **Test**:
-   - Create remote-target agent
-   - Verify card shows `node:<id>`
-   - Start agent and confirm output visible
-
-7. **Production readiness**:
-   - Configure monitoring
-   - Set up log aggregation
-   - Document node capabilities
-
-## Security Best Practices
-
-1. **Use mTLS** for production multi-node deployments
-2. **Rotate shared_secret** periodically
-3. **Limit safe_paths** on each node to minimum required
-4. **Use dedicated service accounts** for AgentHub processes
-5. **Enable audit logging** for node registration/changes
-6. **Network segmentation**: Place nodes in appropriate network zones
-
-## Operational Tips
-
-- **Stable IDs**: Use environment-oriented IDs like `node-east` or `build-fleet-a`
-- **Naming**: Include region/purpose in names: `us-east-gpu-01`
-- **Capacity planning**: Monitor node resource usage
-- **Gradual rollout**: Validate one node before full deployment
-- **Documentation**: Maintain node capability matrix (GPU, memory, etc.)
+See [Remote Node Transport](../deployment/remote-node-transport.md) for the
+deployment security contract and [Workdir and Worktree Strategy](./workdir-worktree-strategy.md)
+for workspace ownership.

--- a/userdocs/docs/core/create-agent.md
+++ b/userdocs/docs/core/create-agent.md
@@ -4,40 +4,49 @@ sidebar_position: 1
 
 # Create Your First Agent
 
-From the Agents page, use the top form to create a new task/agent.
+Open **Agents**, select **Create Agent**, and configure one durable runtime.
 
-## Key Inputs
+## Required Inputs
 
-- **Name**: human-readable label for management
-- **Command or preset**: execution entry (for example a Codex ACP command)
-- **Execution node**: root-only selector for `Main Node` or a registered remote node
-- **Workdir mode**:
-  - `use_existing`: run directly in an existing directory
-  - `create_worktree`: create an isolated worktree for this run
-- **Workdir**: execution path under your allowed safe paths
+- **Name**: a human-readable runtime label.
+- **Command or preset**: the installed ACP entry point, such as
+  `agenthub-acp codex`.
+- **Execution node**: `Main Node` or a registered remote node. Only root
+  operators can select and manage remote nodes.
+- **Workspace mode**:
+  - `use_existing` runs in an existing directory.
+  - `create_worktree` asks AgentHub to create an isolated Git worktree.
+  - `reuse_worktree` attaches an already prepared Git worktree.
+- **Workdir**: an execution path allowed by `safe_paths` on the selected node.
 
-## Remote Node Notes
+Provider-specific model, thinking, mode, and loop controls are optional. The
+available values come from the selected runtime rather than a global fixed
+list.
 
-- Non-root users create agents on `Main Node` only. The execution-node selector
-  and node-management controls are visible to root operators.
-- Only root operators can register or edit remote nodes from the Agents page.
-- Remote nodes use encrypted gRPC transport for control-plane traffic.
-- If a remote node has a configured **Default worktree root**, you can leave
-  `Workdir` blank in `create_worktree` mode and AgentHub will derive the final
-  workdir under that node-specific root.
-- If a remote node does not define a default root, remote `create_worktree`
-  requests must provide an explicit `Workdir`.
+## Choosing a Workspace Mode
 
-## Worktree Strategy Tips
+Prefer `create_worktree` for feature work, experiments, and concurrent agents.
+Use `use_existing` only when direct access to that checkout is intentional and
+you understand its current uncommitted state. Use `reuse_worktree` when another
+workflow owns worktree and branch creation.
 
-- Use `create_worktree` for isolated feature work or experiments
-- Use `use_existing` when you intentionally want to reuse an existing workspace
-- Keep repositories clean and branch-aware to reduce merge/rebase friction
+For a remote node with **Default worktree root**, `create_worktree` can derive
+the final workdir from that root. Without a node default, provide an explicit
+allowed path.
 
 ## After Creation
 
-The new item appears in the running/history card list. You can:
+The agent appears in the Agents list in `created` state. Select it to start the
+runtime, send instructions, inspect history, stop it, or delete it. Deleting an
+agent also removes its managed event history, so treat delete as a deliberate
+cleanup action.
 
-- Start it immediately
-- Open execution view
-- Stop or delete it later from agent actions
+## Common Creation Failures
+
+- The resolved workdir is outside `safe_paths`.
+- The configured command is missing from the service user's `PATH`.
+- A requested remote node is offline or lacks a valid internal gRPC route.
+- `create_worktree` does not have a repository/ref or a writable worktree root.
+
+See [Workdir and Worktree Strategy](./workdir-worktree-strategy.md) before
+running multiple agents against the same repository.

--- a/userdocs/docs/core/run-and-interact.md
+++ b/userdocs/docs/core/run-and-interact.md
@@ -23,7 +23,7 @@ Use the input dock in the output panel:
 
 ## Session Controls
 
-When the active ACP runtime exposes session controls, the debug surface can also
+When the active ACP runtime exposes session controls, the Agent view can also
 let you:
 
 - switch `mode` or `model` from provider-supplied options
@@ -32,7 +32,8 @@ let you:
 - force a new session when recovery is easier than continuing the current one
 
 These controls are runtime-specific. Codex, Gemini, Claude, and other ACP
-providers may surface different option sets.
+providers may surface different option sets. Production hides the Debug tab and
+session metadata until developer mode is enabled from **Admin**.
 
 ## Codex ACP Runtimes
 

--- a/userdocs/docs/core/session-lifecycle.md
+++ b/userdocs/docs/core/session-lifecycle.md
@@ -4,199 +4,108 @@ sidebar_position: 6
 
 # Session Lifecycle
 
-This page explains how session state changes over time, how ACP (Agent Control Protocol) events are captured, and what each action means for users.
+An AgentHub agent is a durable configuration plus a backend-managed runtime.
+Browser tabs observe and control that runtime; they do not own its lifetime.
 
-## Session States
+## Agent States
 
-An agent session transitions through the following states:
+| State | Meaning |
+|-------|---------|
+| `created` | The agent exists but has not started. |
+| `running` | A backend process is active. |
+| `stopped` | The operator stopped the runtime. |
+| `exited` | The process ended normally. |
+| `failed` | Startup or runtime execution failed. |
 
-| State | Description |
-|-------|-------------|
-| `created` | Agent exists but process is not running yet |
-| `running` | Task process is actively executing |
-| `completed` | Task finished successfully |
-| `failed` | Task encountered an error |
-| `cancelled` | Task was manually stopped by user |
-| `exited` | Process exited (may be expected or unexpected) |
+AgentHub permits one active runtime per agent. Repeated start requests do not
+create parallel processes for the same agent.
 
-## User Actions and Effects
+## Actions and Their Scope
 
 ### Start
 
-- Boots the runtime process for the selected agent
-- Reuses single active runtime guard to prevent duplicate starts
-- Initializes ACP session with the configured provider
-- Begins capturing events to persistent storage
+Starts the configured command in the selected workspace, creates a session,
+and begins persisting output.
 
-### Stop/Interrupt
+### Interrupt or Cancel
 
-- Requests the in-progress run to stop gracefully
-- Sends termination signal to the agent process
-- Keeps all history for later audit and replay
-- Session transitions to `cancelled` state
+Cancels the active ACP turn when the provider supports cancellation. Use this
+when a response or tool call needs to stop without discarding the agent.
+
+### Stop
+
+Stops the backend process and keeps the agent definition and persisted history.
+Use **Start** again when you want a new active runtime.
+
+### Clear ACP Session
+
+Forces the next provider interaction to create a new ACP session. This is a
+provider recovery action; it does not delete AgentHub event history.
 
 ### Delete
 
-- Removes the agent entry from management list
-- Optionally removes associated event history (configurable retention)
-- Should be used only after output/history are no longer needed
+Removes the agent and its managed session/event records. Export or back up
+anything you need before deletion.
 
-## ACP Event Model
+## Persisted Events
 
-AgentHub uses the **Agent Control Protocol (ACP)** to capture structured events from agent runs. Unlike raw terminal output, ACP events preserve context and enable rich replay.
+AgentHub stores agent configuration and session metadata in the main SQLite
+database. High-volume output is stored in per-agent SQLite databases under:
 
-### Event Streams
-
-Events are captured in two parallel streams:
-
-- **`acp`**: Structured ACP protocol messages (conversation, tool calls, plans)
-- **`system`**: System-level output (process stdout/stderr, initialization logs)
-
-### Event Storage
-
-Each agent has a dedicated SQLite database for events:
-
-```
-~/.agenthub/agent-events/{agent_id}.db
+```text
+~/.agenthub/agent-events/<agent-id>.db
 ```
 
-The `agent_events` table schema:
+Events record `stdout`, `stderr`, `system`, or structured `acp` streams. The
+history API supports session filtering and cursor-based paging, and the UI uses
+that persisted history for replay after a refresh or reconnect.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INTEGER | Auto-increment primary key |
-| `session_id` | TEXT | ACP session identifier |
-| `seq` | TEXT | Sequence UUID (v7) for ordering |
-| `ts` | INTEGER | Unix timestamp (seconds) |
-| `stream` | TEXT | Stream type: `acp` or `system` |
-| `message` | BLOB | Event payload (JSON bytes) |
+Do not remove individual event database files as a recovery shortcut. The
+running service may still hold connections or metadata that refer to them. Use
+the product's delete action for intentional removal, or stop the service and
+restore a consistent backup when repairing storage.
 
-### Event Types
+## Retention
 
-Common ACP event types captured:
-
-```json
-// Conversation message
-{
-  "type": "conversation",
-  "role": "assistant",
-  "content": "I'll help you with that..."
-}
-
-// Tool call
-{
-  "type": "tool_call",
-  "tool": "shell",
-  "input": { "command": "ls -la" },
-  "output": "..."
-}
-
-// Plan/reasoning
-{
-  "type": "plan",
-  "text": "1. First I'll check the files..."
-}
-
-// Debug information
-{
-  "type": "debug",
-  "level": "info",
-  "message": "Initializing context..."
-}
-```
-
-### Event Retention and Cleanup
-
-AgentHub automatically manages event storage:
-
-**Configuration** (`~/.agenthub/config.toml`):
+History cleanup is controlled by `~/.agenthub/config.toml`:
 
 ```toml
 [history]
-# Days to retain events (default: 5)
 event_retention_days = 5
-
-# Run VACUUM after cleanup (default: false)
 vacuum_on_cleanup = false
+delete_batch_size = 10000
 ```
 
-**Cleanup Behavior**:
+- `event_retention_days = 0` disables age-based deletion.
+- Cleanup deletes old records in bounded batches.
+- `vacuum_on_cleanup = true` may reclaim space but adds I/O and locking work.
 
-- Runs during idle periods (no activity for configured timeout)
-- Processes deletion in batches to minimize impact
-- Removes events older than `event_retention_days`
-- Optionally runs `VACUUM` to reclaim disk space
+Choose a retention window that matches your audit and disk requirements, then
+include the entire AgentHub data directory in backups if session replay is
+important.
 
-**Manual Cleanup**:
+## Reconnect and Replay
 
-If you need to free space immediately:
+1. The backend runtime continues while the browser is disconnected.
+2. The browser loads persisted events when the agent view opens.
+3. Live output resumes through `/sse/agents`.
+4. If SSE is unavailable or stale, the UI polls the event API until streaming
+   recovers.
 
-```bash
-# Stop the agent first
-# Then remove the agent's event database
-rm ~/.agenthub/agent-events/{agent_id}.db
-```
+SSE backpressure or a lagging receiver causes the server to close that stream
+instead of growing memory without bound. The browser reconnects and catches up
+from the database.
 
-## Reconnect Behavior
+## Safe Recovery Order
 
-A key feature of AgentHub is **session persistence** across browser disconnects:
+When an agent appears stuck:
 
-1. **During Disconnect**:
-   - Backend process continues running
-   - Events continue to be captured and stored
-   - Agent state is maintained
+1. Check the connection badge and agent state.
+2. Refresh the page to trigger history replay.
+3. Inspect the server log and the configured ACP binary.
+4. Interrupt the active turn, then stop/start the agent if necessary.
+5. Clear only the ACP provider session when the provider thread is corrupted.
+6. Restore a consistent backup before attempting any database-level repair.
 
-2. **On Reconnect**:
-   - UI retrieves session status from backend
-   - Event history is replayed from storage
-   - Live updates resume via SSE (Server-Sent Events)
-
-3. **Multi-Tab Support**:
-   - Multiple browser tabs can view the same session
-   - All tabs receive live updates
-   - Changes are synchronized across clients
-
-## History Replay
-
-When you reopen a session, AgentHub replays stored events to reconstruct the view:
-
-1. Fetches events from the agent's SQLite database
-2. Renders ACP events as structured timeline
-3. Shows system output in raw/stream view
-4. Maintains chronological ordering via sequence UUIDs
-
-### Performance Considerations
-
-- Each agent has its own database to avoid contention
-- Indexes on `(session_id, seq)` and `(ts)` for efficient queries
-- BLOB storage for message content to handle large payloads
-- Lazy loading for long sessions (loads recent events first)
-
-## Operational Tips
-
-- **One goal per session**: Keep history understandable by focusing each session on a specific task
-- **New sessions for experiments**: Use fresh sessions for risky refactors to isolate potential issues
-- **Keep failed sessions**: Don't delete immediately; failed sessions contain valuable debugging context
-- **Monitor disk usage**: Event databases can grow; adjust retention settings based on your storage
-- **Backup considerations**: Include `~/.agenthub/agent-events/` in backups if history is critical
-
-## Troubleshooting
-
-### Session Shows "Running" But No Output
-
-1. Check browser console for SSE connection errors
-2. Verify `~/.agenthub/agent-events/{agent_id}.db` exists and is writable
-3. Try refreshing the page to trigger history replay
-4. Check server logs for ACP event sink errors
-
-### History Replay Is Slow
-
-- Large sessions (>10k events) may take time to load
-- Consider reducing `event_retention_days` for high-volume agents
-- Event databases are per-agent; deleting old agents frees space
-
-### Events Missing From History
-
-- Events are persisted asynchronously; very recent events may not appear immediately
-- If using `vacuum_on_cleanup = true`, cleanup runs may briefly lock the database
-- Check server logs for SQLite errors
+See [Connection Status and Recovery](../advanced/connection-status-and-recovery.md)
+for stream diagnostics.

--- a/userdocs/docs/core/view-output.md
+++ b/userdocs/docs/core/view-output.md
@@ -4,30 +4,44 @@ sidebar_position: 4
 
 # View Execution Output
 
-AgentHub supports structured ACP rendering for agent output.
+AgentHub renders ACP output as a structured timeline while preserving raw
+runtime events for recovery and diagnosis.
 
-## Output Tabs
+## Main Views
 
-- **Conversation**: user and agent messages in timeline form
-- **Debug / Raw**: low-level event stream useful for diagnosis
+- **Thread**: user and agent messages.
+- **Plan**: structured plan updates when the provider emits them.
+- **Debug**: raw ACP and system detail. This tab is hidden in production until
+  developer mode is enabled from **Admin**.
 
-## What to Watch
+Provider-specific tool calls, permissions, modes, models, and configuration
+controls appear only when the active runtime advertises them.
 
-- Agent status transitions: queued, running, completed, failed
-- Tool calls and command outputs
-- Plan updates and intermediate reasoning chunks
-- Error events and retry behavior
+## Connection Badge
+
+The workspace header distinguishes browser network state from the live stream:
+
+- `Online · SSE connected`: live events are arriving normally.
+- `Online · SSE connecting` or `reconnecting`: the UI is restoring the stream.
+- `Online · SSE idle`: there is no running stream target.
+- `Offline · SSE disconnected`: the browser reports no network connection.
+
+A reconnecting badge does not mean history was lost. The UI falls back to the
+persisted event API while the SSE connection recovers.
 
 ## History Replay
 
-Session history is retained. You can:
+When you reopen an agent, AgentHub loads recent events and lets you request
+older pages. The event API returns at most 20 records per request and uses a
+`before_id` cursor for older history.
 
-- Re-open an older session from history cards
-- Scroll upward to load earlier output records
-- Continue from the last known point without losing context
+Large ACP tool payloads may be compacted in the live stream. The UI can fetch
+the complete persisted event by its event ID when detail is needed.
 
-## Reading Long Sessions Efficiently
+## Review Tips
 
-- Keep focus on the newest actionable block
-- Expand tool/debug details only when needed
-- Use session history to compare behavior before and after changes
+- Read the newest actionable Thread or Plan block first.
+- Open Debug only when structured rendering is insufficient.
+- Confirm the agent status before treating a quiet stream as a connection
+  failure.
+- Refreshing the page is safe; it does not stop the backend process.

--- a/userdocs/docs/core/workdir-worktree-strategy.md
+++ b/userdocs/docs/core/workdir-worktree-strategy.md
@@ -4,400 +4,114 @@ sidebar_position: 2
 
 # Workdir and Worktree Strategy
 
-Choosing the right run location is the biggest lever for stable agent behavior. This guide covers workdir modes, worktree management, and production best practices.
+The workspace mode decides which checkout an agent can change. Choose it before
+starting the runtime; changing strategy normally means creating a new agent.
 
-## Two Modes
+## Workspace Modes
 
-### `use_existing` Mode
+| Mode | Behavior | Use when |
+|------|----------|----------|
+| `use_existing` | Runs directly in the selected directory. | The current checkout and its uncommitted state are intentionally part of the task. |
+| `create_worktree` | Runs `git worktree add` from a repository/ref into an isolated workdir. | You want parallel, reviewable work without sharing checkout state. |
+| `reuse_worktree` | Uses an existing Git worktree path without creating it. | A worktree was prepared outside AgentHub and should remain the execution boundary. |
 
-Run agent directly in an existing directory.
+Prefer `create_worktree` for implementation, dependency updates, and parallel
+agents. Prefer `use_existing` for read-only diagnosis or work that explicitly
+depends on the current checkout. `reuse_worktree` is useful when another
+workflow owns branch/worktree creation.
 
-**Best for**:
-- Direct access to long-lived local workspaces
-- Incremental work on existing branches
-- Scenarios where local uncommitted state should be visible
-- Quick experiments in familiar directories
+## `create_worktree` Inputs
 
-**Trade-offs**:
-- Agent sees all local uncommitted changes
-- Risk of conflicts with your local work
-- Cleanup is manual
+- **Repository path** must identify a Git repository visible on the selected
+  execution node.
+- **Repository ref** defaults to `HEAD` and must be valid for `git worktree add`.
+- **Workdir** may be generated below the default worktree root or explicitly
+  set to an allowed path.
 
-### `create_worktree` Mode
+If the target directory is a registered worktree for the same agent, AgentHub
+can reuse it. It rejects a non-empty ordinary directory and a worktree already
+bound to another agent. A configured ref mismatch is logged when an existing
+worktree is reused; AgentHub does not silently rewrite that checkout.
 
-Create an isolated git worktree under your configured root.
+## Safe Paths
 
-**Best for**:
-- Reproducible isolated runs
-- Parallel tasks on the same repository
-- Clean cleanup boundaries after completion
-- CI-like execution patterns
-
-**Trade-offs**:
-- Requires git repository
-- Takes time to set up new worktree
-- Uses more disk space
-
-## How to Choose
-
-| Scenario | Recommended Mode | Why |
-|----------|-----------------|-----|
-| Daily development | `use_existing` | Familiar context |
-| Feature implementation | `create_worktree` | Isolated branch |
-| Code review | `create_worktree` | Clean slate |
-| Parallel experiments | `create_worktree` | No conflicts |
-| Production fixes | `use_existing` | Quick access |
-| Refactoring | `create_worktree` | Easy rollback |
-
-## Git Worktree Deep Dive
-
-### What Are Git Worktrees?
-
-Git worktrees allow multiple working directories attached to the same repository. Each worktree:
-- Has its own checkout state
-- Shares the same `.git` object database
-- Can be on different branches
-- Can be deleted independently
-
-### Worktree Structure
-
-```
-~/.agenthub/worktrees/
-├── myproject-feature-a-abc123/     # Worktree 1
-│   ├── .git                        # git file (points to main repo)
-│   ├── src/
-│   └── ...
-├── myproject-feature-b-def456/     # Worktree 2
-│   ├── .git
-│   └── ...
-└── myproject-hotfix-ghi789/        # Worktree 3
-    ├── .git
-    └── ...
-```
-
-### Managing Worktrees
-
-**List all worktrees**:
-```bash
-cd ~/your-repo
-git worktree list
-```
-
-**Create worktree manually**:
-```bash
-git worktree add ~/.agenthub/worktrees/myproject-feature ../path/to/repo
-```
-
-**Remove worktree**:
-```bash
-# Safe removal (keeps branch)
-git worktree remove ~/.agenthub/worktrees/myproject-feature
-
-# Force removal if dirty
-git worktree remove --force ~/.agenthub/worktrees/myproject-feature
-```
-
-**Clean up stale worktrees**:
-```bash
-# Prune worktrees that no longer exist on disk
-git worktree prune
-```
-
-## Configuration
-
-### Default Worktree Root
-
-```toml
-[worktree]
-default_root = "/var/agenthub/worktrees"
-```
-
-**Important**: This path is automatically added to `safe_paths`.
-
-### Per-Node Default Root
-
-For remote Agent Nodes, configure a node-specific default:
-
-```toml
-# In node registration UI or API
-default_worktree_root = "/data/agenthub-worktrees"
-```
-
-This allows different filesystem layouts per execution node.
-
-## Naming Convention Best Practices
-
-### Agent Naming
-
-Use predictable, parseable names:
-
-```
-<project>-<goal>-<date>
-<project>-<ticket-id>-<brief-desc>
-<team>-<sprint>-<feature>
-```
-
-Examples:
-- `agenthub-docs-2026-03-15`
-- `myapp-1234-user-auth`
-- `platform-s3-refactor`
-
-### Worktree Naming
-
-AgentHub auto-generates worktree directories:
-
-```
-<repo-name>-<sanitized-goal>-<short-hash>
-```
-
-You can override by specifying explicit `worktree_repo` and `worktree_ref`.
-
-## Safe Path Constraints
-
-All run paths must be under configured `safe_paths`:
+Every final workdir must be below an effective `safe_paths` root. The local
+default root `~/.agenthub/worktrees` is included automatically.
 
 ```toml
 safe_paths = [
-  "/home/you/projects",
-  "/data/sandboxes",
+  "/srv/agenthub/repositories",
+  "/srv/agenthub/workspaces",
 ]
-```
 
-**Effective safe paths** automatically include:
-- All explicitly configured paths
-- `worktree.default_root` (default: `~/.agenthub/worktrees`)
-
-### Path Validation Flow
-
-1. User specifies workdir or leaves blank for worktree
-2. AgentHub resolves full path (expanding `~`)
-3. Validates path is within allowed roots
-4. Rejects if outside safe paths
-5. Creates directory if needed
-
-### Troubleshooting Path Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `path outside safe_paths` | Directory not allowed | Add to `safe_paths` or use allowed location |
-| `workdir does not exist` | Path not found | Create directory first |
-| `permission denied` | Filesystem permissions | Check owner and permissions |
-| `symlink loop detected` | Circular symlinks | Use real paths, not symlinks |
-
-## Production Best Practices
-
-### Isolation Strategy
-
-**High-risk operations** → Always `create_worktree`:
-- Refactoring
-- Dependency updates
-- Database migrations
-- Configuration changes
-
-**Low-risk operations** → Can use `use_existing`:
-- Documentation updates
-- Log analysis
-- Read-only investigations
-- Quick fixes
-
-### Disk Space Management
-
-**Monitor worktree usage**:
-```bash
-# Check total worktree disk usage
-du -sh ~/.agenthub/worktrees/* | sort -hr | head -20
-
-# Find largest worktrees
-find ~/.agenthub/worktrees -maxdepth 1 -type d -exec du -sh {} \; | sort -hr
-```
-
-**Automatic cleanup**:
-- Delete completed agents regularly
-- Archive important changes before deletion
-- Set up cron job for old worktree pruning:
-  ```bash
-  # Delete worktrees older than 30 days
-  find ~/.agenthub/worktrees -maxdepth 1 -type d -mtime +30 -exec rm -rf {} \;
-  ```
-
-### Repository Preparation
-
-For best `create_worktree` performance:
-
-1. **Keep repositories lean**:
-   ```bash
-   git gc --aggressive
-   git remote prune origin
-   ```
-
-2. **Use shallow clones for large repos** (optional):
-   ```bash
-   git clone --depth 100 git@github.com:org/repo.git
-   ```
-
-3. **Configure git hooks** (if needed):
-   ```bash
-   # Hooks run in worktree context
-   .git/hooks/post-checkout
-   ```
-
-### Branch Strategy
-
-**Recommended workflow**:
-
-1. Create worktree from clean main:
-   ```
-   Agent: myapp-feature-x
-   Worktree mode: create_worktree
-   Worktree repo: /home/you/myapp
-   Worktree ref: main
-   ```
-
-2. Agent creates feature branch automatically
-
-3. Work happens in isolated worktree
-
-4. Changes merged via normal PR process
-
-5. Worktree deleted after merge
-
-## Remote Node Considerations
-
-When using `create_worktree` on remote nodes:
-
-1. **Node must have default root configured** OR you must specify explicit workdir
-2. **Repository must be accessible** on the remote node
-3. **Git must be installed** on the remote node
-4. **Network storage** considerations for shared repositories
-
-### Remote Worktree Example
-
-```toml
-# AgentHub config on remote node
 [worktree]
-default_root = "/data/worktrees"
+default_root = "/srv/agenthub/worktrees"
 ```
 
-Agent creation:
-- Execution node: `node-east`
-- Workdir mode: `create_worktree`
-- Worktree repo: `/data/repos/myproject` (must exist on node-east)
-- Workdir: (blank - uses node default)
+`safe_paths` validates the requested workdir; it does not sandbox the
+subprocess from other files readable by the service account.
 
-Result: Worktree created at `/data/worktrees/myproject-<goal>-<hash>/`
+## Remote Nodes
 
-## Migration Between Modes
+Repository and workdir paths are resolved on the selected node, not the main
+control plane. A remote node can define **Default worktree root** in its
+registry record. Without that default, provide an explicit workdir for
+`create_worktree`.
 
-**Switching from `use_existing` to `create_worktree`**:
+Before starting a remote worktree agent, confirm:
 
-1. Complete or stop current agent
-2. Create new agent with `create_worktree`
-3. Manually copy needed files if necessary
-4. Update automation/scripts
+- Git is installed on the node.
+- The repository/ref exists on that node.
+- The service account can create the workdir.
+- Both repository and workdir paths satisfy the remote node's policy.
 
-**Migrating existing work**:
+## Repository State
+
+Before assigning an existing checkout, inspect it:
 
 ```bash
-# Archive current state
-cd /existing/workdir
-git stash push -m "pre-migration"
-git checkout -b migration-backup
-
-# Create new worktree-based agent
-# Copy over relevant files
-# Continue work in isolated environment
+git -C /path/to/repo status --short
+git -C /path/to/repo worktree list
 ```
 
-## Cleanup Practice
+Do not automatically stash, commit, reset, or force-remove user changes. Decide
+who owns existing modifications, then choose a separate worktree when ownership
+is unclear.
 
-### Regular Maintenance
+`create_worktree` shares the repository object database but has its own index
+and working tree. It does not by itself create, push, merge, or delete a branch;
+those actions remain part of the agent/user Git workflow.
 
-**Daily**:
-- Delete completed/failed agents you don't need
-- Keep agents with useful context for reference
+## Cleanup
 
-**Weekly**:
-- Review disk usage
-- Clean up stale worktrees
+Deleting an AgentHub agent is not a substitute for reviewing its Git state.
+Before removing a worktree:
 
-**Monthly**:
-- Archive important worktrees
-- Prune old agent event databases
+1. Stop the agent.
+2. Inspect `git status --short` in the worktree.
+3. Preserve required changes in a commit, patch, or other reviewed artifact.
+4. Confirm no other agent references the path.
+5. Remove it with Git from the owning repository:
 
-### Safe Cleanup Checklist
+   ```bash
+   git -C /path/to/repo worktree remove /path/to/worktree
+   ```
 
-Before deleting an agent:
+6. Run `git -C /path/to/repo worktree prune` only after verifying stale entries.
 
-- [ ] Changes committed to git (if applicable)
-- [ ] Important output saved/logged
-- [ ] Event history no longer needed
-- [ ] Worktree can be recreated if needed
+Avoid scheduled `rm -rf` cleanup. Git worktrees can contain uncommitted user
+work, and filesystem age does not prove that a workspace is safe to delete.
 
-### Automated Cleanup Script
+## Failure Guide
 
-```bash
-#!/bin/bash
-# cleanup-old-agents.sh
+| Error | Check |
+|-------|-------|
+| Workdir outside safe paths | Resolved path and effective roots on the execution node. |
+| `worktree_repo required` | Repository path is set for `create_worktree`. |
+| Worktree does not exist | `reuse_worktree` points to a real checkout. |
+| Workdir is not empty | Use another path or deliberately select the registered worktree. |
+| Worktree belongs to another agent | Keep separate workdirs or stop and reassign ownership explicitly. |
+| `git worktree add failed` | Repository/ref validity, existing branch checkout, permissions, and full Git stderr. |
 
-# Delete agents older than 30 days (requires API access)
-# Adjust retention as needed
-
-RETENTION_DAYS=30
-CUTOFF=$(date -d "${RETENTION_DAYS} days ago" +%s)
-
-# Note: Implement using AgentHub API or database queries
-# This is a placeholder for your automation
-
-echo "Cleaning up agents older than ${RETENTION_DAYS} days"
-```
-
-## Common Pitfalls
-
-### 1. Nested Worktrees
-
-Don't create worktrees inside other worktrees:
-```
-❌ ~/.agenthub/worktrees/a/worktrees/b
-✅ ~/.agenthub/worktrees/a
-✅ ~/.agenthub/worktrees/b
-```
-
-### 2. Long Paths
-
-Avoid deep directory structures:
-```
-❌ /very/long/path/to/the/actual/work/directory/that/exceeds/limits
-✅ /data/worktrees/project-name
-```
-
-### 3. Special Characters
-
-Avoid special characters in agent names:
-```
-❌ agent:foo/bar
-❌ agent;drop table
-✅ agent-foo-bar
-```
-
-### 4. Repository State
-
-Don't use `create_worktree` with dirty repositories:
-```bash
-# Check repository state
-git status
-# Clean or commit changes first
-git stash || git commit -am "WIP"
-```
-
-## Summary
-
-| Aspect | `use_existing` | `create_worktree` |
-|--------|---------------|-------------------|
-| Isolation | Low | High |
-| Setup speed | Fast | Slower |
-| Cleanup | Manual | Automatic |
-| Best for | Daily dev | Isolated tasks |
-| Disk usage | Shared | Separate |
-| Git required | No | Yes |
-
-Choose based on your risk tolerance, cleanup needs, and repository hygiene preferences.
+See [Security and Path Safety](../operations/security-and-path-safety.md) for
+the process-isolation boundary.

--- a/userdocs/docs/deployment/overview-and-topology.md
+++ b/userdocs/docs/deployment/overview-and-topology.md
@@ -13,7 +13,7 @@ AgentHub deployment is intentionally simple:
 
 - One backend process (Rust)
 - One embedded web UI served by that same process
-- One SQLite database for persisted state
+- One main SQLite database plus per-agent SQLite event databases
 - Browser clients connected with HTTP + SSE
 
 Optional scale-out deployments can add remote Agent Nodes for execution and
@@ -23,24 +23,25 @@ mailbox delivery while keeping AgentHub as the main control plane.
 
 Prepare these components before rollout:
 
-1. AgentHub executable (or `cargo run` for development)
+1. Matching `agenthub` and `agenthub-acp` release binaries when using the
+   bundled ACP presets (or a source build for development)
 2. A valid `config.toml`
 3. Writable runtime home (default under `~/.agenthub/`)
 4. Explicit `safe_paths` for all allowed repositories/workdirs
 
 ## Deployment Modes
 
-### Local development mode
+### Single-machine mode
 
-Use this for daily personal work:
+Use this for personal or small internal deployments. Install the release pair,
+write `~/.agenthub/config.toml`, and start the server:
 
 ```bash
-cd web
-npm install
-npm run build
-cd ..
-cargo run -- -c /path/to/config.toml
+agenthub
 ```
+
+Release builds embed the web UI. Source builds and frontend development belong
+to the contributor workflow, not the production deployment path.
 
 ### Team internal mode
 
@@ -60,8 +61,7 @@ Use this when execution must span multiple machines:
 - Use encrypted gRPC between AgentHub and nodes
 - Configure a node-specific default worktree root when remote filesystems differ
 - Keep the current production posture on a dedicated internal `https://` gRPC
-  port; same-port HTTP plus gRPC multiplexing is a future-compatible design
-  target, not the conservative default.
+  port rather than relying on same-port HTTP plus gRPC multiplexing.
 
 #### Distributed node prerequisites
 
@@ -88,11 +88,11 @@ cert_dir = "~/.agenthub/internal-grpc"
 issuer = "agenthub"
 audience = "agenthub-internal"
 # optional: persisted to cert_dir/auth_secret.txt if omitted
-shared_secret = "replace-me-for-production"
+shared_secret = "<shared-secret-from-your-secret-store>"
 
 [internal_grpc.bootstrap]
 # optional: persisted to cert_dir/bootstrap_token.txt if omitted
-token = "replace-me-for-bootstrap"
+token = "<node-bootstrap-token>"
 ```
 
 Operational notes:
@@ -147,19 +147,17 @@ Operational notes:
 - AgentHub listens on internal/private address where possible
 - Users access a single stable URL (for login, UI, and API)
 
-## Basic Startup Commands
+## Startup
 
-If you build a release binary:
-
-```bash
-./agenthub -c /path/to/config.toml
-```
-
-If you run from source:
+AgentHub currently reads `~/.agenthub/config.toml`; there is no alternate
+config-path flag. Start the installed release binary with:
 
 ```bash
-cargo run -- -c /path/to/config.toml
+agenthub
 ```
+
+Use the Debian package's systemd unit for a managed Linux service. For source
+development, follow the repository's contributor documentation.
 
 ## Post-Deploy Smoke Checklist
 

--- a/userdocs/docs/deployment/production-checklist.md
+++ b/userdocs/docs/deployment/production-checklist.md
@@ -4,82 +4,98 @@ sidebar_position: 2
 
 # Production Checklist
 
-Use this checklist before and after deploying AgentHub in a shared environment.
+Use this checklist for a shared AgentHub deployment and for every release
+upgrade.
 
-## Preflight Checklist
+## Artifact Preflight
 
-- Define explicit `safe_paths` for each team/project root.
-- Validate `worktree.default_root` exists and is writable.
-- For Debian package installs, update `/var/lib/agenthub/.agenthub/config.toml` and grant the
-  `agenthub` service user access to each configured workspace root.
-- Confirm runtime user permissions for repository paths.
-- Confirm Node/Rust build artifacts are reproducible in CI.
-- Confirm rollback plan (previous binary + config snapshot).
+- Select one exact release tag and verify `SHA256SUMS.txt`.
+- Install `agenthub` and `agenthub-acp` from that same release.
+- Confirm both `--version` commands before rollout.
+- Validate the official binary on the oldest Linux environment you intend to
+  support; the project's glibc floor is not yet frozen.
+- If using S3, smoke test the release artifact against the exact provider and
+  bucket. An S3-enabled build alone is not provider certification.
+- Keep the previous verified binaries and a configuration/data snapshot for
+  rollback.
 
-## Security Baseline
+## Service and Network Baseline
 
-- Run AgentHub as a non-root user.
-- Keep network exposure minimal (private network + reverse proxy).
-- Use TLS at the edge.
-- Enforce strong user credentials and periodic rotation.
-- Avoid putting sensitive directories under `safe_paths`.
+- Run as a dedicated non-root OS account.
+- Make every `safe_paths` entry explicit and writable by that account.
+- Keep the HTTP listener on loopback/private ingress and terminate shared
+  access with an authenticated HTTPS proxy.
+- Configure `web.rp_id` and `web.rp_origin` to match the public URL before
+  enabling passkeys.
+- Preserve SSE streaming and disable proxy buffering for `/sse/*`.
+- Keep the first-run root initialization page off public unauthenticated
+  ingress.
+
+For Debian packages, the service uses `HOME=/var/lib/agenthub`. Its default
+configuration and state live under `/var/lib/agenthub/.agenthub/`, and its
+default workspace root is `/var/lib/agenthub/workspaces`.
 
 ## Remote Node Baseline
 
-When remote Agent Nodes are enabled:
+When Agent Nodes are enabled:
 
-- Keep node-only processes on internal `https://` gRPC endpoints.
-- Register remote nodes from the main control plane; do not treat registry rows
-  as credential storage.
-- Keep internal gRPC `issuer`, `audience`, and `shared_secret` aligned across
-  peers until per-node identity is available.
-- Keep node clocks synchronized so timestamp-window validation is reliable.
-- Smoke test duplicate relay retries in staging and confirm they do not create
-  duplicate destination mailbox rows.
-- Keep the dedicated gRPC port until same-port HTTP plus gRPC multiplexing has
-  been validated with your reverse proxy.
+- expose node-only internal gRPC on a private `https://` endpoint;
+- keep bootstrap tokens, JWT shared secrets, and TLS keys out of node registry
+  metadata and logs;
+- align issuer/audience/auth configuration across peers;
+- prefer `mtls` when client-certificate identity is required;
+- synchronize clocks and validate each registered `grpc_target` and
+  `tls_server_name`;
+- run one remote-agent start/output/stop smoke before admitting normal work.
 
 ## Data and Backup
 
-AgentHub persists runtime data under `~/.agenthub/` by default.
+The safest default is a consistent snapshot of the complete AgentHub data
+directory while the service is stopped. At minimum account for:
 
-For Debian package installs, the default service sets `HOME=/var/lib/agenthub`, so the persisted
-runtime data is under `/var/lib/agenthub/.agenthub/`.
+- `agenthub.db` and its SQLite sidecar files;
+- `agent-events/` per-agent event databases;
+- `config.toml` and `vapid.json`;
+- `message-archive/` and optional `message-bodies/` stores;
+- local `objects/`, or the corresponding external object-store retention and
+  recovery policy;
+- internal gRPC certificates and generated auth/bootstrap files;
+- worktrees only when uncommitted workspace content must be recoverable.
 
-Minimum backup targets:
+If any path is overridden in configuration, back up the effective path rather
+than assuming it lives below `~/.agenthub`. For S3, back up control-plane
+metadata and make sure bucket versioning/retention matches the database
+recovery point.
 
-- `~/.agenthub/agenthub.db` for source, Homebrew, and archive installs.
-- `/var/lib/agenthub/.agenthub/agenthub.db` for Debian package installs.
-- deployment `config.toml`.
-
-Recommended cadence:
-
-- Daily snapshot for active environments
-- Extra snapshot before each upgrade
+Test restore into an isolated instance. A backup that has never been restored
+is not release evidence.
 
 ## Upgrade Runbook
 
-1. Stop new task submissions.
-2. Backup `agenthub.db` and `config.toml`.
-3. Deploy new binary/config.
-4. Restart service.
-5. Run smoke checks:
-   - login
-   - create/start one test agent
-   - session replay after refresh
-6. Monitor logs for startup/runtime errors.
+1. Stop new task submissions and let important active runs finish.
+2. Stop the service.
+3. Capture a consistent data/config snapshot and record both binary versions.
+4. Install the new matching binary pair.
+5. Start the service and verify `GET /health` returns `ok`.
+6. Sign in, create/start a disposable agent, receive output, and replay it after
+   a browser refresh.
+7. If enabled, test browser push, OpenAPI retrieval, S3 object flow, and one
+   remote Agent Node.
+8. Keep the environment closed until logs and smoke checks are clean.
 
-## Failure Rollback Rule
+## Rollback
 
-If smoke checks fail or critical flows regress:
+If startup or a critical smoke fails, stop the service before changing files.
+Restore the previous binaries and configuration. Restore the pre-upgrade data
+snapshot when the newer process may have migrated or mutated persistent state;
+do not run an older binary against a possibly upgraded database by assumption.
 
-1. Restore previous binary.
-2. Restore previous config.
-3. Restore database snapshot when schema compatibility is uncertain.
-4. Re-run smoke checks before reopening service.
+Record the failed version, exact artifact checksums, first failing step, and
+matching logs before reopening the previous version.
 
 ## Related Pages
 
+- [Installation and Startup](../getting-started/installation.md)
 - [Deployment Overview and Topology](./overview-and-topology.md)
 - [Remote Node Transport](./remote-node-transport.md)
 - [Security and Path Safety](../operations/security-and-path-safety.md)

--- a/userdocs/docs/deployment/remote-node-transport.md
+++ b/userdocs/docs/deployment/remote-node-transport.md
@@ -4,130 +4,87 @@ sidebar_position: 3
 
 # Remote Node Transport
 
-Use this page when deploying AgentHub with remote Agent Nodes.
+Remote Agent Nodes execute agents on other machines while the main AgentHub
+process remains the browser/API control plane.
 
-AgentHub remote-node traffic currently uses authenticated `https://` gRPC on an
-internal endpoint. Browser HTTP, API, and SSE traffic still belong to the main
-control-plane web listener.
+## Supported Topology
 
-## Current Production Posture
+- The `main` process serves HTTP, the web UI, SSE, and internal gRPC client
+  operations.
+- A `node` process serves internal gRPC only; it does not serve the public UI.
+- Registered `grpc_target` values use `https://` on a dedicated private port.
+- The registry stores routing metadata, not bootstrap tokens, JWT shared
+  secrets, or TLS private keys.
 
-The recommended deployment shape is:
+Keep browser traffic on the main HTTP listener and node traffic on the internal
+gRPC listener. Same-port HTTP/gRPC multiplexing is not the conservative
+deployment contract documented here.
 
-- one `main` AgentHub process serving the web UI and API
-- one or more `node` AgentHub processes serving internal gRPC only
-- private-network `https://` gRPC targets for every registered node
-- root-managed node registry rows for `grpc_target`, `tls_server_name`, and
-  optional `default_worktree_root`
-- shared internal gRPC auth/TLS configuration across the small cluster
+## Security Contract
 
-Do not expose the node-only gRPC listener as a public browser endpoint. Node
-mode is for execution and internal control traffic only.
+| Control | Requirement |
+|---------|-------------|
+| TLS | Use `tls` or `mtls`; reserve `disabled` for isolated local tests. |
+| Bootstrap | Copy the one intended bootstrap token from the main control plane and protect it as a secret. |
+| Runtime auth | Keep issuer, audience, and shared-secret configuration aligned on every peer. |
+| Identity | Give every node a unique `server.node_id` other than `main`. |
+| Routing | Register the reachable `https://` target and expected TLS server name. |
+| Time | Synchronize clocks because relay validation uses bounded timestamps. |
 
-## Required Transport Rules
+Mailbox relay is at-least-once. AgentHub uses idempotency and timestamp checks
+to reject duplicate or stale delivery, but operators should still verify this
+behavior in their network and proxy path.
 
-Remote-node deployments should enforce these rules:
-
-| Rule | Requirement |
-|------|-------------|
-| Endpoint scheme | Use `https://` for registered `grpc_target` values. |
-| Registry authority | Register routes from the main control plane; do not rely on route JSON overrides. |
-| TLS material | Store TLS files in internal gRPC config, not in node registry rows or relay payloads. |
-| Bootstrap | Use `Agents -> Join node with token` to copy bootstrap details. |
-| Runtime auth | Keep `issuer`, `audience`, and `shared_secret` aligned across peers today. |
-| Dedupe | Treat remote delivery as at-least-once and make duplicate sends harmless. |
-| Clock skew | Reject stale relay credentials or envelopes outside the allowed timestamp window. |
-
-## Dedupe and Timestamp Window
-
-Remote mailbox relay can retry. Receivers must therefore reject stale requests
-and dedupe repeated delivery before processing the business payload.
-
-Recommended policy:
-
-- accept relay timestamps only inside a `±120s` skew window
-- use the transport `idempotency_key` as the canonical dedupe key
-- for compatibility with old relay metadata, fall back to `(source_node_id,
-  message_id)` only when no first-class `idempotency_key` is present
-- retain accepted dedupe keys for at least `24h` or the configured retry horizon,
-  whichever is longer
-- return success for duplicates after skipping business processing
-- log rejected deliveries with a reason such as `expired`, `duplicate`, or
-  `signature_mismatch`
-
-The goal is at-least-once transport with effectively-once mailbox effects.
-
-## Dedicated Port vs Same-Port Multiplexing
-
-The supported deployment mode today is a dedicated internal gRPC port, for
-example:
+## Node Configuration
 
 ```toml
+[server]
+role = "node"
+node_id = "node-east"
+
 [internal_grpc]
 enabled = true
 listen = "0.0.0.0:50051"
+
+[internal_grpc.security]
+mode = "tls"
+cert_dir = "/etc/agenthub/internal-grpc"
+
+[internal_grpc.auth]
+shared_secret = "<deployment-secret>"
+issuer = "agenthub"
+audience = "agenthub-internal"
+
+[internal_grpc.bootstrap]
+token = "<bootstrap-token-from-main>"
 ```
 
-Same-port HTTP plus gRPC multiplexing is a future deployment simplification.
-The intended design is:
+The main control plane must also enable internal gRPC with matching security and
+auth settings when it operates remote agents or serves `agenthub actor ...`.
 
-- one TLS listener can accept browser HTTP/SSE and internal gRPC
-- ALPN and `Content-Type: application/grpc` route gRPC requests to the internal
-  service
-- normal HTTP requests continue to route to the web/API stack
-- internal gRPC authz stays the same as the dedicated-port mode
-- node-only mode still avoids exposing the public web/API surface
+## Rollout
 
-Keep the dedicated-port mode until your reverse proxy and AgentHub build both
-validate same-port behavior.
+1. Start the main control plane with internal gRPC enabled.
+2. Copy the bootstrap token shown by **Agents → Join node with token**.
+3. Configure and start the remote node with a unique node ID.
+4. Verify its certificate and `https://` gRPC reachability from the main host.
+5. As root, register the route and optional default worktree root in **Agents**.
+6. Create an agent targeting that node.
+7. Start it and confirm status, output, stop, and reconnect behavior from the
+   main UI.
 
-## Identity and mTLS Roadmap
+## Failure Triage
 
-The current small-cluster model uses a shared signing secret plus TLS or mTLS.
-This keeps rollout simple, but it is not the final identity model.
+- `unauthorized`: compare bootstrap token and post-bootstrap JWT
+  issuer/audience/shared secret.
+- certificate verification failure: compare CA trust, certificate SAN, and the
+  registered `tls_server_name`.
+- connection failure: confirm the target is reachable from the main host and
+  that the node process is actually in `server.role = "node"`.
+- workdir failure: validate paths and permissions on the remote filesystem, not
+  on the main host.
+- duplicate/stale relay rejection: check clocks and preserve the message ID and
+  timestamp evidence.
 
-The long-term path is:
-
-1. keep stable `server.node_id` values and registry rows for every node
-2. issue short-lived credentials from the main control plane with `node_id`,
-   `audience`, `scope`, `issued_at`, and `expires_at`
-3. bind production mTLS certificate identity to the same `node_id`
-4. reject requests where token identity and certificate identity disagree
-5. add rotation and revocation before treating per-node identity as the steady-
-   state trust root
-
-Until that path is complete, treat the shared secret as sensitive cluster-wide
-material and rotate it with the same care as an API signing key.
-
-## Preflight Checklist
-
-Before adding a remote node:
-
-1. Confirm the main control plane has `internal_grpc.enabled = true`.
-2. Confirm the remote process uses `server.role = "node"` and a non-`main`
-   `server.node_id`.
-3. Confirm the registered `grpc_target` is reachable from the main process.
-4. Confirm the certificate validates with the configured `tls_server_name`.
-5. Confirm auth `issuer`, `audience`, and `shared_secret` match on both peers.
-6. Confirm clocks are synchronized with NTP or an equivalent time source.
-7. Confirm the remote node's worktree root exists and is inside `safe_paths`.
-
-## Smoke Test
-
-After registration:
-
-1. Create one remote-target agent from the `Agents` page.
-2. Start it and verify the card shows `node:<id>`.
-3. Send a short input and confirm output appears in the main UI.
-4. Confirm the remote node keeps local runtime data while the main control plane
-   keeps the catalog view.
-5. Run a mailbox or Team flow that targets the remote agent and confirm the
-   message is delivered and can be acknowledged.
-6. Retry the same relay delivery in staging and confirm it does not create a
-   duplicate destination mailbox row.
-
-## Related Pages
-
-- [Deployment Overview and Topology](./overview-and-topology.md)
-- [Production Checklist](./production-checklist.md)
-- [Agent Nodes and Remote Execution](../core/agent-nodes.md)
+Do not weaken TLS or expose the node listener publicly as the first recovery
+step.

--- a/userdocs/docs/deployment/vercel-static-userdocs.md
+++ b/userdocs/docs/deployment/vercel-static-userdocs.md
@@ -17,7 +17,7 @@ Before pushing, verify local static build:
 
 ```bash
 cd userdocs
-npm install
+npm ci
 npm run build
 ```
 
@@ -28,7 +28,7 @@ Build output should appear in `userdocs/build/`.
 Use these values in Vercel:
 
 - Root Directory: `userdocs`
-- Install Command: `npm install`
+- Install Command: `npm ci`
 - Build Command: `npm run build`
 - Output Directory: `build`
 
@@ -42,7 +42,7 @@ Use these values in Vercel:
 
 - Wrong root directory (not `userdocs`)
 - Wrong output directory (must be `build`)
-- Missing dependencies due to skipped `npm install`
+- Missing dependencies due to skipped `npm ci`
 
 ## Validation After Deploy
 

--- a/userdocs/docs/getting-started/configuration-basics.md
+++ b/userdocs/docs/getting-started/configuration-basics.md
@@ -4,7 +4,10 @@ sidebar_position: 2
 
 # Configuration Basics
 
-This page lists all available configuration options for AgentHub.
+This page covers the operator-facing runtime options in AgentHub's current
+configuration schema. Experimental integration bindings are intentionally
+documented with their owning feature contract until they become a supported
+user workflow.
 
 ## Configuration File
 
@@ -81,6 +84,7 @@ WebAuthn/Passkey configuration.
 | `rp_id` | string | `"localhost"` | Relying party ID for WebAuthn |
 | `rp_origin` | string | `"http://localhost:8080"` | Origin for WebAuthn |
 | `rp_name` | string | `"AgentHub"` | Display name for WebAuthn |
+| `passkey_enabled` | boolean | `false` | Initial passkey state; root can change it later in Admin settings |
 
 **Production WebAuthn Setup**:
 
@@ -108,7 +112,7 @@ ACP (Agent Control Protocol) provider settings.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `binary` | string | `"agenthub-acp"` | Canonical AgentHub ACP adapter binary name or path |
-| `default_mode` | string | `"auto"` | Default ACP mode (`auto`, `full`, `suggest`) |
+| `default_mode` | string | `"full-access"` | Default Codex ACP mode (`read-only`, `auto`, or `full-access`; `yolo` normalizes to `full-access`) |
 | `multi_agent_enabled` | boolean | `true` | Force Codex ACP `Feature::Collab` on AgentHub-managed sessions |
 
 The canonical Codex command for new agents is `agenthub-acp codex`. The
@@ -116,13 +120,9 @@ The canonical Codex command for new agents is `agenthub-acp codex`. The
 include the `codex` subcommand argument. Existing deployments can still set it
 to `agenthub-codex-acp` or another compatible Codex ACP executable.
 
-The built-in adapter paths assume the repository's current ACP baseline:
-
-- `agenthub-acp codex`
-- official Codex `0.138.x`
-
-If you point `codex_acp.binary` at a custom binary, keep it compatible with the
-same ACP protocol surface before mixing it into a shared deployment.
+If you point `codex_acp.binary` at a custom binary, verify it against the ACP
+protocol surface used by the exact AgentHub release before mixing versions in a
+shared deployment.
 
 Other ACP adapters are configured per agent command rather than through this
 section. For Claude, prefer the AgentHub-distributed `agenthub-acp claude`
@@ -158,8 +158,14 @@ Object storage for uploaded files, generated artifacts, and image-hosting
 objects. AgentHub keeps ownership, publish state, size, checksum, MIME type, and
 cleanup eligibility in SQLite metadata; the object store only stores bytes.
 
-The first supported backend is local filesystem storage. S3-compatible storage
-is available only in builds that enable the `agenthub-object-store/s3` feature.
+The default backend is local filesystem storage. Official release binaries
+include the OpenDAL S3 backend; default/source builds must enable the root
+`object-store-s3` feature explicitly. Runtime storage remains `fs` until
+`backend = "s3"` is configured.
+
+Shipping the S3 backend is not a production certification for every
+S3-compatible provider. Validate the exact release artifact against the target
+service and bucket before rollout.
 Actor-scoped uploads are available from the CLI:
 
 ```bash
@@ -181,6 +187,15 @@ When `backend = "fs"` and `root` is omitted, actor uploads use
 | `region` | string | provider default | S3-compatible region |
 | `access_key_id_env` | string | provider chain | Environment variable name that contains the access key id |
 | `secret_access_key_env` | string | provider chain | Environment variable name that contains the secret access key |
+| `download_max_bytes` | integer | `536870912` | Maximum server-side download size in bytes |
+| `download_max_redirects` | integer | `5` | Maximum redirects for one download |
+| `download_timeout_seconds` | integer | `120` | End-to-end download timeout |
+| `download_retry_attempts` | integer | `3` | Total attempts for retryable download failures |
+| `download_retry_backoff_millis` | integer | `250` | Initial retry backoff |
+| `download_max_concurrent_per_host` | integer | `4` | Per-host concurrent download limit |
+| `download_allow_private_networks` | boolean | `false` | Permit private, loopback, or link-local destinations |
+| `download_allowed_hosts` | array of strings | `[]` | Optional allowlist; non-empty means unmatched hosts are rejected |
+| `download_denied_hosts` | array of strings | `[]` | Explicit denylist evaluated before the allowlist |
 
 **Local Object Store Example**:
 
@@ -203,6 +218,8 @@ prefix = "agenthub/prod"
 public_base_url = "https://img.example.com"
 access_key_id_env = "AGENTHUB_OBJECT_STORE_ACCESS_KEY_ID"
 secret_access_key_env = "AGENTHUB_OBJECT_STORE_SECRET_ACCESS_KEY"
+download_allowed_hosts = ["downloads.example.com", "*.cdn.example.com"]
+download_denied_hosts = ["metadata.google.internal", "169.254.169.254"]
 ```
 
 `access_key_id_env` and `secret_access_key_env` are references to environment
@@ -213,6 +230,40 @@ grant create, read, replace, or delete permission. AgentHub API handlers must
 authorize against the owning metadata row before returning an image URL or
 mutating an object. The current image-hosting helper accepts only raster image
 MIME types: `image/png`, `image/jpeg`, `image/webp`, and `image/gif`.
+
+Server-side download ingestion permits only `http` and `https`. Private,
+loopback, link-local, metadata-service, and rebinding targets remain blocked by
+default. Keep that default unless the deployment has a narrowly reviewed need.
+
+### `[message_archive]` Section
+
+Searchable Team and agent message documents use the LanceDB-backed archive.
+The archive is a derived search surface, not control-plane authority.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `backend` | string | `"lancedb"` | Archive backend |
+| `uri` | string | `"~/.agenthub/message-archive"` | Archive directory |
+| `message_table` | string | `"messages"` | LanceDB message table |
+
+If archive initialization or readiness fails, AgentHub logs the error and runs
+without that search surface. Include the archive directory in backups when you
+want to preserve it, but treat SQLite as the source for control-plane state.
+
+### `[message_body_store]` Section
+
+The optional RocksDB body store keeps compressed message-body copies while
+SQLite remains the compatibility source.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable the tiered message-body store |
+| `path` | string | `"~/.agenthub/message-bodies"` | RocksDB directory |
+| `auto_migrate` | boolean | `true` | Backfill compatible SQLite bodies at startup after the store is enabled |
+
+This option requires a binary built with the root `rocksdb` feature. Official
+release artifacts include it; a default source build does not. Keep the main
+SQLite data in backups even when this store is enabled.
 
 ### `[push]` Section
 
@@ -321,35 +372,25 @@ http = "http://proxy.company.com:8080"
 https = "http://proxy.company.com:8080"
 ```
 
-## Environment Variables
+## Environment Boundary
 
-All configuration options can be overridden via environment variables:
+The server does not currently apply environment overrides for normal TOML
+settings. Variables such as `AGENTHUB_LISTEN`, `AGENTHUB_SAFE_PATHS`, and
+`AGENTHUB_INTERNAL_GRPC_*` are detected only so startup can warn that they were
+ignored. Put those values in `~/.agenthub/config.toml` instead.
 
-| Environment Variable | Config Path |
-|---------------------|-------------|
-| `AGENTHUB_LISTEN` | `server.listen` |
-| `AGENTHUB_SAFE_PATHS` | `safe_paths` (comma-separated) |
-| `AGENTHUB_WEB_DIR` | `web_dir` |
-| `AGENTHUB_LOG_PATH` | `log_path` |
-| `AGENTHUB_RP_ID` | `web.rp_id` |
-| `AGENTHUB_RP_ORIGIN` | `web.rp_origin` |
-| `AGENTHUB_RP_NAME` | `web.rp_name` |
-| `AGENTHUB_CODEX_ACP_BINARY` | `codex_acp.binary` |
-| `AGENTHUB_CODEX_ACP_DEFAULT_MODE` | `codex_acp.default_mode` |
-| `AGENTHUB_HISTORY_EVENT_RETENTION_DAYS` | `history.event_retention_days` |
-| `AGENTHUB_HISTORY_VACUUM_ON_CLEANUP` | `history.vacuum_on_cleanup` |
-| `AGENTHUB_INTERNAL_GRPC_ENABLED` | `internal_grpc.enabled` |
-| `AGENTHUB_INTERNAL_GRPC_LISTEN` | `internal_grpc.listen` |
-| `AGENTHUB_INTERNAL_GRPC_SECURITY_MODE` | `internal_grpc.security.mode` |
-| `AGENTHUB_INTERNAL_GRPC_CERT_DIR` | `internal_grpc.security.cert_dir` |
-| `AGENTHUB_INTERNAL_GRPC_AUTH_SHARED_SECRET` | `internal_grpc.auth.shared_secret` |
-| `AGENTHUB_INTERNAL_GRPC_AUTH_ISSUER` | `internal_grpc.auth.issuer` |
-| `AGENTHUB_INTERNAL_GRPC_AUTH_AUDIENCE` | `internal_grpc.auth.audience` |
-| `AGENTHUB_INTERNAL_GRPC_BOOTSTRAP_TOKEN` | `internal_grpc.bootstrap.token` |
-| `AGENTHUB_HTTP_PROXY` | `proxy.http` |
-| `AGENTHUB_HTTPS_PROXY` | `proxy.https` |
-| `AGENTHUB_ALL_PROXY` | `proxy.all` |
-| `AGENTHUB_VAPID_SUBJECT` | `push.subject` |
+Environment variables still have explicit uses at other boundaries:
+
+- `access_key_id_env` and `secret_access_key_env` name the variables from which
+  the S3 backend reads credentials.
+- ACP provider commands inherit the service environment according to the
+  process-launch policy.
+- `AGENTHUB_SERVER_URL` and `AGENTHUB_TOKEN` are defaults for `agenthub doctor`,
+  not server configuration overrides.
+- Pyroscope uses the three variables documented below.
+
+Treat an `env overrides ignored` startup warning as a configuration error to
+correct, not proof that the requested value was applied.
 
 ## Pyroscope Profiling
 
@@ -403,16 +444,14 @@ After updating configuration:
 
 1. **Restart AgentHub**:
    ```bash
-   # If running as service
-   systemctl restart agenthub
-   
-   # If running directly
-   pkill agenthub && agenthub
+   sudo systemctl restart agenthub.service
    ```
+
+   For a foreground process, stop it normally and start `agenthub` again.
 
 2. **Verify Server Startup**:
    ```bash
-   curl http://localhost:8080/
+   curl --fail http://127.0.0.1:8080/health
    ```
 
 3. **Test Configuration**:
@@ -433,12 +472,13 @@ safe_paths = [
 ]
 
 [server]
-listen = "0.0.0.0:8080"
+listen = "127.0.0.1:8080"
 
 [web]
 rp_id = "agenthub.company.com"
 rp_origin = "https://agenthub.company.com"
 rp_name = "Company AgentHub"
+passkey_enabled = false
 
 [worktree]
 default_root = "/var/agenthub/worktrees"
@@ -460,7 +500,7 @@ mode = "tls"
 cert_dir = "/etc/agenthub/certs"
 
 [internal_grpc.auth]
-shared_secret = "change-me-to-256-bit-random-secret"
+shared_secret = "<load-a-long-random-secret-from-your-deployment-secret-store>"
 issuer = "agenthub"
 audience = "agenthub-internal"
 

--- a/userdocs/docs/getting-started/first-task-walkthrough.md
+++ b/userdocs/docs/getting-started/first-task-walkthrough.md
@@ -4,53 +4,58 @@ sidebar_position: 4
 
 # First Task Walkthrough
 
-This page walks through one full run from login to result review.
+This walkthrough verifies the installed server, ACP adapter, workspace safety,
+live output, and history replay in one short run.
 
-## Goal
+## 1. Sign In
 
-Create one agent, run one concrete coding task, and confirm output is persisted.
+Open `http://localhost:8080` by default and sign in. A new instance first asks
+you to initialize the root operator.
 
-## Step 1: Login
+## 2. Create an Agent
 
-1. Open AgentHub in your browser (`http://localhost:8080` by default).
-2. Sign in with username and password.
-3. Confirm you can see the Agents page.
+1. Open **Agents** and select **Create Agent**.
+2. Set a clear name, such as `docs-pilot`.
+3. Choose the `agenthub-acp codex` preset or another installed ACP provider.
+4. Choose a workspace mode:
+   - `create_worktree` for isolated repository work.
+   - `use_existing` when you intentionally want to use an existing directory.
+   - `reuse_worktree` when an existing Git worktree is already prepared.
+5. Confirm the selected path is under a configured `safe_paths` root.
+6. Create the agent and select its card.
 
-## Step 2: Create an Agent
+## 3. Start and Send an Instruction
 
-1. In the top form, set a clear name, for example `docs-pilot`.
-2. Pick command/preset for your provider.
-3. Select workdir mode:
-   - Use `create_worktree` for isolated work.
-   - Use `use_existing` for an existing local repo path.
-4. Submit and confirm a new agent card appears.
-
-## Step 3: Start and Send Instruction
-
-1. Click **Start** on the new agent.
-2. Wait until status changes to running.
-3. In input dock, send one bounded instruction, for example:
+Select **Start**, wait for the agent to become `running`, and send a bounded
+instruction from the input dock:
 
 ```text
-Summarize the current README and propose 3 concrete improvements.
+Summarize the current README and propose three concrete improvements. Do not edit files.
 ```
 
-## Step 4: Review Output
+Use **Interrupt** if the active turn needs to stop. Interrupting a turn is not
+the same as deleting the agent or its history.
 
-1. Use **Conversation** to read final answer.
-2. Use **Debug / Raw** only if behavior looks wrong.
-3. If needed, press **Interrupt** to stop a long in-progress operation.
+## 4. Review the Result
 
-## Step 5: Reconnect Check
+- Use **Thread** for the user-facing conversation.
+- Use **Plan** when the provider emits structured plan updates.
+- Enable developer mode from **Admin** only when you need the **Debug** tab or
+  session metadata.
 
-1. Refresh the browser tab.
-2. Re-open the same agent/session.
-3. Confirm previous conversation and status are still available.
+The exact tool, mode, model, and configuration controls depend on the selected
+ACP provider.
 
-This verifies backend-side session persistence.
+## 5. Verify Reconnect
+
+Refresh the browser, reopen the agent, and confirm that its status and previous
+output return. Browser disconnects do not terminate the backend-managed
+process; AgentHub replays persisted events and resumes live SSE updates.
 
 ## Done Criteria
 
-- Agent created successfully
-- Task reached a terminal state (`completed` or `failed`)
-- Output history remains visible after reconnect
+- The server accepts login.
+- Both `agenthub` and the selected ACP provider are available.
+- The workspace passes safe-path validation.
+- The task produces structured output.
+- History remains visible after refresh.

--- a/userdocs/docs/getting-started/installation.md
+++ b/userdocs/docs/getting-started/installation.md
@@ -4,123 +4,223 @@ sidebar_position: 1
 
 # Installation and Startup
 
-## Install Release Binaries With Homebrew
+AgentHub publishes native binaries for these platforms:
 
-AgentHub publishes Homebrew release binaries through the `linkerdog/homebrew-tap`
-tap.
+| Platform | Release target | Debian package | npm package |
+| --- | --- | --- | --- |
+| macOS Apple Silicon | `darwin-arm64` | No | Yes |
+| Linux x86_64 | `linux-amd64` | `amd64` | Yes |
+| Linux ARM64 | `linux-arm64` | `arm64` | Yes |
 
-```bash
-brew tap linkerdog/homebrew-tap
-brew install linkerdog/homebrew-tap/agenthub
-```
+Windows and macOS Intel binaries are not currently published.
 
-This installs:
+For a complete agent runtime, install both executables from the same release:
 
-- `agenthub`
-- `agenthub-acp`
+- `agenthub`: the control plane and embedded web UI
+- `agenthub-acp`: the provider adapter used by the default Codex and Claude
+  runtime commands
 
-To run AgentHub as a background service:
+The Debian package contains both executables. GitHub publishes them as separate
+archives. The npm wrapper currently contains only `agenthub`.
 
-```bash
-brew services start linkerdog/homebrew-tap/agenthub
-```
+:::caution Linux runtime baseline
 
-AgentHub reads configuration from `~/.agenthub/config.toml`.
+The minimum supported glibc version for official Linux artifacts is not frozen
+yet. A recent `main` prebuild was verified on Ubuntu 24.04 and required
+`GLIBC_2.38` / `GLIBC_2.39`; it did not start on Ubuntu 22.04. Validate the
+binary on the target host before production rollout and check the selected
+release notes for release-specific compatibility evidence.
 
-To create that file interactively:
+:::
 
-```bash
-agenthub init
-```
+## Choose an Installation Method
 
-Minimal example:
+| Method | Best for | Includes `agenthub-acp` | Service integration |
+| --- | --- | --- | --- |
+| Debian package | Ubuntu/Debian servers | Yes | systemd unit included |
+| GitHub archives | macOS and portable Linux installs | Install the matching archive | Manual |
+| npm | Existing Node.js environments | No | Manual |
+| Homebrew tap | Legacy installations only | Legacy helper only | Homebrew service |
 
-```toml
-[server]
-listen = "127.0.0.1:8080"
-```
+## Debian Package
 
-Then open `http://localhost:8080`.
+Use the Debian package for a system-managed Linux installation. Install the
+GitHub CLI first, or download the matching `.deb` and `SHA256SUMS.txt` from the
+[latest release](https://github.com/hawkingrei/agenthub/releases/latest).
 
-Current release binaries are available for:
-
-- macOS Apple Silicon (`darwin-arm64`)
-- Linux `x86_64`
-- Linux `aarch64`
-
-## Install Debian Packages
-
-Linux releases also publish Debian packages for Ubuntu/Debian-style hosts:
-
-- `agenthub_<version>_amd64.deb`
-- `agenthub_<version>_arm64.deb`
-
-Download the package that matches your host and install it with `apt`:
+For Linux x86_64:
 
 ```bash
-sudo apt install ./agenthub_<version>_amd64.deb
+mkdir -p agenthub-install
+cd agenthub-install
+gh release download --repo hawkingrei/agenthub \
+  --pattern 'agenthub_*_amd64.deb' \
+  --pattern SHA256SUMS.txt
+sha256sum --ignore-missing -c SHA256SUMS.txt
+sudo apt install ./agenthub_*_amd64.deb
 ```
 
-The Debian package installs:
+For Linux ARM64, replace `amd64` with `arm64` in the download pattern and
+package name.
 
-- `agenthub`
-- `agenthub-acp`
+The package installs:
+
+- `/usr/bin/agenthub`
+- `/usr/bin/agenthub-acp`
 - `agenthub.service`
 
-On install, the package creates an `agenthub` system user, creates runtime data under
-`/var/lib/agenthub`, enables the service, and attempts to start it.
-
-Check service status:
-
-```bash
-systemctl status agenthub.service
-journalctl -u agenthub.service -f
-```
-
-The service reads configuration from:
+It also creates an `agenthub` system user, enables the service, and attempts to
+start it. Runtime data is stored under `/var/lib/agenthub`, and the generated
+configuration is:
 
 ```text
 /var/lib/agenthub/.agenthub/config.toml
 ```
 
-The default package config listens on `127.0.0.1:8080` and allows workspaces under
-`/var/lib/agenthub/workspaces`. Edit the config and restart the service when you need a different
-listen address or repository root:
+Check the installation:
 
 ```bash
+agenthub --version
+agenthub-acp --version
+sudo systemctl status agenthub.service --no-pager
+sudo journalctl -u agenthub.service -n 100 --no-pager
+```
+
+The package config listens on `127.0.0.1:8080` and allows workspaces under
+`/var/lib/agenthub/workspaces`. For a remote server, either access it through
+an SSH tunnel:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 user@agenthub-host
+```
+
+or place AgentHub behind an authenticated HTTPS reverse proxy. Do not expose an
+unconfigured instance directly to a public network.
+
+Edit the service configuration with:
+
+```bash
+sudoedit /var/lib/agenthub/.agenthub/config.toml
 sudo systemctl restart agenthub.service
 ```
 
-## Build From Source
+## GitHub Release Archives
 
-### Prerequisites
+Use release archives for macOS or a user-managed Linux installation. This
+example downloads the latest matching `agenthub` and `agenthub-acp` archives.
 
-- Rust `1.96.0` (stable toolchain baseline)
-- Node.js 20+
-- Git
+Set `TARGET` to one of:
 
-### Install Web Dependencies
-
-```bash
-npm --prefix web ci
-```
-
-### Create A Minimal Config
-
-AgentHub reads configuration from `~/.agenthub/config.toml` by default.
-
-If you want a guided first-run setup instead of hand-writing TOML, run:
+- `darwin-arm64`
+- `linux-amd64`
+- `linux-arm64`
 
 ```bash
-cargo run -- init
+TARGET=darwin-arm64
+mkdir -p agenthub-install
+cd agenthub-install
+gh release download --repo hawkingrei/agenthub \
+  --pattern "agenthub-[0-9]*-${TARGET}.tar.gz" \
+  --pattern "agenthub-acp-*-${TARGET}.tar.gz" \
+  --pattern SHA256SUMS.txt
 ```
 
-Start with a minimal single-node config:
+Verify the downloaded assets. On macOS:
+
+```bash
+grep -- "-${TARGET}.tar.gz$" SHA256SUMS.txt | shasum -a 256 -c -
+```
+
+On Linux:
+
+```bash
+grep -- "-${TARGET}.tar.gz$" SHA256SUMS.txt | sha256sum -c -
+```
+
+Extract and install both binaries into a user-owned directory:
+
+```bash
+tar -xzf agenthub-[0-9]*-${TARGET}.tar.gz
+tar -xzf agenthub-acp-*-${TARGET}.tar.gz
+mkdir -p "$HOME/.local/bin"
+install -m 0755 agenthub-[0-9]*-${TARGET}/agenthub "$HOME/.local/bin/agenthub"
+install -m 0755 agenthub-acp-*-${TARGET}/agenthub-acp "$HOME/.local/bin/agenthub-acp"
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Persist the `PATH` update in your shell profile, then verify both commands:
+
+```bash
+agenthub --version
+agenthub-acp --version
+```
+
+Keep the two archives on the same release tag. Mixing the control plane with a
+different ACP adapter generation can cause provider startup or protocol errors.
+
+## npm
+
+The npm package requires Node.js 18 or newer and supports macOS Apple Silicon,
+Linux x86_64, and Linux ARM64:
+
+```bash
+npm install -g @linkerdog/agenthub
+agenthub --version
+```
+
+The npm wrapper installs only the native `agenthub` control-plane binary. To
+run the default Codex or Claude agent commands, also install the matching
+`agenthub-acp` archive from the same GitHub release by following the archive
+instructions above.
+
+If npm reports that the platform package is missing, confirm that optional
+dependencies are enabled and reinstall:
+
+```bash
+npm config get optional
+npm install -g @linkerdog/agenthub@latest --include=optional
+```
+
+## Homebrew Channel Status
+
+:::warning
+
+The `linkerdog/homebrew-tap` formula currently trails the primary GitHub and npm
+release channels and installs the legacy `agenthub-codex-acp` helper instead of
+the current `agenthub-acp` adapter. Do not use it for a new installation that
+needs the current complete runtime. Use the GitHub archives instead.
+
+:::
+
+Existing Homebrew users can inspect the pinned formula and installed binaries
+before deciding whether to migrate:
+
+```bash
+brew update
+brew info linkerdog/homebrew-tap/agenthub
+agenthub --version
+command -v agenthub-acp
+command -v agenthub-codex-acp
+```
+
+## First Startup
+
+Archive and npm installations read configuration from
+`~/.agenthub/config.toml`. Create it with the interactive initializer:
+
+```bash
+agenthub init
+```
+
+`agenthub init` requires an interactive terminal. It configures the instance
+role and internal gRPC bootstrap, but it does not configure provider API keys
+or provider-specific base URLs.
+
+For a minimal local instance, the resulting configuration should include:
 
 ```toml
 safe_paths = [
   "/home/you/projects",
-  "/home/you/sandboxes",
 ]
 
 [server]
@@ -130,74 +230,91 @@ listen = "127.0.0.1:8080"
 default_root = "/home/you/.agenthub/worktrees"
 ```
 
-`safe_paths` should list the repository roots that users are allowed to use as
-agent workdirs.
+On macOS, replace the Linux paths with paths under your home directory.
 
-### Start AgentHub
-
-For the standard local workflow:
+Start AgentHub in the foreground:
 
 ```bash
-make run
+agenthub
 ```
 
-`make run` builds the web UI as part of the normal startup path, so you do not
-need a separate `npm --prefix web run build` step for the default local setup.
+Then open [http://localhost:8080](http://localhost:8080), create the first
+account, and continue with the [first task walkthrough](./first-task-walkthrough.md).
 
-If you want to point at an explicit config file:
+Before starting an agent, configure any provider credentials required by the
+selected adapter. Keep secrets in the provider-supported environment or
+credential store; do not commit them to the AgentHub config or a workspace.
+
+## Upgrade
+
+### Debian package
+
+Download and verify the new package, then install it over the existing version:
 
 ```bash
-cargo run -- -c /path/to/config.toml
+sudo apt install ./agenthub_<new-version>_amd64.deb
+sudo systemctl status agenthub.service --no-pager
 ```
 
-By default, AgentHub serves the UI at `http://localhost:8080`.
+The package preserves `/var/lib/agenthub` during upgrades.
 
-### ACP Provider Baseline
+### GitHub archives
 
-The canonical AgentHub ACP adapter binary is `agenthub-acp`. Use `agenthub-acp codex` for Codex
-sessions and `agenthub-acp claude` for Claude sessions. Existing deployments that still launch
-`agenthub-codex-acp` should migrate to `agenthub-acp codex` before relying on current release
-packages.
+Stop the foreground process or your service manager, download both archives
+from the same new release, verify their checksums, and replace both binaries.
+Keep `~/.agenthub` unchanged.
 
-- Current repository baseline: official Codex `0.138.x`
-- If you override `codex_acp.binary`, keep the replacement ACP binary protocol-
-  compatible with the same Codex generation
+### npm
 
-### Optional App Install
+```bash
+npm install -g @linkerdog/agenthub@latest --include=optional
+agenthub --version
+```
 
-On supported browsers, AgentHub can be installed as a standalone web app.
+Upgrade the separately installed `agenthub-acp` archive to the matching release
+at the same time.
+
+## Uninstall
+
+### Debian package
+
+```bash
+sudo apt remove agenthub
+```
+
+Package removal and purge preserve runtime data under `/var/lib/agenthub`.
+Back it up and remove it manually only when you intentionally want to delete
+all instance state.
+
+### Archive installation
+
+Remove the installed binaries from `$HOME/.local/bin`. Runtime state under
+`~/.agenthub` is not removed automatically.
+
+### npm installation
+
+```bash
+npm uninstall -g @linkerdog/agenthub
+```
+
+This does not remove `~/.agenthub` or a separately installed `agenthub-acp`.
+
+## Install the Web App Shell
+
+On supported browsers, AgentHub can be installed as a standalone web app after
+the server is running.
 
 - The frontend registers its service worker automatically.
 - The same service worker is used for push notifications and installability.
-- AgentHub is **not** offline-first: a normal refresh still fetches the latest
-  app shell and hashed assets from the server.
+- AgentHub is not offline-first; a refresh still fetches the current app shell
+  and hashed assets from the server.
 
-For non-localhost deployments, use HTTPS if you want installability and browser
-push to work reliably.
+Use HTTPS for non-localhost deployments if you need browser installability,
+passkeys, or push notifications.
 
-### Runtime Data Location
+## Build From Source
 
-AgentHub stores runtime data under `~/.agenthub/` by default, including:
-
-- SQLite database
-- runtime session state
-- logs and operational files
-
-For Codex-backed ACP sessions, AgentHub also materializes its managed Team and
-runtime skills under `~/.agents/skills/agenthub-runtime/...`.
-
-- No manual `~/.codex/config.toml` skill configuration is required.
-- Global managed skills should be referenced through an absolute path or
-  `~/...`; do not treat them as current-workdir-relative `.agents/...` paths.
-- Repo-local `.agents/skills` continue to work independently alongside the
-  managed AgentHub skill set.
-
-### Smoke Check
-
-After startup:
-
-1. Open `http://localhost:8080`
-2. Confirm the login page loads
-3. Create one test agent
-4. Start it and send one simple instruction
-5. Confirm output appears in `Conversation`
+Building from source is a contributor workflow, not the recommended user
+installation path. See the repository
+[developer setup](https://github.com/hawkingrei/agenthub/blob/main/docs/developer-setup.md)
+for the pinned Rust toolchain, web build, Bazel, and test commands.

--- a/userdocs/docs/getting-started/login.md
+++ b/userdocs/docs/getting-started/login.md
@@ -4,33 +4,44 @@ sidebar_position: 3
 
 # Login and Access
 
-## First Access
+## Initialize the First Root Operator
 
-Use the join/bootstrap flow to create the first account.
+On a new AgentHub instance, the login page shows **First-run setup**. Create the
+first root operator there:
 
-- `Display Name` is used only when creating the account profile
-- Daily login uses `username + password`
+1. Enter a username. Usernames cannot contain `@` because mentions reserve it.
+2. Enter a display name.
+3. Set a password.
+4. Select **Initialize Root**.
 
-## Recommended Account Setup
-
-- Use a stable team username convention
-- Keep password policy aligned with your internal standard
-- Store credentials in your team password manager
+This first account can manage instance-wide settings, safe paths, users, and
+remote Agent Nodes. Initialize it only from a trusted network and store its
+credentials in your normal secrets manager.
 
 ## Regular Login
 
-1. Open AgentHub in your browser
-2. Enter your username and password
-3. Sign in and enter the workspace
+After initialization, sign in with the username and password created for this
+instance. A successful login creates a 12-hour bearer session in the browser.
 
-## Access Control Notes
+If passkeys are enabled, AgentHub may ask you to finish a WebAuthn challenge or
+register a credential after the password step. Configure the public HTTPS
+origin before enabling passkeys outside localhost.
 
-- Agent operations are permission-protected
-- Key actions are audited (for example login and sensitive path operations)
-- If login fails repeatedly, verify account status and server-side auth settings
+## Joining an Existing Teamspace
 
-## If Login Keeps Failing
+An invitation link creates an operator account for the invited Teamspace. Do
+not use the invite flow to initialize the root account, and do not reuse an
+invite from a different AgentHub instance.
 
-1. Confirm server time is correct
-2. Confirm you are on the correct AgentHub instance
-3. Confirm account was created in this instance, not another environment
+## If Login Fails
+
+1. Open `/api/auth/status` and confirm the instance reports
+   `root_initialized: true`.
+2. Confirm the username belongs to this instance and the server clock is
+   correct.
+3. If passkey verification fails, confirm the configured `web.rp_id` and
+   `web.rp_origin` match the URL in the browser.
+4. Check server logs for the corresponding authentication audit event.
+
+Do not delete the database or VAPID files to recover an account. Restore a
+known-good backup or use an authenticated administrative flow instead.

--- a/userdocs/docs/intro.md
+++ b/userdocs/docs/intro.md
@@ -16,8 +16,8 @@ AgentHub is built for the operational side of agent work:
 - keep agent sessions alive after the browser tab closes
 - inspect structured ACP history instead of relying on raw scrollback
 - manage Team workflows with explicit shared channels, Kanban, and execution surfaces
-- route execution to remote nodes with actor p2p control and mailbox relay when
-  one machine is not enough
+- route execution to remote nodes over the dedicated internal gRPC control
+  plane when one machine is not enough
 - keep runtime state, history, and operator control in one place
 
 If you are evaluating AgentHub as an:
@@ -52,9 +52,8 @@ AgentHub has four primary user-facing surfaces:
   and debug events as structured history
 - **Teams**: coordinate coordinator/worker collaboration with shared channels,
   Kanban, and execution tracking
-- **Agent Nodes and actor p2p**: extend execution onto remote machines without
-  moving the control plane, while keeping mailbox/control traffic on the same
-  operational model
+- **Agent Nodes**: extend execution onto remote machines without moving the
+  main control plane
 
 ## Choose Your Path
 

--- a/userdocs/docs/operations/api-error-reference.md
+++ b/userdocs/docs/operations/api-error-reference.md
@@ -1,312 +1,83 @@
 ---
-sidebar_position: 5
+sidebar_position: 4
 ---
 
 # API Error Reference
 
-This page documents common API error responses from AgentHub and how to resolve them.
-
-## Error Response Format
-
-All API errors follow this JSON structure:
+AgentHub HTTP errors use a small JSON envelope:
 
 ```json
 {
-  "error": "Human-readable error message"
+  "error": "human-readable message"
 }
 ```
 
-HTTP status codes indicate the error category:
+Use the HTTP status for control flow. Error text is useful for diagnosis but is
+not a stable machine-readable code.
 
-| Status Code | Meaning |
-|-------------|---------|
-| `400` | Bad Request - Invalid input parameters |
-| `401` | Unauthorized - Authentication required or failed |
-| `403` | Forbidden - Insufficient permissions |
-| `404` | Not Found - Resource doesn't exist |
-| `409` | Conflict - Resource state conflict |
-| `500` | Internal Server Error - Server-side problem |
+## Status Codes
 
-## Authentication Errors (401)
+| Status | Meaning | Client action |
+|--------|---------|---------------|
+| `400 Bad Request` | The payload, parameter, state transition, or path is invalid. | Correct the request; do not retry unchanged. |
+| `401 Unauthorized` | Bearer token is missing/expired, or the account lacks the required capability. | Sign in again or use an appropriately authorized account. |
+| `403 Forbidden` | A route-specific policy rejected an authenticated action. | Change authorization or request scope. |
+| `404 Not Found` | The resource is absent or not visible in the requested scope. | Refresh IDs and parent scope. |
+| `409 Conflict` | Current state or a concurrent update conflicts with the request. | Reload state, then retry only if still valid. |
+| `500 Internal Server Error` | An unexpected database, runtime, provider, or internal transport failure occurred. | Preserve logs and retry only after checking whether the operation committed. |
+
+Capability failures are currently returned as `401` messages such as
+`runtime:inspect required` or `root required`; do not assume every authorization
+failure uses `403`.
+
+## Common Authentication Errors
 
 ### `missing authorization token`
 
-**Cause**: Request missing `Authorization` header.
+Add the normal bearer header:
 
-**Solution**: Include the header:
 ```bash
-curl -H "Authorization: Bearer <token>" http://localhost:8080/api/...
+curl --fail \
+  -H "Authorization: Bearer ${AGENTHUB_TOKEN}" \
+  http://127.0.0.1:8080/api/agents
 ```
 
 ### `invalid token`
 
-**Cause**: Token is malformed, expired, or revoked.
-
-**Solution**: 
-- Re-authenticate via `/api/login` or `/api/join`
-- Check token hasn't expired
-- Verify token hasn't been revoked
-
-### `root required`
-
-**Cause**: Operation requires root/admin privileges.
-
-**Solution**: 
-- Log in as root user
-- For automation, use root credentials
-- Some operations (like node registration) require root
-
-### `root already initialized`
-
-**Cause**: Attempting to create root user when one already exists.
-
-**Solution**: Root user already configured; use `/api/login` instead of `/api/join`.
-
-### `invalid join token` / `join token expired` / `invalid pin`
-
-**Cause**: Join/bootstrap flow validation failed.
-
-**Solution**:
-- Generate a new join challenge via admin API
-- Complete join within token expiration time
-- Verify PIN is correct
-
-## Validation Errors (400)
-
-### Common Field Validation
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `team name is required` | Missing `name` field | Provide non-empty team name |
-| `title is required` | Missing task title | Include task title in request |
-| `member_id is required` | Missing member reference | Specify which team member |
-| `step_key is required` | Missing step identifier | Provide unique step key |
-| `error_text is required` | Missing error details | Include error description |
-| `spec must be an object` | Invalid spec format | Send spec as JSON object |
-
-### Team Specification Errors
-
-#### `spec.members must be an array`
-
-Team definition missing members array.
-
-```json
-{
-  "spec": {
-    "members": [
-      {"member_id": "coordinator", "description": "...", "skills": []}
-    ],
-    "entrypoint": {...}
-  }
-}
-```
-
-#### `spec.members must not be empty`
-
-Team requires at least one member.
-
-#### `spec.members[].member_id is required`
-
-Each member needs a unique identifier.
-
-#### `spec.coordinator_member_id must reference a defined member`
-
-Coordinator ID must match one of the defined `member_id` values.
-
-#### `spec.steps[].depends_on entries must be non-empty strings`
-
-Dependency references must be valid step keys.
-
-### Agent Creation Errors
-
-#### `workdir is required`
-
-**Cause**: Creating agent without specifying working directory.
-
-**Solution**: Provide `workdir` field, or use `create_worktree` mode with `worktree_repo`.
-
-#### `workdir path must be within allowed safe paths`
-
-**Cause**: Specified path outside configured `safe_paths`.
-
-**Solution**:
-- Add path to `safe_paths` in config
-- Choose a directory within existing safe paths
-- Use `create_worktree` mode for automatic path derivation
-
-### Agent Node Errors
-
-#### `agent node id or name already exists`
-
-**Cause**: Attempting to register node with duplicate ID or name.
-
-**Solution**: Use unique identifier and name for each node.
-
-## Not Found Errors (404)
-
-### `agent not found`
-
-**Cause**: Agent ID doesn't exist or you don't have access.
-
-**Solution**:
-- Verify agent ID is correct
-- Check agent hasn't been deleted
-- Ensure you're authenticated as the owner
-
-### `team not found`
-
-**Cause**: Team ID doesn't exist.
-
-**Solution**: Use list endpoint (`GET /api/teams`) to verify team exists.
-
-### `run not found`
-
-**Cause**: Team run ID doesn't exist for this team.
-
-### `task not found`
-
-**Cause**: Task ID doesn't exist in this team.
-
-### `conversation not found`
-
-**Cause**: Conversation not found for task.
-
-### `step not found`
-
-**Cause**: Step key doesn't exist in run.
-
-### `message not found`
-
-**Cause**: Message ID not found in conversation.
-
-### `agent node not found`
-
-**Cause**: Specified node ID not registered.
-
-## Conflict Errors (409)
-
-### `team name already exists`
-
-**Cause**: Team with this name already exists.
-
-**Solution**: Choose a different name or update existing team.
-
-### `team definition changed concurrently; reload and retry`
-
-**Cause**: Optimistic locking failure - team was modified by another request.
-
-**Solution**: Re-fetch team definition and retry operation.
-
-### `step already exists for run`
-
-**Cause**: Duplicate step key in run.
-
-**Solution**: Use unique step keys within a run.
-
-### `completed run cannot be resumed; use restart`
-
-**Cause**: Attempting to resume a run that already completed.
-
-**Solution**: Start a new run or use restart endpoint.
-
-### `agent is already running`
-
-**Cause**: Attempting to start an already running agent.
-
-**Solution**: Wait for completion or stop current run first.
-
-## Team Runtime Errors
-
-### Permission Review Errors
-
-#### `worker-originated permission review cannot route to worker`
-
-**Cause**: Invalid routing - workers can't review their own requests.
-
-**Solution**: Route to coordinator or another member.
-
-#### `route=to_coordinator requires a coordinator member in spec.members`
-
-**Cause**: Team spec missing coordinator definition.
-
-**Solution**: Define a coordinator member and set `coordinator_member_id`.
-
-### Message Routing Errors
-
-#### `to_actor_id is required when route=to_member`
-
-**Cause**: Direct member routing requires target member ID.
-
-#### `route must be one of: broadcast, to_coordinator, to_member`
-
-**Cause**: Invalid route type specified.
-
-## Internal gRPC Errors
-
-### `internal grpc client not available`
-
-**Cause**: AgentHub not configured with `internal_grpc.enabled = true`.
-
-**Solution**: Add to config:
-```toml
-[internal_grpc]
-enabled = true
-listen = "127.0.0.1:50051"
-```
-
-### `failed to connect to remote node`
-
-**Cause**: Cannot reach registered Agent Node.
-
-**Solution**:
-- Verify node is running
-- Check network connectivity
-- Verify gRPC TLS certificates
-
-## Troubleshooting API Errors
-
-### Enable Debug Logging
-
-Add to config for detailed error information:
-
-```toml
-[logging]
-level = "debug"
-```
-
-### Common Diagnostic Steps
-
-1. **Check Authentication**:
-   ```bash
-   curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/me
-   ```
-
-2. **Validate Request Body**:
-   - Ensure JSON is well-formed
-   - Check required fields are present
-   - Verify data types match schema
-
-3. **Check Server Logs**:
-   ```bash
-   # If running directly
-   agenthub 2>&1 | grep -i error
-   
-   # If using systemd
-   journalctl -u agenthub -f
-   ```
-
-4. **Verify Configuration**:
-   - Check `~/.agenthub/config.toml` syntax
-   - Ensure required sections are present
-   - Validate paths exist and are accessible
-
-### Getting Help
-
-When reporting API errors, include:
-
-1. HTTP status code
-2. Full error message
-3. Request URL and method
-4. Request body (sanitized)
-5. Server logs at debug level
-6. AgentHub version (`agenthub --version`)
+The token is unknown, expired, or revoked. AgentHub browser/API sessions expire
+after 12 hours. Sign in again; there is no refresh-token contract.
+
+### `<capability> required` or `root required`
+
+The session is valid but the role cannot perform the operation. See
+[Security and Path Safety](./security-and-path-safety.md) for the role matrix.
+
+## Common Validation Errors
+
+- Agent creation rejects empty names/commands and workdirs outside the
+  effective safe paths.
+- Remote-node operations reject missing peer configuration, invalid node IDs,
+  or unreachable internal gRPC targets.
+- Agent loop enablement requires a prompt and an idle interval from 10 to
+  86,400 seconds.
+- History requests clamp `limit` to 1 through 20 and page older records with
+  `before_id`.
+- Team requests validate parent Team/run/task scope and state transitions.
+
+Always compare a request with the exact `/api/openapi.json` document shipped by
+the target binary when the operation is covered by OpenAPI.
+
+## Diagnosing an Error
+
+1. Record the method, path, HTTP status, and `error` value.
+2. Confirm `/health` succeeds on the same origin.
+3. Confirm the token is sent in an `Authorization` header, except for browser
+   SSE URLs that use the documented query token.
+4. Validate JSON and `Content-Type: application/json`.
+5. Reload the resource before retrying a conflict.
+6. Inspect the matching server log. Internal errors log their chained causes
+   server-side while returning only the top-level message to the client.
+
+When reporting a problem, include the AgentHub version, sanitized request body,
+response status/body, and matching log window. Redact bearer/query tokens,
+credentials, uploaded content, and private prompt data.

--- a/userdocs/docs/operations/daily-operations-checklist.md
+++ b/userdocs/docs/operations/daily-operations-checklist.md
@@ -4,34 +4,48 @@ sidebar_position: 1
 
 # Daily Operations Checklist
 
-Use this checklist to keep AgentHub runs consistent and low-risk.
+## Before Admitting Work
 
-## Before Starting Work
-
-- Confirm AgentHub is reachable
-- Confirm target repository path is within `safe_paths`
-- Confirm a clean goal for each session
+- `curl --fail http://127.0.0.1:8080/health` returns `ok`.
+- The deployed `agenthub` and `agenthub-acp` versions match.
+- Disk space is healthy for the data directory, worktrees, and local objects.
+- Required remote nodes show a recent last-seen signal.
+- The selected repository/workdir is inside an effective `safe_paths` root.
+- No unresolved backup, migration, or provider incident is in progress.
 
 ## During Execution
 
-- Keep one main objective per prompt
-- Watch status transitions (`running` -> terminal)
-- Use **Interrupt** when output drifts or hangs
+- Keep one bounded objective per agent or Team task.
+- Watch both agent status and the connection badge; an SSE reconnect alone does
+  not mean the process stopped.
+- Review permission requests before allowing mutating tools.
+- Use **Interrupt** for a drifting turn and **Stop** for the runtime; do not
+  delete an agent as a recovery shortcut.
+- Check service logs when repeated starts, provider crashes, or stream recovery
+  failures occur.
 
-## Before Accepting Results
+## Before Accepting a Result
 
-- Verify changed files match requested scope
-- Verify validation commands are provided
-- Run critical tests locally
+- Review the changed files and workspace rather than relying on the final
+  message alone.
+- Run the relevant tests or build commands in the same workspace.
+- Confirm no unrelated secret, artifact, or worktree content was added.
+- Preserve the session or Team task link needed for audit/review.
 
 ## End of Day
 
-- Stop stale or idle agents
-- Clean up obsolete worktrees
-- Keep failed sessions that may be useful for debugging
+- Stop runtimes that should not continue unattended.
+- Keep failed sessions until useful diagnostics are captured.
+- Remove obsolete agents/worktrees only through deliberate product and Git
+  cleanup flows.
+- Review warnings for SQLite, object storage, push, internal gRPC, and provider
+  exits.
 
-## Weekly Hygiene
+## Scheduled Maintenance
 
-- Review path/safety settings with the team
-- Review recurring failures in troubleshooting logs
-- Refine prompt templates for repeated tasks
+- Snapshot and restore-test the complete data set.
+- Review `safe_paths`, users/roles, devices, remote nodes, and TLS expiry.
+- Check event retention and disk growth before enabling SQLite `VACUUM`.
+- Re-run the release artifact smoke after upgrades, including S3 or remote-node
+  paths that your deployment advertises.
+- Patch AgentHub, ACP providers, browsers, and host dependencies.

--- a/userdocs/docs/operations/faq.md
+++ b/userdocs/docs/operations/faq.md
@@ -4,35 +4,70 @@ sidebar_position: 5
 
 # FAQ
 
-## Why does the task continue after I close the browser?
+## Why does a task continue after I close the browser?
 
-AgentHub runs sessions in backend-managed processes. Browser disconnect does not
-terminate the runtime by design.
+The backend owns the agent process. The browser replays persisted history and
+reconnects to live SSE when it returns.
+
+## Which binaries do I need?
+
+Install both `agenthub` and `agenthub-acp` from the same release for the default
+Codex or Claude runtime presets. Debian packages contain both. GitHub publishes
+separate archives. The npm wrapper currently installs only `agenthub`.
+
+## Which platforms have official binaries?
+
+macOS Apple Silicon, Linux x86_64, and Linux ARM64. Windows and macOS Intel are
+not current release targets. The minimum Linux glibc baseline is still being
+finalized, so validate the exact artifact on the deployment host.
+
+## Is Homebrew the recommended install?
+
+Not for a new complete installation while the tap trails the current release
+and adapter naming. Use the verified GitHub archives or Debian package.
+
+## Is `safe_paths` an OS sandbox?
+
+No. It validates accepted workdirs. The subprocess still inherits the service
+account's filesystem and network privileges. Use a dedicated account and host,
+container, or VM isolation for stronger boundaries.
 
 ## Should I use one agent per repository?
 
-Not always. Use one agent per stable intent or workflow. For parallel work,
-separate agents and worktrees are easier to reason about.
+Use one agent per stable intent. Parallel changes are easier to review when
+each agent has its own worktree, even if they share a repository.
 
-## What is the safest default for daily usage?
+## Why is the Debug tab missing?
 
-Use `create_worktree` mode with predictable naming and clean up stale runs
-regularly.
+Production defaults hide developer-only output and session metadata. A root
+operator can enable developer mode from **Admin** for diagnosis.
 
-## Why do I get path permission errors?
+## Why does the badge say `SSE idle`?
 
-Most often the path is outside `safe_paths` or resolved path differs from what
-you expect. Confirm configured safe path list first.
+No running agent currently needs a live stream. This is normal for created,
+stopped, exited, or failed agents.
 
-## How do I debug missing output events?
+## How do I debug missing live output?
 
-1. Check agent state in cards
-2. Inspect Debug/Raw stream
-3. Verify server process and logs
-4. Retry from a fresh session if stream state is unrecoverable
+Check the agent state, connection badge, `/health`, browser Network entry for
+`/sse/agents`, and server logs. Refreshing is safe and triggers persisted event
+replay. Do not delete an event database.
 
-## How do I keep long sessions readable?
+## Does the OpenAPI document cover every HTTP route?
 
-- Keep prompts narrow
-- Split large tasks into phases
-- Start a new session when context drifts too far
+No. It is an incremental public automation contract focused on Team operations
+and scoped uploads. Generate clients from the exact deployed
+`/api/openapi.json` and do not infer stability for omitted routes.
+
+## Does the official binary support S3?
+
+Official release builds include the OpenDAL S3 backend, but storage defaults to
+local `fs`. Source/default builds keep S3 feature-gated. You must configure
+`backend = "s3"` and validate the exact release against your provider; inclusion
+does not certify every S3-compatible service.
+
+## What must I back up?
+
+Prefer a consistent snapshot of the entire AgentHub data directory while the
+service is stopped, plus any externally configured archive, body, object, and
+certificate paths. Include per-agent event databases, not only `agenthub.db`.

--- a/userdocs/docs/operations/notifications.md
+++ b/userdocs/docs/operations/notifications.md
@@ -4,129 +4,76 @@ sidebar_position: 3
 
 # Notifications
 
-AgentHub can notify you when a task is completed, both in-app and via browser push notifications.
+AgentHub shows completion state in the web UI and can deliver an encrypted Web
+Push notification when an agent process finishes.
 
-## In-App Notification
+## Browser Push Requirements
 
-By default, completion signals appear in the AgentHub UI:
+- A browser with service worker, Notification, and Push API support.
+- HTTPS outside localhost.
+- A signed-in AgentHub session with permission to create a subscription.
+- A configured VAPID subject.
 
-- Runtime and connection badges in the active workspace
-- Structured completion state in ACP / Team timelines
-- Browser notifications when push is enabled
+The frontend registers `/sw.js`. After sign-in, grant the browser notification
+permission so it can submit the browser subscription to AgentHub.
 
-## Browser Push Notification
+## Configuration
 
-AgentHub supports Web Push API notifications that work even when the browser
-tab is not focused or closed.
-
-### How It Works
-
-1. **Service worker**: the frontend registers `/sw.js` automatically
-2. **Subscription**: after successful login or join, AgentHub attempts to attach a Push subscription for the current browser session
-3. **Delivery**: when an agent completes, the backend sends a push notification via your browser's push service
-
-### Configuration
-
-VAPID keys are auto-generated on first startup and stored in `~/.agenthub/vapid.json`:
-
-```json
-{
-  "public_key": "<base64-encoded-public-key>",
-  "private_key": "<base64-encoded-private-key>"
-}
+```toml
+[push]
+subject = "mailto:ops@example.com"
+keys_path = "~/.agenthub/vapid.json"
 ```
 
-To rotate VAPID keys (invalidates existing subscriptions):
+The VAPID key pair is created at `keys_path` on first startup and reused across
+restarts. Protect and back up this file alongside other AgentHub state.
+
+Root operators can inspect or rotate keys from **Admin**. The equivalent API is:
 
 ```bash
-# Via API (requires admin)
-curl -X POST -H "Authorization: Bearer <token>" \
-  http://localhost:8080/api/admin/push/rotate-keys
+curl --fail -X POST \
+  -H "Authorization: Bearer ${AGENTHUB_TOKEN}" \
+  http://127.0.0.1:8080/api/push/vapid_rotate
 ```
 
-Or use the Admin Console UI to rotate keys.
+Rotation invalidates the public key associated with existing browser
+subscriptions. Use it for an intentional security event, then have users sign
+in and subscribe again; do not rotate it as routine cleanup.
 
-### Enabling Push Notifications
+## What Is Sent
 
-1. Open AgentHub in a browser that supports service workers and Push API
-2. Sign in or complete the join/bootstrap flow
-3. Allow notifications when the browser asks
-4. Keep using the same browser profile for that subscription
-
-### Notification Payload
-
-Push notifications include:
+The current completion payload contains the event type, agent ID, session ID,
+and server timestamp:
 
 ```json
 {
   "type": "agent_completed",
-  "agent_id": "agent-uuid",
-  "session_id": "session-uuid",
+  "agent_id": "agent-id",
+  "session_id": "session-id",
   "ts": 1710000000
 }
 ```
 
-## Quick Validation
+Push delivery is best effort. The session history and current Agent status are
+the authoritative records.
 
-1. Start a short task
-2. Switch browser tab or minimize the window
-3. Wait for task completion
-4. Confirm:
-   - System notification appears (if push is enabled)
-   - The active AgentHub workspace reflects the completed state
-   - Timeline / history shows the completion event
+## Validate Push
+
+1. Sign in with a browser profile that permits notifications.
+2. Start a short agent run.
+3. Move the tab to the background.
+4. Let the agent process exit.
+5. Confirm the system notification and the persisted AgentHub timeline.
 
 ## Troubleshooting
 
-### Push Notifications Not Received
+| Symptom | Check |
+|---------|-------|
+| No permission prompt | Reset the site's notification permission and reload. |
+| Subscription request is `401` or `403` | Sign in again and confirm the account has push-subscribe capability. |
+| Push works on localhost but not a hostname | Use HTTPS and confirm the service worker is registered for the same origin. |
+| Delivery stops after key rotation | Re-subscribe every browser profile. |
+| Server warns that push is disabled | Set a valid `push.subject` and ensure `keys_path` is writable. |
 
-| Symptom | Check | Solution |
-|---------|-------|----------|
-| No browser prompt | Permission already denied or browser does not support Push | Reset site permissions, then refresh and sign in again |
-| Subscription fails | VAPID keys missing | Restart AgentHub to auto-generate keys |
-| Silent failures | Check browser console for errors | Verify `push.subject` is configured in the `[push]` section |
-| Works locally but not remote | HTTPS required | Push API requires secure context (HTTPS) |
-
-## Installable App Behavior
-
-AgentHub is installable as a standalone browser app on supported platforms.
-
-- Installability and push both rely on the same service worker registration
-- The installed app still prefers fresh server-delivered HTML and hashed assets
-- Do not treat the installed experience as an offline-first shell
-
-### Configuration Options
-
-Add to `~/.agenthub/config.toml`:
-
-```toml
-[push]
-# Required for push notifications
-subject = "mailto:admin@example.com"
-
-# Optional: custom keys path (default: ~/.agenthub/vapid.json)
-keys_path = "/custom/path/vapid.json"
-```
-
-The `push.subject` value should be a contact email or URL for your application.
-
-## Security Considerations
-
-- VAPID private keys are sensitive — protect the keys file
-- Subscriptions are per-user; other users won't receive your notifications
-- Push services (FCM, APNS, etc.) only receive encrypted payload headers
-
-## Future Extensions
-
-Planned notification channels:
-
-- **Webhook**: POST callbacks to external systems
-- **Email**: SMTP-based notifications for critical completions
-- **Slack/Discord**: Direct integrations with team chat
-
-## Recommended Setup
-
-- Enable push notifications for long-running tasks (>5 minutes)
-- Use clear agent naming conventions for easy notification identification
-- Combine notifications with session history for efficient follow-up
-- Rotate VAPID keys periodically if you have high security requirements
+AgentHub does not currently document webhook, email, Slack, or Discord delivery
+as supported notification channels.

--- a/userdocs/docs/operations/security-and-path-safety.md
+++ b/userdocs/docs/operations/security-and-path-safety.md
@@ -4,531 +4,134 @@ sidebar_position: 2
 
 # Security and Path Safety
 
-This guide covers security best practices for deploying and operating AgentHub safely.
+AgentHub launches powerful subprocesses in user-selected workspaces. Its
+authentication and path checks are important control-plane guardrails, but they
+are not an operating-system sandbox.
 
-## Security Model Overview
+## Security Boundary
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Security Layers                       │
-├─────────────────────────────────────────────────────────┤
-│  1. Authentication: Who are you?                        │
-│     - Password-based login                              │
-│     - WebAuthn/Passkey support                          │
-│     - Token-based API access                            │
-├─────────────────────────────────────────────────────────┤
-│  2. Authorization: What can you do?                     │
-│     - Role-based access (root/user)                     │
-│     - Path-based restrictions                           │
-│     - Operation-level controls                          │
-├─────────────────────────────────────────────────────────┤
-│  3. Execution Isolation: What can the agent access?     │
-│     - Safe path restrictions                            │
-│     - Workdir boundaries                                │
-│     - Network policies                                  │
-├─────────────────────────────────────────────────────────┤
-│  4. Data Protection: How is data secured?               │
-│     - Encryption at rest                                │
-│     - TLS in transit                                    │
-│     - Audit logging                                     │
-└─────────────────────────────────────────────────────────┘
-```
+- The web/API layer authenticates a user and checks a capability for each
+  protected operation.
+- `safe_paths` restricts which workdirs AgentHub accepts.
+- The agent process runs with the same operating-system identity and ambient
+  privileges as the AgentHub service unless you add container or host-level
+  isolation.
+- Provider credentials and network access available to that service identity
+  may also be available to the runtime.
 
-## Path Safety
+Setting a process working directory does not prevent it from reading other
+files that the OS account can access. For stronger isolation, use a dedicated
+service account, containers/VMs, filesystem permissions, and network policy.
 
-### Principle: Least Path Access
-
-Only allow paths users actually need.
-
-**Good examples**:
-- `/home/you/projects/agenthub` - Specific project directory
-- `/home/you/workspace/team-a` - Team workspace
-- `/data/sandboxes/experiments` - Isolated sandbox
-
-**Avoid**:
-- `/home/you` - Too broad, includes personal files
-- `/` - System-wide access
-- `/etc`, `/usr` - System directories
-- Network mounts with sensitive data
-
-### Path Validation
-
-AgentHub validates paths at multiple stages:
-
-1. **Configuration time**: `safe_paths` loaded from config
-2. **Agent creation**: Workdir validated against allowed paths
-3. **Runtime**: Agent process restricted to workdir context
-
-### Safe Paths Configuration
+## Minimize `safe_paths`
 
 ```toml
-# ~/.agenthub/config.toml
 safe_paths = [
-  # Development directories
-  "/home/dev/projects",
-  "/home/dev/experiments",
-  
-  # Team workspaces
-  "/data/team-a/workspace",
-  "/data/team-b/sandboxes",
-  
-  # CI/CD builds
-  "/var/ci/builds",
-  
-  # Production (read-only operations)
-  "/opt/services/configs",
+  "/srv/agenthub/workspaces/team-a",
+  "/srv/agenthub/workspaces/team-b",
 ]
 ```
 
-**Important**: `~/.agenthub/worktrees` is automatically included.
+AgentHub always includes `~/.agenthub/worktrees` in the effective safe-path
+list. Additional paths should be specific, owned by the service account, and
+free of unrelated credentials or personal data.
 
-### Path Security Checklist
+Avoid broad roots such as `/`, `/home`, or an entire user home. Review symlinks,
+mount points, and the resolved path seen by the service account when a seemingly
+valid workspace is rejected.
 
-- [ ] Paths are as specific as possible
-- [ ] No parent directories of sensitive data
-- [ ] No world-writable directories
-- [ ] Separate paths for different teams if needed
-- [ ] Regular audit of effective paths
+## Roles and Capabilities
 
-## Authentication
+AgentHub uses explicit capabilities rather than one global user check:
 
-### Password-Based Authentication
+| Role | Intended access |
+|------|-----------------|
+| `root` | All instance, user, auth, runtime, Team, node, diagnostics, and push operations. |
+| `admin` | Agent, Team, node, linker, runtime, diagnostics, and push operations; no root instance/user/auth configuration. |
+| `operator` | Agent and Team management plus runtime operation/inspection and push subscription. |
+| `viewer` | Runtime inspection and push subscription. |
+| `device` | Push subscription only. |
 
-Default authentication method:
+Initialize the first root operator from a trusted network. Teamspace invitation
+links create operator accounts; they do not create another root.
 
-```toml
-# Configure password policy (if applicable)
-[auth]
-min_password_length = 12
-require_special_chars = true
-```
+## Sessions and Passkeys
 
-**Best practices**:
-- Use strong, unique passwords
-- Enable account lockout after failed attempts
-- Rotate passwords regularly
+- Passwords are hashed with Argon2.
+- Browser/API bearer sessions expire after 12 hours. Logging out removes the
+  browser's token; use expiration and credential rotation as the current
+  server-side invalidation boundary.
+- Passkeys are disabled by default and require a correct relying-party origin.
+- Outside localhost, use HTTPS before enabling WebAuthn or browser push.
 
-### WebAuthn/Passkey Support
+Bearer tokens grant the holder the session's capabilities. Never place them in
+URLs, committed files, screenshots, support tickets, or durable shell history.
+The SSE endpoint is the browser-specific exception that uses a query token; keep
+proxy access logs for `/sse/*` appropriately restricted and redacted.
 
-Modern passwordless authentication:
+## Network Exposure
 
-```toml
-[web]
-rp_id = "agenthub.company.com"
-rp_origin = "https://agenthub.company.com"
-rp_name = "Company AgentHub"
-```
+The safe default is:
 
-**Setup**:
-1. Login with password
-2. Go to Settings → Security
-3. Register passkey (Touch ID, YubiKey, etc.)
-4. Use passkey for future logins
-
-**Benefits**:
-- Phishing-resistant
-- No passwords to remember
-- Hardware-backed security
-
-### API Token Security
-
-```bash
-# Get token via login
-TOKEN=$(curl -X POST http://localhost:8080/api/login \
-  -d '{"username":"user","password":"pass"}' \
-  | jq -r '.token')
-
-# Use in API calls
-curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:8080/api/agents
-```
-
-**Token Security**:
-- Store tokens in environment variables or secrets manager
-- Never commit tokens to version control
-- Rotate tokens periodically
-- Revoke tokens on logout/device removal
-
-## Authorization
-
-### Role-Based Access Control
-
-| Role | Permissions |
-|------|-------------|
-| `root` | Full system access, user management, node registration |
-| `user` | Create agents, view own agents, participate in teams |
-
-### Root-Only Operations
-
-Require root privileges:
-
-- Register Agent Nodes
-- Rotate VAPID keys
-- Manage users
-- View all agents (admin mode)
-- System configuration changes
-
-### Team-Level Permissions
-
-Teams have their own permission model:
-
-- **Coordinator**: Planning, task assignment, final approval
-- **Worker**: Implementation, status updates
-- **Human operators**: Conversation, oversight
-
-## Execution Isolation
-
-### Workdir Boundaries
-
-Agent processes are constrained to their configured workdir:
-
-```
-Agent Process
-├── Workdir: /home/dev/projects/myapp
-│   ├── Can read/write here
-│   └── Can execute commands here
-├── Cannot access: /home/dev/other-project
-├── Cannot access: /etc/passwd
-└── Cannot access: /
-```
-
-**Implementation**:
-- Process working directory set to workdir
-- Agent tools validate paths before operations
-- Configuration prevents path traversal
-
-### Container Isolation (Advanced)
-
-For stronger isolation, run agents in containers:
-
-```bash
-# Wrap agent execution in Docker
-docker run \
-  --rm \
-  -v "${WORKDIR}:${WORKDIR}:rw" \
-  -w "${WORKDIR}" \
-  --network none \
-  --security-opt no-new-privileges \
-  agent-runtime:latest \
-  "$@"
-```
-
-**Configuration**:
-```toml
-[codex_acp]
-binary = "/usr/local/bin/agenthub-docker-wrapper"
-```
-
-### Network Policies
-
-Restrict agent network access:
-
-```bash
-# iptables example: Allow only specific egress
-iptables -A OUTPUT -p tcp --dport 443 -d github.com -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 443 -d api.openai.com -j ACCEPT
-iptables -A OUTPUT -p tcp -j DROP
-```
-
-## Data Protection
-
-### Encryption at Rest
-
-AgentHub stores data in SQLite databases:
-
-| Data | Location | Protection |
-|------|----------|------------|
-| Main database | `~/.agenthub/agenthub.db` | File permissions |
-| Event databases | `~/.agenthub/agent-events/*.db` | File permissions |
-| Config | `~/.agenthub/config.toml` | File permissions |
-| Secrets | `~/.agenthub/*.json` | File permissions |
-
-**Recommended**:
-```bash
-# Set restrictive permissions
-chmod 700 ~/.agenthub
-chmod 600 ~/.agenthub/config.toml
-chmod 600 ~/.agenthub/vapid.json
-```
-
-**Full Disk Encryption**:
-- Enable LUKS on Linux
-- Enable FileVault on macOS
-- Enable BitLocker on Windows
-
-### Encryption in Transit
-
-**HTTP/HTTPS**:
 ```toml
 [server]
-# For production, use reverse proxy (nginx, traefik)
-# with TLS termination
 listen = "127.0.0.1:8080"
 ```
 
-**Internal gRPC**:
-```toml
-[internal_grpc.security]
-mode = "tls"  # or "mtls" for mutual TLS
-cert_dir = "/etc/agenthub/certs"
-```
+For shared access, place AgentHub behind an authenticated HTTPS reverse proxy or
+private network. Preserve SSE streaming without proxy buffering. Do not expose a
+fresh first-run instance publicly.
 
-### Secret Management
+Remote Agent Nodes use a separate internal gRPC listener. Keep it on a private
+network, use `tls` or `mtls`, protect the bootstrap token and JWT shared secret,
+and synchronize node clocks. `security.mode = "disabled"` is for isolated local
+testing only.
 
-**Environment Variables** (for containers):
-```bash
-# Don't put secrets in config file
-export AGENTHUB_INTERNAL_GRPC_AUTH_SHARED_SECRET="$(cat /run/secrets/grpc_secret)"
-```
+## Secrets and Stored Data
 
-**HashiCorp Vault**:
-```python
-import hvac
+Protect at least:
 
-client = hvac.Client(url='https://vault.company.com')
-secret = client.secrets.kv.v2.read_secret_version(path='agenthub/grpc')
-shared_secret = secret['data']['data']['shared_secret']
-```
+- `config.toml` when it contains internal gRPC secrets or environment-variable
+  names that reveal credential wiring;
+- `vapid.json`, which contains the Web Push private key;
+- the main and per-agent SQLite databases;
+- optional message-body, message-archive, and object-store data;
+- provider configuration and credentials visible to the service account.
 
-**Kubernetes Secrets**:
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: agenthub-secrets
-type: Opaque
-stringData:
-  shared_secret: "secret-value"
-  vapid_private_key: "key-value"
-```
+Use restrictive directory permissions and encrypted disks or volumes. S3
+credentials should be supplied through the configured environment-variable
+names, not as literal values in `config.toml`.
 
-## Audit Logging
+## S3 and Download Ingestion
 
-### What Gets Logged
+Official release builds include the OpenDAL S3 backend, while source/default
+builds keep it feature-gated and runtime storage defaults to `fs`. Including the
+backend does not certify every S3-compatible provider.
 
-| Event | Logged Data | Purpose |
-|-------|-------------|---------|
-| Login | User ID, IP, success/fail | Security monitoring |
-| Agent creation | User, workdir, command | Activity trace |
-| Agent start/stop | Agent ID, user, timestamp | Operational audit |
-| Node registration | Node ID, user | Infrastructure changes |
-| Permission review | Request, reviewer, decision | Compliance |
+When server-side URL ingestion is enabled:
 
-### Log Format
+- keep private-network downloads disabled unless explicitly required;
+- allowlist expected hosts and retain size, redirect, timeout, retry, and
+  per-host concurrency limits;
+- verify expected size and SHA-256 when the source provides them;
+- authorize object access through AgentHub metadata rather than treating a
+  public object URL as permission.
 
-```json
-{
-  "timestamp": "2026-03-25T10:30:00Z",
-  "level": "INFO",
-  "event": "agent_started",
-  "agent_id": "agent-123",
-  "user_id": "user-456",
-  "ip": "10.0.0.1",
-  "workdir": "/home/dev/project"
-}
-```
+## Operational Hardening Checklist
 
-### Audit Log Configuration
+- Run AgentHub as a dedicated non-root OS account.
+- Minimize `safe_paths` and review them after workspace changes.
+- Keep HTTP and gRPC listeners private; terminate external access with TLS.
+- Back up the complete data set and test restore before upgrades.
+- Keep the main binary and `agenthub-acp` on the same release.
+- Patch the host, browser, ACP providers, and AgentHub dependencies promptly.
+- Review authentication audits, node registration, permission decisions, and
+  unexpected process/network activity.
+- Revoke sessions, rotate exposed secrets, and preserve logs before repairing
+  a suspected compromise.
 
-```toml
-[logging]
-level = "info"
-format = "json"  # or "text"
-output = "/var/log/agenthub/audit.log"
-```
+## Reporting a Vulnerability
 
-### Log Retention
-
-```bash
-# Rotate logs daily
-logrotate /etc/logrotate.d/agenthub
-
-# Keep 30 days
-timeout 30
-```
-
-### Audit Log Monitoring
-
-**SIEM Integration**:
-```bash
-# Forward to Splunk/ELK
-filebeat -c /etc/filebeat/filebeat.yml
-```
-
-**Alerting Rules**:
-```yaml
-# Example: Alert on failed logins
-rules:
-  - name: Failed Login Spike
-    condition: count(event="login_failed") > 10 per 5m
-    action: notify_security_team
-```
-
-## Security Best Practices
-
-### Deployment Security
-
-1. **Run as non-root**:
-   ```bash
-   useradd -r -s /bin/false agenthub
-   sudo -u agenthub agenthub
-   ```
-
-2. **Use dedicated service account** (Kubernetes):
-   ```yaml
-   serviceAccountName: agenthub
-   securityContext:
-     runAsNonRoot: true
-     runAsUser: 1000
-     readOnlyRootFilesystem: true
-   ```
-
-3. **Resource limits**:
-   ```yaml
-   resources:
-     limits:
-       cpu: "2"
-       memory: "4Gi"
-     requests:
-       cpu: "100m"
-       memory: "512Mi"
-   ```
-
-### Operational Security
-
-**Daily**:
-- Review failed login attempts
-- Check for unauthorized path access
-- Monitor agent activity
-
-**Weekly**:
-- Audit user list
-- Review agent nodes
-- Check log integrity
-
-**Monthly**:
-- Rotate secrets
-- Update TLS certificates
-- Security patch review
-
-### Incident Response
-
-**Containment**:
-1. Stop suspicious agents immediately
-2. Revoke compromised tokens
-3. Disable affected user accounts
-
-**Investigation**:
-1. Review audit logs
-2. Check event databases
-3. Analyze agent outputs
-
-**Recovery**:
-1. Patch vulnerabilities
-2. Rotate all secrets
-3. Rebuild affected nodes
-
-## Hardening Checklist
-
-### Pre-Deployment
-
-- [ ] Review and minimize `safe_paths`
-- [ ] Enable TLS for all communications
-- [ ] Configure strong authentication
-- [ ] Set up audit logging
-- [ ] Plan secret management strategy
-
-### Deployment
-
-- [ ] Run as non-root user
-- [ ] Enable firewall rules
-- [ ] Configure resource limits
-- [ ] Set up log aggregation
-- [ ] Enable monitoring/alerting
-
-### Post-Deployment
-
-- [ ] Regular access reviews
-- [ ] Secret rotation schedule
-- [ ] Backup and recovery tested
-- [ ] Incident response plan documented
-- [ ] Security training for users
-
-## Common Security Pitfalls
-
-### 1. Overly Permissive safe_paths
-
-```toml
-# BAD - Too broad
-safe_paths = ["/home"]
-
-# GOOD - Specific directories
-safe_paths = [
-  "/home/dev/projects",
-  "/home/dev/sandboxes"
-]
-```
-
-### 2. Hardcoded Secrets
-
-```toml
-# BAD
-[internal_grpc.auth]
-shared_secret = "my-secret-123"
-
-# GOOD - Use environment variable
-# AGENTHUB_INTERNAL_GRPC_AUTH_SHARED_SECRET loaded at runtime
-```
-
-### 3. Missing TLS
-
-```toml
-# BAD
-[internal_grpc.security]
-mode = "disabled"
-
-# GOOD
-[internal_grpc.security]
-mode = "mtls"
-```
-
-### 4. Running as Root
-
-```bash
-# BAD
-sudo agenthub
-
-# GOOD
-sudo -u agenthub agenthub
-```
-
-## Compliance
-
-### SOC 2 Considerations
-
-- **CC6.1**: Logical access security (authentication/authorization)
-- **CC6.2**: Access removal (user offboarding)
-- **CC7.1**: Security monitoring (audit logs)
-- **CC7.2**: Incident detection (monitoring/alerting)
-
-### GDPR Considerations
-
-- Audit logs contain user activity
-- Event databases store conversation history
-- Implement data retention policies
-- Provide data export/deletion capabilities
-
-## Security Resources
-
-- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks)
-- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
-
-## Reporting Security Issues
-
-If you discover a security vulnerability:
-
-1. Do not open a public issue
-2. Email security@yourcompany.com
-3. Provide detailed reproduction steps
-4. Allow time for patch before disclosure
+Use the repository's private GitHub security-reporting flow. Do not include live
+tokens, credentials, private prompts, or customer data in the report, and do not
+open a public issue for an unpatched vulnerability.

--- a/userdocs/docs/operations/troubleshooting.md
+++ b/userdocs/docs/operations/troubleshooting.md
@@ -4,449 +4,172 @@ sidebar_position: 4
 
 # Troubleshooting
 
-This page helps you diagnose and resolve common AgentHub issues.
+Start with read-only evidence. Avoid deleting databases, clearing all browser
+state, rotating credentials, or weakening TLS until the failure domain is
+known.
 
-## Quick Diagnostic Commands
+## First Five Checks
 
 ```bash
-# Check if AgentHub is running
-curl -i http://localhost:8080/
-
-# Check authentication
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/me
-
-# Verify internal gRPC (if enabled)
-agenthub actor inbox --actor-id test --limit 1
-
-# Check disk space for event databases
-df -h ~/.agenthub
-
-# View recent logs
-journalctl -u agenthub -n 100 --no-pager
+agenthub --version
+agenthub-acp --version
+curl --fail http://127.0.0.1:8080/health
+df -h
 ```
 
-## Login Issues
-
-### Cannot Access Login Page
-
-**Symptoms**: Browser cannot connect to `http://localhost:8080`
-
-**Diagnostic Steps**:
-
-1. Check if AgentHub is running:
-   ```bash
-   pgrep -a agenthub
-   ```
-
-2. Verify the server is listening:
-   ```bash
-   netstat -tlnp | grep 8080
-   # or
-   ss -tlnp | grep 8080
-   ```
-
-3. Check config for correct listen address:
-   ```toml
-   [server]
-   listen = "127.0.0.1:8080"  # or "0.0.0.0:8080" for remote access
-   ```
-
-**Solutions**:
-
-- Start AgentHub: `agenthub`
-- Check firewall rules if accessing remotely
-- Verify port is not in use by another process
-
-### Invalid Credentials
-
-**Symptoms**: "Invalid username or password" error
-
-**Solutions**:
-
-- Verify caps lock is off
-- Check if root user exists: check `~/.agenthub/agenthub.db` with sqlite3
-- If root password lost, you may need to reset the database (data loss)
-
-### Join Token Issues
-
-**Symptoms**: "Invalid join token" or "Join token expired"
-
-**Solutions**:
-
-- Generate new join challenge via admin API
-- Complete join within token expiration window
-- Verify PIN is entered correctly
-
-## Agent Startup Issues
-
-### Agent Cannot Start
-
-**Symptoms**: Clicking Start shows error or no response
-
-**Common Causes**:
-
-| Cause | Diagnostic | Solution |
-|-------|------------|----------|
-| Invalid workdir | Check path exists | Create directory or choose different path |
-| Path outside safe_paths | Check `safe_paths` config | Add path to config or use allowed path |
-| Missing ACP binary | Check configured `codex_acp.binary` (or startup logs showing `config codex_acp_binary`) and verify that exact path exists and is executable | Install the bundled ACP adapter or set `codex_acp.binary` to a valid executable |
-| Permission denied | Check directory permissions | `chmod 755 /path/to/workdir` |
-
-### "Workdir path must be within allowed safe paths"
-
-**Solutions**:
-
-1. Add path to `safe_paths` in config:
-   ```toml
-   safe_paths = [
-     "/home/you/projects",
-     "/new/path/here",
-   ]
-   ```
-
-2. Use `create_worktree` mode (uses configured `default_root`)
-
-3. Restart AgentHub after config changes
-
-### ACP Binary Starts But Fails Immediately
-
-**Symptoms**: Agent starts and exits quickly, or the server logs show ACP
-handshake / startup errors.
-
-**Diagnostic Steps**:
-
-1. Check which binary AgentHub is launching by inspecting the configured
-   `codex_acp.binary` value first.
-2. Verify that exact adapter binary is the expected one:
-   ```bash
-   /path/to/your-configured-agenthub-codex-acp --version
-   ```
-3. Compare the binary path and reported adapter version to the deployed
-   AgentHub build, or rebuild/replace the adapter from the same repository
-   revision if you are unsure they match.
-
-**Solutions**:
-
-- Rebuild from the current repository state if the binary is stale
-- Avoid mixing an older fork-pinned ACP binary into a newer AgentHub deployment
-- If you intentionally use a custom ACP binary, set `codex_acp.binary` to that
-  exact path and verify protocol compatibility first
-
-### "Agent is already running"
-
-**Solutions**:
-
-- Wait for current run to complete
-- Stop the agent first, then restart
-- Check if zombie process exists:
-  ```bash
-  ps aux | grep agenthub-codex-acp
-  ```
-
-## Session and Output Issues
-
-### No Output or Stale Output
-
-**Symptoms**: Agent shows "running" but no new output appears
-
-**Diagnostic Steps**:
-
-1. Check connection badge in UI header
-   - `connected`: SSE connection active
-   - `connecting` / `reconnecting`: Connection issues
-
-2. Check browser console for SSE errors:
-   ```javascript
-   // In browser console
-   new EventSource('/api/agents/{agent_id}/events')
-   ```
-
-3. Verify event database is writable:
-   ```bash
-   ls -la ~/.agenthub/agent-events/{agent_id}.db
-   ```
-
-4. Check server logs for ACP event sink errors
-
-**Recovery Actions**:
-
-1. Keep the current session for evidence
-2. Create a fresh session with same prompt
-3. Compare behavior to isolate differences
-4. Check [Connection Status and Recovery](../advanced/connection-status-and-recovery.md)
-
-### History Replay Is Slow
-
-**Symptoms**: Opening a completed session takes long time to load
-
-**Solutions**:
-
-- Large sessions (>10k events) naturally take time
-- Reduce `event_retention_days` in config
-- Delete old agent event databases:
-  ```bash
-  rm ~/.agenthub/agent-events/{old_agent_id}.db
-  ```
-
-### Events Missing From History
-
-**Symptoms**: Recent events don't appear in session view
-
-**Causes**:
-
-- Events persisted asynchronously (small delay normal)
-- Database locked during cleanup (if `vacuum_on_cleanup = true`)
-- Event database corruption
-
-**Solutions**:
-
-- Wait a few seconds and refresh
-- Check server logs for SQLite errors
-- Restart AgentHub if database appears stuck
-
-## Team Issues
-
-### Team Runtime Won't Start
-
-**Symptoms**: "Start Team" fails or hangs
-
-**Diagnostic Steps**:
-
-1. Check Team spec is valid JSON
-2. Verify all `member_id` references are valid
-3. Ensure `coordinator_member_id` references existing member
-4. Check `entrypoint` is defined
-
-**Common Errors**:
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `spec.members must be an array` | Invalid spec format | Ensure members is JSON array |
-| `spec.coordinator_member_id must reference a defined member` | Coordinator not in members list | Add coordinator to members or fix reference |
-| `step already exists for run` | Duplicate step key | Use unique step keys |
-
-### Permission Review Not Routing
-
-**Symptoms**: Tool permission requests not reaching reviewers
-
-**Solutions**:
-
-- Check Team has coordinator defined
-- Verify `requester_role` is set correctly
-- Ensure `agenthub actor ...` commands work:
-  ```bash
-  agenthub actor team-members --actor-id <coordinator_actor_id>
-  ```
-
-### Team Messages Not Delivered
-
-**Symptoms**: Messages sent but not received by members
-
-**Diagnostic Steps**:
-
-1. Check actor inbox:
-   ```bash
-   agenthub actor inbox --actor-id <member_id> --run-id <run_id>
-   ```
-
-2. Verify mailbox routing is correct
-3. Check internal gRPC connectivity
-
-## Internal gRPC and Actor Issues
-
-### "internal grpc client not available"
-
-**Solutions**:
-
-1. Enable internal gRPC in config:
-   ```toml
-   [internal_grpc]
-   enabled = true
-   listen = "127.0.0.1:50051"
-   ```
-
-2. Restart AgentHub
-3. Verify `shared_secret` is explicitly configured
-
-### Actor CLI Commands Fail
-
-**Symptoms**: `agenthub actor inbox` returns error
-
-**Diagnostic Steps**:
-
-1. Verify internal gRPC is enabled
-2. Check `shared_secret` matches between config and CLI context
-3. Ensure authority process is running
-4. Verify `--actor-id` is correct
-
-**Solutions**:
+For a Debian/systemd installation:
 
 ```bash
-# Test basic connectivity
-agenthub actor team-members --actor-id <id>
-
-# Check inbox with explicit run scope
-agenthub actor inbox --actor-id <id> --run-id <run_id> --limit 10
+sudo systemctl status agenthub.service --no-pager
+sudo journalctl -u agenthub.service -n 200 --no-pager
 ```
 
-## Agent Node Issues
+Confirm which OS account runs the service, which `HOME` it sees, and which
+`config.toml` it loads. Debian uses `/var/lib/agenthub` as `HOME`; archive and
+npm installations normally use the interactive user's home.
 
-### Cannot Register Remote Node
+## Server Does Not Start
 
-**Symptoms**: "failed to connect to remote node" error
+Check, in order:
 
-**Diagnostic Steps**:
+1. TOML syntax and file permissions.
+2. Whether the configured HTTP or internal gRPC port is already in use.
+3. Whether `log_path`, worktree, object, message-store, certificate, and VAPID
+   parent directories are writable.
+4. Whether `server.role = "node"` also has a unique `server.node_id` and
+   `internal_grpc.enabled = true`.
+5. The first complete error chain in the service log.
 
-1. Verify remote AgentHub is running with internal gRPC enabled
-2. Check network connectivity:
+The public UI and `/health` are intentionally absent from a node-only process.
+
+## Login Problems
+
+- On a new instance, use **First-run setup** to create the root operator.
+- Query `/api/auth/status` to distinguish an uninitialized instance from a
+  password failure.
+- Usernames cannot contain `@`.
+- Sessions expire after 12 hours; sign in again on `invalid token`.
+- For passkeys, the browser URL must match `web.rp_id` and `web.rp_origin`, and
+  non-localhost deployments require HTTPS.
+- Teamspace invitations create operator accounts and must belong to the same
+  instance.
+
+Do not replace `agenthub.db` merely to reset login; that discards instance
+state.
+
+## Agent Fails to Start
+
+1. Confirm the resolved workdir exists, is inside `safe_paths`, and is writable
+   by the service user.
+2. Run the configured command as that same OS user:
+
    ```bash
-   telnet remote-host 50051
+   agenthub-acp --version
    ```
-3. Verify TLS certificates are valid
-4. Check firewall rules
 
-### Remote Agent Won't Start
+3. Confirm `agenthub` and `agenthub-acp` come from the same release.
+4. Verify provider credentials in the service environment, not only your
+   interactive shell.
+5. For `create_worktree`, inspect repository/ref validity and the selected
+   node's default worktree root.
+6. If the state says `running` but the process is absent, refresh the Agents
+   view so runtime reconciliation can correct stale state.
 
-**Symptoms**: Agent assigned to remote node but doesn't start
+`agent is already running` means the single-runtime guard is active. Stop the
+existing runtime rather than retrying starts in a loop.
 
-**Solutions**:
+## No or Stale Output
 
-- Verify node is reachable from main control plane
-- Check node's `Default worktree root` is configured or provide explicit `Workdir`
-- Review node logs on remote machine
-- Ensure same `shared_secret` across cluster
+- Read the connection badge first. `SSE idle` is normal without a running
+  target.
+- In browser developer tools, inspect `/sse/agents`:
+  - `401`: sign in again.
+  - `404`: no requested agent is running.
+  - gateway HTML: check the reverse proxy/upstream.
+- Confirm persisted history still loads from
+  `/api/agents/<agent-id>/events`.
+- Refresh the page; the backend process continues and replay should fill gaps.
+- Check logs for ACP exit, SSE backpressure timeout, broadcast lag, or SQLite
+  errors.
 
-## Performance Issues
+Do not remove `~/.agenthub/agent-events/*.db` to reset the UI. See
+[Connection Status and Recovery](../advanced/connection-status-and-recovery.md).
 
-### High CPU Usage
+## History or Disk Problems
 
-**Diagnostic Steps**:
-
-1. Check active agent count
-2. Review event database sizes:
-   ```bash
-   du -sh ~/.agenthub/agent-events/*.db
-   ```
-3. Monitor cleanup operations
-
-**Solutions**:
-
-- Reduce `event_retention_days`
-- Lower `delete_batch_size` for gentler cleanup
-- Delete old/unused agents
-
-### High Disk Usage
-
-**Diagnostic Steps**:
+Check the data paths and configured retention:
 
 ```bash
-# Check AgentHub data directory
- du -sh ~/.agenthub/*
-
-# Find largest event databases
-ls -lhS ~/.agenthub/agent-events/*.db | head -10
+du -sh ~/.agenthub/* 2>/dev/null
+find ~/.agenthub/agent-events -type f -name '*.db' -exec du -h {} + 2>/dev/null | sort -h
 ```
 
-**Solutions**:
+Use `[history]` retention for routine event cleanup. `VACUUM` adds I/O and can
+hold SQLite locks, so enable it deliberately. Deleting an Agent through the UI
+is the supported way to remove its managed event history.
 
-- Enable `vacuum_on_cleanup = true`
-- Manually delete old agent databases
-- Reduce retention period
+For `database is locked`, identify overlapping AgentHub processes, backup jobs,
+or manual SQLite tools. Do not start a second service process against the same
+data directory.
 
-### Slow Query Performance
+If corruption is suspected, stop the service, copy the complete data set, and
+run read-only integrity checks on the copy. Restore a consistent backup rather
+than rebuilding individual files in place.
 
-**Causes**:
+## Push Notifications
 
-- Large event databases without cleanup
-- Missing indexes (should be automatic)
-- Concurrent cleanup operations
+- Set a valid `push.subject` and ensure `keys_path` is writable.
+- Use HTTPS outside localhost and inspect service-worker registration.
+- Confirm the browser permission and `/api/push/subscribe` response.
+- After VAPID rotation, every browser must subscribe again.
+- Treat push as best effort; verify completion in AgentHub history.
 
-**Solutions**:
+## S3/Object Storage
 
-- Regular cleanup via `event_retention_days`
-- Schedule maintenance window for VACUUM
-- Monitor with: `sqlite3 agent.db "PRAGMA integrity_check;"`
+- Confirm the deployed release actually contains S3 support; source/default
+  builds require the root `object-store-s3` feature.
+- Validate bucket, endpoint, region, prefix, and the two configured credential
+  environment-variable names in the service environment.
+- Distinguish an S3-enabled binary from provider certification.
+- For URL ingestion, check host allow/deny policy, private-network policy, size,
+  redirect, timeout, retry, concurrency, and digest constraints.
+- Preserve the failed object metadata and server log before retrying an upload
+  whose commit status is uncertain.
 
-## Notification Issues
+## Remote Agent Nodes
 
-### Push Notifications Not Received
+- Confirm the node runs with `server.role = "node"` and matching node ID.
+- Test the registered `https://` gRPC target from the main host.
+- Compare CA trust and `tls_server_name` for certificate errors.
+- Compare issuer, audience, shared secret, and bootstrap token for unauthorized
+  errors.
+- Check workdir paths on the remote filesystem.
+- Synchronize clocks before investigating duplicate/stale mailbox rejection.
 
-**Diagnostic Steps**:
+Do not switch to plaintext or public ingress to work around a certificate or
+routing error.
 
-1. Check browser notification permission
-2. Verify VAPID keys exist:
-   ```bash
-   cat ~/.agenthub/vapid.json
-   ```
-3. Check subscription status in UI
-4. Verify `subject` is configured
+## OpenAPI and Automation
 
-**Solutions**:
+- Open `/api/openapi/docs` without authentication to inspect the current
+  published contract.
+- Fetch `/api/openapi.json` with a bearer session that has runtime-inspect
+  capability.
+- Remember that the spec is incremental and does not cover every web UI route.
+- Use the HTTP status and `{ "error": "..." }` body; do not parse prose as a
+  stable error code.
 
-- Re-subscribe in browser
-- Rotate VAPID keys if corrupted
-- Check HTTPS requirement for production
+## Escalation Bundle
 
-## Database Issues
+Include:
 
-### SQLite Lock/Timeout Errors
+- exact `agenthub` and `agenthub-acp` versions and install channel;
+- OS/architecture and, for Linux, `ldd --version`;
+- deployment mode, browser, and reverse proxy;
+- sanitized config sections relevant to the failure;
+- resource/agent/Team/node IDs and timestamps;
+- HTTP method/status and a redacted response body;
+- the matching service-log window and whether restart/replay changed behavior.
 
-**Symptoms**: "database is locked" errors in logs
-
-**Solutions**:
-
-- Reduce concurrent operations
-- Check for long-running queries
-- Ensure proper connection pooling
-
-### Database Corruption
-
-**Symptoms**: SQLite integrity check failures
-
-**Recovery**:
-
-```bash
-# Backup first
-cp ~/.agenthub/agenthub.db ~/.agenthub/agenthub.db.backup
-
-# Check integrity
-sqlite3 ~/.agenthub/agenthub.db "PRAGMA integrity_check;"
-
-# For event databases
-sqlite3 ~/.agenthub/agent-events/{agent_id}.db "PRAGMA integrity_check;"
-```
-
-## Getting Help
-
-When reporting issues, include:
-
-1. **AgentHub version**: `agenthub --version`
-2. **Config** (sanitized): `cat ~/.agenthub/config.toml`
-3. **Logs** at debug level:
-   ```toml
-   # Add to config
-   [logging]
-   level = "debug"
-   ```
-4. **System info**:
-   ```bash
-   uname -a
-   df -h
-   free -h
-   ```
-5. **Reproduction steps**
-
-## Recovery Strategy
-
-For serious issues:
-
-1. **Keep evidence**: Don't delete failed sessions
-2. **Create fresh environment**: New workdir/worktree
-3. **Isolate variables**: Test with minimal config
-4. **Incremental changes**: Add complexity gradually
-5. **Monitor**: Watch logs during recovery
-
-See also:
-- [Daily Operations Checklist](./daily-operations-checklist.md)
-- [Security and Path Safety](./security-and-path-safety.md)
-- [API Error Reference](./api-error-reference.md)
+Never include bearer or SSE query tokens, passwords, provider credentials,
+VAPID private keys, internal gRPC secrets, private prompts, or uploaded data.

--- a/userdocs/docs/overview/architecture-overview.md
+++ b/userdocs/docs/overview/architecture-overview.md
@@ -17,7 +17,7 @@ AgentHub is designed as one main control-plane service:
 
 - one Rust backend process
 - one embedded web UI served by the same process
-- one SQLite-backed persistence layer
+- a main SQLite control-plane database plus per-agent SQLite event stores
 - HTTP plus SSE for browser interaction and live updates
 
 That baseline is enough for local and many shared internal deployments while
@@ -80,7 +80,8 @@ When one machine is not enough, AgentHub can add remote Agent Nodes:
 
 - the main AgentHub instance stays the control plane
 - remote nodes run the same `agenthub` binary
-- actor control and mailbox relay use internal gRPC on a p2p-aware path
+- agent lifecycle control and actor mailbox relay use the dedicated internal
+  gRPC transport
 - node-local execution data stays on the selected node
 
 This lets operators keep one main UI and API surface while execution happens
@@ -92,7 +93,9 @@ consistent whether execution is local or remote.
 
 ## Persistence And Reliability
 
-AgentHub stores runtime state in SQLite and on-disk runtime directories so
+AgentHub stores control-plane state in the main SQLite database and high-volume
+agent output in per-agent SQLite databases. Optional message archives, message
+body stores, and object stores add separate data paths. This persistence lets
 these behaviors remain stable:
 
 - browser refresh or disconnect does not stop the task

--- a/userdocs/docs/overview/feature-overview.md
+++ b/userdocs/docs/overview/feature-overview.md
@@ -27,7 +27,7 @@ logs. That gives you:
 - conversation history
 - tool-call and command output context
 - plan and reasoning segments
-- debug and raw-event inspection when something looks wrong
+- developer-mode debug and raw-event inspection when something looks wrong
 
 Use this when task review, auditability, or deep debugging matters.
 
@@ -56,20 +56,6 @@ Key concepts:
 Use this when planning, implementation, and review should be coordinated rather
 than collapsed into one session.
 
-## Recent Product Updates
-
-Recent merges worth knowing before rollout or operator training:
-
-- **Workspace shell convergence**: Team pages now use a more compact
-  workspace shell with clearer `Channels`-first navigation and less duplicated
-  chrome.
-- **Execution wording cleanup**: Team run history is presented as
-  `Execution Runs` to distinguish planning state from raw execution artifacts.
-- **Token-based Agent Node onboarding**: remote node join now uses explicit
-  bootstrap tokens from the `Agents` page instead of QR-style node onboarding.
-- **Rust / Codex baseline refresh**: local builds and bundled ACP integration
-  now track Rust `1.96.0` and the official Codex `0.138.x` line.
-
 ## Installable Web App And Push
 
 AgentHub can also behave like an installable web app:
@@ -81,11 +67,11 @@ AgentHub can also behave like an installable web app:
 AgentHub still prefers fresh server-delivered UI resources on reload; install
 support does not turn it into an offline-first shell.
 
-## Agent Nodes And Actor P2P
+## Agent Nodes
 
 AgentHub can register remote execution nodes and route agent execution to them
-over internal gRPC, while keeping actor control and mailbox delivery on the
-same p2p-aware control path.
+over the dedicated internal gRPC transport, while keeping lifecycle control and
+actor mailbox delivery in the same control plane.
 
 Use this when:
 
@@ -97,7 +83,8 @@ Use this when:
 
 ## Automation And Integration
 
-AgentHub exposes authenticated OpenAPI discovery endpoints for:
+AgentHub exposes authenticated OpenAPI discovery endpoints for the subset of
+HTTP routes with a published automation contract:
 
 - internal tooling
 - typed client generation
@@ -105,6 +92,8 @@ AgentHub exposes authenticated OpenAPI discovery endpoints for:
 - operational automation around agents and Teams
 
 Use this when AgentHub needs to plug into a larger engineering system.
+Always generate clients from the exact deployed release because the OpenAPI
+document is intentionally incremental.
 
 ## Operations And Safety
 

--- a/userdocs/docs/overview/product-overview.md
+++ b/userdocs/docs/overview/product-overview.md
@@ -71,17 +71,18 @@ Three properties tend to matter together:
   the work
 - **structured ACP history**: plans, tools, output, and debug data stay
   reviewable after the run
-- **actor p2p execution model**: remote execution keeps the same actor and
-  mailbox control path instead of introducing a separate orchestration system
+- **shared remote-control model**: remote execution uses the dedicated internal
+  gRPC control plane instead of introducing another human-facing orchestrator
 
 ## What AgentHub Persists
 
 AgentHub keeps operational state in `~/.agenthub/` by default, including:
 
-- SQLite-backed runtime and history state
+- a main SQLite control-plane database and per-agent event databases
 - agent configuration
 - Team state
 - audit and operational records
+- optional local message and object stores
 
 This is why reconnect, history replay, and deployment operations can happen
 without treating the browser as the source of truth.


### PR DESCRIPTION
## Summary

- replace the installation guide with release-artifact-aware Debian, GitHub archive, npm, Homebrew, upgrade, uninstall, and first-start guidance
- align the remaining user guides with current auth, agent lifecycle, worktree, SSE replay, OpenAPI, notification, Agent Node, security, storage, deployment, and recovery behavior
- add a release-readiness journal and track Homebrew parity as a release-blocking follow-up

## Why

The published user docs mixed intended behavior with stale routes, unsupported configuration overrides, incomplete artifact/channel assumptions, and operations guidance that was not backed by the current runtime. A formal release needs user-facing instructions to follow the exact shipped binaries and implemented contracts.

Important release boundaries now documented explicitly:

- `agenthub` and `agenthub-acp` should come from the same release
- npm installs only the main `agenthub` binary
- the Homebrew tap still points to `v0.0.7` and the legacy ACP helper
- official release artifacts include OpenDAL S3 support, while default source builds remain feature-gated and runtime storage still defaults to `fs`
- the minimum Linux glibc baseline remains an open release follow-up

## What Changed

- refreshed README and all major userdocs onboarding, core, advanced, deployment, and operations pages
- corrected authentication, push, history, SSE, Agent Node, and OpenAPI endpoint descriptions
- removed invented monitoring, orchestration, pagination, cleanup, and configuration behavior
- documented complete backup/restore boundaries across the main database, per-agent event databases, archives, message-body storage, objects, VAPID, and internal gRPC material
- recorded the rollout evidence in `docs/journal/2026-08-13-user-documentation-release-readiness.md`

## Related Issues

- N/A

## Testing

- `npm --prefix userdocs ci`
- `npm --prefix userdocs run build`
- `git diff --check`
- stale route, unsafe cleanup, unsupported monitoring, and invalid config-path consistency scans
- live release asset audit for `v0.0.11`
- live npm metadata audit for `@linkerdog/agenthub@0.0.11`
- live Homebrew formula audit for `linkerdog/homebrew-tap`
