### PR TITLE
fix(team): fail closed on permission-review reviewer-target inconsistency

### DIFF
--- a/docs/journal/2026-08-17-permission-review-reviewer-target-consistency.md
+++ b/docs/journal/2026-08-17-permission-review-reviewer-target-consistency.md
@@ -1,0 +1,69 @@
+# Summary
+
+A code-only review of the Team subsystem found that the "current active reviewer" for a pending
+permission review was resolved two different ways depending on *when* it was checked, and the two could
+disagree: dispatch-time selection (`TeamPermissionReviewDispatcher::resolve_review_target`) is
+idle-aware -- it picks the first candidate whose agent runtime looks idle, falling back to the first
+candidate otherwise -- while the internal gRPC `respond_permission_review` handler, whenever
+`review_target_actor_id` hadn't been persisted on the record yet, re-derived a reviewer via
+`resolve_team_permission_review_target`, which is idle-*unaware* and deterministically returns the
+first candidate. If those two selections differed (the first candidate wasn't idle, so dispatch picked
+someone else) and a `respond_permission_review` call landed in the narrow window between dispatch
+delivering the mailbox message and its own `record_review_dispatch` write committing, the actor who
+actually received the review would be rejected while a different actor who was never notified could be
+treated as authorized to approve or deny it.
+
+# Scope
+
+- `src/internal/service/rpc.rs`: `respond_permission_review` no longer re-derives a reviewer from the
+  team spec when `review_target_actor_id` is absent. It now compares directly against the persisted
+  column and fails closed (the same `permission_denied` this function already returns for a genuine
+  wrong-actor mismatch) when no target has been recorded yet.
+- `src/team/permission_review/selection.rs`: removed `resolve_team_permission_review_target`, the
+  idle-unaware wrapper that was the only caller of this now-dead fallback path. Its underlying candidate
+  logic (`collect_team_permission_review_candidates` -- worker-before-coordinator selection,
+  role-trimming, self-review exclusion) is unchanged and still used by the dispatcher's idle-aware
+  selection; only the thin "just take the first candidate" wrapper is gone.
+- `src/team/mod.rs`, `src/internal/service/mod.rs`: dropped the now-dead re-exports.
+- `src/internal/service/tests/permission_review.rs`: the three "legacy fallback" tests that specifically
+  exercised the removed resolution path (`accepts_legacy_team_coordinator_fallback`,
+  `accepts_legacy_team_peer_worker_fallback`, `surfaces_legacy_reviewer_resolution_errors`) are replaced
+  by one test asserting the new fail-closed behavior
+  (`respond_rejects_when_no_reviewer_target_persisted_yet`). Two other tests
+  (`respond_updates_pending_request`, `respond_rejects_conflicting_outcome_fields`) that inserted a
+  pending request via raw SQL without a `review_target_actor_id` -- relying on the old fallback to reach
+  the behavior they actually meant to test -- now seed that column directly.
+- `src/team/permission_review/tests.rs`: the four unit tests that called
+  `resolve_team_permission_review_target` now call `collect_team_permission_review_candidates` directly
+  and check its first candidate, preserving the same coverage of the underlying selection logic.
+
+# Key Decisions
+
+- **Fail closed instead of trying to make the fallback idle-aware too.** Making
+  `respond_permission_review`'s fallback match the dispatcher's idle-aware selection would require
+  wiring the same agent-runtime/mailbox-idle-check machinery (`TeamMailboxHintAgentNudger`) into
+  `TeamInternalControlService`, which doesn't currently have it and isn't otherwise a natural dependency
+  of that service. Since dispatch's `record_review_dispatch` write is the *only* path that ever persists
+  `review_target_actor_id`, an absent value means dispatch either hasn't finished or never started --
+  no agent should have received the review to respond to yet. Confirmed with the person requesting this
+  fix that removing the fallback (rather than trying to duplicate its logic) is the correct scope, since
+  every legitimate caller of this endpoint is an agent responding to a message it already received.
+- **Deleted the dead function rather than keeping it `#[allow(dead_code)]`.** Its own defect (idle-blind
+  selection) was the actual bug; keeping it around unused risked someone re-wiring it back in without
+  realizing why it was removed. Its test coverage was preserved by retargeting to the shared
+  candidate-collection function it used to wrap.
+
+# Validation
+
+- `cargo test --lib team::permission_review::` -- 12 passed.
+- `cargo test --lib internal::service::tests::permission_review` -- 7 passed, including the new
+  fail-closed regression test and the two raw-SQL tests updated to seed a persisted reviewer target.
+- `cargo test --lib team::` -- 211 passed; `cargo test --lib internal::` -- 67 passed. No regressions.
+- `cargo test --lib` -- 765 passed; the 2 pre-existing `state::tests::*` failures (unrelated
+  `lance-namespace-impls` panic) were already present on `main` before this change.
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- The other findings from the same 2026-08-17 Team-subsystem review round remain open, tracked in
+  `docs/todo.md`'s Agent Team Correctness item.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -228,6 +228,21 @@ Main shape:
   `webidl.util.markAsUncloneable is not a function` -- jsdom 30 explicitly requires Node >=22, and the
   `Web`/`Web E2E`/`Web E2E Mobile` jobs were still pinned to Node 20 (`userdocs.yml`'s unrelated
   Docusaurus build stays on Node 20, out of scope). Bumped those three jobs to Node 22.
+- A code-only review of the Team subsystem (Task/Run/Step lifecycle, goal-lease/fork concurrency,
+  mailbox, remote relay, permission review, actor protocol) found `task_updates.rs`'s `team_tasks`
+  writes had no optimistic-concurrency guard, `release_task_goal_in_tx` released whatever lease was
+  active rather than the specific generation observed, and `claim_task_goal_in_tx`/
+  `claim_execution_entity` decided claimability in Rust from a stale read but wrote unconditionally --
+  all three now guarded via the existing `ControlStore` idiom. Fixing this surfaced a real, separate bug:
+  writing `team_tasks.updated_at` from a plain second-granularity `now()` let two same-second writes
+  collide and silently defeat the new CAS guard; every writer of that column now writes
+  `MAX(updated_at + 1, now())` so it's strictly monotonic regardless of which function touches it. The
+  same review also found permission-review's "current reviewer" was resolved two different ways --
+  idle-aware at dispatch time, idle-*unaware* (always the first candidate) when re-derived at approval
+  time because the persisted target hadn't landed yet -- letting the wrong actor approve/deny a review
+  it never received; the approval-time fallback is now removed entirely (fail closed on no persisted
+  target) rather than trying to duplicate dispatch's idle-check machinery. Four other findings from the
+  same review remain open in a new Agent Team Correctness `todo.md` item.
 
 Start with:
 
@@ -247,6 +262,8 @@ Start with:
 - `2026-08-17-pwa-icon-borrowed-slock-mark-fix.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 - `2026-08-17-ci-web-node22-for-jsdom30.md`
+- `2026-08-17-goal-lease-cas-hardening.md`
+- `2026-08-17-permission-review-reviewer-target-consistency.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,6 +101,34 @@ Stable contracts:
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
 
+## Agent Team Correctness
+
+- [ ] `P1` Close out the remaining findings from a 2026-08-17 code-only review of the Team subsystem
+  (Task/Run/Step lifecycle, mailbox, remote relay/permission review, actor protocol): `update_task`'s
+  gRPC `context_json` (`Replace` patch) accepts any valid JSON, not just objects, unlike its
+  `context_merge_json` sibling -- storing e.g. an array or `null` there plants a landmine that panics the
+  *next* unrelated run-status-changing request in `run_task_status_sync.rs`'s
+  `compute_next_task_execution_context` (`.as_object_mut().expect(...)`); a caller can set
+  `payload.requires_user_visible_reply: false` on a human-to-agent mailbox message to silently disable
+  the system's reply-obligation tracking for it, since normalization only backfills the field when absent
+  instead of enforcing the server-computed value for human-originated messages; reply-obligation "credit"
+  matching keys only on `(agent_actor_id, human_actor_id)` and consumes credits newest-first, so replying
+  to an older still-open request can incorrectly close a newer, unrelated one instead; transfer/escalate/
+  takeover (`reassign_reply_required_message`) has no guard on the source message's handling disposition
+  in its `UPDATE` (unlike the sibling `triage_message_impl`) and inserts the reassigned message with
+  `idempotency_key = NULL`, so a concurrent double-reassign can duplicate it; the SQLite index-repair
+  path (`message_index_projection.rs`) silently coerces unparseable `payload_json`/`input_json` to
+  `Value::Null`/defaults with no logging, so a corrupted authority row loses its conversation/task linkage
+  during a rebuild with the repair report still claiming success. Two findings from the same review are
+  fixed separately: `task_updates.rs`'s missing optimistic-concurrency guard on `team_tasks` writes,
+  `release_task_goal_in_tx` releasing whatever lease is active instead of the specific generation
+  observed, and `claim_task_goal_in_tx`/`claim_execution_entity`'s check-then-act upserts, see
+  [journal/2026-08-17-goal-lease-cas-hardening.md](journal/2026-08-17-goal-lease-cas-hardening.md);
+  the permission-review reviewer-selection inconsistency between dispatch time and approval time, see
+  [journal/2026-08-17-permission-review-reviewer-target-consistency.md](journal/2026-08-17-permission-review-reviewer-target-consistency.md).
+  Evidence for the rest: this review round has no dedicated journal entry yet -- write one when starting
+  on the next item from this list.
+
 ## Message Storage
 
 - [x] `P1` Complete the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). SQLite authority rows now rebuild the conversation, actor mailbox, run-event, and agent-event projections; guarded ordered reads compare high-water marks and exact SQLite page IDs, fall back on any gap, and queue a startup worker for asynchronous repair. Orphan/prune helpers remain diagnostics and explicit maintenance only. Keep normal SQLite bodies readable until a later authority-cutover decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).

--- a/src/internal/service/mod.rs
+++ b/src/internal/service/mod.rs
@@ -29,7 +29,7 @@ pub(super) use crate::team::{
     TeamStepStatus, TeamTaskAssignmentUpdate, TeamTaskContextPatch, TeamTaskCreateInput,
     TeamTaskListQuery, TeamTaskNoteCreateInput, TeamTaskNoteKind, TeamTaskPriority, TeamTaskStatus,
     TeamTaskUpdateWithNoteInput, dispatch_actor_mailbox_immediate_hint,
-    plan_actor_mailbox_immediate_hint, resolve_team_permission_review_target,
+    plan_actor_mailbox_immediate_hint,
 };
 
 pub(super) use super::auth::{InternalAction, InternalAuthz, InternalRole};

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -1040,34 +1040,16 @@ impl TeamInternalControl for TeamInternalControlService {
                 "requester cannot review its own permission request",
             ));
         }
-        let team = self
-            .deps
-            .teams
-            .get_team(team_id)
-            .await
-            .map_err(map_manager_error)?;
-        let active_reviewer =
-            if let Some(review_target_actor_id) = record.review_target_actor_id.as_deref() {
-                Some(review_target_actor_id.to_string())
-            } else {
-                let requester_actor_id = record.requester_actor_id.as_deref().ok_or_else(|| {
-                    Status::failed_precondition("permission request is missing requester actor")
-                })?;
-                Some(
-                    resolve_team_permission_review_target(
-                        &team.spec,
-                        requester_actor_id,
-                        record.requester_role.as_deref().unwrap_or_default(),
-                    )
-                    .map(|(reviewer, _)| reviewer)
-                    .map_err(|err| {
-                        Status::failed_precondition(format!(
-                            "failed to resolve active reviewer for permission request: {err}"
-                        ))
-                    })?,
-                )
-            };
-        if active_reviewer.as_deref() != Some(actor_id) {
+        // `review_target_actor_id` is the single source of truth for who dispatch actually notified --
+        // it's chosen with idle-aware selection (`TeamPermissionReviewDispatcher::resolve_review_target`)
+        // and persisted before the human-review fallback timer can fire. Re-deriving a reviewer here from
+        // the team spec when it's absent used to call the *idle-unaware* `resolve_team_permission_review_target`,
+        // which can disagree with dispatch's own idle-aware pick during the narrow window between dispatch
+        // delivering the mailbox message and its own `record_review_dispatch` write committing -- letting
+        // an actor who never received the review approve/deny it while the actual recipient is wrongly
+        // rejected. Fail closed instead: no persisted target means dispatch hasn't finished (or never
+        // started), so no actor is yet authorized to respond.
+        if record.review_target_actor_id.as_deref() != Some(actor_id) {
             return Err(Status::permission_denied(
                 "current actor is not the active reviewer for this permission request",
             ));

--- a/src/internal/service/tests/permission_review.rs
+++ b/src/internal/service/tests/permission_review.rs
@@ -55,13 +55,14 @@ async fn internal_grpc_permission_review_respond_updates_pending_request() {
                 team_id,
                 requester_actor_id,
                 requester_role,
+                review_target_actor_id,
                 tool_call_id,
                 options_json,
                 tool_call_json,
                 status,
                 created_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', ?11)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12)
             "#,
     )
     .bind("perm-internal-1")
@@ -71,6 +72,7 @@ async fn internal_grpc_permission_review_respond_updates_pending_request() {
     .bind(&run.team_id)
     .bind("reviewer")
     .bind("worker")
+    .bind("planner")
     .bind("tool-call-1")
     .bind(
         json!([
@@ -123,10 +125,15 @@ async fn internal_grpc_permission_review_respond_updates_pending_request() {
 }
 
 #[tokio::test]
-async fn internal_grpc_permission_review_respond_accepts_legacy_team_coordinator_fallback() {
+async fn internal_grpc_permission_review_respond_rejects_when_no_reviewer_target_persisted_yet() {
+    // `review_target_actor_id` is the single source of truth for who dispatch actually notified. A
+    // pending request that hasn't had it persisted yet (dispatch still in flight, or never started)
+    // must reject every actor rather than re-deriving a plausible reviewer from the team spec -- that
+    // used to be resolved via an idle-*unaware* fallback that could disagree with dispatch's own
+    // idle-aware pick, letting the wrong actor approve/deny a review it never received.
     let fixture = setup_permission_review_fixture_with_spec(
-        "legacy-coordinator-fallback",
-        "validate legacy coordinator fallback",
+        "no-reviewer-target-persisted",
+        "validate fail-closed behavior with no persisted reviewer target",
         json!({
             "entrypoint":"planner",
             "coordinator_member_id":"planner",
@@ -143,128 +150,14 @@ async fn internal_grpc_permission_review_respond_accepts_legacy_team_coordinator
         &fixture.state,
         &fixture.run,
         PermissionReviewSeed {
-            request_id: "perm-legacy-coordinator-1",
-            agent_id: "legacy-worker-agent",
-            session_id: "legacy-worker-session",
-            acp_session_id: "acp-session-legacy-1",
+            request_id: "perm-no-target-1",
+            agent_id: "no-target-worker-agent",
+            session_id: "no-target-worker-session",
+            acp_session_id: "acp-session-no-target-1",
             requester_actor_id: "reviewer",
             requester_role: "worker",
             review_target_actor_id: None,
-            tool_call_id: "tool-call-legacy-1",
-            status: "pending",
-        },
-        fixture.now,
-    )
-    .await;
-
-    let response = TeamInternalControl::respond_permission_review(
-        &fixture.service,
-        authenticated_request(
-            RespondPermissionReviewRequest {
-                team_id: fixture.run.team_id.clone(),
-                actor_id: "planner".to_string(),
-                permission_id: "perm-legacy-coordinator-1".to_string(),
-                option_id: "allow".to_string(),
-                outcome: String::new(),
-            },
-            &fixture.token,
-        ),
-    )
-    .await
-    .expect("respond permission review")
-    .into_inner();
-
-    assert_eq!(response.status, "ok");
-    assert_eq!(response.request_status, "responded");
-    assert_eq!(response.reviewed_by_actor_id, "planner");
-}
-
-#[tokio::test]
-async fn internal_grpc_permission_review_respond_accepts_legacy_team_peer_worker_fallback() {
-    let fixture = setup_permission_review_fixture_with_spec(
-        "legacy-peer-worker-fallback",
-        "validate legacy peer worker fallback",
-        json!({
-            "entrypoint":"planner",
-            "coordinator_member_id":"planner",
-            "members":[
-                {"member_id":"planner","role":"coordinator"},
-                {"member_id":"requester","role":"worker"},
-                {"member_id":"reviewer","role":"worker"}
-            ]
-        }),
-        InternalRole::Worker,
-        "reviewer",
-    )
-    .await;
-    seed_permission_review_request(
-        &fixture.state,
-        &fixture.run,
-        PermissionReviewSeed {
-            request_id: "perm-legacy-peer-worker-1",
-            agent_id: "legacy-peer-worker-agent",
-            session_id: "legacy-peer-worker-session",
-            acp_session_id: "acp-session-legacy-peer-worker-1",
-            requester_actor_id: "requester",
-            requester_role: "worker",
-            review_target_actor_id: None,
-            tool_call_id: "tool-call-legacy-peer-worker-1",
-            status: "pending",
-        },
-        fixture.now,
-    )
-    .await;
-
-    let response = TeamInternalControl::respond_permission_review(
-        &fixture.service,
-        authenticated_request(
-            RespondPermissionReviewRequest {
-                team_id: fixture.run.team_id.clone(),
-                actor_id: "reviewer".to_string(),
-                permission_id: "perm-legacy-peer-worker-1".to_string(),
-                option_id: "allow".to_string(),
-                outcome: String::new(),
-            },
-            &fixture.token,
-        ),
-    )
-    .await
-    .expect("respond permission review")
-    .into_inner();
-
-    assert_eq!(response.status, "ok");
-    assert_eq!(response.request_status, "responded");
-    assert_eq!(response.reviewed_by_actor_id, "reviewer");
-}
-
-#[tokio::test]
-async fn internal_grpc_permission_review_respond_surfaces_legacy_reviewer_resolution_errors() {
-    let fixture = setup_permission_review_fixture_with_spec(
-        "legacy-reviewer-resolution-error",
-        "validate legacy reviewer resolution errors",
-        json!({
-            "entrypoint":"reviewer",
-            "coordinator_member_id":"reviewer",
-            "members":[
-                {"member_id":"reviewer","role":"worker"}
-            ]
-        }),
-        InternalRole::Worker,
-        "reviewer",
-    )
-    .await;
-    seed_permission_review_request(
-        &fixture.state,
-        &fixture.run,
-        PermissionReviewSeed {
-            request_id: "perm-legacy-resolution-error-1",
-            agent_id: "legacy-resolution-error-agent",
-            session_id: "legacy-resolution-error-session",
-            acp_session_id: "acp-session-legacy-resolution-error-1",
-            requester_actor_id: "removed-planner",
-            requester_role: "coordinator",
-            review_target_actor_id: None,
-            tool_call_id: "tool-call-legacy-resolution-error-1",
+            tool_call_id: "tool-call-no-target-1",
             status: "pending",
         },
         fixture.now,
@@ -276,8 +169,8 @@ async fn internal_grpc_permission_review_respond_surfaces_legacy_reviewer_resolu
         authenticated_request(
             RespondPermissionReviewRequest {
                 team_id: fixture.run.team_id.clone(),
-                actor_id: "reviewer".to_string(),
-                permission_id: "perm-legacy-resolution-error-1".to_string(),
+                actor_id: "planner".to_string(),
+                permission_id: "perm-no-target-1".to_string(),
                 option_id: "allow".to_string(),
                 outcome: String::new(),
             },
@@ -285,12 +178,12 @@ async fn internal_grpc_permission_review_respond_surfaces_legacy_reviewer_resolu
         ),
     )
     .await
-    .expect_err("legacy reviewer resolution should fail");
+    .expect_err("respond must be rejected before a reviewer target is persisted");
 
-    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
     assert!(
         err.message()
-            .contains("failed to resolve active reviewer for permission request"),
+            .contains("current actor is not the active reviewer for this permission request"),
         "unexpected error message: {err}"
     );
 }
@@ -561,13 +454,14 @@ async fn internal_grpc_permission_review_respond_rejects_conflicting_outcome_fie
                 team_id,
                 requester_actor_id,
                 requester_role,
+                review_target_actor_id,
                 tool_call_id,
                 options_json,
                 tool_call_json,
                 status,
                 created_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', ?11)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12)
             "#,
     )
     .bind("perm-conflict-review-1")
@@ -577,6 +471,7 @@ async fn internal_grpc_permission_review_respond_rejects_conflicting_outcome_fie
     .bind(&run.team_id)
     .bind("reviewer")
     .bind("worker")
+    .bind("planner")
     .bind("tool-call-conflict-1")
     .bind(
         json!([

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -45,7 +45,6 @@ pub use manager::{
 pub(crate) use manager::{
     count_pending_conversation_body_migration, migrate_conversation_bodies_into_store,
 };
-pub(crate) use permission_review::resolve_team_permission_review_target;
 pub use permission_review::{
     TeamPermissionReviewDispatcher, TeamPermissionReviewDispatcherSettings,
 };

--- a/src/team/permission_review/mod.rs
+++ b/src/team/permission_review/mod.rs
@@ -2,7 +2,6 @@ mod dispatcher;
 mod payload;
 mod selection;
 pub use dispatcher::{TeamPermissionReviewDispatcher, TeamPermissionReviewDispatcherSettings};
-pub(crate) use selection::resolve_team_permission_review_target;
 use std::time::Duration;
 
 const TEAM_PERMISSION_REVIEW_PAYLOAD_TYPE: &str = "permission_review_request";

--- a/src/team/permission_review/selection.rs
+++ b/src/team/permission_review/selection.rs
@@ -69,19 +69,6 @@ pub(super) fn collect_team_permission_review_candidates(
     Ok(candidates)
 }
 
-pub(crate) fn resolve_team_permission_review_target(
-    spec: &Value,
-    requester_actor_id: &str,
-    requester_role: &str,
-) -> anyhow::Result<(String, &'static str)> {
-    let candidate =
-        collect_team_permission_review_candidates(spec, requester_actor_id, requester_role)?
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("team has no non-requester reviewer configured"))?;
-    Ok((candidate.actor_id, candidate.dispatch_status))
-}
-
 fn team_coordinator_member_id(spec: &Value) -> Option<&str> {
     let spec_obj = spec.as_object()?;
     let members = spec_obj.get("members")?.as_array()?;

--- a/src/team/permission_review/tests.rs
+++ b/src/team/permission_review/tests.rs
@@ -71,11 +71,14 @@ fn worker_request_skips_coordinator_even_if_coordinator_member_role_is_misconfig
         ]
     });
 
-    let (reviewer, dispatch_status) =
-        resolve_team_permission_review_target(&spec, "worker", "worker").expect("resolve reviewer");
+    let candidate = collect_team_permission_review_candidates(&spec, "worker", "worker")
+        .expect("collect reviewer candidates")
+        .into_iter()
+        .next()
+        .expect("has a reviewer candidate");
 
-    assert_eq!(reviewer, "reviewer");
-    assert_eq!(dispatch_status, "worker_dispatched");
+    assert_eq!(candidate.actor_id, "reviewer");
+    assert_eq!(candidate.dispatch_status, "worker_dispatched");
 }
 
 #[test]
@@ -89,12 +92,14 @@ fn requester_role_is_trimmed_before_review_target_resolution() {
         ]
     });
 
-    let (reviewer, dispatch_status) =
-        resolve_team_permission_review_target(&spec, "planner", " coordinator ")
-            .expect("resolve reviewer");
+    let candidate = collect_team_permission_review_candidates(&spec, "planner", " coordinator ")
+        .expect("collect reviewer candidates")
+        .into_iter()
+        .next()
+        .expect("has a reviewer candidate");
 
-    assert_eq!(reviewer, "reviewer");
-    assert_eq!(dispatch_status, "worker_dispatched");
+    assert_eq!(candidate.actor_id, "reviewer");
+    assert_eq!(candidate.dispatch_status, "worker_dispatched");
 }
 
 #[test]
@@ -146,12 +151,14 @@ fn worker_request_uses_coordinator_when_no_peer_worker_exists() {
         ]
     });
 
-    let (reviewer, dispatch_status) =
-        resolve_team_permission_review_target(&spec, "worker", "worker")
-            .expect("resolve coordinator fallback reviewer");
+    let candidate = collect_team_permission_review_candidates(&spec, "worker", "worker")
+        .expect("collect coordinator fallback candidates")
+        .into_iter()
+        .next()
+        .expect("has a reviewer candidate");
 
-    assert_eq!(reviewer, "coordinator");
-    assert_eq!(dispatch_status, "coordinator_dispatched");
+    assert_eq!(candidate.actor_id, "coordinator");
+    assert_eq!(candidate.dispatch_status, "coordinator_dispatched");
 }
 
 #[test]
@@ -164,7 +171,7 @@ fn coordinator_request_errors_without_subordinate_reviewer() {
         ]
     });
 
-    let err = resolve_team_permission_review_target(&spec, "coordinator", "coordinator")
+    let err = collect_team_permission_review_candidates(&spec, "coordinator", "coordinator")
         .expect_err("coordinator should need a subordinate reviewer");
 
     assert!(


### PR DESCRIPTION
## Summary

- The "current active reviewer" for a pending permission review was resolved two different ways depending on *when* it was checked: dispatch time (`TeamPermissionReviewDispatcher::resolve_review_target`, idle-aware — picks the first idle candidate) vs. approval time in `respond_permission_review`, whenever `review_target_actor_id` hadn't been persisted yet (idle-*unaware*, always the first candidate via the now-removed `resolve_team_permission_review_target`).
- If those two selections disagreed and a `respond_permission_review` call landed in the narrow window between dispatch delivering the mailbox message and its own `record_review_dispatch` write committing, the actor who actually received the review would be rejected while a different actor who was never notified could be treated as authorized to approve or deny it.
- `respond_permission_review` no longer re-derives a reviewer from the team spec when no target is persisted — it fails closed (reuses the existing `permission_denied` this endpoint already returns for a genuine mismatch), since the only path that ever persists `review_target_actor_id` is dispatch itself; an absent value means dispatch hasn't finished (or never started), so no agent should have anything to respond to yet.
- Removed the now-dead `resolve_team_permission_review_target` wrapper rather than keeping it `#[allow(dead_code)]` — its own idle-blindness was the bug. Its underlying candidate-selection logic (`collect_team_permission_review_candidates`) is unchanged and still used by the dispatcher's idle-aware path; its test coverage was retargeted to call that function directly.

## Test plan

- [x] `cargo test --lib team::permission_review::` — 12 passed
- [x] `cargo test --lib internal::service::tests::permission_review` — 7 passed, including a new `respond_rejects_when_no_reviewer_target_persisted_yet` regression test and two existing tests updated to seed a persisted reviewer target (they were relying on the removed fallback to reach the behavior they actually meant to test)
- [x] `cargo test --lib team::` (210 passed), `cargo test --lib internal::` (67 passed) — no regressions
- [x] `cargo test --lib` — 765 passed; 2 pre-existing `state::tests::*` failures (unrelated `lance-namespace-impls` panic, confirmed present on `main` before this change)
- [x] `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)