### PR TITLE
fix(internal): compare bootstrap gRPC token in constant time

### DIFF
--- a/docs/journal/2026-08-16-bootstrap-token-constant-time-compare.md
+++ b/docs/journal/2026-08-16-bootstrap-token-constant-time-compare.md
@@ -1,0 +1,44 @@
+# Summary
+
+`TeamInternalControlService::ensure_bootstrap_token` (flagged in the 2026-08-16 backend correctness
+review, tracked in `docs/todo.md`'s Backend Correctness item) compared the caller-supplied bootstrap
+token against the configured secret with a plain `!=`. This is the endpoint that mints
+cluster-bootstrap credentials for new agent nodes (`issue_node_credential`), so an attacker who can
+reach the internal gRPC listener and measure response latency could in principle recover the token
+byte-by-byte via a timing side-channel, since `!=` on `&str`/`String` short-circuits at the first
+mismatching byte.
+
+# Scope
+
+- `src/internal/service/mod.rs`: added a small `constant_time_eq(a: &[u8], b: &[u8]) -> bool` helper
+  (length check first, then an XOR-fold over every byte with no early return) and switched
+  `ensure_bootstrap_token` to use it instead of `!=`.
+
+# Key Decisions
+
+- Hand-rolled the comparison instead of adding a dependency (`subtle`, `constant_time_eq`). Both crates
+  are already present transitively (via TLS/crypto dependencies) but promoting either to a direct
+  dependency of the `agenthub` package requires a `CARGO_BAZEL_REPIN` pass to regenerate
+  `MODULE.bazel.lock`, since `crate_universe` resolves this workspace's Bazel crate graph from
+  `Cargo.toml`/`Cargo.lock`. For a six-line, well-understood XOR-fold, that Bazel-repin blast radius
+  wasn't worth it -- this keeps the fix to a pure Cargo-only, zero-dependency-graph change.
+- Length is still checked (and short-circuits) before the fold. This is standard practice for this kind
+  of comparison (matching what `subtle`/`constant_time_eq` do too): token length isn't the secret, only
+  its content is, so leaking length via a fast path is an accepted tradeoff, not a gap.
+
+# Validation
+
+- `cargo test --lib internal::service` -- 46 passed, including the pre-existing
+  `issue_node_credential_rejects_bootstrap_token_mismatch` end-to-end test (still correct: `!=`-shaped
+  behavior is preserved, only the comparison strategy changed) and a new
+  `constant_time_eq_matches_ordinary_byte_equality` unit test covering equal, empty, differing-length,
+  and differing-content-at-various-positions cases.
+- `cargo test --lib internal::` -- 69 passed, no regressions.
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- Two findings from the 2026-08-16 backend review remain open in `docs/todo.md`'s Backend Correctness
+  item: the remote-relay panic-poisoning `Mutex` trap, and the `context_json` panic landmine in
+  `update_team_task`/`run_task_status_sync.rs`. Also still open: the child-process stdin timeout gap and
+  the silently-swallowed DB/parse errors noted in the same review.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -216,9 +216,11 @@ Main shape:
   leak: the common relay path mints a fresh, timestamp-embedded access token per message, so the cache
   key is unique almost every call and every delivery leaked a live gRPC `Channel` forever; now bounded
   by TTL-based lazy eviction, which also closes a second gap where callers with stable tokens could keep
-  serving an expired bearer token from a long-lived cache entry. Three other findings from the same
-  review (a remote-relay panic-poisoning trap, a panic landmine from an unvalidated task context shape,
-  a bootstrap-token timing side-channel) remain open in the Backend Correctness `todo.md` item.
+  serving an expired bearer token from a long-lived cache entry. The internal gRPC bootstrap-token
+  comparison (the endpoint that mints cluster-bootstrap credentials for new nodes) used a plain `!=`
+  that short-circuits at the first mismatching byte, a timing side-channel; now a constant-time XOR-fold
+  comparison. Two other findings from the same review (a remote-relay panic-poisoning trap, a panic
+  landmine from an unvalidated task context shape) remain open in the Backend Correctness `todo.md` item.
 
 Start with:
 
@@ -233,6 +235,7 @@ Start with:
 - `2026-08-16-pwa-icon-branding-fix.md`
 - `2026-08-16-safe-paths-workdir-enforcement.md`
 - `2026-08-16-grpc-relay-client-cache-ttl.md`
+- `2026-08-16-bootstrap-token-constant-time-compare.md`
 - `2026-08-16-frontend-uiux-review-round1-fixes.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -88,16 +88,16 @@ Stable contracts:
   with no restart or alerting; `update_team_task`'s gRPC handler accepts a non-object `context_json`
   (only validates it's *valid* JSON, unlike its `context_merge_json` sibling which checks the shape),
   which plants a landmine that panics the *next*, unrelated run-status-changing request touching that
-  task at `run_task_status_sync.rs`'s `.as_object_mut().expect(...)`; a timing side-channel on the
-  internal gRPC bootstrap-token comparison (`src/internal/service/mod.rs:137`, plain `!=` instead of
-  constant-time) on the endpoint that mints cluster-bootstrap credentials for new nodes; no timeout on
-  the child-process stdin write path, so a hung child can block that agent's stdin lock indefinitely;
-  several silently-swallowed DB/parse errors that leave no log trace (corrupt JSON resets linked-task-
-  sync context to `{}`, a failed startup `safe_paths` seed insert is invisible). Two findings from the
-  same review are fixed separately: `safe_paths` workdir enforcement, see
+  task at `run_task_status_sync.rs`'s `.as_object_mut().expect(...)`; no timeout on the child-process
+  stdin write path, so a hung child can block that agent's stdin lock indefinitely; several silently-
+  swallowed DB/parse errors that leave no log trace (corrupt JSON resets linked-task-sync context to
+  `{}`, a failed startup `safe_paths` seed insert is invisible). Three findings from the same review are
+  fixed separately: `safe_paths` workdir enforcement, see
   [journal/2026-08-16-safe-paths-workdir-enforcement.md](journal/2026-08-16-safe-paths-workdir-enforcement.md);
   the unbounded `TeamRemoteRelayAdapter.grpc_client_cache` leak and its token-staleness correctness gap,
-  see [journal/2026-08-16-grpc-relay-client-cache-ttl.md](journal/2026-08-16-grpc-relay-client-cache-ttl.md).
+  see [journal/2026-08-16-grpc-relay-client-cache-ttl.md](journal/2026-08-16-grpc-relay-client-cache-ttl.md);
+  the internal gRPC bootstrap-token comparison's timing side-channel, see
+  [journal/2026-08-16-bootstrap-token-constant-time-compare.md](journal/2026-08-16-bootstrap-token-constant-time-compare.md).
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
 

--- a/src/internal/service/mod.rs
+++ b/src/internal/service/mod.rs
@@ -64,6 +64,19 @@ const MAX_INTERNAL_TEAM_TASK_LIST_LIMIT: i64 = 500;
 const DEFAULT_TOKEN_TTL_SECONDS: i64 = 3600;
 const MAX_TOKEN_TTL_SECONDS: i64 = 24 * 60 * 60;
 
+/// Byte-for-byte equality that doesn't short-circuit on the first mismatching byte, so comparing a
+/// bootstrap token candidate against the real secret doesn't leak how many leading bytes matched
+/// through response timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |diff, (x, y)| diff | (x ^ y))
+        == 0
+}
+
 #[derive(Clone)]
 pub(crate) struct TeamInternalControlDeps {
     pub db: sqlx::SqlitePool,
@@ -134,7 +147,7 @@ impl TeamInternalControlService {
         if provided.is_empty() {
             return Err(Status::unauthenticated("empty bootstrap token"));
         }
-        if provided != self.bootstrap_token {
+        if !constant_time_eq(provided.as_bytes(), self.bootstrap_token.as_bytes()) {
             return Err(Status::permission_denied("bootstrap token mismatch"));
         }
         Ok(())

--- a/src/internal/service/tests/misc.rs
+++ b/src/internal/service/tests/misc.rs
@@ -937,3 +937,15 @@ async fn coordinator_transition_step_checks_run_scope_before_mutation() {
     assert_eq!(step_after.status, crate::team::TeamStepStatus::Working);
     assert_eq!(step_after.output, None);
 }
+
+#[test]
+fn constant_time_eq_matches_ordinary_byte_equality() {
+    use super::super::constant_time_eq;
+
+    assert!(constant_time_eq(b"", b""));
+    assert!(constant_time_eq(b"bootstrap-token", b"bootstrap-token"));
+    assert!(!constant_time_eq(b"bootstrap-token", b"bootstrap-toke"));
+    assert!(!constant_time_eq(b"bootstrap-token", b"bootstrap-tokeX"));
+    assert!(!constant_time_eq(b"bootstrap-token", b"Xootstrap-token"));
+    assert!(!constant_time_eq(b"short", b"much-longer-value"));
+}


### PR DESCRIPTION
## Summary

- `TeamInternalControlService::ensure_bootstrap_token` (flagged in the 2026-08-16 backend correctness review) compared the caller-supplied bootstrap token against the configured secret with a plain `!=`, which short-circuits at the first mismatching byte.
- This is the endpoint that mints cluster-bootstrap credentials for new agent nodes (`issue_node_credential`), so an attacker able to reach the internal gRPC listener could in principle recover the token byte-by-byte via response-timing differences.
- Fixed with a small `constant_time_eq` helper (length check, then an XOR-fold over every byte with no early return), used in place of `!=`. Hand-rolled rather than adding `subtle`/`constant_time_eq` as a new Cargo dependency, since promoting either from a transitive dependency to a direct one would require a `CARGO_BAZEL_REPIN` pass to regenerate `MODULE.bazel.lock` — not worth the blast radius for a six-line comparison.

## Test plan

- [x] `cargo test --lib internal::service` — 46 passed, including the pre-existing `issue_node_credential_rejects_bootstrap_token_mismatch` end-to-end test (still correct — only the comparison strategy changed) and a new `constant_time_eq_matches_ordinary_byte_equality` unit test
- [x] `cargo test --lib internal::` — 69 passed, no regressions
- [x] `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)