### PR TITLE
fix(team): reject non-object task context_json and stop the resulting panic

### DIFF
--- a/docs/journal/2026-08-17-task-context-json-shape-validation.md
+++ b/docs/journal/2026-08-17-task-context-json-shape-validation.md
@@ -1,0 +1,54 @@
+# Summary
+
+A code-only review of the Team subsystem found that `update_team_task`'s gRPC handler only validated
+that its `context_json` field (a full `Replace` patch to a task's context) was *valid* JSON, unlike its
+`context_merge_json` sibling, which additionally checks it's an object. Storing a non-object value this
+way -- an array, `null`, a bare string -- planted a landmine: the next time that task's linked run
+transitioned to `in_progress`, `run_task_status_sync.rs`'s `compute_next_task_execution_context` would
+panic on `.as_object_mut().expect(...)`, crashing an otherwise-unrelated `create_run` (or any other
+run-status-changing) call.
+
+# Scope
+
+- `src/internal/service/rpc.rs`: `update_team_task` now rejects a non-object `context_json` with
+  `invalid_argument("context_json must be a JSON object")`, mirroring the existing
+  `context_merge_json` check.
+- `src/team/manager/run_task_status_sync.rs`: `compute_next_task_execution_context` no longer assumes
+  its input is an object. If the stored context isn't one, it starts from `{}` instead of panicking.
+
+# Key Decisions
+
+- **Fixed both the ingestion gap and the panic itself**, not just one. The RPC-layer validation closes
+  the only known way to write a non-object context, but `TeamManager::update_task_with_context` (the
+  underlying manager API `resolve_task_context_patch` sits behind) has no such guard of its own, and
+  `TeamTaskContextPatch::Replace` is a `pub` variant any future caller could construct without going
+  through the RPC layer at all. Making the run-sync path tolerate a non-object context defends against
+  both that and any row that predates this fix, without needing to push the same validation into every
+  current and future caller of the manager API.
+- Self-healing to `{}` (rather than, say, leaving a non-object context in place and skipping the
+  attempt-number bump) matches this file's existing philosophy for corrupted/unexpected stored data
+  (`sync_linked_task_status_tx` already does `unwrap_or_else(|_| json!({}))` on a JSON *parse* failure a
+  few lines up) -- this closes the matching gap for a value that parses fine but has the wrong shape.
+
+# Validation
+
+- New `internal_grpc_team_task_update_rejects_non_object_context_json` (`context_tasks.rs`) asserts an
+  array, `null`, and a string are all rejected with `InvalidArgument`.
+- New `create_run_does_not_panic_when_linked_task_context_is_not_an_object` (`task_cases.rs`)
+  reproduces the exact original bug end-to-end: bypasses the RPC-layer validation via the manager API
+  directly (simulating a row that predates this fix), then calls `create_run` linking that task and
+  asserts it completes without panicking, with the task correctly transitioning to `in_progress` and the
+  self-healed context still tracking `execution.attempt_number`. Confirmed this test panics with the
+  original message (`team task context should always be a JSON object`) when the
+  `run_task_status_sync.rs` fix is reverted.
+- `cargo test --lib team::manager::tests::task_cases` (14 passed),
+  `cargo test --lib internal::service::tests::context_tasks` (13 passed).
+- `cargo test --lib team::` (211 passed), `cargo test --lib internal::` (68 passed) -- no regressions.
+- `cargo test --lib` -- 765 passed; 2 pre-existing `state::tests::*` failures (unrelated
+  `lance-namespace-impls` panic) confirmed present on `main` before this change.
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- The other findings from the same 2026-08-17 Team-subsystem review round remain open, tracked in
+  `docs/todo.md`'s Agent Team Correctness item.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -228,6 +228,26 @@ Main shape:
   `webidl.util.markAsUncloneable is not a function` -- jsdom 30 explicitly requires Node >=22, and the
   `Web`/`Web E2E`/`Web E2E Mobile` jobs were still pinned to Node 20 (`userdocs.yml`'s unrelated
   Docusaurus build stays on Node 20, out of scope). Bumped those three jobs to Node 22.
+- A code-only review of the Team subsystem (Task/Run/Step lifecycle, goal-lease/fork concurrency,
+  mailbox, remote relay, permission review, actor protocol) found `task_updates.rs`'s `team_tasks`
+  writes had no optimistic-concurrency guard, `release_task_goal_in_tx` released whatever lease was
+  active rather than the specific generation observed, and `claim_task_goal_in_tx`/
+  `claim_execution_entity` decided claimability in Rust from a stale read but wrote unconditionally --
+  all three now guarded via the existing `ControlStore` idiom. Fixing this surfaced a real, separate bug:
+  writing `team_tasks.updated_at` from a plain second-granularity `now()` let two same-second writes
+  collide and silently defeat the new CAS guard; every writer of that column now writes
+  `MAX(updated_at + 1, now())` so it's strictly monotonic regardless of which function touches it. The
+  same review also found permission-review's "current reviewer" was resolved two different ways --
+  idle-aware at dispatch time, idle-*unaware* (always the first candidate) when re-derived at approval
+  time because the persisted target hadn't landed yet -- letting the wrong actor approve/deny a review
+  it never received; the approval-time fallback is now removed entirely (fail closed on no persisted
+  target) rather than trying to duplicate dispatch's idle-check machinery. `update_task`'s gRPC
+  `context_json` (`Replace` patch) only validated it was *valid* JSON, unlike its `context_merge_json`
+  sibling which checks the shape -- a non-object value stored this way panicked the next unrelated
+  run-status-changing request; now rejected at the RPC boundary, and the consuming
+  `run_task_status_sync.rs` code self-heals instead of panicking as defense-in-depth for any
+  already-corrupted row. Three other findings from the same review remain open in a new Agent Team
+  Correctness `todo.md` item.
 
 Start with:
 
@@ -247,6 +267,9 @@ Start with:
 - `2026-08-17-pwa-icon-borrowed-slock-mark-fix.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 - `2026-08-17-ci-web-node22-for-jsdom30.md`
+- `2026-08-17-goal-lease-cas-hardening.md`
+- `2026-08-17-permission-review-reviewer-target-consistency.md`
+- `2026-08-17-task-context-json-shape-validation.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,6 +101,33 @@ Stable contracts:
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
 
+## Agent Team Correctness
+
+- [ ] `P1` Close out the remaining findings from a 2026-08-17 code-only review of the Team subsystem
+  (Task/Run/Step lifecycle, mailbox, remote relay/permission review, actor protocol): a caller can set
+  `payload.requires_user_visible_reply: false` on a human-to-agent mailbox message to silently disable
+  the system's reply-obligation tracking for it, since normalization only backfills the field when absent
+  instead of enforcing the server-computed value for human-originated messages; reply-obligation "credit"
+  matching keys only on `(agent_actor_id, human_actor_id)` and consumes credits newest-first, so replying
+  to an older still-open request can incorrectly close a newer, unrelated one instead; transfer/escalate/
+  takeover (`reassign_reply_required_message`) has no guard on the source message's handling disposition
+  in its `UPDATE` (unlike the sibling `triage_message_impl`) and inserts the reassigned message with
+  `idempotency_key = NULL`, so a concurrent double-reassign can duplicate it; the SQLite index-repair
+  path (`message_index_projection.rs`) silently coerces unparseable `payload_json`/`input_json` to
+  `Value::Null`/defaults with no logging, so a corrupted authority row loses its conversation/task linkage
+  during a rebuild with the repair report still claiming success. Three findings from the same review are
+  fixed separately: `task_updates.rs`'s missing optimistic-concurrency guard on `team_tasks` writes,
+  `release_task_goal_in_tx` releasing whatever lease is active instead of the specific generation
+  observed, and `claim_task_goal_in_tx`/`claim_execution_entity`'s check-then-act upserts, see
+  [journal/2026-08-17-goal-lease-cas-hardening.md](journal/2026-08-17-goal-lease-cas-hardening.md);
+  the permission-review reviewer-selection inconsistency between dispatch time and approval time, see
+  [journal/2026-08-17-permission-review-reviewer-target-consistency.md](journal/2026-08-17-permission-review-reviewer-target-consistency.md);
+  `update_task`'s gRPC `context_json` (`Replace` patch) accepting non-object JSON and the resulting
+  `run_task_status_sync.rs` panic landmine, see
+  [journal/2026-08-17-task-context-json-shape-validation.md](journal/2026-08-17-task-context-json-shape-validation.md).
+  Evidence for the rest: this review round has no dedicated journal entry yet -- write one when starting
+  on the next item from this list.
+
 ## Message Storage
 
 - [x] `P1` Complete the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). SQLite authority rows now rebuild the conversation, actor mailbox, run-event, and agent-event projections; guarded ordered reads compare high-water marks and exact SQLite page IDs, fall back on any gap, and queue a startup worker for asynchronous repair. Orphan/prune helpers remain diagnostics and explicit maintenance only. Keep normal SQLite bodies readable until a later authority-cutover decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).

--- a/src/internal/service/rpc.rs
+++ b/src/internal/service/rpc.rs
@@ -579,6 +579,13 @@ impl TeamInternalControl for TeamInternalControlService {
             .as_deref()
             .map(|raw| parse_json_required(raw, "context_json"))
             .transpose()?;
+        if let Some(context_json) = context_json.as_ref()
+            && !context_json.is_object()
+        {
+            return Err(Status::invalid_argument(
+                "context_json must be a JSON object",
+            ));
+        }
         let context_merge_json = payload
             .context_merge_json
             .as_deref()

--- a/src/internal/service/tests/context_tasks.rs
+++ b/src/internal/service/tests/context_tasks.rs
@@ -463,6 +463,85 @@ async fn internal_grpc_team_task_update_rolls_back_note_when_metadata_patch_fail
 }
 
 #[tokio::test]
+async fn internal_grpc_team_task_update_rejects_non_object_context_json() {
+    // `context_json` (a full Replace patch) previously only validated it was *valid* JSON, unlike its
+    // `context_merge_json` sibling which checks the shape too. A non-object value stored this way would
+    // later panic an unrelated run-status-changing request in `compute_next_task_execution_context`'s
+    // `.as_object_mut().expect(...)` the next time that task's run transitioned to `in_progress`.
+    let state = build_test_state().await;
+    let run = create_team_run(&state).await;
+    let authz = build_authz();
+    let token = issue_token(
+        &authz,
+        InternalRole::Coordinator,
+        Some("planner"),
+        Some(&run.id),
+    );
+    let service = TeamInternalControlService::new(
+        control_deps(&state),
+        authz,
+        super::InternalGrpcSecurityMode::Disabled,
+        std::env::temp_dir(),
+        "bootstrap-token".to_string(),
+    );
+
+    let created = TeamInternalControl::create_team_task(
+        &service,
+        authenticated_request(
+            CreateTeamTaskRequest {
+                team_id: run.team_id.clone(),
+                actor_id: "planner".to_string(),
+                title: "Reject non-object context_json".to_string(),
+                status: "open".to_string(),
+                priority: "high".to_string(),
+                assigned_member_id: "planner".to_string(),
+                topic: "non-object-context".to_string(),
+                context_json: json!({"goal":"stay an object"}).to_string(),
+            },
+            &token,
+        ),
+    )
+    .await
+    .expect("create team task")
+    .into_inner();
+    let created_json: serde_json::Value =
+        serde_json::from_str(&created.output_json).expect("decode created task");
+    let task_id = created_json["task"]["id"]
+        .as_str()
+        .expect("created task id")
+        .to_string();
+
+    for non_object in [json!(["not", "an", "object"]), json!(null), json!("text")] {
+        let err = TeamInternalControl::update_team_task(
+            &service,
+            authenticated_request(
+                UpdateTeamTaskRequest {
+                    team_id: run.team_id.clone(),
+                    actor_id: "planner".to_string(),
+                    task_id: task_id.clone(),
+                    status: None,
+                    assigned_member_id: None,
+                    clear_assigned_member_id: false,
+                    priority: None,
+                    context_json: Some(non_object.to_string()),
+                    context_merge_json: None,
+                    note_kind: None,
+                    note_text: None,
+                },
+                &token,
+            ),
+        )
+        .await
+        .expect_err("non-object context_json should be rejected");
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(
+            err.message().contains("context_json must be a JSON object"),
+            "unexpected error for {non_object}: {err}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn internal_grpc_team_channel_controls_are_wire_compatible() {
     let state = build_test_state().await;
     let run = create_team_run(&state).await;

--- a/src/team/manager/run_task_status_sync.rs
+++ b/src/team/manager/run_task_status_sync.rs
@@ -60,7 +60,14 @@ fn compute_next_task_execution_context(
         return None;
     }
 
-    let mut next_context = current_context.clone();
+    // `context_json` is meant to always be a JSON object, and the write path validates that -- but this
+    // defends against any row that predates that validation (or reached this shape some other way)
+    // rather than panicking and taking down every other in-flight run-status sync with it.
+    let mut next_context = if current_context.is_object() {
+        current_context.clone()
+    } else {
+        serde_json::json!({})
+    };
     let next_attempt_number = current_context
         .pointer("/execution/attempt_number")
         .and_then(Value::as_i64)
@@ -69,7 +76,7 @@ fn compute_next_task_execution_context(
 
     let context_obj = next_context
         .as_object_mut()
-        .expect("team task context should always be a JSON object");
+        .expect("next_context was just constructed as a JSON object");
     let execution = context_obj
         .entry("execution".to_string())
         .or_insert_with(|| serde_json::json!({}));

--- a/src/team/manager/tests/task_cases.rs
+++ b/src/team/manager/tests/task_cases.rs
@@ -833,6 +833,75 @@ async fn update_task_context_rejects_execution_plan_with_unknown_member() {
 }
 
 #[tokio::test]
+async fn create_run_does_not_panic_when_linked_task_context_is_not_an_object() {
+    // The internal gRPC handler now rejects a non-object `context_json` Replace patch outright (see
+    // `internal_grpc_team_task_update_rejects_non_object_context_json`), but a row that predates that
+    // validation could still have a non-object context stored. `compute_next_task_execution_context`
+    // used to panic on such a row via `.as_object_mut().expect(...)` the moment its task's run
+    // transitioned to `in_progress` -- crashing an otherwise-unrelated `create_run` call. It must now
+    // self-heal instead.
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "non-object-context-team".to_string(),
+            description: None,
+            spec: json!({
+                "entrypoint":"coordinator",
+                "members":[{"member_id":"coordinator","role":"coordinator"}]
+            }),
+        })
+        .await
+        .expect("create team");
+
+    let (task, _) = manager
+        .create_task(
+            &team.id,
+            "Task with corrupted context",
+            "coordinator",
+            json!({"repo":"agenthub"}),
+            "group_chat",
+            Some("corrupted-context"),
+        )
+        .await
+        .expect("create task");
+
+    // Bypass the RPC-layer object-shape validation (the manager API itself has no such guard) to
+    // reproduce a row that was already corrupted before that validation existed.
+    manager
+        .update_task_with_context(
+            &task.id,
+            None,
+            TeamTaskAssignmentUpdate::Unchanged,
+            Some(TeamTaskContextPatch::Replace(json!([
+                "not", "an", "object"
+            ]))),
+        )
+        .await
+        .expect("manager API does not itself enforce the object shape");
+    let corrupted = manager.get_task(&task.id).await.expect("reload task");
+    assert!(
+        !corrupted.context.is_object(),
+        "context must actually be non-object for this test to be meaningful"
+    );
+
+    let run = manager
+        .create_run(&team.id, None, json!({"task_id": task.id}))
+        .await
+        .expect("create run linked to a task with a non-object context must not panic");
+
+    let synced_task = manager.get_task(&task.id).await.expect("reload task");
+    assert_eq!(synced_task.status, TeamTaskStatus::InProgress);
+    assert_eq!(
+        synced_task.context.pointer("/execution/attempt_number"),
+        Some(&json!(1)),
+        "the self-healed context should still track the attempt number"
+    );
+    assert_eq!(run.status, TeamRunStatus::Submitted);
+}
+
+#[tokio::test]
 async fn list_tasks_with_query_filters_by_run_topic_and_owner() {
     let db = setup_test_db().await;
     let manager = TeamManager::new(db.clone());


### PR DESCRIPTION
## Summary

- `update_team_task`'s gRPC handler only validated that `context_json` (a full `Replace` patch to a task's context) was *valid* JSON, unlike its `context_merge_json` sibling, which also checks it's an object.
- Storing a non-object value this way — an array, `null`, a bare string — planted a landmine: the next time that task's linked run transitioned to `in_progress`, `run_task_status_sync.rs`'s `compute_next_task_execution_context` panicked on `.as_object_mut().expect(...)`, crashing an otherwise-unrelated `create_run` call.
- `update_team_task` now rejects a non-object `context_json` with the same `invalid_argument` the merge patch already uses.
- `compute_next_task_execution_context` no longer assumes its input is an object either, as defense-in-depth for any row that predates this validation — the underlying `TeamManager` API has no shape guard of its own, and `TeamTaskContextPatch::Replace` is a `pub` variant any future caller could construct without going through this RPC handler.

## Test plan

- [x] New `internal_grpc_team_task_update_rejects_non_object_context_json` (`context_tasks.rs`) — asserts an array, `null`, and a string are all rejected with `InvalidArgument`
- [x] New `create_run_does_not_panic_when_linked_task_context_is_not_an_object` (`task_cases.rs`) — reproduces the exact original bug end-to-end (bypasses RPC validation via the manager API directly, simulating a pre-existing corrupted row, then calls `create_run` and asserts no panic). Confirmed this test panics with the original message when the `run_task_status_sync.rs` fix is reverted.
- [x] `cargo test --lib team::manager::tests::task_cases` (14 passed), `cargo test --lib internal::service::tests::context_tasks` (13 passed)
- [x] `cargo test --lib team::` (211 passed), `cargo test --lib internal::` (70 passed) — no regressions
- [x] `cargo test --lib` — 765 passed; 2 pre-existing `state::tests::*` failures (unrelated `lance-namespace-impls` panic, confirmed present on `main` before this change)
- [x] `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)