### PR TITLE
fix(web): guard null WebAuthn options

### DIFF
--- a/web/src/webauthn.test.ts
+++ b/web/src/webauthn.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  publicKeyCredentialCreationOptionsFromJson,
+  publicKeyCredentialRequestOptionsFromJson,
+} from "./webauthn";
+
+describe("WebAuthn option parsing", () => {
+  it("rejects null registration options with a useful error", () => {
+    expect(() => publicKeyCredentialCreationOptionsFromJson(null)).toThrow(
+      "missing WebAuthn registration options"
+    );
+  });
+
+  it("rejects null authentication options with a useful error", () => {
+    expect(() => publicKeyCredentialRequestOptionsFromJson(null)).toThrow(
+      "missing WebAuthn authentication options"
+    );
+  });
+});

--- a/web/src/webauthn.ts
+++ b/web/src/webauthn.ts
@@ -1,8 +1,14 @@
 export function publicKeyCredentialCreationOptionsFromJson(
   options: unknown
 ): PublicKeyCredentialCreationOptions {
+  if (!options || typeof options !== "object") {
+    throw new Error("missing WebAuthn registration options");
+  }
   const maybe = options as { publicKey?: PublicKeyCredentialCreationOptions };
   const o = (maybe.publicKey ?? options) as PublicKeyCredentialCreationOptions;
+  if (!o || typeof o !== "object") {
+    throw new Error("missing WebAuthn registration options");
+  }
   const challenge = toArrayBuffer(o.challenge, "challenge");
   const user = o.user as PublicKeyCredentialUserEntity;
   const userId = toArrayBuffer(user.id, "user.id");
@@ -21,8 +27,14 @@ export function publicKeyCredentialCreationOptionsFromJson(
 export function publicKeyCredentialRequestOptionsFromJson(
   options: unknown
 ): PublicKeyCredentialRequestOptions {
+  if (!options || typeof options !== "object") {
+    throw new Error("missing WebAuthn authentication options");
+  }
   const maybe = options as { publicKey?: PublicKeyCredentialRequestOptions };
   const o = (maybe.publicKey ?? options) as PublicKeyCredentialRequestOptions;
+  if (!o || typeof o !== "object") {
+    throw new Error("missing WebAuthn authentication options");
+  }
   const challenge = toArrayBuffer(o.challenge, "challenge");
   const allow = (o.allowCredentials ?? []).map((c) => ({
     ...c,


### PR DESCRIPTION
## Summary

- Guard WebAuthn registration and authentication option parsers against null or non-object input.
- Return actionable client errors instead of dereferencing `publicKey` from a null response.
- Add focused regression tests for both parser paths.

## Root cause

The WebAuthn helpers assumed the backend response always contained an object and accessed `publicKey` before validating the value. A missing or null challenge payload therefore surfaced as a browser-level `publicKey` property error.

## Validation

- `npm --prefix web run test -- --run src/webauthn.test.ts`
- `npm --prefix web run build`
- `cargo build --release`

## Notes

The deployed runtime configuration change (`passkey_enabled = true`) is host-local configuration and is intentionally not included in this PR.
