### PR TITLE
fix(team): log JSON parse failures during message index repair

### DIFF
--- a/docs/journal/2026-08-17-message-index-repair-corruption-visibility.md
+++ b/docs/journal/2026-08-17-message-index-repair-corruption-visibility.md
@@ -1,0 +1,50 @@
+# Summary
+
+A code-only review of the Team subsystem found that `message_index_projection.rs`'s index-repair
+passes silently coerced unparseable `payload_json`/`input_json` columns to `Value::Null` (or, for
+`team_run_events`, an empty `MessageArchiveScopeFallback`) with no logging. A row with genuinely
+corrupt JSON -- from a bug elsewhere, manual DB surgery, or storage-layer bit rot -- would index as a
+plain empty message during a rebuild, with no trace left anywhere that anything was wrong.
+
+# Scope
+
+- `src/team/manager/message_index_projection.rs`: added `parse_projection_json(source, message_id,
+  field, raw)`, a small helper that parses a stored JSON column and, on failure, logs a structured
+  `tracing::warn!` (source table, row id, field name, the parse error) before falling back to
+  `Value::Null` -- same fallback behavior as before, now with a diagnostic trail. Replaced the four
+  inline `serde_json::from_str(..).unwrap_or(Value::Null)` call sites (conversation messages' and actor
+  messages' `payload_json`, run events' `payload_json` and the joined run's `input_json`) with calls to
+  the helper.
+
+# Key Decisions
+
+- **Keep the fallback, add visibility.** The finding was about the silence, not the fallback choice
+  itself: aborting the whole repair batch on one corrupt row would be worse (an operator can't fix a
+  years-old bad row without it blocking every subsequent message from being indexed), so `Value::Null`
+  stays the recovery value. The fix only makes the event observable.
+- **One shared helper over four inline duplicates**, parameterized by the source table constant already
+  defined for each repair function (`TEAM_CONVERSATION_MESSAGE_SOURCE`, `TEAM_ACTOR_MESSAGE_SOURCE`,
+  `TEAM_RUN_EVENT_SOURCE`) and the row id already in scope, so every warning is immediately
+  actionable (which table, which row, which column, why it failed) without introducing per-call-site
+  logging boilerplate.
+
+# Validation
+
+- New `parse_projection_json_returns_parsed_value_for_valid_json` and
+  `parse_projection_json_indexes_as_null_instead_of_panicking_on_corrupt_json` unit tests cover the
+  helper's parsing behavior directly (valid JSON parses through; invalid JSON still yields `Value::Null`,
+  preserving the pre-existing fallback contract). This codebase has no existing pattern for asserting
+  `tracing` output in tests, so the tests validate the parsing/fallback behavior the refactor must not
+  regress, not the log line itself.
+- `cargo test -p agenthub --lib team::manager::tests::conversation_cases` (all repair-function
+  integration tests) -- 29 passed.
+- `cargo test -p agenthub --lib` -- 770 passed, only 2 pre-existing unrelated `state::tests::*`
+  (`lance-namespace-impls`) failures.
+- `cargo clippy -p agenthub --lib --tests` and `cargo fmt -p agenthub -- --check` clean.
+
+# Follow-Ups
+
+None outstanding from the 2026-08-17 Team-subsystem review round; all seven findings (goal-lease CAS,
+permission-review reviewer-target consistency, `context_json` shape validation, client-spoofable reply
+obligation suppression, thread-scoped reply-obligation credit matching, mailbox reassignment CAS/
+idempotency, and this one) are now addressed.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -228,6 +228,27 @@ Main shape:
   `webidl.util.markAsUncloneable is not a function` -- jsdom 30 explicitly requires Node >=22, and the
   `Web`/`Web E2E`/`Web E2E Mobile` jobs were still pinned to Node 20 (`userdocs.yml`'s unrelated
   Docusaurus build stays on Node 20, out of scope). Bumped those three jobs to Node 22.
+- A code-only Team-subsystem review found reply-obligation "credit" matching keyed only on
+  `(agent_actor_id, human_actor_id)`, ignoring which thread/conversation a message belonged to; a reply
+  in one conversation could incorrectly close an unrelated open obligation in a different one. Fixed with
+  a two-tier key (exact thread/conversation scope first, untagged-reply loose-pool fallback) so a reply
+  that declares a thread can never satisfy an obligation in a different one, while plain untagged replies
+  keep working as before. Other findings from the same review round are tracked in the Backend
+  Correctness `todo.md` item.
+- The same review found `reassign_reply_required_message` (transfer/escalate/takeover) had no CAS guard
+  on its source-message `UPDATE`, unlike `triage_message_impl`, and inserted the reassigned message with
+  `idempotency_key = NULL`. Added the guard plus a stable idempotency key with an `INSERT OR IGNORE` +
+  fetch-existing fallback. A genuine-concurrency soak test (new WAL-mode `setup_concurrent_mailbox_db`
+  helper) found SQLite's WAL snapshot-conflict detection already prevents literal duplicate rows in this
+  stack -- the CAS guard is kept as defense-in-depth and for a correct `Conflict` error rather than a raw
+  database error, not as the sole mechanism; the idempotency key is the part with directly fix-sensitive
+  test coverage (client-retry duplicate submission).
+- The same review's last finding: `message_index_projection.rs`'s repair passes silently coerced
+  unparseable `payload_json`/`input_json` to `Value::Null` with no logging, so genuinely corrupt rows
+  indexed as empty messages with no trace. Kept the `Value::Null` fallback (aborting the whole repair
+  batch on one bad row would be worse) but added a structured `tracing::warn!` (source table, row id,
+  field, parse error) via a new shared `parse_projection_json` helper replacing four inline duplicates.
+  This closes out all seven findings from the 2026-08-17 Team-subsystem review round.
 
 Start with:
 
@@ -247,6 +268,9 @@ Start with:
 - `2026-08-17-pwa-icon-borrowed-slock-mark-fix.md`
 - `2026-08-14-team-idea-propagation-judgment.md`
 - `2026-08-17-ci-web-node22-for-jsdom30.md`
+- `2026-08-17-reply-obligation-thread-scoped-matching.md`
+- `2026-08-17-mailbox-reassignment-cas-and-idempotency.md`
+- `2026-08-17-message-index-repair-corruption-visibility.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -100,6 +100,24 @@ Stable contracts:
   [journal/2026-08-16-bootstrap-token-constant-time-compare.md](journal/2026-08-16-bootstrap-token-constant-time-compare.md).
   Evidence for the rest: this review round has no dedicated journal entry yet (findings were reported
   inline, not yet written up) -- write one when starting on the next item from this list.
+- [x] `P1` Close out the 2026-08-17 code-only Team-subsystem review: goal-lease CAS hardening across
+  `task_updates.rs`/`teamspace.rs`/`run_task_status_sync.rs`, see
+  [journal/2026-08-17-goal-lease-cas-hardening.md](journal/2026-08-17-goal-lease-cas-hardening.md);
+  permission-review reviewer-target consistency (removing the idle-unaware fallback resolver), see
+  [journal/2026-08-17-permission-review-reviewer-target-consistency.md](journal/2026-08-17-permission-review-reviewer-target-consistency.md);
+  `context_json`/`context_merge_json` shape validation, see
+  [journal/2026-08-17-task-context-json-shape-validation.md](journal/2026-08-17-task-context-json-shape-validation.md);
+  the client-spoofable `requires_user_visible_reply` suppression via `source_kind`, see
+  [journal/2026-08-17-reply-obligation-client-suppression-fix.md](journal/2026-08-17-reply-obligation-client-suppression-fix.md);
+  the pair-only, thread-unaware reply-obligation credit matching that let a reply in one conversation
+  incorrectly close an unrelated obligation in another, see
+  [journal/2026-08-17-reply-obligation-thread-scoped-matching.md](journal/2026-08-17-reply-obligation-thread-scoped-matching.md);
+  `reassign_reply_required_message`'s missing CAS guard and `idempotency_key = NULL` reassignment insert
+  (transfer/escalate/takeover in `mailbox_service_escalation.rs`), see
+  [journal/2026-08-17-mailbox-reassignment-cas-and-idempotency.md](journal/2026-08-17-mailbox-reassignment-cas-and-idempotency.md);
+  and `message_index_projection.rs` silently coercing unparseable `payload_json`/`input_json` to
+  `Value::Null`/defaults during index rebuild with no logging, see
+  [journal/2026-08-17-message-index-repair-corruption-visibility.md](journal/2026-08-17-message-index-repair-corruption-visibility.md).
 
 ## Message Storage
 

--- a/src/team/manager/message_index_projection.rs
+++ b/src/team/manager/message_index_projection.rs
@@ -23,6 +23,22 @@ const AGENT_EVENT_SOURCE: &str = "agent_events";
 const PER_AGENT_EVENT_SOURCE: &str = "per_agent_agent_events";
 const MAIN_AGENT_EVENT_INDEX_STREAM: &str = "agent_events:main";
 
+/// Parses a stored JSON column during index repair, warning (with enough context to locate the row)
+/// and indexing as an empty payload instead of aborting the whole repair pass on one corrupt row.
+fn parse_projection_json(source: &str, message_id: i64, field: &str, raw: &str) -> Value {
+    serde_json::from_str::<Value>(raw).unwrap_or_else(|err| {
+        tracing::warn!(
+            source,
+            message_id,
+            field,
+            "message index repair: failed to parse {} as JSON, indexing as empty payload: {}",
+            field,
+            err
+        );
+        Value::Null
+    })
+}
+
 fn classify_message_kind(payload: &Value) -> MessageKind {
     match payload
         .get("kind")
@@ -283,7 +299,12 @@ impl TeamManager {
                 let group_id: Option<String> = row.try_get("group_id").ok().flatten();
                 let team_id: String = row.get("team_id");
                 let payload_json: String = row.get("payload_json");
-                let payload = serde_json::from_str::<Value>(&payload_json).unwrap_or(Value::Null);
+                let payload = parse_projection_json(
+                    TEAM_CONVERSATION_MESSAGE_SOURCE,
+                    message_id,
+                    "payload_json",
+                    &payload_json,
+                );
                 let correlation_id: String = row.try_get("correlation_id").unwrap_or_default();
                 let normalized_correlation_id =
                     (!correlation_id.trim().is_empty()).then_some(correlation_id);
@@ -380,7 +401,12 @@ impl TeamManager {
                 let to_actor_id: String = row.get("to_actor_id");
                 let to_peer_id: String = row.get("to_peer_id");
                 let payload_json: String = row.get("payload_json");
-                let payload = serde_json::from_str::<Value>(&payload_json).unwrap_or(Value::Null);
+                let payload = parse_projection_json(
+                    TEAM_ACTOR_MESSAGE_SOURCE,
+                    message_id,
+                    "payload_json",
+                    &payload_json,
+                );
                 let group_id: Option<String> = row.try_get("group_id").ok().flatten();
                 let team_id: String = row.get("team_id");
                 let index_group_id = group_id.clone().unwrap_or(team_id);
@@ -495,9 +521,19 @@ impl TeamManager {
                 let run_id: String = row.get("run_id");
                 let event_type: String = row.get("event_type");
                 let payload_json: String = row.get("payload_json");
-                let payload = serde_json::from_str::<Value>(&payload_json).unwrap_or(Value::Null);
+                let payload = parse_projection_json(
+                    TEAM_RUN_EVENT_SOURCE,
+                    event_id,
+                    "payload_json",
+                    &payload_json,
+                );
                 let input_json: String = row.get("input_json");
-                let run_input = serde_json::from_str::<Value>(&input_json).unwrap_or(Value::Null);
+                let run_input = parse_projection_json(
+                    TEAM_RUN_EVENT_SOURCE,
+                    event_id,
+                    "input_json",
+                    &input_json,
+                );
                 let base_scope = MessageArchiveScopeFallback::from_run_input(&run_input);
                 let group_id: Option<String> = row.try_get("group_id").ok().flatten();
                 let team_id: String = row.get("team_id");
@@ -745,6 +781,28 @@ async fn fetch_agent_event_projection_rows(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_projection_json_returns_parsed_value_for_valid_json() {
+        let parsed = parse_projection_json(
+            TEAM_ACTOR_MESSAGE_SOURCE,
+            42,
+            "payload_json",
+            r#"{"text":"hello"}"#,
+        );
+        assert_eq!(parsed, serde_json::json!({"text": "hello"}));
+    }
+
+    #[test]
+    fn parse_projection_json_indexes_as_null_instead_of_panicking_on_corrupt_json() {
+        let parsed = parse_projection_json(
+            TEAM_ACTOR_MESSAGE_SOURCE,
+            42,
+            "payload_json",
+            "{not valid json",
+        );
+        assert_eq!(parsed, Value::Null);
+    }
 
     #[test]
     fn classify_message_kind_uses_payload_hint() {


### PR DESCRIPTION
## Summary
- `message_index_projection.rs`'s index-repair passes silently coerced unparseable `payload_json`/`input_json` to `Value::Null` with no logging, so a genuinely corrupt row (from a bug elsewhere, manual DB surgery, or storage bit rot) indexed as a plain empty message with no trace left anywhere that something was wrong.
- Kept the `Value::Null` fallback -- aborting the whole repair batch on one bad row would be worse, an operator can't fix a years-old bad row without it blocking every subsequent message from being indexed -- but added a structured `tracing::warn!` (source table, row id, field name, parse error) via a new shared `parse_projection_json` helper, replacing four inline duplicates of the same silent pattern.
- Finding #21, the last of the 2026-08-17 code-only Team-subsystem review round (see #1050-#1055 for the other six).

## Test plan
- [x] New `parse_projection_json_returns_parsed_value_for_valid_json` / `parse_projection_json_indexes_as_null_instead_of_panicking_on_corrupt_json` unit tests cover the helper's parsing/fallback behavior. This codebase has no existing pattern for asserting `tracing` output in tests, so these validate the behavior the refactor must not regress rather than the log line itself.
- [x] `cargo test -p agenthub --lib team::manager::tests::conversation_cases` (all repair-function integration tests) -- 29 passed.
- [x] `cargo test -p agenthub --lib` -- 767 passed, only 3 known pre-existing unrelated `lance-namespace-impls` failures.
- [x] `cargo clippy -p agenthub --lib --tests` clean.
- [x] `cargo fmt -p agenthub -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)