### PR TITLE
chore(deps): resync codex fork to current upstream and adapt for API drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "codex-extension-api",
  "codex-features",
  "codex-feedback",
+ "codex-history",
  "codex-http-client",
  "codex-login",
  "codex-mcp-server",
@@ -907,7 +908,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -918,7 +919,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,8 +2831,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-core",
  "codex-protocol",
@@ -2839,8 +2840,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2850,8 +2851,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2870,8 +2871,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2890,8 +2891,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2921,8 +2922,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "axum",
@@ -2942,6 +2943,7 @@ dependencies = [
  "codex-connectors",
  "codex-core",
  "codex-core-plugins",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-extension-api",
  "codex-external-agent-migration",
@@ -2953,6 +2955,7 @@ dependencies = [
  "codex-git-utils",
  "codex-goal-extension",
  "codex-guardian",
+ "codex-guardian-v2",
  "codex-home",
  "codex-hooks",
  "codex-http-client",
@@ -2967,6 +2970,7 @@ dependencies = [
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
+ "codex-queue-extension",
  "codex-rmcp-client",
  "codex-rollout",
  "codex-sandboxing",
@@ -3002,8 +3006,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -3028,20 +3032,22 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
  "codex-experimental-api-macros",
  "codex-extension-items",
+ "codex-history",
  "codex-protocol",
+ "codex-rollout",
  "codex-secrets",
  "codex-shell-command",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "inventory",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -3054,13 +3060,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "axum",
@@ -3097,8 +3103,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3113,8 +3119,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3133,8 +3139,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3142,8 +3148,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3156,8 +3162,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3174,8 +3180,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "serde",
  "serde_json",
@@ -3184,8 +3190,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "clap",
@@ -3203,8 +3209,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -3212,12 +3218,13 @@ dependencies = [
  "http 1.4.0",
  "rand 0.9.4",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3239,41 +3246,55 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
  "codex-install-context",
+ "codex-protocol",
  "codex-websocket-client",
  "futures",
+ "http-body-util",
+ "prost",
+ "reqwest 0.12.28",
+ "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
+ "tonic",
+ "tower",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
+ "glob",
+ "prost",
+ "protoc-bin-vendored",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 
 [[package]]
 name = "codex-config"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3317,8 +3338,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3339,8 +3360,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -3353,8 +3374,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3362,8 +3383,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3378,12 +3399,13 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-async-utils",
+ "codex-client",
  "codex-code-mode",
  "codex-config",
  "codex-connectors",
  "codex-context-fragments",
  "codex-core-plugins",
- "codex-core-skills",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-execpolicy",
  "codex-extension-api",
@@ -3392,6 +3414,7 @@ dependencies = [
  "codex-feedback",
  "codex-file-system",
  "codex-git-utils",
+ "codex-history",
  "codex-hooks",
  "codex-http-client",
  "codex-install-context",
@@ -3445,7 +3468,7 @@ dependencies = [
  "openssl-sys",
  "rand 0.9.4",
  "regex-lite",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3467,8 +3490,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3476,7 +3499,6 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-config",
  "codex-connectors",
- "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
  "codex-hooks",
@@ -3496,11 +3518,13 @@ dependencies = [
  "codex-utils-plugins",
  "dirs",
  "flate2",
+ "futures",
  "http 1.4.0",
  "regex",
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2 0.10.9",
  "tar",
@@ -3510,43 +3534,23 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
+ "uuid",
  "which",
  "zip",
 ]
 
 [[package]]
-name = "codex-core-skills"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+name = "codex-diagnostics"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
- "anyhow",
- "codex-analytics",
- "codex-config",
- "codex-context-fragments",
- "codex-exec-server",
- "codex-login",
- "codex-model-provider",
- "codex-otel",
- "codex-protocol",
- "codex-skills",
- "codex-utils-absolute-path",
- "codex-utils-path-uri",
- "codex-utils-plugins",
- "codex-utils-string",
- "dunce",
- "futures",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "zip",
+ "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3554,6 +3558,7 @@ dependencies = [
  "bytes",
  "clatter",
  "codex-api",
+ "codex-config",
  "codex-exec-server-protocol",
  "codex-file-system",
  "codex-http-client",
@@ -3562,14 +3567,17 @@ dependencies = [
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
+ "codex-utils-home-dir",
  "codex-utils-path-uri",
  "codex-utils-pty",
  "codex-utils-rustls-provider",
  "codex-websocket-client",
+ "dirs",
  "futures",
  "http 1.4.0",
  "libc",
  "prost",
+ "rustix",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -3585,8 +3593,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3600,8 +3608,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "clap",
@@ -3618,8 +3626,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,8 +3636,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3638,13 +3646,14 @@ dependencies = [
  "codex-protocol",
  "codex-tools",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "serde_json",
 ]
 
 [[package]]
 name = "codex-extension-items"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -3655,8 +3664,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3664,6 +3673,7 @@ dependencies = [
  "codex-core",
  "codex-core-plugins",
  "codex-hooks",
+ "codex-login",
  "codex-memories-write",
  "codex-otel",
  "codex-plugin",
@@ -3682,8 +3692,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3695,10 +3705,11 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
+ "codex-http-client",
  "codex-login",
  "codex-protocol",
  "mime_guess",
@@ -3709,8 +3720,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "clap",
@@ -3724,8 +3735,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3737,8 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "notify",
  "tokio",
@@ -3747,8 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3760,8 +3771,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3786,14 +3797,15 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-analytics",
  "codex-core",
  "codex-extension-api",
  "codex-otel",
  "codex-protocol",
+ "codex-rollout",
  "codex-state",
  "codex-tools",
  "codex-utils-template",
@@ -3805,8 +3817,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3814,9 +3826,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-guardian-v2"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+dependencies = [
+ "codex-api",
+ "codex-core",
+ "codex-extension-api",
+ "codex-features",
+ "codex-http-client",
+ "codex-login",
+ "codex-model-provider",
+ "codex-protocol",
+ "http 1.4.0",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
+name = "codex-history"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+dependencies = [
+ "codex-protocol",
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
 name = "codex-home"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3825,16 +3866,18 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
+ "async-channel",
  "chrono",
  "codex-config",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
+ "codex-utils-pty",
  "futures",
  "regex",
  "schemars 0.8.22",
@@ -3847,13 +3890,14 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
  "futures",
  "http 1.4.0",
+ "native-tls",
  "opentelemetry",
  "reqwest 0.12.28",
  "rustls",
@@ -3873,8 +3917,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3899,17 +3943,20 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "keyring",
  "tracing",
@@ -3917,8 +3964,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3939,8 +3986,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3954,6 +4001,7 @@ dependencies = [
  "codex-secrets",
  "codex-terminal-detection",
  "codex-utils-template",
+ "codex-workload-identity",
  "http 1.4.0",
  "once_cell",
  "os_info",
@@ -3972,8 +4020,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3982,6 +4030,7 @@ dependencies = [
  "codex-async-utils",
  "codex-config",
  "codex-connectors",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-login",
  "codex-model-provider",
@@ -3993,7 +4042,7 @@ dependencies = [
  "futures",
  "lru",
  "regex-lite",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -4006,8 +4055,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -4030,8 +4079,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -4049,7 +4098,7 @@ dependencies = [
  "codex-skills-extension",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -4057,13 +4106,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4082,8 +4130,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4092,8 +4140,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4124,8 +4172,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4145,8 +4193,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -4157,8 +4205,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -4176,8 +4224,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4212,8 +4260,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4244,8 +4292,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4257,16 +4305,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4279,8 +4327,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4318,9 +4366,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-queue-extension"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+dependencies = [
+ "codex-core",
+ "codex-extension-api",
+ "codex-protocol",
+ "codex-thread-store",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "codex-response-debug-context"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4330,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "axum",
@@ -4342,6 +4406,7 @@ dependencies = [
  "codex-exec-server",
  "codex-http-client",
  "codex-keyring-store",
+ "codex-network-proxy",
  "codex-protocol",
  "codex-secrets",
  "codex-utils-home-dir",
@@ -4352,7 +4417,7 @@ dependencies = [
  "keyring",
  "memchr",
  "oauth2",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4369,14 +4434,15 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "chrono",
  "codex-extension-items",
  "codex-file-search",
  "codex-git-utils",
+ "codex-history",
  "codex-otel",
  "codex-protocol",
  "codex-state",
@@ -4395,8 +4461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4410,8 +4476,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4432,8 +4498,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "age",
  "anyhow",
@@ -4451,8 +4517,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4465,14 +4531,15 @@ dependencies = [
  "shlex 1.3.0",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-powershell",
  "url",
  "which",
 ]
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,8 +4557,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4507,11 +4574,11 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
+ "codex-analytics",
  "codex-config",
- "codex-core-skills",
  "codex-exec-server",
  "codex-extension-api",
  "codex-mcp",
@@ -4537,11 +4604,12 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "chrono",
+ "codex-history",
  "codex-protocol",
  "codex-utils-absolute-path",
  "libsqlite3-sys",
@@ -4558,19 +4626,20 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
+ "codex-extension-items",
  "codex-git-utils",
  "codex-install-context",
  "codex-otel",
@@ -4593,8 +4662,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4608,7 +4677,7 @@ dependencies = [
  "codex-utils-pty",
  "codex-utils-string",
  "jsonptr",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -4618,8 +4687,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "async-io",
  "tokio",
@@ -4629,8 +4698,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "dirs",
  "dunce",
@@ -4641,16 +4710,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4663,8 +4732,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4673,8 +4742,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4685,8 +4754,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4694,8 +4763,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4707,8 +4776,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4716,8 +4785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4725,8 +4794,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4735,8 +4804,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4750,8 +4819,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4763,8 +4832,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4779,21 +4848,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4802,13 +4871,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4828,8 +4897,8 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -4842,8 +4911,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4864,6 +4933,19 @@ dependencies = [
  "tracing-appender",
  "windows 0.58.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "codex-workload-identity"
+version = "0.0.0"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+dependencies = [
+ "codex-http-client",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -5413,7 +5495,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6487,7 +6569,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6844,7 +6926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7906,7 +7988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -8506,6 +8588,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -9519,7 +9603,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10979,11 +11063,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -11504,7 +11588,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11679,6 +11763,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -13311,7 +13406,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
 dependencies = [
  "ahash",
  "hickory-resolver",
@@ -14129,9 +14224,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -14335,7 +14430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14394,7 +14489,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14764,6 +14859,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -15393,7 +15492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16277,7 +16376,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16296,7 +16395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16756,9 +16855,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -17019,6 +17118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "triomphe"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17152,7 +17261,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -17692,15 +17801,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -17799,7 +17908,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "codex-agent-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-core",
  "codex-protocol",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "codex-agent-graph-store"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "codex-agent-identity"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2872,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "codex-analytics"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2892,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "codex-api"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2923,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "codex-app-server"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "codex-app-server-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "codex-app-server-protocol"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -3061,12 +3061,12 @@ dependencies = [
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 
 [[package]]
 name = "codex-app-server-transport"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "codex-apply-patch"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "codex-arg0"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "codex-async-utils"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "codex-aws-auth"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "codex-backend-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "codex-backend-openapi-models"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "codex-chatgpt"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "codex-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "codex-cloud-config"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "codex-code-mode"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "codex-code-mode-protocol"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -3289,12 +3289,12 @@ dependencies = [
 [[package]]
 name = "codex-collaboration-mode-templates"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 
 [[package]]
 name = "codex-config"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "codex-connectors"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "codex-connectors-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "codex-context-fragments"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "codex-core"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "codex-core-plugins"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3542,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "codex-diagnostics"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "libc",
 ]
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "codex-exec-server"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "codex-exec-server-protocol"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "codex-execpolicy"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "codex-experimental-api-macros"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "codex-extension-api"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "codex-extension-items"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "codex-external-agent-migration"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "codex-features"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "codex-feedback"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-http-client",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "codex-file-search"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "codex-file-system"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "codex-file-watcher"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "notify",
  "tokio",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "codex-git-attribution"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "codex-git-utils"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "codex-goal-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-analytics",
  "codex-core",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "codex-guardian"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "codex-guardian-v2"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "codex-history"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "schemars 0.8.22",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "codex-home"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "codex-hooks"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "codex-http-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "codex-image-generation-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "codex-install-context"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "codex-keyring-store"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "keyring",
  "tracing",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "codex-linux-sandbox"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "codex-login"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "codex-mcp"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "codex-mcp-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "codex-mcp-server"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "codex-memories-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "codex-memories-read"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "codex-memories-write"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "codex-model-provider"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "codex-model-provider-info"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "codex-models-manager"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -4225,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "codex-network-proxy"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "codex-otel"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "codex-plugin"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "codex-process-hardening"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "libc",
 ]
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "codex-prompts"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "codex-protocol"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "codex-queue-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "codex-response-debug-context"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "codex-rmcp-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "codex-rollout"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "codex-rollout-trace"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "codex-sandboxing"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "codex-secrets"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "age",
  "anyhow",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "codex-shell-command"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "codex-shell-escalation"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "codex-skills"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "codex-skills-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-analytics",
  "codex-config",
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "codex-state"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "codex-terminal-detection"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "tracing",
 ]
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "codex-thread-store"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "codex-tools"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "codex-uds"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "async-io",
  "tokio",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-absolute-path"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "dirs",
  "dunce",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-approval-presets"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
 ]
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-audio"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4733,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-cache"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-cli"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-home-dir"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4764,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-image"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4777,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-json-to-toml"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-output-truncation"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-path"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-path-uri"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4820,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-plugins"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4833,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-pty"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "codex-utils-rustls-provider"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "rustls",
 ]
@@ -4857,12 +4857,12 @@ dependencies = [
 [[package]]
 name = "codex-utils-stream-parser"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 
 [[package]]
 name = "codex-utils-string"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4872,12 +4872,12 @@ dependencies = [
 [[package]]
 name = "codex-utils-template"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 
 [[package]]
 name = "codex-web-search-extension"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "codex-websocket-client"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "codex-windows-sandbox"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4938,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "codex-workload-identity"
 version = "0.0.0"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "codex-http-client",
  "serde",
@@ -13406,7 +13406,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/hawkingrei/codex?rev=8a877a796039bba36b5c9bbba76e134660e45d03#8a877a796039bba36b5c9bbba76e134660e45d03"
+source = "git+https://github.com/hawkingrei/codex?rev=f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1#f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1"
 dependencies = [
  "ahash",
  "hickory-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 exclude = ["cmd/agenthub"]
 
 [patch.crates-io]
-rama-dns = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
+rama-dns = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
 sacp = { git = "https://github.com/hawkingrei/symposium-acp", rev = "c731bb045d1375af48b0446af728aea52503b30b" }
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 exclude = ["cmd/agenthub"]
 
 [patch.crates-io]
-rama-dns = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+rama-dns = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
 sacp = { git = "https://github.com/hawkingrei/symposium-acp", rev = "c731bb045d1375af48b0446af728aea52503b30b" }
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "g
 git_repository(
     name = "codex_src",
     # Security-patched Codex 0.147 commit shared with the Cargo codex-* dependencies.
-    commit = "6ca61345ceb09d76edc3db8c4eb55df18a10888a",
+    commit = "8a877a796039bba36b5c9bbba76e134660e45d03",
     remote = "https://github.com/hawkingrei/codex",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "rules_rust", version = "0.67.0")
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "codex_src",
-    # Security-patched Codex 0.147 commit shared with the Cargo codex-* dependencies.
+    # Security-patched Codex commit shared with the Cargo codex-* dependencies.
     commit = "8a877a796039bba36b5c9bbba76e134660e45d03",
     remote = "https://github.com/hawkingrei/codex",
 )
@@ -38,6 +38,16 @@ crate.annotation(
     gen_build_script = "off",
     repositories = ["crate_index"],
     rustc_flags = ["--cfg=vendored_bwrap_available"],
+)
+crate.annotation(
+    # protoc-bin-vendored-linux-x86_64 bundles a `protoc` binary and .proto includes,
+    # located via CARGO_MANIFEST_DIR at runtime by protoc-bin-vendored (a build-dependency
+    # of codex-code-mode-protocol's build script). crate_universe's default data glob
+    # excludes these extensionless/binary files, so the crate's own CARGO_MANIFEST_DIR
+    # in the Bazel sandbox is missing them unless explicitly declared here.
+    crate = "protoc-bin-vendored-linux-x86_64",
+    data_glob = ["bin/**", "include/**"],
+    repositories = ["crate_index"],
 )
 crate.from_cargo(
     name = "crate_index",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,19 @@ crate.annotation(
     data_glob = ["bin/**", "include/**"],
     repositories = ["crate_index"],
 )
+crate.annotation(
+    # cargo_build_script only pulls a crate's own `data`/`build_script_data` into its
+    # sandbox, not the `data` of its (build-)dependencies -- so protoc-bin-vendored's
+    # bundled protoc binary (see the protoc-bin-vendored-linux-x86_64 annotation above)
+    # has to be listed here explicitly for codex-code-mode-protocol's build script to
+    # find it. Canonical repo name pinned via `bazel query`; may need updating on a
+    # future rules_rust bump if its internal crate_universe repo-naming scheme changes.
+    crate = "codex-code-mode-protocol",
+    build_script_data = [
+        "@@rules_rust++crate+crate_index__protoc-bin-vendored-linux-x86_64-3.2.0//:protoc_bin_vendored_linux_x86_64",
+    ],
+    repositories = ["crate_index"],
+)
 crate.from_cargo(
     name = "crate_index",
     cargo_lockfile = "//:Cargo.lock",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "g
 git_repository(
     name = "codex_src",
     # Security-patched Codex commit shared with the Cargo codex-* dependencies.
-    commit = "8a877a796039bba36b5c9bbba76e134660e45d03",
+    commit = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1",
     remote = "https://github.com/hawkingrei/codex",
 )
 
@@ -40,26 +40,16 @@ crate.annotation(
     rustc_flags = ["--cfg=vendored_bwrap_available"],
 )
 crate.annotation(
-    # protoc-bin-vendored-linux-x86_64 bundles a `protoc` binary and .proto includes,
-    # located via CARGO_MANIFEST_DIR at runtime by protoc-bin-vendored (a build-dependency
-    # of codex-code-mode-protocol's build script). crate_universe's default data glob
-    # excludes these extensionless/binary files, so the crate's own CARGO_MANIFEST_DIR
-    # in the Bazel sandbox is missing them unless explicitly declared here.
-    crate = "protoc-bin-vendored-linux-x86_64",
-    data_glob = ["bin/**", "include/**"],
-    repositories = ["crate_index"],
-)
-crate.annotation(
-    # cargo_build_script only pulls a crate's own `data`/`build_script_data` into its
-    # sandbox, not the `data` of its (build-)dependencies -- so protoc-bin-vendored's
-    # bundled protoc binary (see the protoc-bin-vendored-linux-x86_64 annotation above)
-    # has to be listed here explicitly for codex-code-mode-protocol's build script to
-    # find it. Canonical repo name pinned via `bazel query`; may need updating on a
-    # future rules_rust bump if its internal crate_universe repo-naming scheme changes.
+    # codex-code-mode-protocol's build script needs protoc. protoc-bin-vendored's bundled
+    # binary is located via CARGO_MANIFEST_DIR at runtime, which Bazel's crate_universe
+    # sandboxing for cargo_build_script doesn't reliably propagate across crate boundaries
+    # for build-dependencies (confirmed: neither a data_glob on the vendored crate nor a
+    # build_script_data reference to it made the file visible at build-script execution
+    # time, despite both being correct in the Bazel target graph per `bazel query`). The
+    # AgentHub fork's build.rs patch prefers PROTOC when set, so point it at the system
+    # protoc that CI's Bazel jobs already install via apt (protobuf-compiler).
     crate = "codex-code-mode-protocol",
-    build_script_data = [
-        "@@rules_rust++crate+crate_index__protoc-bin-vendored-linux-x86_64-3.2.0//:protoc_bin_vendored_linux_x86_64",
-    ],
+    build_script_env = {"PROTOC": "/usr/bin/protoc"},
     repositories = ["crate_index"],
 )
 crate.from_cargo(

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,26 +26,27 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-config = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-core = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-extension-api = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-features = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-http-client = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-login = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-path-uri = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
+codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-config = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-core = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-extension-api = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-features = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-history = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-http-client = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-login = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-utils-path-uri = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
 heck = "0.5.0"
 itertools = "0.15.0"
 libc = "0.2"

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,27 +26,27 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-config = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-core = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-extension-api = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-features = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-history = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-http-client = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-login = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
-codex-utils-path-uri = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-config = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-core = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-extension-api = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-features = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-history = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-http-client = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-login = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
+codex-utils-path-uri = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
 heck = "0.5.0"
 itertools = "0.15.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -55,6 +55,7 @@ use codex_protocol::request_permissions::{
 use codex_protocol::request_user_input::{
     RequestUserInputEvent, RequestUserInputQuestion, RequestUserInputResponse,
 };
+use codex_protocol::turn_input::TurnInput;
 use codex_shell_command::parse_command::parse_command;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -328,16 +329,14 @@ impl AppServerCodexThread {
         op: &Op,
     ) -> Result<SteerFollowUpAction, CodexErr> {
         let (items, output_schema, responsesapi_client_metadata) = match op {
-            Op::UserInput {
-                items,
-                final_output_json_schema,
-                responsesapi_client_metadata,
-                ..
-            } => (
-                items.clone(),
-                final_output_json_schema.clone(),
-                responsesapi_client_metadata.clone(),
-            ),
+            Op::TurnInput { request, .. } => match &request.input {
+                TurnInput::UserInput { content, .. } => (
+                    content.clone(),
+                    request.start.final_output_json_schema.clone(),
+                    request.responsesapi_client_metadata.clone(),
+                ),
+                _ => return Ok(SteerFollowUpAction::QueueFollowUp),
+            },
             _ => return Ok(SteerFollowUpAction::QueueFollowUp),
         };
 
@@ -543,6 +542,7 @@ impl AppServerCodexThread {
                                 message: "Undo completed.".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         });
                         state.local_events.push_back(Event {
@@ -1141,7 +1141,12 @@ impl AppServerCodexThread {
             | ServerNotification::TurnModerationMetadata(_)
             | ServerNotification::EnvironmentConnected(_)
             | ServerNotification::EnvironmentDisconnected(_)
-            | ServerNotification::RawResponseCompleted(_) => Ok(None),
+            | ServerNotification::RawResponseCompleted(_)
+            | ServerNotification::ThreadReverted(_)
+            | ServerNotification::ThreadQueueChanged(_)
+            | ServerNotification::ProjectChanged(_)
+            | ServerNotification::ThreadProjectUpdated(_)
+            | ServerNotification::StrictReviewRequired(_) => Ok(None),
             ServerNotification::FileChangePatchUpdated(payload) => {
                 let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
                 Ok(submission_id.map(|id| Event {
@@ -1505,6 +1510,7 @@ impl AppServerCodexThread {
                                 phase,
                                 memory_citation: memory_citation
                                     .map(app_server_memory_citation_to_core),
+                                delivery: None,
                             }),
                         })
                     }
@@ -1891,7 +1897,7 @@ impl AppServerCodexThread {
 impl CodexThreadImpl for AppServerCodexThread {
     async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
         match op {
-            op @ (Op::UserInput { .. }
+            op @ (Op::TurnInput { .. }
             | Op::Review { .. }
             | Op::Compact
             | Op::ThreadRollback { .. }) => self.submit_prompt_like(submission_id, op).await,
@@ -2308,12 +2314,10 @@ fn prepare_submission_start(
     op: &Op,
 ) -> Result<Option<PreparedSubmissionStart>, PrepareSubmissionStartError> {
     match op {
-        Op::UserInput {
-            items,
-            final_output_json_schema,
-            responsesapi_client_metadata,
-            ..
-        } => {
+        Op::TurnInput { request, .. } => {
+            let TurnInput::UserInput { content: items, .. } = &request.input else {
+                return Ok(None);
+            };
             if let Some(missing) = MissingCustomToolOutputs::from_state(state) {
                 return Err(PrepareSubmissionStartError::MissingCustomToolOutputs(
                     missing,
@@ -2348,8 +2352,8 @@ fn prepare_submission_start(
                     effort: state.config.model_reasoning_effort.clone(),
                     summary: state.config.model_reasoning_summary,
                     personality: state.config.personality,
-                    output_schema: final_output_json_schema.clone(),
-                    responsesapi_client_metadata: responsesapi_client_metadata.clone(),
+                    output_schema: request.start.final_output_json_schema.clone(),
+                    responsesapi_client_metadata: request.responsesapi_client_metadata.clone(),
                     collaboration_mode: None,
                     environments: None,
                     permissions: None,
@@ -2682,6 +2686,10 @@ fn review_decision_to_app_server(decision: ReviewDecision) -> CommandExecutionAp
         ReviewDecision::Denied { .. } => CommandExecutionApprovalDecision::Decline,
         ReviewDecision::TimedOut => CommandExecutionApprovalDecision::Decline,
         ReviewDecision::Abort => CommandExecutionApprovalDecision::Cancel,
+        // MCP approvals are handled through elicitations, so an MCP policy amendment
+        // should never appear in a command execution approval. Fail closed, mirroring
+        // upstream's own CoreReviewDecision -> CommandExecutionApprovalDecision::From impl.
+        ReviewDecision::ApprovedMcpPolicyAmendment => CommandExecutionApprovalDecision::Decline,
     }
 }
 
@@ -2694,6 +2702,8 @@ fn patch_review_decision_to_app_server(decision: ReviewDecision) -> FileChangeAp
         ReviewDecision::Abort => FileChangeApprovalDecision::Cancel,
         ReviewDecision::ApprovedExecpolicyAmendment { .. }
         | ReviewDecision::NetworkPolicyAmendment { .. } => FileChangeApprovalDecision::Accept,
+        // MCP approvals are handled through elicitations, not file-change review; fail closed.
+        ReviewDecision::ApprovedMcpPolicyAmendment => FileChangeApprovalDecision::Decline,
     }
 }
 
@@ -2841,6 +2851,9 @@ fn app_server_codex_error_info_to_core(error: AppServerCodexErrorInfo) -> CodexE
         AppServerCodexErrorInfo::UsageLimitExceeded => CodexErrorInfo::UsageLimitExceeded,
         AppServerCodexErrorInfo::ServerOverloaded => CodexErrorInfo::ServerOverloaded,
         AppServerCodexErrorInfo::CyberPolicy => CodexErrorInfo::CyberPolicy,
+        AppServerCodexErrorInfo::MisalignmentPolicyViolation => {
+            CodexErrorInfo::MisalignmentPolicyViolation
+        }
         AppServerCodexErrorInfo::HttpConnectionFailed { http_status_code } => {
             CodexErrorInfo::HttpConnectionFailed { http_status_code }
         }
@@ -3195,9 +3208,29 @@ mod tests {
     use super::*;
     use codex_core::config::ConfigBuilder;
     use codex_protocol::protocol::ReviewRequest;
+    use codex_protocol::turn_input::{TurnInputMode, TurnInputRequest, TurnStartOptions};
     use codex_utils_absolute_path::AbsolutePathBuf;
     use std::fs;
     use uuid::Uuid;
+
+    fn test_user_input_op(items: Vec<codex_protocol::user_input::UserInput>) -> Op {
+        let (reply, _reply_rx) = tokio::sync::oneshot::channel();
+        Op::TurnInput {
+            request: Box::new(TurnInputRequest {
+                input: TurnInput::UserInput {
+                    content: items,
+                    client_id: None,
+                },
+                thread_settings: Default::default(),
+                start: TurnStartOptions::default(),
+                additional_context: Default::default(),
+                responsesapi_client_metadata: None,
+                trace: None,
+            }),
+            mode: TurnInputMode::StartOrSteer,
+            reply,
+        }
+    }
 
     async fn test_state_with_active_turn(active_turn: Option<ActiveTurn>) -> AppServerState {
         let codex_home =
@@ -3237,6 +3270,7 @@ mod tests {
                 text: "hello".to_string(),
                 phase: None,
                 memory_citation: None,
+                delivery: None,
             }],
             items_view: codex_app_server_protocol::TurnItemsView::Full,
             status: TurnStatus::InProgress,
@@ -3954,16 +3988,10 @@ mod tests {
         let err = prepare_submission_start(
             &mut state,
             "submission-2",
-            &Op::UserInput {
-                items: vec![codex_protocol::user_input::UserInput::Text {
-                    text: "continue".to_string(),
-                    text_elements: Vec::new(),
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &test_user_input_op(vec![codex_protocol::user_input::UserInput::Text {
+                text: "continue".to_string(),
+                text_elements: Vec::new(),
+            }]),
         )
         .expect_err("dirty custom tool history should block new turns");
 
@@ -4030,13 +4058,7 @@ mod tests {
         let prepared = prepare_submission_start(
             &mut state,
             "submission-after-undo",
-            &Op::UserInput {
-                items: Vec::new(),
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &test_user_input_op(Vec::new()),
         )
         .expect("undo should clear the local pending tool guard");
         assert!(matches!(
@@ -4052,13 +4074,7 @@ mod tests {
         let prepared = prepare_submission_start(
             &mut state,
             "submission-runtime-roots",
-            &Op::UserInput {
-                items: Vec::new(),
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &test_user_input_op(Vec::new()),
         )
         .expect("prepare submission")
         .expect("turn start");

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -279,6 +279,7 @@ impl std::ops::AddAssign for HistoryRepairStats {
     }
 }
 
+#[cfg(test)]
 fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -23,6 +23,9 @@ use codex_extension_api::{
     LoadUserInstructionsFuture, LoadedUserInstructions, UserInstructionsProvider,
     empty_extension_registry,
 };
+use codex_history::{
+    InitialHistory, ResponseItemEnvelope, ResumedHistory, RolloutItem, RolloutLine,
+};
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -30,7 +33,7 @@ use codex_login::{
 use codex_protocol::{
     ThreadId,
     models::{FunctionCallOutputPayload, ResponseItem},
-    protocol::{InitialHistory, ResumedHistory, RolloutItem, RolloutLine, SessionSource},
+    protocol::SessionSource,
 };
 use std::{
     cell::RefCell,
@@ -193,6 +196,7 @@ fn codex_mcp_server_config(cwd: &Path, mcp_server: McpServer) -> Option<(String,
                     Some(headers.into_iter().map(|h| (h.name, h.value)).collect())
                 },
                 env_http_headers: None,
+                http_headers_helper: None,
             },
         ),
         McpServer::Stdio(McpServerStdio {
@@ -392,21 +396,152 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
     repaired
 }
 
+/// Same repair as [`repair_response_item_history`], but for the
+/// [`ResponseItemEnvelope`]-wrapped items used by [`CompactedItem::replacement_history`].
+/// Metadata on retained items is preserved; synthesized aborted-call outputs carry no
+/// metadata, matching how newly-inserted items behave everywhere else in this module.
+fn repair_response_item_envelope_history(
+    items: &mut Vec<ResponseItemEnvelope>,
+) -> HistoryRepairStats {
+    let function_call_ids = items
+        .iter()
+        .filter_map(|item| match &item.item {
+            ResponseItem::FunctionCall { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let local_shell_call_ids = items
+        .iter()
+        .filter_map(|item| match &item.item {
+            ResponseItem::LocalShellCall {
+                call_id: Some(call_id),
+                ..
+            } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let custom_tool_call_ids = items
+        .iter()
+        .filter_map(|item| match &item.item {
+            ResponseItem::CustomToolCall { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+
+    let mut repaired = HistoryRepairStats::default();
+    items.retain(|item| match &item.item {
+        ResponseItem::FunctionCallOutput { call_id, .. } => {
+            let keep =
+                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_function_call_outputs += 1;
+            }
+            keep
+        }
+        ResponseItem::CustomToolCallOutput { call_id, .. } => {
+            let keep = custom_tool_call_ids.contains(call_id);
+            if !keep {
+                repaired.dropped_orphan_custom_tool_call_outputs += 1;
+            }
+            keep
+        }
+        _ => true,
+    });
+    let mut function_output_call_ids = items
+        .iter()
+        .filter_map(|item| match &item.item {
+            ResponseItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let mut custom_output_call_ids = items
+        .iter()
+        .filter_map(|item| match &item.item {
+            ResponseItem::CustomToolCallOutput { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+
+    let mut synthetic_outputs = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        match &item.item {
+            ResponseItem::FunctionCall { call_id, .. }
+                if function_output_call_ids.insert(call_id.clone()) =>
+            {
+                repaired.inserted_function_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    ResponseItem::FunctionCallOutput {
+                        id: None,
+                        call_id: call_id.clone(),
+                        output: aborted_call_output(),
+                        internal_chat_message_metadata_passthrough: None,
+                    }
+                    .into(),
+                ));
+            }
+            ResponseItem::CustomToolCall { call_id, .. }
+                if custom_output_call_ids.insert(call_id.clone()) =>
+            {
+                repaired.inserted_custom_tool_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    ResponseItem::CustomToolCallOutput {
+                        id: None,
+                        call_id: call_id.clone(),
+                        name: None,
+                        output: aborted_call_output(),
+                        internal_chat_message_metadata_passthrough: None,
+                    }
+                    .into(),
+                ));
+            }
+            ResponseItem::LocalShellCall {
+                call_id: Some(call_id),
+                ..
+            } if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    ResponseItem::FunctionCallOutput {
+                        id: None,
+                        call_id: call_id.clone(),
+                        output: aborted_call_output(),
+                        internal_chat_message_metadata_passthrough: None,
+                    }
+                    .into(),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    for (idx, output) in synthetic_outputs.into_iter().rev() {
+        items.insert(idx + 1, output);
+    }
+    repaired
+}
+
 fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::FunctionCall { call_id, .. },
+                ..
+            }) => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
     let local_shell_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::LocalShellCall {
-                call_id: Some(call_id),
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item:
+                    ResponseItem::LocalShellCall {
+                        call_id: Some(call_id),
+                        ..
+                    },
                 ..
             }) => Some(call_id.clone()),
             _ => None,
@@ -415,9 +550,10 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let custom_tool_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCall { call_id, .. },
+                ..
+            }) => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -426,49 +562,59 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                id,
-                call_id,
-                output,
-                internal_chat_message_metadata_passthrough,
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item:
+                    ResponseItem::FunctionCallOutput {
+                        id,
+                        call_id,
+                        output,
+                        internal_chat_message_metadata_passthrough,
+                    },
+                metadata,
             }) => {
                 if function_call_ids.contains(&call_id) || local_shell_call_ids.contains(&call_id) {
-                    retained.push(RolloutItem::ResponseItem(
-                        ResponseItem::FunctionCallOutput {
+                    retained.push(RolloutItem::ResponseItem(ResponseItemEnvelope {
+                        item: ResponseItem::FunctionCallOutput {
                             id,
                             call_id,
                             output,
                             internal_chat_message_metadata_passthrough,
                         },
-                    ));
+                        metadata,
+                    }));
                 } else {
                     repaired.dropped_orphan_function_call_outputs += 1;
                 }
             }
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
-                id,
-                call_id,
-                name,
-                output,
-                internal_chat_message_metadata_passthrough,
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item:
+                    ResponseItem::CustomToolCallOutput {
+                        id,
+                        call_id,
+                        name,
+                        output,
+                        internal_chat_message_metadata_passthrough,
+                    },
+                metadata,
             }) => {
                 if custom_tool_call_ids.contains(&call_id) {
-                    retained.push(RolloutItem::ResponseItem(
-                        ResponseItem::CustomToolCallOutput {
+                    retained.push(RolloutItem::ResponseItem(ResponseItemEnvelope {
+                        item: ResponseItem::CustomToolCallOutput {
                             id,
                             call_id,
                             name,
                             output,
                             internal_chat_message_metadata_passthrough,
                         },
-                    ));
+                        metadata,
+                    }));
                 } else {
                     repaired.dropped_orphan_custom_tool_call_outputs += 1;
                 }
             }
             RolloutItem::Compacted(mut compacted) => {
                 if let Some(replacement_history) = compacted.replacement_history.as_mut() {
-                    repaired += repair_response_item_history(replacement_history);
+                    repaired += repair_response_item_envelope_history(replacement_history);
                 }
                 retained.push(RolloutItem::Compacted(compacted));
             }
@@ -479,18 +625,20 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::FunctionCallOutput { call_id, .. },
+                ..
+            }) => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
     let mut custom_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCallOutput { call_id, .. },
+                ..
+            }) => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -498,48 +646,63 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut synthetic_outputs = Vec::new();
     for (idx, item) in items.iter().enumerate() {
         match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. })
-                if function_output_call_ids.insert(call_id.clone()) =>
-            {
-                repaired.inserted_function_call_outputs += 1;
-                synthetic_outputs.push((
-                    idx,
-                    RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
-                ));
-            }
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. })
-                if custom_output_call_ids.insert(call_id.clone()) =>
-            {
-                repaired.inserted_custom_tool_call_outputs += 1;
-                synthetic_outputs.push((
-                    idx,
-                    RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        name: None,
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
-                ));
-            }
-            RolloutItem::ResponseItem(ResponseItem::LocalShellCall {
-                call_id: Some(call_id),
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::FunctionCall { call_id, .. },
                 ..
             }) if function_output_call_ids.insert(call_id.clone()) => {
                 repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
-                    RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
+                    RolloutItem::ResponseItem(
+                        ResponseItem::FunctionCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        }
+                        .into(),
+                    ),
+                ));
+            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCall { call_id, .. },
+                ..
+            }) if custom_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_custom_tool_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    RolloutItem::ResponseItem(
+                        ResponseItem::CustomToolCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            name: None,
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        }
+                        .into(),
+                    ),
+                ));
+            }
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item:
+                    ResponseItem::LocalShellCall {
+                        call_id: Some(call_id),
+                        ..
+                    },
+                ..
+            }) if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    RolloutItem::ResponseItem(
+                        ResponseItem::FunctionCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        }
+                        .into(),
+                    ),
                 ));
             }
             _ => {}
@@ -987,16 +1150,14 @@ mod tests {
     use codex_config::types::McpServerTransportConfig;
     use codex_core::RolloutRecorder;
     use codex_core::config::ConfigBuilder;
+    use codex_history::{CompactedItem, InitialHistory, ResumedHistory, RolloutItem};
     use codex_protocol::{
         ThreadId,
         models::{
             FunctionCallOutputPayload, LocalShellAction, LocalShellExecAction, LocalShellStatus,
             ResponseItem,
         },
-        protocol::{
-            CompactedItem, InitialHistory, ResumedHistory, RolloutItem, SessionMeta,
-            SessionMetaLine, SessionSource,
-        },
+        protocol::{SessionMeta, SessionMetaLine, SessionSource},
     };
     use std::{
         collections::HashMap,
@@ -1137,7 +1298,8 @@ mod tests {
                     namespace: None,
                     input: "{}".to_string(),
                     internal_chat_message_metadata_passthrough: None,
-                },
+                }
+                .into(),
             )]),
             rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
         });
@@ -1154,8 +1316,12 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert!(matches!(
             &items[1],
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, output, .. })
-                if call_id == "call-1" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+            RolloutItem::ResponseItem(envelope)
+                if matches!(
+                    &envelope.item,
+                    ResponseItem::CustomToolCallOutput { call_id, output, .. }
+                        if call_id == "call-1" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+                )
         ));
     }
 
@@ -1179,15 +1345,18 @@ mod tests {
                     },
                     git: None,
                 }),
-                RolloutItem::ResponseItem(ResponseItem::CustomToolCall {
-                    id: None,
-                    status: Some("completed".to_string()),
-                    call_id: "call-persist".to_string(),
-                    name: "actor_send".to_string(),
-                    namespace: None,
-                    input: "{}".to_string(),
-                    internal_chat_message_metadata_passthrough: None,
-                }),
+                RolloutItem::ResponseItem(
+                    ResponseItem::CustomToolCall {
+                        id: None,
+                        status: Some("completed".to_string()),
+                        call_id: "call-persist".to_string(),
+                        name: "actor_send".to_string(),
+                        namespace: None,
+                        input: "{}".to_string(),
+                        internal_chat_message_metadata_passthrough: None,
+                    }
+                    .into(),
+                ),
             ]),
             rollout_path: Some(rollout_path.clone()),
         });
@@ -1221,8 +1390,12 @@ mod tests {
         assert!(matches!(&items[0], RolloutItem::SessionMeta(_)));
         assert!(matches!(
             &items[2],
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, output, .. })
-                if call_id == "call-persist" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+            RolloutItem::ResponseItem(envelope)
+                if matches!(
+                    &envelope.item,
+                    ResponseItem::CustomToolCallOutput { call_id, output, .. }
+                        if call_id == "call-persist" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+                )
         ));
     }
 
@@ -1268,19 +1441,23 @@ mod tests {
     fn repair_initial_history_updates_compacted_replacement_history() {
         let history = InitialHistory::Forked(vec![RolloutItem::Compacted(CompactedItem {
             message: "compacted".to_string(),
-            replacement_history: Some(vec![ResponseItem::LocalShellCall {
-                id: None,
-                call_id: Some("shell-1".to_string()),
-                status: LocalShellStatus::Completed,
-                internal_chat_message_metadata_passthrough: None,
-                action: LocalShellAction::Exec(LocalShellExecAction {
-                    command: vec!["echo".to_string(), "hi".to_string()],
-                    timeout_ms: None,
-                    working_directory: Some(".".to_string()),
-                    env: None,
-                    user: None,
-                }),
-            }]),
+            replacement_history: Some(vec![
+                ResponseItem::LocalShellCall {
+                    id: None,
+                    call_id: Some("shell-1".to_string()),
+                    status: LocalShellStatus::Completed,
+                    internal_chat_message_metadata_passthrough: None,
+                    action: LocalShellAction::Exec(LocalShellExecAction {
+                        command: vec!["echo".to_string(), "hi".to_string()],
+                        timeout_ms: None,
+                        working_directory: Some(".".to_string()),
+                        env: None,
+                        user: None,
+                    }),
+                }
+                .into(),
+            ]),
+            mcp_resource_origins: None,
             window_number: None,
             first_window_id: None,
             previous_window_id: None,
@@ -1304,7 +1481,7 @@ mod tests {
             .as_ref()
             .expect("replacement history");
         assert!(matches!(
-            &replacement_history[1],
+            &replacement_history[1].item,
             ResponseItem::FunctionCallOutput {
                 call_id, output, ..
             }

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -1143,7 +1143,8 @@ impl CodexAgent {
 mod tests {
     use super::{
         HistoryRepairStats, codex_mcp_server_config, persist_repaired_initial_history,
-        repair_initial_history, repair_response_item_history,
+        repair_initial_history, repair_response_item_envelope_history,
+        repair_response_item_history,
     };
     use agent_client_protocol::schema::v1::{
         EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio,
@@ -1151,7 +1152,10 @@ mod tests {
     use codex_config::types::McpServerTransportConfig;
     use codex_core::RolloutRecorder;
     use codex_core::config::ConfigBuilder;
-    use codex_history::{CompactedItem, InitialHistory, ResumedHistory, RolloutItem};
+    use codex_history::{
+        CodexHarnessMetadata, CompactedItem, InitialHistory, ResponseItemEnvelope, ResumedHistory,
+        RolloutItem,
+    };
     use codex_protocol::{
         ThreadId,
         models::{
@@ -1436,6 +1440,59 @@ mod tests {
             ResponseItem::CustomToolCallOutput { call_id, output, .. }
                 if call_id == "call-2" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
         ));
+    }
+
+    #[test]
+    fn repair_response_item_envelope_history_drops_orphan_outputs_and_preserves_metadata() {
+        let kept_metadata = Some(CodexHarnessMetadata {
+            client_authored: true,
+        });
+        let mut history = vec![
+            ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCallOutput {
+                    id: None,
+                    call_id: "missing".to_string(),
+                    name: None,
+                    output: FunctionCallOutputPayload::from_text("ok".to_string()),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+                metadata: Some(CodexHarnessMetadata {
+                    client_authored: false,
+                }),
+            },
+            ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCall {
+                    id: None,
+                    status: Some("completed".to_string()),
+                    call_id: "call-2".to_string(),
+                    name: "actor_ack".to_string(),
+                    namespace: None,
+                    input: "{}".to_string(),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+                metadata: kept_metadata.clone(),
+            },
+        ];
+
+        let repaired = repair_response_item_envelope_history(&mut history);
+        assert_eq!(
+            repaired,
+            HistoryRepairStats {
+                inserted_custom_tool_call_outputs: 1,
+                dropped_orphan_custom_tool_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
+        assert_eq!(history.len(), 2);
+        // The retained call's own metadata survives the repair pass...
+        assert_eq!(history[0].metadata, kept_metadata);
+        assert!(matches!(
+            &history[1].item,
+            ResponseItem::CustomToolCallOutput { call_id, output, .. }
+                if call_id == "call-2" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+        ));
+        // ...while the synthesized output for the aborted call carries no metadata of its own.
+        assert_eq!(history[1].metadata, None);
     }
 
     #[test]

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -25,6 +25,7 @@ use codex_core::{
     config::{Config, set_project_trust_level},
     review_prompts::user_facing_hint,
 };
+use codex_history::RolloutItem;
 use codex_login::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::{
@@ -48,8 +49,8 @@ use codex_protocol::{
         ModelRerouteEvent, NetworkApprovalContext, NetworkPolicyRuleAction, Op,
         PatchApplyBeginEvent, PatchApplyEndEvent, PatchApplyStatus, PatchApplyUpdatedEvent,
         ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent, ReviewDecision,
-        ReviewOutputEvent, ReviewRequest, ReviewTarget, RolloutItem, SandboxPolicy,
-        StreamErrorEvent, TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
+        ReviewOutputEvent, ReviewRequest, ReviewTarget, SandboxPolicy, StreamErrorEvent,
+        TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
         ThreadSettingsOverrides, TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent,
         TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent,
         WebSearchBeginEvent, WebSearchEndEvent,
@@ -62,6 +63,7 @@ use codex_protocol::{
         RequestUserInputResponse,
     },
     review_format::format_review_findings_block,
+    turn_input::{TurnInput, TurnInputMode, TurnInputRequest, TurnStartOptions},
     user_input::UserInput,
 };
 use codex_shell_command::parse_command::parse_command;
@@ -1328,7 +1330,8 @@ impl PromptState {
             | EventMsg::PlanDelta(..)
             | EventMsg::EnvironmentConnected(..)
             | EventMsg::EnvironmentDisconnected(..)
-            | EventMsg::RawResponseCompleted(..) => {}
+            | EventMsg::RawResponseCompleted(..)
+            | EventMsg::ThreadQueueChanged(..) => {}
             EventMsg::GuardianAssessment(..) => {}
         }
     }
@@ -2453,6 +2456,9 @@ fn build_exec_permission_options(
                 decision: ReviewDecision::denied("denied"),
             }),
             ReviewDecision::TimedOut => None,
+            // MCP approvals are handled through elicitations, so this decision should never
+            // appear as an exec-approval UI option.
+            ReviewDecision::ApprovedMcpPolicyAmendment => None,
             ReviewDecision::Abort => Some(ExecPermissionOption {
                 option_id: "denied",
                 permission_option: PermissionOption::new(
@@ -3450,16 +3456,10 @@ impl<A: Auth> ThreadActor<A> {
                 "compact" => op = Op::Compact,
                 "undo" => op = Op::ThreadRollback { num_turns: 1 },
                 "init" => {
-                    op = Op::UserInput {
-                        items: vec![UserInput::Text {
-                            text: INIT_COMMAND_PROMPT.into(),
-                            text_elements: vec![],
-                        }],
-                        final_output_json_schema: None,
-                        responsesapi_client_metadata: None,
-                        additional_context: Default::default(),
-                        thread_settings: ThreadSettingsOverrides::default(),
-                    }
+                    op = build_user_input_op(vec![UserInput::Text {
+                        text: INIT_COMMAND_PROMPT.into(),
+                        text_elements: vec![],
+                    }])
                 }
                 "review" => {
                     let instructions = rest.trim();
@@ -3505,24 +3505,10 @@ impl<A: Auth> ThreadActor<A> {
                     self.auth.logout().await?;
                     return Err(Error::auth_required());
                 }
-                _ => {
-                    op = Op::UserInput {
-                        items,
-                        final_output_json_schema: None,
-                        responsesapi_client_metadata: None,
-                        additional_context: Default::default(),
-                        thread_settings: ThreadSettingsOverrides::default(),
-                    }
-                }
+                _ => op = build_user_input_op(items),
             }
         } else {
-            op = Op::UserInput {
-                items,
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }
+            op = build_user_input_op(items)
         }
 
         let submission_seed = Uuid::new_v4().to_string();
@@ -3536,7 +3522,7 @@ impl<A: Auth> ThreadActor<A> {
         );
         let submission_id = self
             .thread
-            .submit(submission_seed, op.clone())
+            .submit(submission_seed, op)
             .instrument(submit_span)
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
@@ -4377,6 +4363,32 @@ fn prompt_blocks_to_answer_strings(prompt: &[ContentBlock]) -> Result<Vec<String
     Ok(answers)
 }
 
+/// Builds a fire-and-forget user-input turn submission op.
+///
+/// Upstream replaced the old flat `Op::UserInput` with `Op::TurnInput`, which routes through
+/// Core's start-or-steer turn machinery and reports its outcome via an embedded oneshot reply
+/// channel. Callers here never awaited a result from plain user input before (outcomes were
+/// always observed through the subsequent event stream instead), so the receiver is dropped
+/// unused, preserving the original fire-and-forget behavior exactly.
+fn build_user_input_op(items: Vec<UserInput>) -> Op {
+    let (reply, _reply_rx) = oneshot::channel();
+    Op::TurnInput {
+        request: Box::new(TurnInputRequest {
+            input: TurnInput::UserInput {
+                content: items,
+                client_id: None,
+            },
+            thread_settings: ThreadSettingsOverrides::default(),
+            start: TurnStartOptions::default(),
+            additional_context: Default::default(),
+            responsesapi_client_metadata: None,
+            trace: None,
+        }),
+        mode: TurnInputMode::StartOrSteer,
+        reply,
+    }
+}
+
 fn build_prompt_items(prompt: Vec<ContentBlock>) -> Vec<UserInput> {
     let trusted_root = managed_skills_root(None)
         .ok()
@@ -4909,7 +4921,7 @@ mod tests {
             }) if text == "Compact task completed"
         ));
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::Compact]);
+        assert!(matches!(ops.as_slice(), [Op::Compact]));
 
         Ok(())
     }
@@ -4959,7 +4971,10 @@ mod tests {
         ));
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::ThreadRollback { num_turns: 1 }]);
+        assert!(matches!(
+            ops.as_slice(),
+            [Op::ThreadRollback { num_turns: 1 }]
+        ));
 
         Ok(())
     }
@@ -4999,18 +5014,22 @@ mod tests {
             "notifications don't match {notifications:?}"
         );
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::UserInput {
-                items: vec![UserInput::Text {
-                    text: INIT_COMMAND_PROMPT.to_string(),
-                    text_elements: vec![]
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::TurnInput {
+                    request,
+                    mode: TurnInputMode::StartOrSteer,
+                    ..
+                }] if matches!(
+                    &request.input,
+                    TurnInput::UserInput { content, client_id: None }
+                        if content == &vec![UserInput::Text {
+                            text: INIT_COMMAND_PROMPT.to_string(),
+                            text_elements: vec![]
+                        }]
+                )
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5054,14 +5073,15 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::UncommittedChanges)),
-                    target: ReviewTarget::UncommittedChanges,
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::UncommittedChanges)),
+                        target: ReviewTarget::UncommittedChanges,
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5109,18 +5129,19 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::Custom {
-                        instructions: instructions.to_owned()
-                    })),
-                    target: ReviewTarget::Custom {
-                        instructions: instructions.to_owned()
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::Custom {
+                            instructions: instructions.to_owned()
+                        })),
+                        target: ReviewTarget::Custom {
+                            instructions: instructions.to_owned()
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5164,20 +5185,21 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::Commit {
-                        sha: "123456".to_owned(),
-                        title: None
-                    })),
-                    target: ReviewTarget::Commit {
-                        sha: "123456".to_owned(),
-                        title: None
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::Commit {
+                            sha: "123456".to_owned(),
+                            title: None
+                        })),
+                        target: ReviewTarget::Commit {
+                            sha: "123456".to_owned(),
+                            title: None
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5221,18 +5243,19 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::BaseBranch {
-                        branch: "feature".to_owned()
-                    })),
-                    target: ReviewTarget::BaseBranch {
-                        branch: "feature".to_owned()
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::BaseBranch {
+                            branch: "feature".to_owned()
+                        })),
+                        target: ReviewTarget::BaseBranch {
+                            branch: "feature".to_owned()
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5276,18 +5299,22 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::UserInput {
-                items: vec![UserInput::Text {
-                    text: "/custom foo".into(),
-                    text_elements: vec![]
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::TurnInput {
+                    request,
+                    mode: TurnInputMode::StartOrSteer,
+                    ..
+                }] if matches!(
+                    &request.input,
+                    TurnInput::UserInput { content, client_id: None }
+                        if content == &vec![UserInput::Text {
+                            text: "/custom foo".into(),
+                            text_elements: vec![]
+                        }]
+                )
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5343,8 +5370,8 @@ mod tests {
 
                 let ops = thread.ops.lock().unwrap();
                 assert_eq!(ops.len(), 2, "ops don't match {ops:?}");
-                assert!(matches!(ops[0], Op::UserInput { .. }));
-                assert!(matches!(ops[1], Op::UserInput { .. }));
+                assert!(matches!(ops[0], Op::TurnInput { .. }));
+                assert!(matches!(ops[1], Op::TurnInput { .. }));
 
                 drop(message_tx);
                 anyhow::Ok(())
@@ -5383,6 +5410,7 @@ mod tests {
                             message: "resumed output".to_string(),
                             phase: None,
                             memory_citation: None,
+                            delivery: None,
                         }),
                     })
                     .await;
@@ -5671,7 +5699,7 @@ mod tests {
                 {
                     let ops = thread.ops.lock().unwrap();
                     assert_eq!(ops.len(), 2, "ops don't match {ops:?}");
-                    assert!(matches!(ops[0], Op::UserInput { .. }));
+                    assert!(matches!(ops[0], Op::TurnInput { .. }));
                     match &ops[1] {
                         Op::UserInputAnswer { id, response } => {
                             assert_eq!(id, "shared-submission");
@@ -5837,6 +5865,75 @@ mod tests {
         }
     }
 
+    /// Rebuilds an owned copy of `op` for test-recording purposes.
+    ///
+    /// `Op` no longer derives `Clone` because `Op::TurnInput` embeds a `oneshot::Sender` reply
+    /// channel. Every other variant is still structurally cloneable, so this reconstructs each
+    /// one field-by-field; `TurnInput`'s reply channel is rebuilt fresh and its receiver is
+    /// dropped unused, since recorded ops are only ever inspected, never resubmitted.
+    fn record_op(op: &Op) -> Op {
+        match op {
+            Op::TurnInput { request, mode, .. } => {
+                let (reply, _reply_rx) = oneshot::channel();
+                Op::TurnInput {
+                    request: request.clone(),
+                    mode: mode.clone(),
+                    reply,
+                }
+            }
+            Op::Compact => Op::Compact,
+            Op::Interrupt => Op::Interrupt,
+            Op::Shutdown => Op::Shutdown,
+            Op::ThreadRollback { num_turns } => Op::ThreadRollback {
+                num_turns: *num_turns,
+            },
+            Op::ThreadSettings { thread_settings } => Op::ThreadSettings {
+                thread_settings: thread_settings.clone(),
+            },
+            Op::Review { review_request } => Op::Review {
+                review_request: review_request.clone(),
+            },
+            Op::ExecApproval {
+                id,
+                turn_id,
+                decision,
+            } => Op::ExecApproval {
+                id: id.clone(),
+                turn_id: turn_id.clone(),
+                decision: decision.clone(),
+            },
+            Op::PatchApproval { id, decision } => Op::PatchApproval {
+                id: id.clone(),
+                decision: decision.clone(),
+            },
+            Op::ResolveElicitation {
+                server_name,
+                request_id,
+                decision,
+                content,
+                meta,
+            } => Op::ResolveElicitation {
+                server_name: server_name.clone(),
+                request_id: request_id.clone(),
+                decision: *decision,
+                content: content.clone(),
+                meta: meta.clone(),
+            },
+            Op::UserInputAnswer { id, response } => Op::UserInputAnswer {
+                id: id.clone(),
+                response: response.clone(),
+            },
+            Op::RequestPermissionsResponse { id, response } => Op::RequestPermissionsResponse {
+                id: id.clone(),
+                response: response.clone(),
+            },
+            other => unimplemented!(
+                "record_op: unhandled Op variant in test mock: {}",
+                other.kind()
+            ),
+        }
+    }
+
     #[async_trait::async_trait]
     impl CodexThreadImpl for StubCodexThread {
         async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
@@ -5848,10 +5945,14 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(submission_id.clone());
-            self.ops.lock().unwrap().push(op.clone());
+            self.ops.lock().unwrap().push(record_op(&op));
 
             match op {
-                Op::UserInput { items, .. } => {
+                Op::TurnInput { request, .. } => {
+                    let TurnInputRequest { input, .. } = *request;
+                    let TurnInput::UserInput { content: items, .. } = input else {
+                        unimplemented!("StubCodexThread only handles TurnInput::UserInput");
+                    };
                     *self.active_prompt_id.lock().unwrap() = Some(submission_id.clone());
                     let prompt = items
                         .into_iter()
@@ -6016,6 +6117,7 @@ mod tests {
                                     message: prompt,
                                     phase: None,
                                     memory_citation: None,
+                                    delivery: None,
                                 }),
                             })
                             .unwrap();
@@ -6051,6 +6153,7 @@ mod tests {
                                 message: "Compact task completed".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -6071,6 +6174,7 @@ mod tests {
                                 message: "Undo in progress...".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -6082,6 +6186,7 @@ mod tests {
                                 message: "Undo completed.".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -7184,6 +7289,7 @@ mod tests {
                             message: "still flowing".to_string(),
                             phase: None,
                             memory_citation: None,
+                            delivery: None,
                         }),
                     )
                     .await;

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp-runtime = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
+codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "f7f30a851dbe8d4b31d130e1e3c0ca4a6790ceb1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp-runtime = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
+codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "8a877a796039bba36b5c9bbba76e134660e45d03" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]

--- a/docs/journal/2026-08-19-codex-fork-resync.md
+++ b/docs/journal/2026-08-19-codex-fork-resync.md
@@ -6,8 +6,9 @@ The fork branch was built by adding two custom commits (a security-dependency pa
 external-crate-rename fix) directly on top of the fork's own `main`, but that `main` was never
 resynced with upstream after the patches landed, so every dependent crate in agenthub was
 building against a codex snapshot from 2026-03-27 while upstream had moved 4619 commits further.
-Resynced the fork to current upstream, rebased both patches on top, and adapted agenthub's own
-ACP adapter code (`agenthub-codex-acp`) for the real API drift that surfaced.
+Resynced the fork to current upstream, rebased both patches on top, adapted agenthub's own ACP
+adapter code (`agenthub-codex-acp`) for the real API drift that surfaced, and added a third fork
+commit fixing a Bazel-only `protoc` build-script failure the resync uncovered.
 
 # Scope
 
@@ -86,6 +87,27 @@ ACP adapter code (`agenthub-codex-acp`) for the real API drift that surfaced.
   patterns with inner-field equality checks instead, since pattern matching doesn't require
   `Op: PartialEq` the way value comparison does.
 
+**CI follow-up: `codex-code-mode-protocol`'s `protoc` dependency.** This crate is new at the
+resynced commit and its `build.rs` unconditionally calls `protoc_bin_vendored::protoc_bin_path()`,
+which locates the bundled `protoc` binary via `env!("CARGO_MANIFEST_DIR")` (a path baked in at
+compile time). Under a plain `cargo build` this works because Cargo always places a crate's own
+package files at that path. Under Bazel it does not: CI's `Bazel Test (Crates)` job failed with
+`internal: protoc not found <sandbox path>/protoc-bin-vendored-linux-x86_64-3.2.0/bin/protoc`.
+Two `crate.annotation()` attempts to fix this at the Bazel-config level were tried and both were
+confirmed *graph-correct* via `bazel query --output=build` (the vendored-protoc target really was
+listed in the right place: first `data_glob` on `protoc-bin-vendored-linux-x86_64` itself, then
+`build_script_data` on `codex-code-mode-protocol` referencing that target directly, once tracing
+through `cargo_build_script.bzl` showed `data` of a *dependency* crate doesn't propagate into a
+build script's sandbox the way `data`/`build_script_data` of the crate running the script does) --
+yet CI reproduced the identical failure both times. Without a Linux Bazel environment to actually
+execute the sandboxed action and inspect it (as opposed to statically querying the target graph),
+this session couldn't pin down why the correctly-declared `data` didn't materialize at the exact
+path the compiled-in `CARGO_MANIFEST_DIR` expects. Patched the fork's `build.rs` instead (a third
+commit) to prefer a `PROTOC` env var when set, falling back to the vendored lookup otherwise --
+zero effect on a plain `cargo build`, and sidesteps the whole cross-crate data-propagation question
+by wiring `PROTOC` to the system `protoc` CI's Bazel jobs already install via `apt`
+(`protobuf-compiler`). Removed both now-unnecessary `crate.annotation()` blocks.
+
 # Key Decisions
 
 - Cherry-pick the 2 real patch commits onto fresh upstream rather than rebase the full branch
@@ -107,6 +129,12 @@ ACP adapter code (`agenthub-codex-acp`) for the real API drift that surfaced.
   variants -- deliberately matched to upstream's own conversion and its explicit code comment
   reasoning, rather than picked independently, since upstream had already made and documented this
   exact judgment call for the identical scenario.
+- Patched the fork's `build.rs` rather than continuing to iterate on Bazel `crate.annotation()`
+  configuration for the `protoc` sandbox issue, after two graph-verified-correct attempts both
+  failed identically in CI -- a build-script-level `PROTOC` env check is a one-line, safe,
+  purely-additive change (no effect when unset) that sidesteps a Bazel/crate_universe behavior this
+  session couldn't fully diagnose without a Linux Bazel environment to execute against, rather than
+  continuing to guess at Bazel-config-only fixes against a ~15-20 minute CI round-trip each time.
 
 # Validation
 
@@ -125,13 +153,24 @@ ACP adapter code (`agenthub-codex-acp`) for the real API drift that surfaced.
 - `cargo fmt -- --check` -- clean.
 - `bazel mod deps --lockfile_mode=update` -- resolves cleanly against the new pin (confirms the
   Bazel external-crate-rename patch still applies correctly across the version jump).
-- `bazel build` of targets under `agenthub-codex-acp`/`agenthub-acp-adapter` could not be
-  validated locally: this codex snapshot's `codex-app-server` pulls in `codex-arg0` ->
-  `codex-linux-sandbox` -> a vendored `bwrap` FFI target that's constrained to
-  `@@platforms//os:linux`, which fails to build on macOS regardless of this change. CI's Bazel job
-  runs on Linux and will perform the real native-build validation this session's tooling couldn't.
+- `bazel build`/`bazel query --output=build` of targets under `agenthub-codex-acp`/
+  `agenthub-acp-adapter` could not be run to full completion locally: this codex snapshot's
+  `codex-app-server` pulls in `codex-arg0` -> `codex-linux-sandbox` -> a vendored `bwrap` FFI
+  target constrained to `@@platforms//os:linux`, which fails to build on macOS regardless of this
+  change. `bazel query`/`bazel mod deps` (graph construction, not execution) work fine locally and
+  were used throughout the `protoc` investigation; CI's Linux Bazel job performs the real
+  native-build validation this session's tooling couldn't.
+- CI (`Bazel Test (Crates)`) confirmed the actual regression this session couldn't reproduce
+  locally: the `protoc` sandbox issue described above. The `PROTOC`-override fix's own CI
+  confirmation is the next step after this entry is written.
 
 # Follow-Ups
 
-- None identified. The fork resync and adaptation are both complete and symmetric with prior
-  behavior; no reduced or partially-migrated state was left behind.
+- The `PROTOC` path (`/usr/bin/protoc`) wired into `codex-code-mode-protocol`'s
+  `crate.annotation()` is a literal absolute path matching what CI's `apt-get install
+  protobuf-compiler` installs on `ubuntu-latest`, not a hermetic Bazel toolchain reference. It has
+  no effect on `cargo build` (Bazel-only) and doesn't make local macOS Bazel builds any more or
+  less broken than the pre-existing `codex-linux-sandbox` platform gate already does, but it is
+  coupled to the CI runner's OS/package-manager specifics. Worth revisiting with a proper
+  `rules_proto`/`toolchains_protoc` dependency if agenthub ever needs a hermetic protoc for other
+  Bazel-built proto codegen.

--- a/docs/journal/2026-08-19-codex-fork-resync.md
+++ b/docs/journal/2026-08-19-codex-fork-resync.md
@@ -1,0 +1,137 @@
+# Summary
+
+The `codex` dependency -- pinned via git rev to a private fork, `hawkingrei/codex`, branch
+`agenthub-security-deps` -- had been stuck roughly 5 months behind real upstream `openai/codex`.
+The fork branch was built by adding two custom commits (a security-dependency patch and a Bazel
+external-crate-rename fix) directly on top of the fork's own `main`, but that `main` was never
+resynced with upstream after the patches landed, so every dependent crate in agenthub was
+building against a codex snapshot from 2026-03-27 while upstream had moved 4619 commits further.
+Resynced the fork to current upstream, rebased both patches on top, and adapted agenthub's own
+ACP adapter code (`agenthub-codex-acp`) for the real API drift that surfaced.
+
+# Scope
+
+**Fork resync** (`hawkingrei/codex`):
+- Confirmed the fork's `main` was a clean fast-forward ancestor of upstream `openai/codex`'s
+  `main` (no divergent history), so a plain `git rebase --onto upstream/main origin/main
+  agenthub-security-deps` was attempted first -- it tried to replay 4067 commits instead of the
+  expected 2, because `agenthub-security-deps`'s deeper history contains commits that are
+  content-identical to, but SHA-different from, what's now on the fork's `main` (an artifact of
+  a prior sync/rebase pass). Aborted and instead cherry-picked just the 2 real patch commits
+  (`fix(deps): patch AgentHub security dependencies`, `fix(bazel): honor renamed external
+  crates`) onto a fresh branch cut from `upstream/main`.
+- The security-deps patch conflicted on 3 files: `codex-rs/Cargo.toml` (upstream had
+  independently moved `rmcp` from `=3.0.0` to `=3.1.2`; kept upstream's newer version alongside
+  the patch's own `reqwest-otel` addition), `codex-rs/Cargo.lock`, and `MODULE.bazel.lock` (both
+  regenerated from the resolved `Cargo.toml`/`MODULE.bazel` rather than merged by hand -- a full
+  `cargo generate-lockfile` was tried first and over-resolved unrelated transitive deps to
+  versions requiring a newer Rust toolchain than the repo pins; a plain `cargo check` against the
+  reset-to-upstream lockfile added only the two new entries needed). The Bazel fix's target file
+  (`defs.bzl`) auto-merged cleanly.
+- Pushed the result as a new branch, `agenthub-security-deps-2026-08`, rather than force-pushing
+  over the existing `agenthub-security-deps` branch -- non-destructive, and Cargo/Bazel pin by
+  commit SHA rather than branch name anyway.
+- Repointed all 20 git-rev references across `Cargo.toml`, `crates/agenthub-acp-adapter/Cargo.toml`,
+  `agenthub-codex-acp/Cargo.toml`, and `MODULE.bazel` to the new commit. `cargo update -p
+  tonic-prost-build --precise 0.14.3` was needed alongside the workspace lockfile update: the new
+  codex snapshot's `codex-code-mode-protocol` hard-pins `=0.14.3`, conflicting with agenthub's own
+  already-resolved `0.14.6` (compatible with agenthub's own `"0.14"` requirement, so this is a
+  safe downgrade within the same requirement, not a version bump).
+
+**API-drift adaptation** (`agenthub-codex-acp`), found via `cargo check` after the pin bump:
+- `Op::UserInput` was replaced by `Op::TurnInput { request: Box<TurnInputRequest>, mode:
+  TurnInputMode, reply: oneshot::Sender<CodexResult<TurnInputSubmission>> }`, a genuine
+  architecture change: turn submission now routes through Core's start-or-steer machinery and
+  reports its outcome via an embedded reply channel, rather than being pure fire-and-forget.
+  Constructs `Op::TurnInput` with `TurnInputMode::StartOrSteer` (matching the old `Op::UserInput`
+  semantics) and a fresh reply channel whose receiver is deliberately dropped unused at every
+  call site -- callers never awaited a submission result for plain user input before (outcomes
+  were always observed through the subsequent event stream instead), so this preserves behavior
+  exactly. `agenthub-codex-acp`'s own `CodexThreadImpl` trait is shared by two backends -- an
+  in-process Core thread and an RPC-backed `AppServerCodexThread` -- and a `oneshot::Sender` can't
+  cross an RPC boundary; `AppServerCodexThread` already had its own independent steer-vs-start
+  decision logic (`try_steer_submission`/`prepare_submission_start`, driving `TurnStart`/`TurnSteer`
+  RPC calls), so its adaptation was just extracting the equivalent fields from the new
+  `TurnInputRequest` shape rather than any redesign of that logic.
+- Rollout-history types (`RolloutItem`, `InitialHistory`, `ResumedHistory`, `CompactedItem`)
+  moved from `codex_protocol::protocol` to a new `codex-history` crate; `RolloutItem::ResponseItem`
+  now wraps a `ResponseItemEnvelope` (adds an optional harness-metadata field) instead of a bare
+  `ResponseItem`. `repair_rollout_items` (operates on `Vec<RolloutItem>`) was adapted in place,
+  threading metadata through on retained items. A second repair function,
+  `repair_response_item_history` (operates on bare `Vec<ResponseItem>`, kept as-is since it has
+  its own direct unit test and other callers), couldn't be reused for
+  `CompactedItem.replacement_history` once that field's type changed to
+  `Vec<ResponseItemEnvelope>`; added an envelope-aware sibling,
+  `repair_response_item_envelope_history`, mirroring the same logic.
+- New enum variants needed handling: `EventMsg::ThreadQueueChanged` and five new
+  `ServerNotification` variants (`ThreadReverted`, `ThreadQueueChanged`, `ProjectChanged`,
+  `ThreadProjectUpdated`, `StrictReviewRequired`) joined existing no-op/unhandled buckets.
+  `ReviewDecision::ApprovedMcpPolicyAmendment` fails closed (declined/filtered out) in both the
+  command-execution and file-change approval paths, mirroring upstream's own
+  `CoreReviewDecision -> CommandExecutionApprovalDecision` conversion and its documented
+  reasoning: MCP approvals are handled through elicitations, so this decision should never reach
+  either approval flow. `CodexErrorInfo::MisalignmentPolicyViolation` maps 1:1 between the
+  app-server and core variants of that enum, alongside the existing `CyberPolicy` arm.
+  `AgentMessageEvent`/`ThreadItem::AgentMessage` gained an optional `delivery` field
+  (`AgentMessageDelivery::Async` marks async-delivered messages); every construction site in
+  agenthub sends ordinary synchronous messages, so `delivery: None` throughout.
+  `McpServerTransportConfig::StreamableHttp` gained `http_headers_helper: Option<String>` (a
+  local-shell-command hook for dynamic headers); `None`, since agenthub doesn't use it.
+- `Op` no longer derives `Clone`/`PartialEq` (the new `TurnInput` variant's reply channel isn't
+  cloneable or comparable), which broke a test-double's op-recording (`StubCodexThread` in
+  `thread.rs` cloned every submitted op for later assertions) and several `assert_eq!` comparisons
+  against literal `Op` values. Added `record_op`, a manual field-by-field reconstruction covering
+  every variant that flows through the test mock (rebuilding `TurnInput` with a fresh, again
+  unused, reply channel); converted whole-value `assert_eq!` comparisons to `matches!`-based slice
+  patterns with inner-field equality checks instead, since pattern matching doesn't require
+  `Op: PartialEq` the way value comparison does.
+
+# Key Decisions
+
+- Cherry-pick the 2 real patch commits onto fresh upstream rather than rebase the full branch
+  history -- the branch's actual unique-to-it commit count (2) diverged sharply from what
+  `git rev-list` reported (4067) due to a prior sync artifact; rebasing the reported range would
+  have replayed thousands of already-upstream commits and hit spurious conflicts on all of them.
+- Push the resync as a new branch (`agenthub-security-deps-2026-08`) instead of force-pushing over
+  `agenthub-security-deps` -- avoids rewriting a remote branch's history; Cargo/Bazel pin by exact
+  commit SHA, so the branch name is purely a human-readable label with no functional role in the
+  pin itself.
+- `Op::TurnInput`'s reply channel is constructed and then deliberately dropped unawaited at every
+  agenthub call site, rather than threading a `TurnInputSubmission` result back to callers --
+  confirmed by checking that `TurnInputMode::StartOrSteer` (unlike `StartIfIdle`) has no documented
+  decline path, so dropping the receiver loses no information callers previously had; the
+  subsequent event stream remains the sole mechanism for observing what actually happened, exactly
+  as before this change.
+- `ApprovedMcpPolicyAmendment` fails closed (declined) in agenthub's own approval-decision mapping
+  functions, rather than being treated as an implicit accept alongside other amendment-kind
+  variants -- deliberately matched to upstream's own conversion and its explicit code comment
+  reasoning, rather than picked independently, since upstream had already made and documented this
+  exact judgment call for the identical scenario.
+
+# Validation
+
+- `cargo build --workspace --lib --tests` -- clean, only a single expected `#[cfg(test)]`-only
+  dead-code warning (a function only exercised by its own dedicated unit test, unrelated to this
+  change).
+- `cargo test -p agenthub-codex-acp-runtime` -- 133 passed, including every test exercising the
+  redesigned submission path (`test_init`, `test_prompt`, `test_review`, `test_undo`,
+  `test_custom_review`, `test_branch_review`, `test_commit_review`,
+  `prepare_submission_start_leaves_runtime_workspace_roots_unset`, and others).
+- `cargo test -p agenthub --lib` -- 767 passed; only the 3 pre-existing, already-documented
+  `lance-namespace-impls` panics (`state::tests::initialize_services_*`, an unrelated crate-version
+  issue tracked separately) failed.
+- `cargo clippy -p agenthub -p agenthub-acp-adapter -p agenthub-codex-acp-runtime
+  -p agenthub-object-store --lib --tests` -- clean.
+- `cargo fmt -- --check` -- clean.
+- `bazel mod deps --lockfile_mode=update` -- resolves cleanly against the new pin (confirms the
+  Bazel external-crate-rename patch still applies correctly across the version jump).
+- `bazel build` of targets under `agenthub-codex-acp`/`agenthub-acp-adapter` could not be
+  validated locally: this codex snapshot's `codex-app-server` pulls in `codex-arg0` ->
+  `codex-linux-sandbox` -> a vendored `bwrap` FFI target that's constrained to
+  `@@platforms//os:linux`, which fails to build on macOS regardless of this change. CI's Bazel job
+  runs on Linux and will perform the real native-build validation this session's tooling couldn't.
+
+# Follow-Ups
+
+- None identified. The fork resync and adaptation are both complete and symmetric with prior
+  behavior; no reduced or partially-migrated state was left behind.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -279,6 +279,18 @@ Main shape:
   and all three independent consumers (agent-creation/Team-adoption enforcement, the ACP skill-loading
   allowlist which is now fully unrestricted, and a team-runtime repo-inference heuristic which is deleted
   outright rather than repointed).
+- The pinned `codex` fork (hawkingrei/codex, agenthub-security-deps branch) had been stuck ~5
+  months behind real upstream openai/codex since its base was never resynced after two custom
+  patches (a security-dependency bump, a Bazel crate-rename fix) landed on top of it. Resynced to
+  current upstream (4619 commits forward) via a targeted 2-commit cherry-pick rather than a full
+  branch rebase (which tried replaying 4067 commits due to a prior sync artifact), pushed as a new
+  branch, and repointed all 20 pins. This surfaced real upstream API drift in
+  `agenthub-codex-acp`: `Op::UserInput` was replaced by `Op::TurnInput`, a genuine
+  start-or-steer-turn redesign with an embedded oneshot reply channel that agenthub's own
+  `CodexThreadImpl` trait shares across an in-process Core thread and an RPC-backed app-server
+  thread (a channel that can't cross the RPC boundary); adapted by constructing the new op with a
+  deliberately unawaited reply channel at every call site, preserving the prior fire-and-forget
+  semantics exactly.
 
 Start with:
 
@@ -306,6 +318,7 @@ Start with:
 - `2026-08-17-mailbox-reassignment-cas-and-idempotency.md`
 - `2026-08-17-message-index-repair-corruption-visibility.md`
 - `2026-08-19-safe-paths-removal.md`
+- `2026-08-19-codex-fork-resync.md`
 
 ## Compaction Rules
 


### PR DESCRIPTION
## Summary
- The pinned `codex` fork (`hawkingrei/codex`, `agenthub-security-deps` branch) had been stuck ~5 months behind real upstream `openai/codex` since its base was never resynced after two custom patches (security-dependency bump vendoring `rama-dns`, Bazel external-crate-rename fix) landed on top of it.
- Resynced the fork to current upstream (4619 commits forward) by cherry-picking just the 2 real patch commits onto a fresh branch (`agenthub-security-deps-2026-08`, pushed non-destructively rather than force-pushing over the old branch), and repointed all 20 git-rev pins across `Cargo.toml`/`MODULE.bazel`.
- Adapted `agenthub-codex-acp` for the real upstream API drift this surfaced — most notably `Op::UserInput` was replaced by `Op::TurnInput`, a genuine start-or-steer-turn redesign with an embedded oneshot reply channel. Since agenthub's `CodexThreadImpl` trait is shared by an in-process Core thread and an RPC-backed `AppServerCodexThread` (a channel that can't cross the RPC boundary), constructs the new op with a deliberately unawaited reply channel at every call site, preserving the prior fire-and-forget semantics exactly.
- Full scope, every conflict/decision, and reasoning for each adaptation: `docs/journal/2026-08-19-codex-fork-resync.md`.

## Test plan
- [x] `cargo build --workspace --lib --tests` — clean
- [x] `cargo test -p agenthub-codex-acp-runtime` — 133 passed, including every test exercising the redesigned submission path (`test_init`, `test_prompt`, `test_review`, `test_undo`, etc.)
- [x] `cargo test -p agenthub --lib` — 767 passed; only the 3 pre-existing, unrelated `lance-namespace-impls` panics failed
- [x] `cargo clippy -p agenthub -p agenthub-acp-adapter -p agenthub-codex-acp-runtime -p agenthub-object-store --lib --tests` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `bazel mod deps --lockfile_mode=update` — resolves cleanly against the new pin
- [ ] `bazel build` of codex-dependent targets — could not validate locally (this codex snapshot's `codex-app-server` pulls in a Linux-only vendored `bwrap` FFI target that fails to build on macOS regardless of this change); CI's Linux Bazel job will validate this

🤖 Generated with [Claude Code](https://claude.com/claude-code)