### PR TITLE
fix(team): scope reply-obligation credit matching by thread/conversation

### DIFF
--- a/docs/journal/2026-08-17-reply-obligation-thread-scoped-matching.md
+++ b/docs/journal/2026-08-17-reply-obligation-thread-scoped-matching.md
@@ -1,0 +1,60 @@
+# Summary
+
+A code-only review of the Team subsystem found that reply-obligation "credit" matching -- the mechanism
+that decides which pending human-to-agent messages a visible reply satisfies -- only keyed on
+`(agent_actor_id, human_actor_id)`, ignoring which thread or conversation a message actually belonged
+to. Combined with the matching walk processing messages newest-to-oldest, this meant a reply in one
+conversation could incorrectly close an unrelated, still-open obligation in a *different* conversation
+with the same agent/human pair, while leaving the message the reply was actually answering marked open.
+
+# Scope
+
+- `src/team/manager/mailbox.rs`: `ReplyActorPairKey` gained a `thread_scope: Option<ReplyThreadScope>`
+  field (`Thread(i64)` from `thread_root_message_id`, else `Conversation(String)` from
+  `conversation_id`, else `None` for untagged messages), plus a `reply_thread_scope` helper to derive it.
+- `src/team/manager/mailbox_reply_obligation_payloads.rs`, `mailbox_reply_obligations.rs`: all three
+  `ReplyActorPairKey` constructors now populate `thread_scope` from the message's own
+  `conversation_id`/`thread_root_message_id`.
+- `src/team/manager/mailbox_reply_obligation_summary.rs`: credit lookup/consumption is now two-tier via
+  new `consume_reply_credit`/`has_reply_credit` helpers -- an exact thread-scoped match is tried first;
+  only when the *obligation* is thread-scoped and has no scoped credit available does it fall back to
+  the untagged (`thread_scope: None`) pool, so an untagged reply can still satisfy a scoped obligation
+  (preserving prior behavior for the common unthreaded case), but a reply that *does* declare a thread
+  can never satisfy an obligation in a different one.
+
+# Key Decisions
+
+- **Two-tier matching, not a single stricter key.** The first implementation just added `thread_scope`
+  to the key with no fallback, which broke a real, previously-working case: a plain agent reply with no
+  `conversation_id`/`thread_root_message_id` of its own no longer matched a thread-scoped obligation at
+  all (caught by an existing integration test, `team_run_messages_api_triage_resolves_open_reply_obligation`,
+  which exercises exactly this "untagged reply closes a tagged obligation" scenario). An untagged reply
+  carries no signal about *which* thread it answers, so falling back to the old pair-only pool for that
+  specific ambiguous case is the correct, backward-compatible choice -- the fix only needs to stop a
+  reply that *does* declare a thread from leaking into an unrelated one, not to require every reply to
+  declare a thread.
+- Left the LIFO-within-a-thread behavior (matching the most recently seen still-open obligation first)
+  unchanged. The review's described failure was specifically about *unrelated* (different-thread)
+  obligations being closed by the wrong reply; multiple concurrently-open, unanswered obligations within
+  the *same* thread is a narrower, lower-severity scenario not addressed here.
+
+# Validation
+
+- New `reply_obligation_credit_matching_is_scoped_per_thread_not_just_actor_pair`
+  (`mailbox_basic_cases.rs`): a human sends two reply-required messages to the same agent in two
+  different conversations; a reply tagged to the first conversation closes only that one, leaving the
+  second's obligation open. Confirmed this test fails (reproducing the original bug exactly) with
+  `thread_scope` reverted to always `None`.
+- `team_run_messages_api_triage_resolves_open_reply_obligation` (`api/teams/tests_core.rs`, pre-existing)
+  -- broke when `thread_scope` was added without the loose-pool fallback (an untagged reply against a
+  `conversation_id`-tagged obligation), now passes again with the two-tier lookup.
+- `cargo test --lib team::manager::tests::mailbox_basic_cases` -- 18 passed.
+- `cargo test --lib team::` -- 211 passed; `cargo test --lib` -- 766 passed, 3 pre-existing
+  `state::tests::*` failures (unrelated `lance-namespace-impls` panic) confirmed present on `main`
+  before this change.
+- `cargo clippy --lib --tests -p agenthub` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+- The other findings from the same 2026-08-17 Team-subsystem review round remain open, tracked in
+  `docs/todo.md`'s Agent Team Correctness item.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -228,6 +228,13 @@ Main shape:
   `webidl.util.markAsUncloneable is not a function` -- jsdom 30 explicitly requires Node >=22, and the
   `Web`/`Web E2E`/`Web E2E Mobile` jobs were still pinned to Node 20 (`userdocs.yml`'s unrelated
   Docusaurus build stays on Node 20, out of scope). Bumped those three jobs to Node 22.
+- A code-only Team-subsystem review found reply-obligation "credit" matching keyed only on
+  `(agent_actor_id, human_actor_id)`, ignoring which thread/conversation a message belonged to; a reply
+  in one conversation could incorrectly close an unrelated open obligation in a different one. Fixed with
+  a two-tier key (exact thread/conversation scope first, untagged-reply loose-pool fallback) so a reply
+  that declares a thread can never satisfy an obligation in a different one, while plain untagged replies
+  keep working as before. Other findings from the same review round are tracked in the Backend
+  Correctness `todo.md` item.
 
 Start with:
 
@@ -247,6 +254,7 @@ Start with:
 - `2026-08-17-pwa-icon-borrowed-slock-mark-fix.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 - `2026-08-17-ci-web-node22-for-jsdom30.md`
+- `2026-08-17-reply-obligation-thread-scoped-matching.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -100,6 +100,24 @@ Stable contracts:
   [journal/2026-08-16-bootstrap-token-constant-time-compare.md](journal/2026-08-16-bootstrap-token-constant-time-compare.md).
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
+- [ ] `P1` Close out the remaining findings from the 2026-08-17 code-only Team-subsystem review:
+  `reassign_reply_required_message` (transfer/escalate/takeover in `mailbox_service_escalation.rs`) has
+  no CAS guard on the source message's handling disposition in its `UPDATE`, unlike `triage_message_impl`,
+  and inserts the reassigned message with `idempotency_key = NULL`, letting a concurrent double-reassign
+  duplicate it; `message_index_projection.rs` silently coerces unparseable `payload_json`/`input_json` to
+  `Value::Null`/defaults during index rebuild with no logging, hiding real data corruption as an empty
+  message. Five findings from the same review are fixed separately: goal-lease CAS hardening across
+  `task_updates.rs`/`teamspace.rs`/`run_task_status_sync.rs`, see
+  [journal/2026-08-17-goal-lease-cas-hardening.md](journal/2026-08-17-goal-lease-cas-hardening.md);
+  permission-review reviewer-target consistency (removing the idle-unaware fallback resolver), see
+  [journal/2026-08-17-permission-review-reviewer-target-consistency.md](journal/2026-08-17-permission-review-reviewer-target-consistency.md);
+  `context_json`/`context_merge_json` shape validation, see
+  [journal/2026-08-17-task-context-json-shape-validation.md](journal/2026-08-17-task-context-json-shape-validation.md);
+  the client-spoofable `requires_user_visible_reply` suppression via `source_kind`, see
+  [journal/2026-08-17-reply-obligation-client-suppression-fix.md](journal/2026-08-17-reply-obligation-client-suppression-fix.md);
+  and the pair-only, thread-unaware reply-obligation credit matching that let a reply in one conversation
+  incorrectly close an unrelated obligation in another, see
+  [journal/2026-08-17-reply-obligation-thread-scoped-matching.md](journal/2026-08-17-reply-obligation-thread-scoped-matching.md).
 
 ## Message Storage
 

--- a/src/team/manager/mailbox.rs
+++ b/src/team/manager/mailbox.rs
@@ -72,6 +72,26 @@ pub(crate) struct ResolvedMailboxRecipientDelivery {
 pub(super) struct ReplyActorPairKey {
     pub(super) agent_actor_id: String,
     pub(super) human_actor_id: String,
+    /// Scopes credit-matching to the specific thread/conversation a message belongs to (preferring
+    /// `thread_root_message_id`, falling back to `conversation_id`) so a reply in one thread can't
+    /// close an unrelated obligation from the same agent/human pair in a different thread. `None` for
+    /// unthreaded mailbox messages, where the pair alone is the best signal available.
+    pub(super) thread_scope: Option<ReplyThreadScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum ReplyThreadScope {
+    Thread(i64),
+    Conversation(String),
+}
+
+pub(super) fn reply_thread_scope(
+    conversation_id: Option<&str>,
+    thread_root_message_id: Option<i64>,
+) -> Option<ReplyThreadScope> {
+    thread_root_message_id
+        .map(ReplyThreadScope::Thread)
+        .or_else(|| conversation_id.map(|value| ReplyThreadScope::Conversation(value.to_string())))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/team/manager/mailbox_reply_obligation_payloads.rs
+++ b/src/team/manager/mailbox_reply_obligation_payloads.rs
@@ -1,6 +1,6 @@
 use super::mailbox::{
     MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_IGNORED, MAILBOX_RESOLUTION_TAKEN_OVER,
-    MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+    MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey, reply_thread_scope,
 };
 use super::mailbox_payloads::is_human_actor_id;
 use super::mailbox_reply_obligation_snapshot_conversion::resolve_canonical_chat_reply_from_snapshot;
@@ -24,6 +24,10 @@ pub(super) fn reply_actor_pair_for_inbound_obligation_snapshot(
     Some(ReplyActorPairKey {
         agent_actor_id: message.to_actor_id.clone(),
         human_actor_id: message.from_actor_id.clone(),
+        thread_scope: reply_thread_scope(
+            message.conversation_id.as_deref(),
+            message.thread_root_message_id,
+        ),
     })
 }
 
@@ -42,6 +46,10 @@ pub(super) fn reply_actor_pair_for_visible_reply_snapshot(
     Some(ReplyActorPairKey {
         agent_actor_id: message.from_actor_id.clone(),
         human_actor_id: message.to_actor_id.clone(),
+        thread_scope: reply_thread_scope(
+            message.conversation_id.as_deref(),
+            message.thread_root_message_id,
+        ),
     })
 }
 

--- a/src/team/manager/mailbox_reply_obligation_summary.rs
+++ b/src/team/manager/mailbox_reply_obligation_summary.rs
@@ -11,6 +11,57 @@ use super::mailbox_reply_obligation_snapshots::ReplyObligationMessageSnapshot;
 pub(super) use super::mailbox_reply_obligation_snapshots::load_reply_obligation_message_snapshots_on_executor;
 use crate::team::TeamActorMessageRecord;
 
+/// The untagged fallback bucket for a pair key: replies that carry no thread/conversation info of
+/// their own land here, and a thread-scoped obligation may still draw on it (but never on another
+/// thread's scoped credits) -- this keeps plain, unthreaded replies working exactly as before while
+/// still preventing a reply that *does* declare a thread from satisfying an obligation in a different
+/// one.
+fn loose_pair_key(pair_key: &ReplyActorPairKey) -> ReplyActorPairKey {
+    ReplyActorPairKey {
+        agent_actor_id: pair_key.agent_actor_id.clone(),
+        human_actor_id: pair_key.human_actor_id.clone(),
+        thread_scope: None,
+    }
+}
+
+/// Consumes one credit for `pair_key`, preferring an exact thread-scoped match and falling back to
+/// the untagged pool only when the obligation itself is thread-scoped (an untagged obligation already
+/// uses the loose pool as its primary key).
+fn consume_reply_credit(
+    credits: &mut HashMap<ReplyActorPairKey, i64>,
+    pair_key: &ReplyActorPairKey,
+) -> bool {
+    if let Some(count) = credits.get_mut(pair_key)
+        && *count > 0
+    {
+        *count -= 1;
+        return true;
+    }
+    if pair_key.thread_scope.is_some() {
+        let loose_key = loose_pair_key(pair_key);
+        if let Some(count) = credits.get_mut(&loose_key)
+            && *count > 0
+        {
+            *count -= 1;
+            return true;
+        }
+    }
+    false
+}
+
+fn has_reply_credit(
+    credits: &HashMap<ReplyActorPairKey, i64>,
+    pair_key: &ReplyActorPairKey,
+) -> bool {
+    if credits.get(pair_key).is_some_and(|count| *count > 0) {
+        return true;
+    }
+    pair_key.thread_scope.is_some()
+        && credits
+            .get(&loose_pair_key(pair_key))
+            .is_some_and(|count| *count > 0)
+}
+
 pub(super) fn summarize_open_reply_obligations_from_snapshots(
     messages: &[ReplyObligationMessageSnapshot],
 ) -> TeamReplyObligationSummary {
@@ -28,10 +79,7 @@ pub(super) fn summarize_open_reply_obligations_from_snapshots(
         if reply_obligation_snapshot_is_terminal(message) {
             continue;
         }
-        if let Some(credits) = visible_reply_credits.get_mut(&pair_key)
-            && *credits > 0
-        {
-            *credits -= 1;
+        if consume_reply_credit(&mut visible_reply_credits, &pair_key) {
             continue;
         }
         *summary
@@ -75,24 +123,14 @@ pub(super) fn has_visible_reply_credit_for_message(
         };
         if reply_obligation_snapshot_is_terminal(message) {
             if message.message_id == target_message_id {
-                return visible_reply_credits
-                    .get(&pair_key)
-                    .is_some_and(|credits| *credits > 0);
+                return has_reply_credit(&visible_reply_credits, &pair_key);
             }
-            continue;
-        }
-        if let Some(credits) = visible_reply_credits.get_mut(&pair_key)
-            && *credits > 0
-        {
-            if message.message_id == target_message_id {
-                return true;
-            }
-            *credits -= 1;
             continue;
         }
         if message.message_id == target_message_id {
-            return false;
+            return has_reply_credit(&visible_reply_credits, &pair_key);
         }
+        consume_reply_credit(&mut visible_reply_credits, &pair_key);
     }
     false
 }

--- a/src/team/manager/mailbox_reply_obligations.rs
+++ b/src/team/manager/mailbox_reply_obligations.rs
@@ -2,7 +2,7 @@ use serde_json::{Map, Value};
 
 use super::mailbox::{
     MAILBOX_RESOLUTION_ESCALATED, MAILBOX_RESOLUTION_IGNORED, MAILBOX_RESOLUTION_TAKEN_OVER,
-    MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey,
+    MAILBOX_RESOLUTION_TRANSFERRED, ReplyActorPairKey, reply_thread_scope,
 };
 use super::mailbox_reply_obligation_snapshot_conversion::{
     mailbox_resolution_kind, mailbox_resolution_reason,
@@ -25,6 +25,10 @@ pub(super) fn reply_actor_pair_for_inbound_obligation(
     Some(ReplyActorPairKey {
         agent_actor_id: message.to_actor_id.clone(),
         human_actor_id: message.from_actor_id.clone(),
+        thread_scope: reply_thread_scope(
+            envelope.conversation_id.as_deref(),
+            envelope.thread_root_message_id,
+        ),
     })
 }
 

--- a/src/team/manager/tests/mailbox_basic_cases.rs
+++ b/src/team/manager/tests/mailbox_basic_cases.rs
@@ -203,6 +203,114 @@ async fn summarize_open_reply_obligations_prefers_lightweight_snapshot_loader() 
 }
 
 #[tokio::test]
+async fn reply_obligation_credit_matching_is_scoped_per_thread_not_just_actor_pair() {
+    // A human sends two unrelated reply-required messages to the same agent in two different
+    // conversations. A reply in the *first* conversation must close that conversation's obligation --
+    // not silently satisfy the unrelated, still-open obligation in the second conversation just
+    // because both share the same (agent, human) pair.
+    let db = setup_test_db().await;
+    let manager = TeamManager::new(db.clone());
+
+    let team = manager
+        .create_team(TeamDefinitionConfig {
+            name: "reply-obligation-thread-scope-team".to_string(),
+            description: Some("team for thread-scoped reply obligation matching".to_string()),
+            spec: json!({
+                "entrypoint":"planner",
+                "members":[{"member_id":"planner"},{"member_id":"reviewer"}]
+            }),
+        })
+        .await
+        .expect("create team");
+    let run = manager
+        .create_run(
+            &team.id,
+            Some("ctx-reply-obligation-thread-scope"),
+            json!({"payload":"start"}),
+        )
+        .await
+        .expect("create run");
+
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "user:alice",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "reviewer",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"Please review PR #100",
+                "requires_user_visible_reply":true,
+                "task_conversation_id":"conv-pr-100"
+            }),
+            idempotency_key: None,
+            message_kind: None,
+        })
+        .await
+        .expect("send first inbound obligation");
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "user:alice",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "reviewer",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"What is the ETA on task X?",
+                "requires_user_visible_reply":true,
+                "task_conversation_id":"conv-task-x"
+            }),
+            idempotency_key: None,
+            message_kind: None,
+        })
+        .await
+        .expect("send second, unrelated inbound obligation");
+    manager
+        .send_actor_message(SendActorMessageInput {
+            run_id: &run.id,
+            from_actor_id: "reviewer",
+            from_peer_id: ACTOR_MAIN_PEER_ID,
+            to_actor_id: "user:alice",
+            to_peer_id: ACTOR_MAIN_PEER_ID,
+            channel: "coordination",
+            transport: TeamActorMessageTransport::Local,
+            route: None,
+            payload: json!({
+                "type":"chat_message",
+                "text":"PR #100 looks good, approved",
+                "task_conversation_id":"conv-pr-100"
+            }),
+            idempotency_key: None,
+            message_kind: None,
+        })
+        .await
+        .expect("send visible reply scoped to the first conversation");
+
+    let summary = manager
+        .summarize_open_reply_obligations(&run.id)
+        .await
+        .expect("summarize reply obligations");
+
+    assert_eq!(
+        summary.open_total, 1,
+        "only the unrelated task-x obligation should remain open"
+    );
+    assert_eq!(summary.open_items.len(), 1);
+    assert_eq!(
+        summary.open_items[0].conversation_id.as_deref(),
+        Some("conv-task-x")
+    );
+}
+
+#[tokio::test]
 async fn actor_messages_detect_pending_payload_type_by_actor_inbox() {
     let db = setup_test_db().await;
     let manager = TeamManager::new(db);


### PR DESCRIPTION
## Summary
- Reply-obligation "credit" matching keyed only on `(agent_actor_id, human_actor_id)`, ignoring which thread/conversation a message belonged to. A visible reply in one conversation could incorrectly close an unrelated, still-open obligation in a different conversation with the same agent/human pair.
- Extends `ReplyActorPairKey` with an optional thread/conversation scope and matches credits two-tier: exact scope first, falling back to the untagged loose pool only when the *obligation* itself is scoped. This means a reply that declares a thread can never satisfy an obligation in a different thread, while plain untagged replies keep matching exactly as before (needed to avoid regressing `team_run_messages_api_triage_resolves_open_reply_obligation`, which relies on an untagged reply closing a scoped obligation).
- Finding #19 from the 2026-08-17 code-only Team-subsystem review.

## Test plan
- [x] New `reply_obligation_credit_matching_is_scoped_per_thread_not_just_actor_pair` fails when reverted to the old pair-only key, reproducing the original bug exactly.
- [x] `cargo test -p agenthub --lib team::manager::tests::mailbox_basic_cases` — 18 passed.
- [x] `cargo test -p agenthub --lib` — 766 passed, only 3 known pre-existing unrelated `lance-namespace-impls` failures.
- [x] `cargo clippy -p agenthub --lib --tests` clean.
- [x] `cargo fmt -p agenthub -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)