### PR TITLE
fix(team): bound gRPC relay client cache with TTL eviction

### DIFF
--- a/docs/journal/2026-08-16-grpc-relay-client-cache-ttl.md
+++ b/docs/journal/2026-08-16-grpc-relay-client-cache-ttl.md
@@ -1,0 +1,69 @@
+# Summary
+
+`TeamRemoteRelayAdapter.grpc_client_cache` (flagged in the 2026-08-16 backend correctness review,
+tracked in `docs/todo.md`'s Backend Correctness item) never evicted anything. For the common
+"registered" gRPC relay path, the cache key includes a freshly-minted access token stamped with the
+current timestamp on every relayed message, so almost every delivery inserted a brand-new entry that
+was looked up exactly once and then kept forever -- an unbounded, per-message leak of live gRPC
+`Channel`s, not a small admin-bounded one. Separately, callers that *do* reuse a stable, explicit
+`access_token` in their route got real cache hits, but the cached `InternalGrpcMailboxClient` pins the
+token it was built with and never refreshes it, so a long-lived cache entry could silently start
+sending an expired bearer token once the token's TTL elapsed.
+
+# Background
+
+`grpc_client_for_route` (`src/team/manager/remote_relay_grpc.rs`) is the sole reader/writer of the
+cache, called once per relayed message from `deliver_grpc`. The only existing eviction was a blunt
+full-`clear()` in `configure_grpc_tls_defaults`, triggered only when cluster-wide gRPC TLS defaults are
+reconfigured -- unrelated to normal cache growth or token freshness. `access_token`, part of the cache
+key (`GrpcRelayClientCacheKey`), is minted per call via `issue_registered_grpc_access_token` with a
+600s TTL and an embedded `iat`/`exp`, so the key is effectively unique per delivery on that path.
+
+# Scope
+
+- `src/team/manager/remote_relay_types.rs`: cache value changed from `InternalGrpcMailboxClient` to
+  `CachedGrpcRelayClient { client, inserted_at: Instant }`. New `RELAY_GRPC_CLIENT_CACHE_TTL` constant
+  (240s -- kept below the 600s minted-token TTL so a cached client is dropped, and a fresh token
+  obtained, before the token it holds expires).
+- `src/team/manager/remote_relay_grpc.rs`: `grpc_client_for_route` now sweeps (`HashMap::retain`) every
+  entry older than the TTL on each call, before checking for a cache hit, then inserts new entries with
+  the current `Instant`. This runs on both hits and misses, so the cache is bounded even under a
+  never-hits key pattern (the common per-message-token case) -- it never grows past roughly one TTL
+  window's worth of entries, instead of growing forever.
+- `src/internal/client/mod.rs`: added a `#[cfg(test)]`-only `InternalGrpcMailboxClient::test_stub`
+  constructor (a `Channel` built via `connect_lazy()`, no real I/O) so tests can populate synthetic
+  cache entries without standing up a live gRPC server.
+
+# Key Decisions
+
+- TTL-based lazy eviction, not a size cap/LRU: an LRU bounds memory but doesn't address the token-
+  staleness correctness gap (a cached client with an expired token would keep being served and start
+  failing auth). A fixed TTL close to the minted-token lifetime fixes both the leak and the staleness
+  issue in one change, confirmed with the person requesting this fix.
+- Eviction is lazy (sweep-on-call), not a background task: this is a request-driven cache with no
+  existing periodic-task infrastructure in this adapter; sweeping on every call (hit or miss) already
+  bounds growth without needing a new timer/task lifecycle.
+- Left the full-`clear()` on TLS-default reconfiguration in place -- orthogonal to TTL expiry and still
+  correct (any client built against now-stale TLS material should be dropped immediately, not wait out
+  the TTL).
+
+# Validation
+
+- `cargo test --lib team::manager::remote_relay` -- 17 passed (2 new:
+  `grpc_client_for_route_returns_cached_client_before_ttl_expires`,
+  `grpc_client_for_route_evicts_expired_entries_and_reconnects`). Both use `test_stub` clients and a
+  deliberately unconnectable `target` string, so an `Ok` result can only mean a cache hit and an `Err`
+  containing "gRPC connect failed" can only mean a real (failing) reconnect was attempted --
+  distinguishing "served from cache" from "evicted and rebuilt" without needing a live gRPC server.
+- `cargo test --lib team::manager` (183 passed) and `cargo test --lib internal::client` (15 passed) --
+  no regressions in either module the change touches.
+- `cargo test --lib` -- 764 passed, 3 pre-existing failures in `state::tests::*`
+  (`lance-namespace-impls` panic, "the directory manifest dataset must not enable old-version
+  cleanup") confirmed present on `main` before this change via `git stash`; unrelated to this fix.
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- The other three findings from the 2026-08-16 backend review (remote-relay panic-poisoning `Mutex`
+  trap, `context_json` panic landmine, bootstrap-token timing side-channel, stdin timeout gap, silent
+  DB/parse errors) remain open in `docs/todo.md`'s Backend Correctness item.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -211,10 +211,14 @@ Main shape:
 - A code-only Rust backend correctness review found `safe_paths` never actually restricted an agent's
   `workdir` -- only skill-file loading checked it -- letting any `AgentsManage`-capable account bypass
   the operator-configured allowlist entirely; now enforced (empty allowlist stays permissive, matching
-  every existing deployment) for both direct agent creation and Team workspace-copy adoption. Four other
-  findings from the same review (an unbounded gRPC client cache leak, a remote-relay panic-poisoning
-  trap, a panic landmine from an unvalidated task context shape, a bootstrap-token timing side-channel)
-  are tracked as a new Backend Correctness `todo.md` item.
+  every existing deployment) for both direct agent creation and Team workspace-copy adoption. The same
+  review's `TeamRemoteRelayAdapter.grpc_client_cache` finding turned out worse than an admin-bounded
+  leak: the common relay path mints a fresh, timestamp-embedded access token per message, so the cache
+  key is unique almost every call and every delivery leaked a live gRPC `Channel` forever; now bounded
+  by TTL-based lazy eviction, which also closes a second gap where callers with stable tokens could keep
+  serving an expired bearer token from a long-lived cache entry. Three other findings from the same
+  review (a remote-relay panic-poisoning trap, a panic landmine from an unvalidated task context shape,
+  a bootstrap-token timing side-channel) remain open in the Backend Correctness `todo.md` item.
 
 Start with:
 
@@ -228,6 +232,7 @@ Start with:
 - `2026-08-13-user-documentation-release-readiness.md`
 - `2026-08-16-pwa-icon-branding-fix.md`
 - `2026-08-16-safe-paths-workdir-enforcement.md`
+- `2026-08-16-grpc-relay-client-cache-ttl.md`
 - `2026-08-16-frontend-uiux-review-round1-fixes.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -82,22 +82,22 @@ Stable contracts:
 
 ## Backend Correctness
 
-- [ ] `P1` Close out the remaining findings from the 2026-08-16 code-only Rust backend review: an
-  unbounded `TeamRemoteRelayAdapter.grpc_client_cache` leaks a live gRPC `Channel` per relay delivery
-  (cache key includes a freshly-minted, timestamp-embedded access token, so it almost never hits) under
-  sustained remote-relay traffic; the remote relay worker's `std::sync::Mutex::lock().expect(...)` calls
-  mean any panic while one is held permanently and silently poisons the lock, killing remote message
-  relay for the process's lifetime with no restart or alerting; `update_team_task`'s gRPC handler accepts
-  a non-object `context_json` (only validates it's *valid* JSON, unlike its `context_merge_json` sibling
-  which checks the shape), which plants a landmine that panics the *next*, unrelated run-status-changing
-  request touching that task at `run_task_status_sync.rs`'s `.as_object_mut().expect(...)`; a timing
-  side-channel on the internal gRPC bootstrap-token comparison (`src/internal/service/mod.rs:137`, plain
-  `!=` instead of constant-time) on the endpoint that mints cluster-bootstrap credentials for new nodes;
-  no timeout on the child-process stdin write path, so a hung child can block that agent's stdin lock
-  indefinitely; several silently-swallowed DB/parse errors that leave no log trace (corrupt JSON resets
-  linked-task-sync context to `{}`, a failed startup `safe_paths` seed insert is invisible). The
-  `safe_paths` workdir-enforcement gap from the same review is fixed separately; see
-  [journal/2026-08-16-safe-paths-workdir-enforcement.md](journal/2026-08-16-safe-paths-workdir-enforcement.md).
+- [ ] `P1` Close out the remaining findings from the 2026-08-16 code-only Rust backend review: the
+  remote relay worker's `std::sync::Mutex::lock().expect(...)` calls mean any panic while one is held
+  permanently and silently poisons the lock, killing remote message relay for the process's lifetime
+  with no restart or alerting; `update_team_task`'s gRPC handler accepts a non-object `context_json`
+  (only validates it's *valid* JSON, unlike its `context_merge_json` sibling which checks the shape),
+  which plants a landmine that panics the *next*, unrelated run-status-changing request touching that
+  task at `run_task_status_sync.rs`'s `.as_object_mut().expect(...)`; a timing side-channel on the
+  internal gRPC bootstrap-token comparison (`src/internal/service/mod.rs:137`, plain `!=` instead of
+  constant-time) on the endpoint that mints cluster-bootstrap credentials for new nodes; no timeout on
+  the child-process stdin write path, so a hung child can block that agent's stdin lock indefinitely;
+  several silently-swallowed DB/parse errors that leave no log trace (corrupt JSON resets linked-task-
+  sync context to `{}`, a failed startup `safe_paths` seed insert is invisible). Two findings from the
+  same review are fixed separately: `safe_paths` workdir enforcement, see
+  [journal/2026-08-16-safe-paths-workdir-enforcement.md](journal/2026-08-16-safe-paths-workdir-enforcement.md);
+  the unbounded `TeamRemoteRelayAdapter.grpc_client_cache` leak and its token-staleness correctness gap,
+  see [journal/2026-08-16-grpc-relay-client-cache-ttl.md](journal/2026-08-16-grpc-relay-client-cache-ttl.md).
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
 

--- a/src/internal/client/mod.rs
+++ b/src/internal/client/mod.rs
@@ -220,6 +220,15 @@ impl InternalGrpcMailboxClient {
         self.request(payload)
             .map_err(|err| anyhow::anyhow!("{:?}: {}", err.code, err.message))
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_stub(access_token: &str) -> Self {
+        let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:0").connect_lazy();
+        Self {
+            channel,
+            access_token: access_token.to_string(),
+        }
+    }
 }
 
 fn internal_grpc_timeout_message() -> String {

--- a/src/team/manager/remote_relay/tests.rs
+++ b/src/team/manager/remote_relay/tests.rs
@@ -1,5 +1,7 @@
 use super::TeamRemoteRelayAdapter;
-use crate::internal::client::InternalGrpcPeerClientConfig;
+use crate::internal::client::{
+    InternalGrpcMailboxClient, InternalGrpcMailboxClientConfig, InternalGrpcPeerClientConfig,
+};
 use crate::internal::p2p::NodeTransportMetadata;
 use crate::internal::tls::InternalGrpcSecurityMode;
 use crate::team::manager::remote_relay_route::{
@@ -7,8 +9,10 @@ use crate::team::manager::remote_relay_route::{
     relay_timeout_ms,
 };
 use crate::team::manager::remote_relay_types::{
-    GrpcRelayTlsDefaults, GrpcRemoteRelayRouteValue, ParsedRemoteRelayRoute,
-    RELAY_DEFAULT_TIMEOUT_MS, RELAY_TIMEOUT_MAX_MS, RELAY_TIMEOUT_MIN_MS, RemoteRelaySigningValue,
+    CachedGrpcRelayClient, GrpcRelayClientCacheKey, GrpcRelayTlsDefaults,
+    GrpcRemoteRelayRouteValue, ParsedRemoteRelayRoute, RELAY_DEFAULT_TIMEOUT_MS,
+    RELAY_GRPC_CLIENT_CACHE_TTL, RELAY_TIMEOUT_MAX_MS, RELAY_TIMEOUT_MIN_MS,
+    RemoteRelaySigningValue,
 };
 use crate::team::{TeamActorMessageRecord, TeamActorMessageStatus, TeamActorMessageTransport};
 use agenthub_team_actor::{ACTOR_MAIN_PEER_ID, ACTOR_NODE_PEER_ID, ActorIdentityKind};
@@ -16,6 +20,7 @@ use chrono::Utc;
 use serde_json::json;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use std::time::{Duration, Instant};
 
 async fn test_db() -> SqlitePool {
     let options = SqliteConnectOptions::new()
@@ -513,5 +518,92 @@ fn apply_route_signing_sets_signature_timestamp_and_message_id_headers() {
             .get("X-AgentHub-Message-Id")
             .and_then(|value| value.to_str().ok()),
         Some("42")
+    );
+}
+
+fn stub_grpc_client_config() -> InternalGrpcMailboxClientConfig {
+    // Deliberately not a connectable target: a real `connect()` attempt against it fails fast,
+    // so an `Ok` result from `grpc_client_for_route` can only mean the cache was hit.
+    InternalGrpcMailboxClientConfig {
+        target: "not a valid grpc target".to_string(),
+        access_token: "cache-test-token".to_string(),
+        ca_cert_path: None,
+        tls_server_name: None,
+        client_cert_path: None,
+        client_key_path: None,
+    }
+}
+
+fn stub_grpc_client_cache_key(config: &InternalGrpcMailboxClientConfig) -> GrpcRelayClientCacheKey {
+    GrpcRelayClientCacheKey {
+        target: config.target.clone(),
+        access_token: config.access_token.clone(),
+        ca_cert_path: config.ca_cert_path.clone(),
+        tls_server_name: config.tls_server_name.clone(),
+        client_cert_path: config.client_cert_path.clone(),
+        client_key_path: config.client_key_path.clone(),
+    }
+}
+
+#[tokio::test]
+async fn grpc_client_for_route_returns_cached_client_before_ttl_expires() {
+    let db = test_db().await;
+    let adapter = TeamRemoteRelayAdapter::new(db);
+    let config = stub_grpc_client_config();
+    let cache_key = stub_grpc_client_cache_key(&config);
+    adapter
+        .grpc_client_cache
+        .lock()
+        .expect("lock grpc client cache")
+        .insert(
+            cache_key,
+            CachedGrpcRelayClient {
+                client: InternalGrpcMailboxClient::test_stub(&config.access_token),
+                inserted_at: Instant::now(),
+            },
+        );
+
+    adapter
+        .grpc_client_for_route(config)
+        .await
+        .expect("fresh cache entry should be served without reconnecting");
+}
+
+#[tokio::test]
+async fn grpc_client_for_route_evicts_expired_entries_and_reconnects() {
+    let db = test_db().await;
+    let adapter = TeamRemoteRelayAdapter::new(db);
+    let config = stub_grpc_client_config();
+    let cache_key = stub_grpc_client_cache_key(&config);
+    let expired_at = Instant::now()
+        .checked_sub(RELAY_GRPC_CLIENT_CACHE_TTL + Duration::from_secs(1))
+        .expect("process uptime exceeds cache TTL");
+    adapter
+        .grpc_client_cache
+        .lock()
+        .expect("lock grpc client cache")
+        .insert(
+            cache_key.clone(),
+            CachedGrpcRelayClient {
+                client: InternalGrpcMailboxClient::test_stub(&config.access_token),
+                inserted_at: expired_at,
+            },
+        );
+
+    let err = match adapter.grpc_client_for_route(config).await {
+        Err(err) => err,
+        Ok(_) => panic!("expired entry must not be served, forcing a real (failing) reconnect"),
+    };
+    assert!(
+        err.to_string().contains("gRPC connect failed"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !adapter
+            .grpc_client_cache
+            .lock()
+            .expect("lock grpc client cache")
+            .contains_key(&cache_key),
+        "expired entry should have been swept from the cache"
     );
 }

--- a/src/team/manager/remote_relay_grpc.rs
+++ b/src/team/manager/remote_relay_grpc.rs
@@ -1,10 +1,12 @@
+use std::time::Instant;
+
 use agenthub_team_actor::ActorRelayError;
 use reqwest::Url;
 use sqlx::Row;
 
 use super::remote_relay_types::{
-    GrpcRelayClientCacheKey, GrpcRemoteRelayRouteValue, TeamRemoteRelayAdapter,
-    TeamRemoteRelayError,
+    CachedGrpcRelayClient, GrpcRelayClientCacheKey, GrpcRemoteRelayRouteValue,
+    RELAY_GRPC_CLIENT_CACHE_TTL, TeamRemoteRelayAdapter, TeamRemoteRelayError,
 };
 use crate::agent::AGENT_NODE_MAIN_ID;
 use crate::internal::auth::InternalRole;
@@ -152,13 +154,17 @@ impl TeamRemoteRelayAdapter {
             client_cert_path: config.client_cert_path.clone(),
             client_key_path: config.client_key_path.clone(),
         };
-        if let Some(client) = self
-            .grpc_client_cache
-            .lock()
-            .expect("lock grpc client cache")
-            .get(&cache_key)
-            .cloned()
-        {
+        let now = Instant::now();
+        if let Some(client) = {
+            let mut cache = self
+                .grpc_client_cache
+                .lock()
+                .expect("lock grpc client cache");
+            cache.retain(|_, entry| {
+                now.duration_since(entry.inserted_at) < RELAY_GRPC_CLIENT_CACHE_TTL
+            });
+            cache.get(&cache_key).map(|entry| entry.client.clone())
+        } {
             return Ok(client);
         }
 
@@ -170,7 +176,13 @@ impl TeamRemoteRelayAdapter {
         self.grpc_client_cache
             .lock()
             .expect("lock grpc client cache")
-            .insert(cache_key, client.clone());
+            .insert(
+                cache_key,
+                CachedGrpcRelayClient {
+                    client: client.clone(),
+                    inserted_at: now,
+                },
+            );
         Ok(client)
     }
 }

--- a/src/team/manager/remote_relay_types.rs
+++ b/src/team/manager/remote_relay_types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use reqwest::Client;
 use serde::Deserialize;
@@ -11,6 +12,10 @@ pub(super) const RELAY_DEFAULT_TIMEOUT_MS: u64 = 30_000;
 pub(super) const RELAY_TIMEOUT_MIN_MS: u64 = 100;
 pub(super) const RELAY_TIMEOUT_MAX_MS: u64 = 60_000;
 
+/// Kept below the 600s TTL that `issue_registered_grpc_access_token` mints so cached clients are
+/// dropped, and a fresh access token obtained, before the token they were built with expires.
+pub(super) const RELAY_GRPC_CLIENT_CACHE_TTL: Duration = Duration::from_secs(240);
+
 #[derive(Clone)]
 pub(super) struct TeamRemoteRelayAdapter {
     pub(super) db: SqlitePool,
@@ -18,7 +23,13 @@ pub(super) struct TeamRemoteRelayAdapter {
     pub(super) grpc_tls_defaults: Arc<Mutex<Option<GrpcRelayTlsDefaults>>>,
     pub(super) grpc_peer_client_config: Arc<Mutex<Option<InternalGrpcPeerClientConfig>>>,
     pub(super) grpc_client_cache:
-        Arc<Mutex<HashMap<GrpcRelayClientCacheKey, InternalGrpcMailboxClient>>>,
+        Arc<Mutex<HashMap<GrpcRelayClientCacheKey, CachedGrpcRelayClient>>>,
+}
+
+#[derive(Clone)]
+pub(super) struct CachedGrpcRelayClient {
+    pub(super) client: InternalGrpcMailboxClient,
+    pub(super) inserted_at: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- `TeamRemoteRelayAdapter.grpc_client_cache` (flagged in the 2026-08-16 backend correctness review) never evicted entries. The common "registered" relay path mints a fresh, timestamp-embedded access token per message, so the cache key is unique almost every call — every relayed message leaked a live gRPC `Channel` forever, not just an admin-bounded amount.
- Callers that do reuse a stable, explicit `access_token` got real cache hits, but the cached client never refreshes its token — a long-lived entry could silently start sending an expired bearer token.
- Fixed with TTL-based lazy eviction (240s, under the 600s minted-token lifetime): entries are swept on every cache access (hit or miss), bounding growth regardless of hit rate and forcing a reconnect before a cached client's token can expire.

## Test plan

- [x] `cargo test --lib team::manager::remote_relay` — 17 passed (2 new tests distinguishing cache-hit vs. evicted-and-reconnected behavior via a deliberately unconnectable target + `#[cfg(test)]`-only lazy-channel stub, no live gRPC server needed)
- [x] `cargo test --lib team::manager` (183 passed), `cargo test --lib internal::client` (15 passed) — no regressions
- [x] `cargo test --lib` — 764 passed; 3 pre-existing `state::tests::*` failures confirmed present on `main` via `git stash` (unrelated `lance-namespace-impls` panic)
- [x] `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)