### PR TITLE
fix(team-actor): force reply-obligation tracking for human-to-agent messages

### DIFF
--- a/crates/agenthub-team-actor/src/message.rs
+++ b/crates/agenthub-team-actor/src/message.rs
@@ -370,15 +370,21 @@ fn infer_actor_message_reply_target(payload: &Value) -> Option<Value> {
 }
 
 fn infer_requires_user_visible_reply(
-    source_kind: &ActorMessageSourceKind,
+    from_actor_id: &str,
     to_actor_id: &str,
     payload: &Value,
 ) -> bool {
-    if let Some(explicit) = actor_message_payload_requires_user_visible_reply(payload) {
-        return explicit;
-    }
-    matches!(source_kind, ActorMessageSourceKind::Human)
+    // A human message to an agent must always be tracked until visibly answered -- this is the
+    // system's own reply-obligation guarantee, not user-facing content, so it must not be
+    // overridable by whatever the caller puts in `payload`. `from_actor_id` (not the payload's
+    // `source_kind`, which itself can be spoofed the same way) is the one signal here that a
+    // sender can't rewrite to claim a different identity than the one it authenticated as.
+    if infer_actor_identity_kind(from_actor_id) == ActorIdentityKind::Human
         && infer_actor_identity_kind(to_actor_id) == ActorIdentityKind::Agent
+    {
+        return true;
+    }
+    actor_message_payload_requires_user_visible_reply(payload).unwrap_or(false)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -402,7 +408,7 @@ pub fn project_actor_message_envelope(
         source_surface: infer_actor_message_source_surface(message_kind, payload),
         reply_target: infer_actor_message_reply_target(payload),
         requires_user_visible_reply: infer_requires_user_visible_reply(
-            &source_kind,
+            from_actor_id,
             to_actor_id,
             payload,
         ),
@@ -936,6 +942,42 @@ mod tests {
                 thread_root_message_id: None,
             }
         );
+    }
+
+    #[test]
+    fn project_actor_message_envelope_rejects_client_suppressed_human_reply_obligation() {
+        // A human-to-agent message must always be tracked until visibly answered, no matter what
+        // the payload claims -- this is the system's own guarantee, not something the sender
+        // controls.
+        let projection = project_actor_message_envelope(
+            "user:alice",
+            "worker-1",
+            &ActorMessageKind::HumanRequest,
+            &json!({
+                "task_id":"task-1",
+                "requires_user_visible_reply": false
+            }),
+        );
+        assert!(projection.requires_user_visible_reply);
+    }
+
+    #[test]
+    fn project_actor_message_envelope_rejects_spoofed_source_kind_alongside_suppressed_reply_obligation()
+     {
+        // Even if the payload also claims a fabricated `source_kind: "agent"` for a message that
+        // actually came from a human `from_actor_id`, the reply obligation must still be forced --
+        // `source_kind` is itself payload-derived and must not be trusted for this decision.
+        let projection = project_actor_message_envelope(
+            "user:alice",
+            "worker-1",
+            &ActorMessageKind::HumanRequest,
+            &json!({
+                "task_id":"task-1",
+                "source_kind": "agent",
+                "requires_user_visible_reply": false
+            }),
+        );
+        assert!(projection.requires_user_visible_reply);
     }
 
     #[test]

--- a/docs/journal/2026-08-17-reply-obligation-client-suppression-fix.md
+++ b/docs/journal/2026-08-17-reply-obligation-client-suppression-fix.md
@@ -1,0 +1,61 @@
+# Summary
+
+A code-only review of the Team subsystem found that any caller of the mailbox send API could set
+`payload.requires_user_visible_reply: false` on a message from a human to an agent, silently disabling
+the system's guarantee that a human message to an agent is tracked until visibly answered.
+`normalize_actor_message_envelope_payload` only *backfilled* this field when absent from the caller's
+payload; an explicit `false` was always honored verbatim. `send_team_run_message`
+(`src/api/teams.rs`) passes the raw client-supplied JSON body straight through to the mailbox layer with
+no field allowlist, so this was reachable from the public HTTP API by any authenticated caller with
+runtime-operate capability, human or agent.
+
+# Scope
+
+- `crates/agenthub-team-actor/src/message.rs`: `infer_requires_user_visible_reply` now checks whether
+  the message is human-to-agent *first*, using `from_actor_id`/`to_actor_id` identity (the "must always
+  be tracked" case), before ever consulting the payload's `requires_user_visible_reply` field. Only when
+  that isn't the case does the caller-supplied value (if present) apply, matching prior behavior for
+  every other combination.
+
+# Key Decisions
+
+- **The check derives "is this from a human" from `from_actor_id`, not from `source_kind`.**
+  `source_kind` is itself payload-derived (`infer_actor_message_source_kind` also trusts an explicit
+  `payload.source_kind` when present) and could otherwise be spoofed the same way in the same request --
+  confirmed with a test that sets both `source_kind: "agent"` and `requires_user_visible_reply: false`
+  on a message whose `from_actor_id` is genuinely human, and asserts the reply obligation still holds.
+  `from_actor_id` is the one signal here a sender can't rewrite to claim a different identity than the
+  one it's actually sending as.
+- **Scoped the fix to human-to-agent only, not "payload can never set this field."** Every other
+  direction (agent-to-agent, agent-to-human) keeps the existing explicit-override behavior unchanged --
+  this is relied on by legitimate internal callers, notably `mailbox_service_escalation.rs`'s
+  reassign/escalate/transfer flow, which re-derives the envelope from the *original* message's
+  `from_actor_id` so a human-originated request correctly keeps requiring tracking across a reassignment
+  hop, without that flow needing its own special-case logic.
+- Considered stripping `requires_user_visible_reply`/`source_kind` from the client payload at the HTTP
+  boundary (`send_team_run_message`) instead. Rejected: that field-stripping approach only protects the
+  one entrypoint it's applied to, and there are multiple current internal callers of
+  `normalize_actor_message_envelope_payload` (mailbox_facade, mailbox_store_delivery, the mailbox
+  escalation flow, a broadcast-forwarding path in `api/teams.rs`) that would each need the same
+  treatment, with any future caller silently missing it. Fixing the shared inference function once
+  closes the gap for all current and future callers uniformly.
+
+# Validation
+
+- New `project_actor_message_envelope_rejects_client_suppressed_human_reply_obligation` and
+  `project_actor_message_envelope_rejects_spoofed_source_kind_alongside_suppressed_reply_obligation`
+  (`message.rs`) in `agenthub-team-actor`. Confirmed both fail with the original code (reverted the fix
+  locally and reran).
+- `cargo test -p agenthub-team-actor` -- 34 passed, including all pre-existing
+  `requires_user_visible_reply` tests unchanged (none of them exercise a human-to-agent message with an
+  explicit `false`, so none needed updating).
+- `cargo test --lib team::` (`agenthub`) -- 211 passed, no regressions.
+- `cargo test --lib` -- 767 passed; 3 pre-existing `state::tests::*` failures (unrelated
+  `lance-namespace-impls` panic) confirmed present on `main` before this change.
+- `cargo clippy --lib --tests -p agenthub` and `-p agenthub-team-actor`, plus `cargo fmt -- --check` for
+  both, clean.
+
+# Follow-Ups
+
+- The other findings from the same 2026-08-17 Team-subsystem review round remain open, tracked in
+  `docs/todo.md`'s Agent Team Correctness item.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -228,6 +228,30 @@ Main shape:
   `webidl.util.markAsUncloneable is not a function` -- jsdom 30 explicitly requires Node >=22, and the
   `Web`/`Web E2E`/`Web E2E Mobile` jobs were still pinned to Node 20 (`userdocs.yml`'s unrelated
   Docusaurus build stays on Node 20, out of scope). Bumped those three jobs to Node 22.
+- A code-only review of the Team subsystem (Task/Run/Step lifecycle, goal-lease/fork concurrency,
+  mailbox, remote relay, permission review, actor protocol) found `task_updates.rs`'s `team_tasks`
+  writes had no optimistic-concurrency guard, `release_task_goal_in_tx` released whatever lease was
+  active rather than the specific generation observed, and `claim_task_goal_in_tx`/
+  `claim_execution_entity` decided claimability in Rust from a stale read but wrote unconditionally --
+  all three now guarded via the existing `ControlStore` idiom. Fixing this surfaced a real, separate bug:
+  writing `team_tasks.updated_at` from a plain second-granularity `now()` let two same-second writes
+  collide and silently defeat the new CAS guard; every writer of that column now writes
+  `MAX(updated_at + 1, now())` so it's strictly monotonic regardless of which function touches it. The
+  same review also found permission-review's "current reviewer" was resolved two different ways --
+  idle-aware at dispatch time, idle-*unaware* (always the first candidate) when re-derived at approval
+  time because the persisted target hadn't landed yet -- letting the wrong actor approve/deny a review
+  it never received; the approval-time fallback is now removed entirely (fail closed on no persisted
+  target) rather than trying to duplicate dispatch's idle-check machinery. `update_task`'s gRPC
+  `context_json` (`Replace` patch) only validated it was *valid* JSON, unlike its `context_merge_json`
+  sibling which checks the shape -- a non-object value stored this way panicked the next unrelated
+  run-status-changing request; now rejected at the RPC boundary, and the consuming
+  `run_task_status_sync.rs` code self-heals instead of panicking as defense-in-depth for any
+  already-corrupted row. A caller could also set `payload.requires_user_visible_reply: false` on a
+  human-to-agent mailbox message to silently disable the system's reply-obligation tracking for it, since
+  normalization only backfilled the field when absent; the human-to-agent case is now forced regardless
+  of payload, derived from `from_actor_id` (not the payload's own spoofable `source_kind`) so it can't be
+  defeated by also faking the source. Two other findings from the same review remain open in a new Agent
+  Team Correctness `todo.md` item.
 
 Start with:
 
@@ -247,6 +271,10 @@ Start with:
 - `2026-08-17-pwa-icon-borrowed-slock-mark-fix.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 - `2026-08-17-ci-web-node22-for-jsdom30.md`
+- `2026-08-17-goal-lease-cas-hardening.md`
+- `2026-08-17-permission-review-reviewer-target-consistency.md`
+- `2026-08-17-task-context-json-shape-validation.md`
+- `2026-08-17-reply-obligation-client-suppression-fix.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,6 +101,34 @@ Stable contracts:
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
 
+## Agent Team Correctness
+
+- [ ] `P1` Close out the remaining findings from a 2026-08-17 code-only review of the Team subsystem
+  (Task/Run/Step lifecycle, mailbox, remote relay/permission review, actor protocol): reply-obligation
+  "credit" matching keys only on `(agent_actor_id, human_actor_id)` and consumes credits newest-first, so
+  replying to an older still-open request can incorrectly close a newer, unrelated one instead;
+  transfer/escalate/takeover (`reassign_reply_required_message`) has no guard on the source message's
+  handling disposition in its `UPDATE` (unlike the sibling `triage_message_impl`) and inserts the
+  reassigned message with `idempotency_key = NULL`, so a concurrent double-reassign can duplicate it; the
+  SQLite index-repair path (`message_index_projection.rs`) silently coerces unparseable
+  `payload_json`/`input_json` to `Value::Null`/defaults with no logging, so a corrupted authority row
+  loses its conversation/task linkage during a rebuild with the repair report still claiming success.
+  Four findings from the same review are fixed separately: `task_updates.rs`'s missing
+  optimistic-concurrency guard on `team_tasks` writes, `release_task_goal_in_tx` releasing whatever lease
+  is active instead of the specific generation observed, and `claim_task_goal_in_tx`/
+  `claim_execution_entity`'s check-then-act upserts, see
+  [journal/2026-08-17-goal-lease-cas-hardening.md](journal/2026-08-17-goal-lease-cas-hardening.md);
+  the permission-review reviewer-selection inconsistency between dispatch time and approval time, see
+  [journal/2026-08-17-permission-review-reviewer-target-consistency.md](journal/2026-08-17-permission-review-reviewer-target-consistency.md);
+  `update_task`'s gRPC `context_json` (`Replace` patch) accepting non-object JSON and the resulting
+  `run_task_status_sync.rs` panic landmine, see
+  [journal/2026-08-17-task-context-json-shape-validation.md](journal/2026-08-17-task-context-json-shape-validation.md);
+  a caller being able to set `payload.requires_user_visible_reply: false` on a human-to-agent mailbox
+  message to silently disable its reply-obligation tracking, see
+  [journal/2026-08-17-reply-obligation-client-suppression-fix.md](journal/2026-08-17-reply-obligation-client-suppression-fix.md).
+  Evidence for the rest: this review round has no dedicated journal entry yet -- write one when starting
+  on the next item from this list.
+
 ## Message Storage
 
 - [x] `P1` Complete the RocksDB `cf_index` authority-derived repair path, per [features/message-storage-tiering.md](features/message-storage-tiering.md). SQLite authority rows now rebuild the conversation, actor mailbox, run-event, and agent-event projections; guarded ordered reads compare high-water marks and exact SQLite page IDs, fall back on any gap, and queue a startup worker for asynchronous repair. Orphan/prune helpers remain diagnostics and explicit maintenance only. Keep normal SQLite bodies readable until a later authority-cutover decision. Notes: [journal/2026-06-10-message-store-foundation-crate.md](journal/2026-06-10-message-store-foundation-crate.md).


### PR DESCRIPTION
## Summary

- Any caller of the mailbox send API could set `payload.requires_user_visible_reply: false` on a message from a human to an agent, silently disabling the system's guarantee that a human message to an agent is tracked until visibly answered. `normalize_actor_message_envelope_payload` only backfilled the field when absent — an explicit `false` was always honored verbatim.
- The raw client payload reaches this normalization with no field allowlist (e.g. `send_team_run_message` in `src/api/teams.rs`), so this was reachable by any authenticated caller with runtime-operate capability.
- `infer_requires_user_visible_reply` now checks whether the message is human-to-agent *first*, using `from_actor_id`/`to_actor_id` identity — not the payload's own `source_kind` field, which is itself payload-overridable and could be spoofed the same way in the same request (confirmed with a test that fakes both fields at once). Only when the message isn't human-to-agent does the caller-supplied value still apply, unchanged from before.
- This keeps every other direction (agent-to-agent, agent-to-human) and the mailbox escalation/reassignment flow's reliance on the explicit override working exactly as before — none of the existing tests needed updating.

## Test plan

- [x] New `project_actor_message_envelope_rejects_client_suppressed_human_reply_obligation` and `project_actor_message_envelope_rejects_spoofed_source_kind_alongside_suppressed_reply_obligation` (`message.rs`). Confirmed both fail with the original code (reverted the fix locally and reran).
- [x] `cargo test -p agenthub-team-actor` — 34 passed, all pre-existing `requires_user_visible_reply` tests unchanged
- [x] `cargo test --lib team::` (`agenthub`) — 210 passed, no regressions
- [x] `cargo test --lib` — 767 passed; 3 pre-existing `state::tests::*` failures (unrelated `lance-namespace-impls` panic, confirmed present on `main` before this change)
- [x] `cargo clippy --lib --tests -p agenthub` and `-p agenthub-team-actor`, plus `cargo fmt -- --check` for both, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)