### PR TITLE
fix(api): enforce safe_paths against agent workdir

### DIFF
--- a/docs/journal/2026-08-16-safe-paths-workdir-enforcement.md
+++ b/docs/journal/2026-08-16-safe-paths-workdir-enforcement.md
@@ -1,0 +1,70 @@
+# Summary
+
+A code-only backend correctness review found that `safe_paths` -- the admin-configured allowlist meant
+to restrict where agent processes can run -- was never actually checked against an agent's `workdir`.
+`is_path_allowed` (the allowlist-membership check) was only ever called for ACP skill-file loading; the
+`workdir` supplied when creating an agent, or when adopting an existing agent into a Team with a
+workspace-content copy destination, was accepted unchecked and used directly as the spawned process's
+`cwd`. Any account holding `AgentsManage` (an operator-level, non-root capability) could set `workdir` to
+an arbitrary filesystem path and fully bypass the allowlist an operator configured via `/admin/safe_paths`.
+
+# Background
+
+`crates/agenthub-config/src/path_utils::is_path_allowed` already existed with correct `..`/`.` lexical
+normalization, tested and used by `crates/agenthub-acp`'s skill-loading path
+(`is_skill_path_allowed`). It was never wired into the agent-creation code paths that actually decide
+where a process runs. `is_skill_path_allowed` fails closed when `safe_paths` is empty (nothing is
+allowed); applying that same default to `workdir` validation would mean every install that has never
+configured `safe_paths` -- which today is effectively every existing deployment, since this check never
+enforced anything for `workdir` before -- would immediately be unable to create any agent, until an
+operator added at least one allowlist entry. That's a hard breaking change for a security fix that closes
+a gap nobody has been relying on being closed. Confirmed with the person requesting this fix: an empty
+`safe_paths` list should continue to mean "no restriction configured yet," matching every existing test
+and deployment; the allowlist becomes enforced only once at least one entry exists.
+
+# Scope
+
+- `src/api/agents.rs`: new `pub(super) async fn ensure_workdir_within_safe_paths`, called in
+  `create_agent` right after `resolve_create_agent_workdir` resolves the final workdir (whether explicit
+  or auto-generated under `default_worktree_root`). No-op when `safe_paths` is empty; otherwise rejects
+  with `403 Forbidden` if the resolved workdir isn't inside any configured entry.
+- `src/api/teams.rs`: the same check, called in `adopt_existing_agent_to_team` -- but only when the
+  caller supplies an explicit `workspace_copy_destination`. When no destination is given, `workdir` falls
+  back to the source agent's already-existing workdir, which is not re-validated: retroactively enforcing
+  the allowlist on agents that already existed before this fix would be a separate, larger migration
+  decision, not part of closing this specific bypass. The check runs before `copy_adoption_workspace`
+  actually copies files, so a rejected request never touches the filesystem.
+
+# Key Decisions
+
+- Empty `safe_paths` = no restriction (not fail-closed), by explicit confirmation, to avoid a breaking
+  change for every deployment that has never configured the allowlist. This intentionally diverges from
+  `is_skill_path_allowed`'s fail-closed default for the same underlying check function -- the two call
+  sites have different blast radii (skill loading is best-effort and narrow; agent creation is core
+  product functionality) and different pre-existing behavior to stay compatible with.
+- Only the *newly supplied, untrusted* input is validated. `adopt_existing_agent_to_team`'s fallback to
+  `source.workdir` when no destination is given is deliberately left unchecked, so adopting an
+  already-existing agent (created before this fix, potentially outside any configured safe_paths) doesn't
+  suddenly start failing.
+- Did not address the secondary, lower-severity finding from the same review: `is_path_allowed` resolves
+  `..`/`.` lexically, not via filesystem canonicalization, so a symlink planted inside an allowed
+  directory that points outside it could still defeat the check. Canonicalization requires the path to
+  exist on disk, which doesn't hold for workdirs about to be created (`worktree_mode: create_worktree`),
+  so this needs its own design pass, not a drop-in change alongside this fix.
+
+# Validation
+
+- `cargo test --lib api::agents` -- 59 passed (2 new: rejects a workdir outside a configured allowlist
+  with `403` and the exact error message; allows any workdir when no `safe_paths` are configured at all).
+- `cargo test --lib api::teams` -- 103 passed (1 new: `adopt_existing_agent_to_team` rejects a
+  `workspace_copy_destination` outside a configured allowlist, and confirms the source agent is left
+  unowned by any team -- the rejected adoption did not partially apply).
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- Symlink/canonicalization gap in `is_path_allowed` (see Key Decisions) -- needs a design decision on how
+  to canonicalize a path that may not exist yet.
+- The other three findings from the same review round (unbounded gRPC client cache, remote-relay
+  panic-poisoning trap, panic landmine on non-object `context_json`) are tracked separately and not
+  addressed in this change.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -208,6 +208,13 @@ Main shape:
   existing humanizer, hand-rolled Team dialogs missing focus trap/return, destructive actions with no
   confirmation, empty admin lists rendering nothing, no loading guard on the join/register flow),
   remainder tracked as a new Frontend UI/UX `todo.md` item.
+- A code-only Rust backend correctness review found `safe_paths` never actually restricted an agent's
+  `workdir` -- only skill-file loading checked it -- letting any `AgentsManage`-capable account bypass
+  the operator-configured allowlist entirely; now enforced (empty allowlist stays permissive, matching
+  every existing deployment) for both direct agent creation and Team workspace-copy adoption. Four other
+  findings from the same review (an unbounded gRPC client cache leak, a remote-relay panic-poisoning
+  trap, a panic landmine from an unvalidated task context shape, a bootstrap-token timing side-channel)
+  are tracked as a new Backend Correctness `todo.md` item.
 
 Start with:
 
@@ -220,6 +227,7 @@ Start with:
 - `2026-08-12-dependabot-security-remediation.md`
 - `2026-08-13-user-documentation-release-readiness.md`
 - `2026-08-16-pwa-icon-branding-fix.md`
+- `2026-08-16-safe-paths-workdir-enforcement.md`
 - `2026-08-16-frontend-uiux-review-round1-fixes.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -80,6 +80,27 @@ Stable contracts:
   `acp_tool_fold.tsx`'s `IntersectionObserver` auto-collapse silently closes a manually-opened tool card
   when it scrolls out of view. Evidence: [journal/2026-08-16-frontend-uiux-review-round1-fixes.md](journal/2026-08-16-frontend-uiux-review-round1-fixes.md).
 
+## Backend Correctness
+
+- [ ] `P1` Close out the remaining findings from the 2026-08-16 code-only Rust backend review: an
+  unbounded `TeamRemoteRelayAdapter.grpc_client_cache` leaks a live gRPC `Channel` per relay delivery
+  (cache key includes a freshly-minted, timestamp-embedded access token, so it almost never hits) under
+  sustained remote-relay traffic; the remote relay worker's `std::sync::Mutex::lock().expect(...)` calls
+  mean any panic while one is held permanently and silently poisons the lock, killing remote message
+  relay for the process's lifetime with no restart or alerting; `update_team_task`'s gRPC handler accepts
+  a non-object `context_json` (only validates it's *valid* JSON, unlike its `context_merge_json` sibling
+  which checks the shape), which plants a landmine that panics the *next*, unrelated run-status-changing
+  request touching that task at `run_task_status_sync.rs`'s `.as_object_mut().expect(...)`; a timing
+  side-channel on the internal gRPC bootstrap-token comparison (`src/internal/service/mod.rs:137`, plain
+  `!=` instead of constant-time) on the endpoint that mints cluster-bootstrap credentials for new nodes;
+  no timeout on the child-process stdin write path, so a hung child can block that agent's stdin lock
+  indefinitely; several silently-swallowed DB/parse errors that leave no log trace (corrupt JSON resets
+  linked-task-sync context to `{}`, a failed startup `safe_paths` seed insert is invisible). The
+  `safe_paths` workdir-enforcement gap from the same review is fixed separately; see
+  [journal/2026-08-16-safe-paths-workdir-enforcement.md](journal/2026-08-16-safe-paths-workdir-enforcement.md).
+  Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
+  inline, not yet written up) -- write one when starting on the next item from this list.
+
 ## Message Storage
 
 - [x] `P1` Complete the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). SQLite authority rows now rebuild the conversation, actor mailbox, run-event, and agent-event projections; guarded ordered reads compare high-water marks and exact SQLite page IDs, fall back on any gap, and queue a startup worker for asynchronous repair. Orphan/prune helpers remain diagnostics and explicit maintenance only. Keep normal SQLite bodies readable until a later authority-cutover decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -13,6 +13,7 @@ use agenthub_auth_domain::UserCapability;
 use agenthub_config::{
     normalize_optional_codex_acp_mode_id, normalize_optional_runtime_model,
     normalize_optional_thinking_level,
+    path_utils::{expand_tilde, is_path_allowed},
 };
 
 use crate::acp::{
@@ -308,6 +309,7 @@ async fn create_agent(
         &worktree_mode,
         default_worktree_root.as_deref(),
     )?;
+    ensure_workdir_within_safe_paths(&state, &workdir).await?;
     let config = AgentConfig {
         name,
         workdir,
@@ -1049,6 +1051,30 @@ fn resolve_create_agent_workdir(
         ));
     };
     Ok(default_worktree_path(agent_name, default_worktree_root))
+}
+
+/// Reject a workdir outside the configured `safe_paths` allowlist.
+///
+/// An empty allowlist means no operator has opted into restricting agent workdirs yet, so this is
+/// a no-op in that case (matches the pre-existing, unrestricted behavior) rather than failing every
+/// agent-creation request on an install that has never configured `safe_paths`.
+pub(super) async fn ensure_workdir_within_safe_paths(
+    state: &AppState,
+    workdir: &str,
+) -> Result<(), ApiError> {
+    let safe_paths = state.agents.list_safe_paths().await?;
+    if safe_paths.is_empty() {
+        return Ok(());
+    }
+    let allowed = safe_paths
+        .iter()
+        .any(|safe_path| is_path_allowed(workdir, &expand_tilde(safe_path)));
+    if !allowed {
+        return Err(ApiError::forbidden(
+            "workdir is outside the configured safe_paths allowlist",
+        ));
+    }
+    Ok(())
 }
 
 fn default_worktree_path(agent_name: &str, default_worktree_root: &str) -> String {
@@ -2484,6 +2510,80 @@ mod tests {
             let body = decode_json_body(response).await;
             assert_eq!(body["error"], json!("agents:manage required"), "{route}");
         }
+    }
+
+    #[tokio::test]
+    async fn create_agent_rejects_workdir_outside_configured_safe_paths() {
+        let state = build_test_state().await;
+        let operator_token = create_role_auth_token(&state, UserRole::Operator).await;
+        let app = router(state.clone());
+        let allowed = std::env::temp_dir()
+            .join(format!("agenthub-safe-path-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .to_string();
+        sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+            .bind(&allowed)
+            .bind(chrono::Utc::now().timestamp())
+            .execute(&state.db)
+            .await
+            .expect("insert allowed safe path");
+
+        let outside_workdir = std::env::temp_dir()
+            .join(format!("agenthub-outside-safe-path-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .to_string();
+        let response = app
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&operator_token),
+                Some(json!({
+                    "name": "escapes-safe-paths",
+                    "workdir": outside_workdir,
+                    "command": "agenthub-codex-acp",
+                    "args": [],
+                    "worktree_mode": "use_existing"
+                })),
+            ))
+            .await
+            .expect("create agent outside safe_paths");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = decode_json_body(response).await;
+        assert_eq!(
+            body["error"],
+            json!("workdir is outside the configured safe_paths allowlist")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_agent_allows_any_workdir_when_no_safe_paths_are_configured() {
+        let state = build_test_state().await;
+        let operator_token = create_role_auth_token(&state, UserRole::Operator).await;
+        let app = router(state.clone());
+        let workdir = std::env::temp_dir()
+            .join(format!(
+                "agenthub-unconfigured-safe-paths-{}",
+                Uuid::new_v4()
+            ))
+            .to_string_lossy()
+            .to_string();
+
+        let response = app
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&operator_token),
+                Some(json!({
+                    "name": "no-safe-paths-configured",
+                    "workdir": workdir,
+                    "command": "agenthub-codex-acp",
+                    "args": [],
+                    "worktree_mode": "use_existing"
+                })),
+            ))
+            .await
+            .expect("create agent with no safe_paths configured");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     fn run_git(repo_dir: &std::path::Path, args: &[&str]) {

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -918,6 +918,9 @@ async fn adopt_existing_agent_to_team(
         ));
     }
     let workdir = destination.unwrap_or(&source.workdir).to_string();
+    if destination.is_some() {
+        super::agents::ensure_workdir_within_safe_paths(&state, &workdir).await?;
+    }
     let mut spec = payload.spec;
     let member_id = Uuid::new_v4().to_string();
     replace_adopted_member_placeholder(&mut spec, &member_id);

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -2167,6 +2167,114 @@ include!("tests_core.rs");
 include!("tests_router.rs");
 
 #[tokio::test]
+async fn adopt_existing_agent_rejects_workspace_copy_destination_outside_safe_paths() {
+    let state = build_test_state().await;
+    let headers = auth_headers(&state).await;
+
+    let source_workdir = std::env::temp_dir()
+        .join(format!("agenthub-adopt-source-{}", Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+    let source = state
+        .agents
+        .create_agent(crate::agent::AgentConfig {
+            name: format!("adopt-source-{}", Uuid::new_v4()),
+            workdir: source_workdir,
+            command: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "sleep 10".to_string()],
+            target_node_id: None,
+            worktree_mode: WorktreeMode::UseExisting,
+            worktree_repo: None,
+            worktree_ref: None,
+            code_mode: true,
+            codex_acp_default_mode: None,
+            runtime_model: None,
+            thinking_level: None,
+            agent_loop_enabled: false,
+            agent_loop_idle_seconds: None,
+            agent_loop_prompt: None,
+        })
+        .await
+        .expect("create standalone source agent");
+
+    let Json(team) = create_team(
+        State(state.clone()),
+        headers.clone(),
+        Json(CreateTeamRequest {
+            name: format!("adopt-safe-path-team-{}", Uuid::new_v4()),
+            description: None,
+            spec: json!({
+                "entrypoint": "coordinator",
+                "members": [{"member_id": "coordinator", "role": "coordinator"}]
+            }),
+        }),
+    )
+    .await
+    .expect("create team");
+
+    // Configure a safe_paths allowlist that does NOT include the destination below, so the
+    // workdir-validation gap this test guards against would otherwise let workspace-content
+    // copy write agent files outside the operator-configured allowlist.
+    let allowed = std::env::temp_dir()
+        .join(format!("agenthub-adopt-allowed-{}", Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+    sqlx::query("INSERT INTO safe_paths (path, created_at) VALUES (?1, ?2)")
+        .bind(&allowed)
+        .bind(Utc::now().timestamp())
+        .execute(&state.db)
+        .await
+        .expect("insert allowed safe path");
+
+    let outside_destination = std::env::temp_dir()
+        .join(format!("agenthub-adopt-outside-{}", Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+
+    let result = super::adopt_existing_agent_to_team(
+        State(state.clone()),
+        headers.clone(),
+        Path(team.id.clone()),
+        Json(super::AdoptExistingAgentRequest {
+            source_agent_id: source.id.clone(),
+            name: "adopted-agent".to_string(),
+            spec: json!({
+                "entrypoint": "coordinator",
+                "members": [
+                    {"member_id": "coordinator", "role": "coordinator"},
+                    {"member_id": super::ADOPTED_MEMBER_ID_PLACEHOLDER, "role": "worker"}
+                ]
+            }),
+            expected_updated_at: team.updated_at,
+            workspace_copy_destination: Some(outside_destination),
+            memory_seed: None,
+        }),
+    )
+    .await;
+
+    let err = result.expect_err("adoption must reject a destination outside safe_paths");
+    let response = err.into_response();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let body: Value = serde_json::from_slice(&body).expect("decode response body");
+    assert_eq!(
+        body["error"],
+        json!("workdir is outside the configured safe_paths allowlist")
+    );
+
+    // The source agent must still be unowned by any team -- the rejected adoption must not have
+    // partially applied.
+    let owning_teams = state
+        .teams
+        .list_teams_referencing_member(&source.id)
+        .await
+        .expect("list teams referencing source agent");
+    assert!(owning_teams.is_empty());
+}
+
+#[tokio::test]
 async fn start_agent_with_actor_context_injects_runtime_env_vars() {
     let state = build_test_state().await;
     let workdir = std::env::temp_dir().join(format!("agenthub-actor-env-{}", Uuid::new_v4()));

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -2226,10 +2226,11 @@ async fn adopt_existing_agent_rejects_workspace_copy_destination_outside_safe_pa
         .await
         .expect("insert allowed safe path");
 
-    let outside_destination = std::env::temp_dir()
-        .join(format!("agenthub-adopt-outside-{}", Uuid::new_v4()))
-        .to_string_lossy()
-        .to_string();
+    // Deliberately NOT under `std::env::temp_dir()`: `seed_default_team_member_agents` (called by
+    // `build_test_state()`) unconditionally seeds a blanket "/tmp" safe_paths entry, and on Linux
+    // `temp_dir()` *is* "/tmp" -- a temp-dir-based "outside" path would silently pass validation
+    // there while still failing correctly on macOS, where `temp_dir()` differs from "/tmp".
+    let outside_destination = format!("/agenthub-outside-safe-paths-allowlist-{}", Uuid::new_v4());
 
     let result = super::adopt_existing_agent_to_team(
         State(state.clone()),


### PR DESCRIPTION
## Summary

A code-only backend correctness review found that `safe_paths` — the admin-configured allowlist meant to restrict where agent processes can run — was never actually checked against an agent's `workdir`. `is_path_allowed` (the allowlist-membership check) was only ever called for ACP skill-file loading; the `workdir` supplied when creating an agent, or when adopting an existing agent into a Team with a workspace-content copy destination, was accepted unchecked and used directly as the spawned process's `cwd`. **Any account holding `AgentsManage` (an operator-level, non-root capability) could set `workdir` to an arbitrary filesystem path and fully bypass the allowlist an operator configured via `/admin/safe_paths`.**

- `src/api/agents.rs`: new `ensure_workdir_within_safe_paths`, called in `create_agent` right after the workdir is resolved (whether explicit or auto-generated).
- `src/api/teams.rs`: same check in `adopt_existing_agent_to_team`, but only when the caller supplies an explicit `workspace_copy_destination` — runs *before* `copy_adoption_workspace` actually copies files, so a rejected request never touches the filesystem.

**Empty-allowlist behavior was an explicit design decision, confirmed with the requester before implementing:** `is_skill_path_allowed` (the existing precedent for this same underlying check) fails closed when `safe_paths` is empty. Applying that here would mean every deployment that has never configured `safe_paths` — effectively every existing install today, since this check never enforced anything for `workdir` before — would immediately be unable to create *any* agent. Instead, an empty allowlist stays permissive (matches current/pre-fix behavior for every existing test and deployment); the allowlist becomes enforced only once at least one entry exists. The adoption flow's fallback to the source agent's already-existing `workdir` (when no new destination is given) is also deliberately left unchecked, so adopting a pre-existing agent created before this fix doesn't newly break.

**Deliberately not addressed here** (tracked in `docs/todo.md`): `is_path_allowed` resolves `..`/`.` lexically, not via filesystem canonicalization, so a symlink planted inside an allowed directory pointing outside it could still defeat the check. Canonicalization requires the path to exist on disk, which doesn't hold for `worktree_mode: create_worktree` workdirs about to be created — needs its own design pass, not a drop-in alongside this fix.

## Test plan

- [x] `cargo test --lib api::agents` — 59 passed (2 new: rejects a workdir outside a configured allowlist with `403` and the exact error message; allows any workdir when no `safe_paths` are configured at all)
- [x] `cargo test --lib api::teams` — 103 passed (1 new: `adopt_existing_agent_to_team` rejects a `workspace_copy_destination` outside a configured allowlist, and confirms the source agent is left unowned by any team — the rejected adoption did not partially apply)
- [x] `cargo clippy --lib --tests -p agenthub` clean
- [x] `cargo fmt -p agenthub -- --check` clean
- [ ] Bazel CI (this repo's sandbox can't reliably re-splice the crate index locally within a reasonable time — CI is the real signal here, same as prior PRs this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)