### PR TITLE
feat(acp): support official Codex multimodal workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "codex-extension-api",
  "codex-features",
  "codex-feedback",
+ "codex-history",
  "codex-http-client",
  "codex-login",
  "codex-mcp-server",
@@ -2830,8 +2831,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-core",
  "codex-protocol",
@@ -2839,8 +2840,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2850,8 +2851,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2861,7 +2862,7 @@ dependencies = [
  "crypto_box",
  "ed25519-dalek",
  "http 1.4.0",
- "jsonwebtoken 10.4.0",
+ "jsonwebtoken 9.3.1",
  "rand 0.9.4",
  "serde",
  "serde_json",
@@ -2870,8 +2871,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2890,8 +2891,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2921,8 +2922,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2942,6 +2943,7 @@ dependencies = [
  "codex-connectors",
  "codex-core",
  "codex-core-plugins",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-extension-api",
  "codex-external-agent-migration",
@@ -2952,7 +2954,7 @@ dependencies = [
  "codex-git-attribution",
  "codex-git-utils",
  "codex-goal-extension",
- "codex-guardian",
+ "codex-guardian-v2",
  "codex-home",
  "codex-hooks",
  "codex-http-client",
@@ -2967,6 +2969,7 @@ dependencies = [
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
+ "codex-queue-extension",
  "codex-rmcp-client",
  "codex-rollout",
  "codex-sandboxing",
@@ -3002,8 +3005,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -3028,20 +3031,22 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
  "codex-experimental-api-macros",
  "codex-extension-items",
+ "codex-history",
  "codex-protocol",
+ "codex-rollout",
  "codex-secrets",
  "codex-shell-command",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "inventory",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -3054,13 +3059,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3080,7 +3085,7 @@ dependencies = [
  "gethostname",
  "hmac 0.12.1",
  "httpdate",
- "jsonwebtoken 10.4.0",
+ "jsonwebtoken 9.3.1",
  "owo-colors",
  "rand 0.9.4",
  "serde",
@@ -3097,8 +3102,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3113,8 +3118,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3133,8 +3138,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3142,8 +3147,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3156,8 +3161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3174,8 +3179,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3184,8 +3189,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3203,8 +3208,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -3212,12 +3217,13 @@ dependencies = [
  "http 1.4.0",
  "rand 0.9.4",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3239,41 +3245,55 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
  "codex-install-context",
+ "codex-protocol",
  "codex-websocket-client",
  "futures",
+ "http-body-util",
+ "prost",
+ "reqwest 0.12.28",
+ "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
+ "tonic",
+ "tower",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
+ "glob",
+ "prost",
+ "protoc-bin-vendored",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 
 [[package]]
 name = "codex-config"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3317,8 +3337,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3339,11 +3359,12 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
+ "codex-file-system",
  "codex-plugin",
  "codex-utils-path-uri",
  "serde_json",
@@ -3353,8 +3374,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3362,8 +3383,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3378,12 +3399,13 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-async-utils",
+ "codex-client",
  "codex-code-mode",
  "codex-config",
  "codex-connectors",
  "codex-context-fragments",
  "codex-core-plugins",
- "codex-core-skills",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-execpolicy",
  "codex-extension-api",
@@ -3392,6 +3414,7 @@ dependencies = [
  "codex-feedback",
  "codex-file-system",
  "codex-git-utils",
+ "codex-history",
  "codex-hooks",
  "codex-http-client",
  "codex-install-context",
@@ -3445,7 +3468,7 @@ dependencies = [
  "openssl-sys",
  "rand 0.9.4",
  "regex-lite",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3467,8 +3490,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3476,7 +3499,6 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-config",
  "codex-connectors",
- "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
  "codex-hooks",
@@ -3496,11 +3518,13 @@ dependencies = [
  "codex-utils-plugins",
  "dirs",
  "flate2",
+ "futures",
  "http 1.4.0",
  "regex",
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2 0.10.9",
  "tar",
@@ -3510,43 +3534,23 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
+ "uuid",
  "which",
  "zip",
 ]
 
 [[package]]
-name = "codex-core-skills"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+name = "codex-diagnostics"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
- "anyhow",
- "codex-analytics",
- "codex-config",
- "codex-context-fragments",
- "codex-exec-server",
- "codex-login",
- "codex-model-provider",
- "codex-otel",
- "codex-protocol",
- "codex-skills",
- "codex-utils-absolute-path",
- "codex-utils-path-uri",
- "codex-utils-plugins",
- "codex-utils-string",
- "dunce",
- "futures",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "zip",
+ "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3554,6 +3558,7 @@ dependencies = [
  "bytes",
  "clatter",
  "codex-api",
+ "codex-config",
  "codex-exec-server-protocol",
  "codex-file-system",
  "codex-http-client",
@@ -3562,14 +3567,17 @@ dependencies = [
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
+ "codex-utils-home-dir",
  "codex-utils-path-uri",
  "codex-utils-pty",
  "codex-utils-rustls-provider",
  "codex-websocket-client",
+ "dirs",
  "futures",
  "http 1.4.0",
  "libc",
  "prost",
+ "rustix",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -3585,8 +3593,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3600,8 +3608,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3618,8 +3626,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,8 +3636,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3638,13 +3646,14 @@ dependencies = [
  "codex-protocol",
  "codex-tools",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "serde_json",
 ]
 
 [[package]]
 name = "codex-extension-items"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -3655,8 +3664,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3664,6 +3673,7 @@ dependencies = [
  "codex-core",
  "codex-core-plugins",
  "codex-hooks",
+ "codex-login",
  "codex-memories-write",
  "codex-otel",
  "codex-plugin",
@@ -3682,8 +3692,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3695,10 +3705,11 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
+ "codex-http-client",
  "codex-login",
  "codex-protocol",
  "mime_guess",
@@ -3709,8 +3720,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3724,8 +3735,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3737,8 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "notify",
  "tokio",
@@ -3747,8 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3760,8 +3771,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3786,14 +3797,15 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-analytics",
  "codex-core",
  "codex-extension-api",
  "codex-otel",
  "codex-protocol",
+ "codex-rollout",
  "codex-state",
  "codex-tools",
  "codex-utils-template",
@@ -3804,19 +3816,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-guardian"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+name = "codex-guardian-v2"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
+ "codex-api",
  "codex-core",
  "codex-extension-api",
+ "codex-features",
+ "codex-http-client",
+ "codex-login",
+ "codex-model-provider",
  "codex-protocol",
+ "http 1.4.0",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
+name = "codex-history"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+dependencies = [
+ "codex-protocol",
+ "schemars 0.8.22",
+ "serde",
 ]
 
 [[package]]
 name = "codex-home"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3825,16 +3856,18 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
+ "async-channel",
  "chrono",
  "codex-config",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
+ "codex-utils-pty",
  "futures",
  "regex",
  "schemars 0.8.22",
@@ -3847,13 +3880,14 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
  "futures",
  "http 1.4.0",
+ "native-tls",
  "opentelemetry",
  "reqwest 0.12.28",
  "rustls",
@@ -3873,8 +3907,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3899,17 +3933,20 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "keyring",
  "tracing",
@@ -3917,8 +3954,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -3939,8 +3976,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3954,6 +3991,7 @@ dependencies = [
  "codex-secrets",
  "codex-terminal-detection",
  "codex-utils-template",
+ "codex-workload-identity",
  "http 1.4.0",
  "once_cell",
  "os_info",
@@ -3972,8 +4010,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3982,6 +4020,7 @@ dependencies = [
  "codex-async-utils",
  "codex-config",
  "codex-connectors",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-login",
  "codex-model-provider",
@@ -3993,7 +4032,7 @@ dependencies = [
  "futures",
  "lru",
  "regex-lite",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -4006,8 +4045,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -4030,8 +4069,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -4049,7 +4088,7 @@ dependencies = [
  "codex-skills-extension",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -4057,13 +4096,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4082,8 +4120,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4092,8 +4130,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4124,8 +4162,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4145,8 +4183,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -4157,8 +4195,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -4176,8 +4214,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4212,8 +4250,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4230,7 +4268,6 @@ dependencies = [
  "opentelemetry_sdk",
  "os_info",
  "reqwest 0.12.28",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "strum_macros 0.28.0",
@@ -4244,8 +4281,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4257,16 +4294,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4279,8 +4316,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4318,9 +4355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-queue-extension"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+dependencies = [
+ "codex-core",
+ "codex-extension-api",
+ "codex-protocol",
+ "codex-thread-store",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "codex-response-debug-context"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4330,8 +4383,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "axum",
@@ -4342,6 +4395,7 @@ dependencies = [
  "codex-exec-server",
  "codex-http-client",
  "codex-keyring-store",
+ "codex-network-proxy",
  "codex-protocol",
  "codex-secrets",
  "codex-utils-home-dir",
@@ -4350,9 +4404,10 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "keyring",
+ "libc",
  "memchr",
  "oauth2",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4365,18 +4420,20 @@ dependencies = [
  "urlencoding",
  "webbrowser",
  "which",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-rollout"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "chrono",
  "codex-extension-items",
  "codex-file-search",
  "codex-git-utils",
+ "codex-history",
  "codex-otel",
  "codex-protocol",
  "codex-state",
@@ -4395,8 +4452,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4410,8 +4467,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4432,8 +4489,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "age",
  "anyhow",
@@ -4451,8 +4508,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4465,14 +4522,15 @@ dependencies = [
  "shlex 1.3.0",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-powershell",
  "url",
  "which",
 ]
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4490,8 +4548,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4507,11 +4565,11 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
+ "codex-analytics",
  "codex-config",
- "codex-core-skills",
  "codex-exec-server",
  "codex-extension-api",
  "codex-mcp",
@@ -4537,11 +4595,12 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "chrono",
+ "codex-history",
  "codex-protocol",
  "codex-utils-absolute-path",
  "libsqlite3-sys",
@@ -4558,19 +4617,20 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
+ "codex-extension-items",
  "codex-git-utils",
  "codex-install-context",
  "codex-otel",
@@ -4593,8 +4653,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4608,7 +4668,7 @@ dependencies = [
  "codex-utils-pty",
  "codex-utils-string",
  "jsonptr",
- "rmcp 3.0.0",
+ "rmcp 3.1.2",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -4618,8 +4678,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "async-io",
  "tokio",
@@ -4629,8 +4689,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "dirs",
  "dunce",
@@ -4641,16 +4701,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4663,8 +4723,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4673,8 +4733,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4685,8 +4745,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4694,8 +4754,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4707,8 +4767,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4716,8 +4776,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4725,8 +4785,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4735,8 +4795,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4750,8 +4810,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4763,8 +4823,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4779,21 +4839,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4802,13 +4862,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4828,8 +4888,8 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -4842,8 +4902,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4864,6 +4924,19 @@ dependencies = [
  "tracing-appender",
  "windows 0.58.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "codex-workload-identity"
+version = "0.149.1"
+source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+dependencies = [
+ "codex-http-client",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -6751,6 +6824,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,9 +7616,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.83.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -7584,20 +7669,21 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-archive"
-version = "0.32.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
 dependencies = [
  "bstr",
  "gix-date",
@@ -7608,9 +7694,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -7634,9 +7720,9 @@ dependencies = [
 
 [[package]]
 name = "gix-blame"
-version = "0.13.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -7663,9 +7749,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
 dependencies = [
  "bstr",
  "gix-path",
@@ -7676,9 +7762,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.37.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
+checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -7690,9 +7776,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.56.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -7701,16 +7787,18 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
+ "memchr",
  "smallvec",
  "thiserror 2.0.20",
  "unicode-bom",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.18.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -7734,30 +7822,31 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.63.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
  "gix-fs",
  "gix-hash",
- "gix-imara-diff",
  "gix-object",
  "gix-path",
  "gix-tempfile",
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
+ "imara-diff 0.1.8",
+ "imara-diff 0.2.0",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.25.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -7775,9 +7864,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.51.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
 dependencies = [
  "bstr",
  "dunce",
@@ -7799,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.48.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -7818,9 +7907,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.30.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -7839,9 +7928,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
 dependencies = [
  "bstr",
  "fastrand",
@@ -7853,9 +7942,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -7865,9 +7954,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -7877,9 +7966,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -7888,9 +7977,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.21.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -7900,20 +7989,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-imara-diff"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
-dependencies = [
- "bstr",
- "hashbrown 0.17.1",
-]
-
-[[package]]
 name = "gix-index"
-version = "0.51.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -7939,9 +8018,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.0"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -7950,9 +8029,9 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.16.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
 dependencies = [
  "bstr",
  "gix-command",
@@ -7960,7 +8039,6 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
- "gix-imara-diff",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -7970,15 +8048,16 @@ dependencies = [
  "gix-tempfile",
  "gix-trace",
  "gix-worktree",
+ "imara-diff 0.1.8",
  "nonempty",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.31.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -7990,9 +8069,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.60.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -8000,18 +8079,20 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
+ "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.20",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.80.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -8022,7 +8103,6 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
- "memmap2",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.20",
@@ -8030,9 +8110,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.70.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -8061,9 +8141,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -8073,9 +8153,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.18.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -8088,9 +8168,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.61.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
 dependencies = [
  "bstr",
  "gix-date",
@@ -8103,6 +8183,7 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.20",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8118,9 +8199,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.63.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -8134,13 +8215,14 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.20",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.41.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
 dependencies = [
  "bstr",
  "gix-error",
@@ -8154,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.45.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -8172,9 +8254,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.31.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -8188,9 +8270,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.14.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
 dependencies = [
  "bitflags 2.13.1",
  "gix-path",
@@ -8200,9 +8282,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.12.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -8213,9 +8295,9 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.30.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
 dependencies = [
  "bstr",
  "filetime",
@@ -8236,9 +8318,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.30.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
 dependencies = [
  "bstr",
  "gix-config",
@@ -8251,9 +8333,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.0"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -8270,9 +8352,9 @@ checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
 dependencies = [
  "bstr",
  "gix-command",
@@ -8286,9 +8368,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.57.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -8303,9 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.36.0"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
 dependencies = [
  "bstr",
  "gix-path",
@@ -8335,9 +8417,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.52.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -8353,9 +8435,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.30.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
 dependencies = [
  "bstr",
  "gix-features",
@@ -8371,9 +8453,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.32.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -8506,6 +8588,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -8585,22 +8669,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
+name = "hickory-proto"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto",
  "idna",
  "ipnet",
- "jni",
- "rand 0.10.2",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
  "thiserror 2.0.20",
  "tinyvec",
  "tokio",
@@ -8609,46 +8694,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.2",
- "ring",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-net",
  "hickory-proto",
  "ipconfig",
- "ipnet",
- "jni",
  "moka",
- "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
- "system-configuration",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -9314,6 +9374,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9497,9 +9576,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iri-string"
@@ -9774,26 +9850,17 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
  "pem 3.0.6",
- "rand 0.8.6",
- "rsa",
+ "ring",
  "serde",
  "serde_json",
- "sha2 0.10.9",
- "signature 2.2.0",
  "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
@@ -10979,11 +11046,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -11682,6 +11749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12071,9 +12149,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -12085,9 +12163,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.32.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -12097,22 +12175,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.32.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -12120,19 +12198,19 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
  "tonic",
- "tonic-types",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.32.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -12140,28 +12218,28 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
+ "serde_json",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.20",
  "tokio",
@@ -12810,17 +12888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12919,9 +12986,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -13311,7 +13378,8 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/hawkingrei/codex?rev=6ca61345ceb09d76edc3db8c4eb55df18a10888a#6ca61345ceb09d76edc3db8c4eb55df18a10888a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e340fef2799277e204260b17af01bc23604712092eacd6defe40167f304baed8"
 dependencies = [
  "ahash",
  "hickory-resolver",
@@ -13982,11 +14050,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -13995,7 +14061,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -14129,9 +14194,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -14764,6 +14829,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -16259,9 +16328,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.46"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -16702,9 +16771,9 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
-version = "0.14.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "axum",
@@ -16745,9 +16814,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost",
@@ -16756,9 +16825,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -16768,17 +16837,6 @@ dependencies = [
  "syn 2.0.117",
  "tempfile",
  "tonic-build",
-]
-
-[[package]]
-name = "tonic-types"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
 ]
 
 [[package]]
@@ -16943,9 +17001,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.33.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -17017,6 +17075,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "triomphe"
@@ -17692,15 +17760,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ members = [
 exclude = ["cmd/agenthub"]
 
 [patch.crates-io]
-rama-dns = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
 sacp = { git = "https://github.com/hawkingrei/symposium-acp", rev = "c731bb045d1375af48b0446af728aea52503b30b" }
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
@@ -126,9 +125,9 @@ agenthub-message-store = { path = "crates/agenthub-message-store" }
 agenthub-object-store = { path = "crates/agenthub-object-store" }
 agenthub-pyroscope = { path = "crates/agenthub-pyroscope" }
 agent-client-protocol = { version = "2.0.0", features = ["unstable"] }
-prost = "0.14"
-tonic-prost = "0.14"
-tonic = { version = "0.14", features = ["transport", "tls-native-roots"] }
+prost = "=0.14.3"
+tonic-prost = "=0.14.3"
+tonic = { version = "=0.14.3", features = ["transport", "tls-native-roots"] }
 rcgen = "0.14"
 rustls = "0.23.40"
 
@@ -136,7 +135,7 @@ rustls = "0.23.40"
 tower = { version = "0.5", features = ["util"] }
 
 [build-dependencies]
-tonic-prost-build = "0.14"
+tonic-prost-build = "=0.14.3"
 protoc-bin-vendored = "3"
 
 [profile.release]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 
@@ -38,6 +39,16 @@ crate.annotation(
     gen_build_script = "off",
     repositories = ["crate_index"],
     rustc_flags = ["--cfg=vendored_bwrap_available"],
+)
+crate.annotation(
+    crate = "codex-code-mode-protocol",
+    # The vendored protoc path is captured in a different Bazel sandbox. Keep
+    # Codex's build script but give it Bazel's hermetic protoc executable.
+    build_script_env = {"PROTOC": "$(execpath @@protobuf+//:protoc)"},
+    build_script_tools = ["@@protobuf+//:protoc"],
+    patch_args = ["-p1"],
+    patches = ["//third_party/codex_code_mode_protocol:use_bazel_protoc.patch"],
+    repositories = ["crate_index"],
 )
 crate.from_cargo(
     name = "crate_index",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,9 +11,9 @@ bazel_dep(name = "rules_rust", version = "0.67.0")
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "codex_src",
-    # Security-patched Codex 0.147 commit shared with the Cargo codex-* dependencies.
-    commit = "6ca61345ceb09d76edc3db8c4eb55df18a10888a",
-    remote = "https://github.com/hawkingrei/codex",
+    # Official Codex 0.149.1 commit shared with the Cargo codex-* dependencies.
+    commit = "ff29a44391deccde0aba0f8390337d7f3c319ea4",
+    remote = "https://github.com/openai/codex",
 )
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -26,26 +26,27 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-config = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-arg0 = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-app-server-client = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-app-server-protocol = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-core = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-exec-server = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-extension-api = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-features = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-feedback = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-http-client = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-mcp-server = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-protocol = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-login = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-models-manager = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-shell-command = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-approval-presets = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-absolute-path = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
-codex-utils-path-uri = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
+codex-apply-patch = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-config = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-app-server-client = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-core = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-exec-server = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-extension-api = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-features = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-feedback = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-http-client = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-history = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-mcp-server = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-login = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-models-manager = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-shell-command = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
 heck = "0.5.0"
 itertools = "0.15.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -33,20 +33,27 @@ use codex_protocol::approvals::{
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::dynamic_tools::DynamicToolCallRequest;
 use codex_protocol::error::CodexErr;
+use codex_protocol::items::{
+    CollabAgentTool as CoreCollabAgentTool, CollabAgentToolCallItem as CoreCollabAgentToolCallItem,
+    CollabAgentToolCallStatus as CoreCollabAgentToolCallStatus,
+    SubAgentActivityItem as CoreSubAgentActivityItem, TurnItem as CoreTurnItem,
+};
 use codex_protocol::mcp::{CallToolResult, RequestId as McpRequestId};
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs};
 use codex_protocol::protocol::{
-    AgentMessageContentDeltaEvent, AgentMessageEvent, CodexErrorInfo, ContextCompactedEvent,
-    DeprecationNoticeEvent, EnteredReviewModeEvent, ErrorEvent, Event, EventMsg,
-    ExecCommandBeginEvent, ExecCommandEndEvent, ExecCommandOutputDeltaEvent, ExecCommandSource,
-    ExecCommandStatus, ExitedReviewModeEvent, FileChange, McpInvocation, McpToolCallBeginEvent,
-    McpToolCallEndEvent, ModelRerouteEvent, NonSteerableTurnKind, Op, PatchApplyBeginEvent,
-    PatchApplyEndEvent, PatchApplyStatus, ReviewDecision, ReviewOutputEvent, ReviewTarget,
-    StreamErrorEvent, TerminalInteractionEvent, TokenCountEvent, TokenUsage, TokenUsageInfo,
-    TurnAbortReason, TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, ViewImageToolCallEvent,
-    WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
+    AgentMessageContentDeltaEvent, AgentMessageEvent, AgentStatus, CodexErrorInfo,
+    ContextCompactedEvent, DeprecationNoticeEvent, EnteredReviewModeEvent, ErrorEvent, Event,
+    EventMsg, ExecCommandBeginEvent, ExecCommandEndEvent, ExecCommandOutputDeltaEvent,
+    ExecCommandSource, ExecCommandStatus, ExitedReviewModeEvent, FileChange,
+    ImageGenerationBeginEvent, ImageGenerationEndEvent, ItemCompletedEvent, ItemStartedEvent,
+    McpInvocation, McpToolCallBeginEvent, McpToolCallEndEvent, ModelRerouteEvent,
+    NonSteerableTurnKind, Op, PatchApplyBeginEvent, PatchApplyEndEvent, PatchApplyStatus,
+    ReviewDecision, ReviewOutputEvent, ReviewTarget, StreamErrorEvent,
+    SubAgentActivityKind as CoreSubAgentActivityKind, TerminalInteractionEvent, TokenCountEvent,
+    TokenUsage, TokenUsageInfo, TurnAbortReason, TurnAbortedEvent, TurnCompleteEvent,
+    TurnStartedEvent, ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
 };
 use codex_protocol::request_permissions::{
     PermissionGrantScope, RequestPermissionProfile, RequestPermissionsEvent,
@@ -55,6 +62,8 @@ use codex_protocol::request_permissions::{
 use codex_protocol::request_user_input::{
     RequestUserInputEvent, RequestUserInputQuestion, RequestUserInputResponse,
 };
+use codex_protocol::turn_input::TurnInput as ProtocolTurnInput;
+use codex_protocol::{AgentPath, ThreadId};
 use codex_shell_command::parse_command::parse_command;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -328,16 +337,14 @@ impl AppServerCodexThread {
         op: &Op,
     ) -> Result<SteerFollowUpAction, CodexErr> {
         let (items, output_schema, responsesapi_client_metadata) = match op {
-            Op::UserInput {
-                items,
-                final_output_json_schema,
-                responsesapi_client_metadata,
-                ..
-            } => (
-                items.clone(),
-                final_output_json_schema.clone(),
-                responsesapi_client_metadata.clone(),
-            ),
+            Op::TurnInput { request, .. } => match &request.input {
+                ProtocolTurnInput::UserInput { content, .. } => (
+                    content.clone(),
+                    request.start.final_output_json_schema.clone(),
+                    request.responsesapi_client_metadata.clone(),
+                ),
+                _ => return Ok(SteerFollowUpAction::QueueFollowUp),
+            },
             _ => return Ok(SteerFollowUpAction::QueueFollowUp),
         };
 
@@ -543,6 +550,7 @@ impl AppServerCodexThread {
                                 message: "Undo completed.".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         });
                         state.local_events.push_back(Event {
@@ -1445,6 +1453,19 @@ impl AppServerCodexThread {
                     }),
                     (
                         Some(id),
+                        item @ (codex_app_server_protocol::ThreadItem::CollabAgentToolCall {
+                            ..
+                        }
+                        | codex_app_server_protocol::ThreadItem::SubAgentActivity { .. }),
+                    ) => app_server_item_started_to_core(
+                        payload.thread_id,
+                        payload.turn_id,
+                        payload.started_at_ms,
+                        item,
+                    )
+                    .map(|msg| Event { id, msg }),
+                    (
+                        Some(id),
                         codex_app_server_protocol::ThreadItem::FileChange {
                             id: call_id,
                             changes,
@@ -1472,6 +1493,14 @@ impl AppServerCodexThread {
                             msg: EventMsg::WebSearchBegin(WebSearchBeginEvent { call_id: item.id }),
                         })
                     }
+                    (Some(id), codex_app_server_protocol::ThreadItem::ImageGeneration(item)) => {
+                        Some(Event {
+                            id,
+                            msg: EventMsg::ImageGenerationBegin(ImageGenerationBeginEvent {
+                                call_id: item.id,
+                            }),
+                        })
+                    }
                     (
                         Some(id),
                         codex_app_server_protocol::ThreadItem::ImageView { id: call_id, path },
@@ -1491,6 +1520,7 @@ impl AppServerCodexThread {
                             text,
                             phase,
                             memory_citation,
+                            delivery,
                             ..
                         },
                     ) => {
@@ -1505,6 +1535,7 @@ impl AppServerCodexThread {
                                 phase,
                                 memory_citation: memory_citation
                                     .map(app_server_memory_citation_to_core),
+                                delivery,
                             }),
                         })
                     }
@@ -1691,6 +1722,19 @@ impl AppServerCodexThread {
                             },
                         ),
                     }),
+                    (
+                        Some(id),
+                        item @ (codex_app_server_protocol::ThreadItem::CollabAgentToolCall {
+                            ..
+                        }
+                        | codex_app_server_protocol::ThreadItem::SubAgentActivity { .. }),
+                    ) => app_server_item_completed_to_core(
+                        payload.thread_id,
+                        payload.turn_id,
+                        payload.completed_at_ms,
+                        item,
+                    )
+                    .map(|msg| Event { id, msg }),
                     (Some(id), codex_app_server_protocol::ThreadItem::WebSearch(item)) => {
                         Some(Event {
                             id,
@@ -1702,6 +1746,20 @@ impl AppServerCodexThread {
                                     .map(app_server_web_search_action_to_core)
                                     .unwrap_or(codex_protocol::models::WebSearchAction::Other),
                                 results: item.results,
+                            }),
+                        })
+                    }
+                    (Some(id), codex_app_server_protocol::ThreadItem::ImageGeneration(item)) => {
+                        Some(Event {
+                            id,
+                            msg: EventMsg::ImageGenerationEnd(ImageGenerationEndEvent {
+                                call_id: item.id,
+                                status: item.status,
+                                revised_prompt: item.revised_prompt,
+                                result: item.result,
+                                transparent_background: item.transparent_background,
+                                failure: item.failure,
+                                saved_path: item.saved_path,
                             }),
                         })
                     }
@@ -1826,6 +1884,11 @@ impl AppServerCodexThread {
             | ServerNotification::ThreadStatusChanged(_)
             | ServerNotification::ThreadArchived(_)
             | ServerNotification::ThreadUnarchived(_)
+            | ServerNotification::ThreadReverted(_)
+            | ServerNotification::ThreadQueueChanged(_)
+            | ServerNotification::ProjectChanged(_)
+            | ServerNotification::ThreadProjectUpdated(_)
+            | ServerNotification::StrictReviewRequired(_)
             | ServerNotification::SkillsChanged(_)
             | ServerNotification::HookStarted(_)
             | ServerNotification::HookCompleted(_)
@@ -1891,7 +1954,7 @@ impl AppServerCodexThread {
 impl CodexThreadImpl for AppServerCodexThread {
     async fn submit(&self, submission_id: String, op: Op) -> Result<String, CodexErr> {
         match op {
-            op @ (Op::UserInput { .. }
+            op @ (Op::TurnInput { .. }
             | Op::Review { .. }
             | Op::Compact
             | Op::ThreadRollback { .. }) => self.submit_prompt_like(submission_id, op).await,
@@ -2308,12 +2371,10 @@ fn prepare_submission_start(
     op: &Op,
 ) -> Result<Option<PreparedSubmissionStart>, PrepareSubmissionStartError> {
     match op {
-        Op::UserInput {
-            items,
-            final_output_json_schema,
-            responsesapi_client_metadata,
-            ..
-        } => {
+        Op::TurnInput { request, .. } => {
+            let ProtocolTurnInput::UserInput { content: items, .. } = &request.input else {
+                return Ok(None);
+            };
             if let Some(missing) = MissingCustomToolOutputs::from_state(state) {
                 return Err(PrepareSubmissionStartError::MissingCustomToolOutputs(
                     missing,
@@ -2348,8 +2409,8 @@ fn prepare_submission_start(
                     effort: state.config.model_reasoning_effort.clone(),
                     summary: state.config.model_reasoning_summary,
                     personality: state.config.personality,
-                    output_schema: final_output_json_schema.clone(),
-                    responsesapi_client_metadata: responsesapi_client_metadata.clone(),
+                    output_schema: request.start.final_output_json_schema.clone(),
+                    responsesapi_client_metadata: request.responsesapi_client_metadata.clone(),
                     collaboration_mode: None,
                     environments: None,
                     permissions: None,
@@ -2434,6 +2495,145 @@ fn clear_submission_if_active(state: &mut AppServerState, submission_id: &str) {
         .is_some_and(|turn| turn.submission_id == submission_id)
     {
         clear_active_turn_state(state);
+    }
+}
+
+fn app_server_item_started_to_core(
+    thread_id: String,
+    turn_id: String,
+    started_at_ms: i64,
+    item: ThreadItem,
+) -> Option<EventMsg> {
+    Some(EventMsg::ItemStarted(ItemStartedEvent {
+        thread_id: ThreadId::from_string(&thread_id).ok()?,
+        turn_id,
+        item: app_server_collab_item_to_core(item)?,
+        started_at_ms,
+    }))
+}
+
+fn app_server_item_completed_to_core(
+    thread_id: String,
+    turn_id: String,
+    completed_at_ms: i64,
+    item: ThreadItem,
+) -> Option<EventMsg> {
+    Some(EventMsg::ItemCompleted(ItemCompletedEvent {
+        thread_id: ThreadId::from_string(&thread_id).ok()?,
+        turn_id,
+        item: app_server_collab_item_to_core(item)?,
+        started_at_ms: None,
+        completed_at_ms,
+    }))
+}
+
+fn app_server_collab_item_to_core(item: ThreadItem) -> Option<CoreTurnItem> {
+    match item {
+        ThreadItem::CollabAgentToolCall {
+            id,
+            tool,
+            status,
+            sender_thread_id,
+            receiver_thread_ids,
+            prompt,
+            model,
+            reasoning_effort,
+            agents_states,
+        } => {
+            let receiver_thread_ids = receiver_thread_ids
+                .into_iter()
+                .map(|id| ThreadId::from_string(&id).ok())
+                .collect::<Option<Vec<_>>>()?;
+            let agents_states = agents_states
+                .into_iter()
+                .map(|(id, state)| {
+                    Some((
+                        ThreadId::from_string(&id).ok()?,
+                        app_server_collab_agent_state_to_core(state),
+                    ))
+                })
+                .collect::<Option<HashMap<_, _>>>()?;
+            Some(CoreTurnItem::CollabAgentToolCall(
+                CoreCollabAgentToolCallItem {
+                    id,
+                    tool: match tool {
+                        codex_app_server_protocol::CollabAgentTool::SpawnAgent => {
+                            CoreCollabAgentTool::SpawnAgent
+                        }
+                        codex_app_server_protocol::CollabAgentTool::SendInput => {
+                            CoreCollabAgentTool::SendInput
+                        }
+                        codex_app_server_protocol::CollabAgentTool::ResumeAgent => {
+                            CoreCollabAgentTool::ResumeAgent
+                        }
+                        codex_app_server_protocol::CollabAgentTool::Wait => {
+                            CoreCollabAgentTool::Wait
+                        }
+                        codex_app_server_protocol::CollabAgentTool::CloseAgent => {
+                            CoreCollabAgentTool::CloseAgent
+                        }
+                    },
+                    status: match status {
+                        codex_app_server_protocol::CollabAgentToolCallStatus::InProgress => {
+                            CoreCollabAgentToolCallStatus::InProgress
+                        }
+                        codex_app_server_protocol::CollabAgentToolCallStatus::Completed => {
+                            CoreCollabAgentToolCallStatus::Completed
+                        }
+                        codex_app_server_protocol::CollabAgentToolCallStatus::Failed => {
+                            CoreCollabAgentToolCallStatus::Failed
+                        }
+                    },
+                    sender_thread_id: ThreadId::from_string(&sender_thread_id).ok()?,
+                    receiver_thread_ids,
+                    receiver_agents: Vec::new(),
+                    prompt,
+                    model,
+                    reasoning_effort,
+                    agents_states,
+                },
+            ))
+        }
+        ThreadItem::SubAgentActivity {
+            id,
+            kind,
+            agent_thread_id,
+            agent_path,
+        } => Some(CoreTurnItem::SubAgentActivity(CoreSubAgentActivityItem {
+            id,
+            kind: match kind {
+                codex_app_server_protocol::SubAgentActivityKind::Started => {
+                    CoreSubAgentActivityKind::Started
+                }
+                codex_app_server_protocol::SubAgentActivityKind::Interacted => {
+                    CoreSubAgentActivityKind::Interacted
+                }
+                codex_app_server_protocol::SubAgentActivityKind::Interrupted => {
+                    CoreSubAgentActivityKind::Interrupted
+                }
+            },
+            agent_thread_id: ThreadId::from_string(&agent_thread_id).ok()?,
+            agent_path: AgentPath::try_from(agent_path).ok()?,
+        })),
+        _ => None,
+    }
+}
+
+fn app_server_collab_agent_state_to_core(
+    state: codex_app_server_protocol::CollabAgentState,
+) -> AgentStatus {
+    match state.status {
+        codex_app_server_protocol::CollabAgentStatus::PendingInit => AgentStatus::PendingInit,
+        codex_app_server_protocol::CollabAgentStatus::Running => AgentStatus::Running,
+        codex_app_server_protocol::CollabAgentStatus::Interrupted => AgentStatus::Interrupted,
+        codex_app_server_protocol::CollabAgentStatus::Completed => {
+            AgentStatus::Completed(state.message)
+        }
+        codex_app_server_protocol::CollabAgentStatus::Errored => {
+            AgentStatus::Errored(state.message.unwrap_or_default())
+        }
+        codex_app_server_protocol::CollabAgentStatus::Shutdown => AgentStatus::Shutdown,
+        codex_app_server_protocol::CollabAgentStatus::NotFound => AgentStatus::NotFound,
     }
 }
 
@@ -2669,6 +2869,7 @@ fn review_decision_to_app_server(decision: ReviewDecision) -> CommandExecutionAp
     match decision {
         ReviewDecision::Approved => CommandExecutionApprovalDecision::Accept,
         ReviewDecision::ApprovedForSession => CommandExecutionApprovalDecision::AcceptForSession,
+        ReviewDecision::ApprovedMcpPolicyAmendment => CommandExecutionApprovalDecision::Decline,
         ReviewDecision::ApprovedExecpolicyAmendment {
             proposed_execpolicy_amendment,
         } => CommandExecutionApprovalDecision::AcceptWithExecpolicyAmendment {
@@ -2692,6 +2893,7 @@ fn patch_review_decision_to_app_server(decision: ReviewDecision) -> FileChangeAp
         ReviewDecision::Denied { .. } => FileChangeApprovalDecision::Decline,
         ReviewDecision::TimedOut => FileChangeApprovalDecision::Decline,
         ReviewDecision::Abort => FileChangeApprovalDecision::Cancel,
+        ReviewDecision::ApprovedMcpPolicyAmendment => FileChangeApprovalDecision::Decline,
         ReviewDecision::ApprovedExecpolicyAmendment { .. }
         | ReviewDecision::NetworkPolicyAmendment { .. } => FileChangeApprovalDecision::Accept,
     }
@@ -2841,6 +3043,9 @@ fn app_server_codex_error_info_to_core(error: AppServerCodexErrorInfo) -> CodexE
         AppServerCodexErrorInfo::UsageLimitExceeded => CodexErrorInfo::UsageLimitExceeded,
         AppServerCodexErrorInfo::ServerOverloaded => CodexErrorInfo::ServerOverloaded,
         AppServerCodexErrorInfo::CyberPolicy => CodexErrorInfo::CyberPolicy,
+        AppServerCodexErrorInfo::MisalignmentPolicyViolation => {
+            CodexErrorInfo::MisalignmentPolicyViolation
+        }
         AppServerCodexErrorInfo::HttpConnectionFailed { http_status_code } => {
             CodexErrorInfo::HttpConnectionFailed { http_status_code }
         }
@@ -3237,6 +3442,7 @@ mod tests {
                 text: "hello".to_string(),
                 phase: None,
                 memory_citation: None,
+                delivery: None,
             }],
             items_view: codex_app_server_protocol::TurnItemsView::Full,
             status: TurnStatus::InProgress,
@@ -3257,6 +3463,41 @@ mod tests {
         assert!(active_turn.steerable);
         assert_eq!(active_turn.turn_id.as_deref(), Some("turn-1"));
         assert_eq!(active_turn.last_agent_message.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn subagent_activity_items_translate_to_core_lifecycle_events() {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let event = app_server_item_completed_to_core(
+            parent_thread_id.to_string(),
+            "turn-1".to_string(),
+            42,
+            ThreadItem::SubAgentActivity {
+                id: "activity-1".to_string(),
+                kind: codex_app_server_protocol::SubAgentActivityKind::Started,
+                agent_thread_id: child_thread_id.to_string(),
+                agent_path: "/root/reviewer".to_string(),
+            },
+        )
+        .expect("subagent activity event");
+
+        let EventMsg::ItemCompleted(ItemCompletedEvent {
+            thread_id,
+            turn_id,
+            item: CoreTurnItem::SubAgentActivity(item),
+            completed_at_ms,
+            ..
+        }) = event
+        else {
+            panic!("expected completed subagent activity");
+        };
+        assert_eq!(thread_id, parent_thread_id);
+        assert_eq!(turn_id, "turn-1");
+        assert_eq!(completed_at_ms, 42);
+        assert_eq!(item.agent_thread_id, child_thread_id);
+        assert_eq!(item.agent_path.as_str(), "/root/reviewer");
+        assert_eq!(item.kind, CoreSubAgentActivityKind::Started);
     }
 
     #[test]
@@ -3954,16 +4195,10 @@ mod tests {
         let err = prepare_submission_start(
             &mut state,
             "submission-2",
-            &Op::UserInput {
-                items: vec![codex_protocol::user_input::UserInput::Text {
-                    text: "continue".to_string(),
-                    text_elements: Vec::new(),
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &crate::thread::user_input_op(vec![codex_protocol::user_input::UserInput::Text {
+                text: "continue".to_string(),
+                text_elements: Vec::new(),
+            }]),
         )
         .expect_err("dirty custom tool history should block new turns");
 
@@ -4030,13 +4265,7 @@ mod tests {
         let prepared = prepare_submission_start(
             &mut state,
             "submission-after-undo",
-            &Op::UserInput {
-                items: Vec::new(),
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &crate::thread::user_input_op(Vec::new()),
         )
         .expect("undo should clear the local pending tool guard");
         assert!(matches!(
@@ -4052,13 +4281,7 @@ mod tests {
         let prepared = prepare_submission_start(
             &mut state,
             "submission-runtime-roots",
-            &Op::UserInput {
-                items: Vec::new(),
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            },
+            &crate::thread::user_input_op(Vec::new()),
         )
         .expect("prepare submission")
         .expect("turn start");

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -23,6 +23,9 @@ use codex_extension_api::{
     LoadUserInstructionsFuture, LoadedUserInstructions, UserInstructionsProvider,
     empty_extension_registry,
 };
+use codex_history::{
+    InitialHistory, ResponseItemEnvelope, ResumedHistory, RolloutItem, RolloutLine,
+};
 use codex_login::auth::{read_codex_api_key_from_env, read_openai_api_key_from_env};
 use codex_login::{
     AuthManager, CLIENT_ID, CODEX_API_KEY_ENV_VAR, CodexAuth, OPENAI_API_KEY_ENV_VAR,
@@ -30,7 +33,7 @@ use codex_login::{
 use codex_protocol::{
     ThreadId,
     models::{FunctionCallOutputPayload, ResponseItem},
-    protocol::{InitialHistory, ResumedHistory, RolloutItem, RolloutLine, SessionSource},
+    protocol::SessionSource,
 };
 use std::{
     cell::RefCell,
@@ -193,6 +196,7 @@ fn codex_mcp_server_config(cwd: &Path, mcp_server: McpServer) -> Option<(String,
                     Some(headers.into_iter().map(|h| (h.name, h.value)).collect())
                 },
                 env_http_headers: None,
+                http_headers_helper: None,
             },
         ),
         McpServer::Stdio(McpServerStdio {
@@ -275,17 +279,17 @@ impl std::ops::AddAssign for HistoryRepairStats {
     }
 }
 
-fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairStats {
+fn repair_response_item_history(items: &mut Vec<ResponseItemEnvelope>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
-        .filter_map(|item| match item {
+        .filter_map(|item| match &item.item {
             ResponseItem::FunctionCall { call_id, .. } => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
     let local_shell_call_ids = items
         .iter()
-        .filter_map(|item| match item {
+        .filter_map(|item| match &item.item {
             ResponseItem::LocalShellCall {
                 call_id: Some(call_id),
                 ..
@@ -295,14 +299,14 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
         .collect::<HashSet<_>>();
     let custom_tool_call_ids = items
         .iter()
-        .filter_map(|item| match item {
+        .filter_map(|item| match &item.item {
             ResponseItem::CustomToolCall { call_id, .. } => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
 
     let mut repaired = HistoryRepairStats::default();
-    items.retain(|item| match item {
+    items.retain(|item| match &item.item {
         ResponseItem::FunctionCallOutput { call_id, .. } => {
             let keep =
                 function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
@@ -322,14 +326,14 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
     });
     let mut function_output_call_ids = items
         .iter()
-        .filter_map(|item| match item {
+        .filter_map(|item| match &item.item {
             ResponseItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
     let mut custom_output_call_ids = items
         .iter()
-        .filter_map(|item| match item {
+        .filter_map(|item| match &item.item {
             ResponseItem::CustomToolCallOutput { call_id, .. } => Some(call_id.clone()),
             _ => None,
         })
@@ -337,19 +341,19 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
 
     let mut synthetic_outputs = Vec::new();
     for (idx, item) in items.iter().enumerate() {
-        match item {
+        match &item.item {
             ResponseItem::FunctionCall { call_id, .. }
                 if function_output_call_ids.insert(call_id.clone()) =>
             {
                 repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
-                    ResponseItem::FunctionCallOutput {
+                    ResponseItemEnvelope::from(ResponseItem::FunctionCallOutput {
                         id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
                         internal_chat_message_metadata_passthrough: None,
-                    },
+                    }),
                 ));
             }
             ResponseItem::CustomToolCall { call_id, .. }
@@ -358,13 +362,13 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 repaired.inserted_custom_tool_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
-                    ResponseItem::CustomToolCallOutput {
+                    ResponseItemEnvelope::from(ResponseItem::CustomToolCallOutput {
                         id: None,
                         call_id: call_id.clone(),
                         name: None,
                         output: aborted_call_output(),
                         internal_chat_message_metadata_passthrough: None,
-                    },
+                    }),
                 ));
             }
             ResponseItem::LocalShellCall {
@@ -374,12 +378,12 @@ fn repair_response_item_history(items: &mut Vec<ResponseItem>) -> HistoryRepairS
                 repaired.inserted_function_call_outputs += 1;
                 synthetic_outputs.push((
                     idx,
-                    ResponseItem::FunctionCallOutput {
+                    ResponseItemEnvelope::from(ResponseItem::FunctionCallOutput {
                         id: None,
                         call_id: call_id.clone(),
                         output: aborted_call_output(),
                         internal_chat_message_metadata_passthrough: None,
-                    },
+                    }),
                 ));
             }
             _ => {}
@@ -396,28 +400,33 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let function_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::FunctionCall { call_id, .. } => Some(call_id.clone()),
+                _ => None,
+            },
             _ => None,
         })
         .collect::<HashSet<_>>();
     let local_shell_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::LocalShellCall {
-                call_id: Some(call_id),
-                ..
-            }) => Some(call_id.clone()),
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::LocalShellCall {
+                    call_id: Some(call_id),
+                    ..
+                } => Some(call_id.clone()),
+                _ => None,
+            },
             _ => None,
         })
         .collect::<HashSet<_>>();
     let custom_tool_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::CustomToolCall { call_id, .. } => Some(call_id.clone()),
+                _ => None,
+            },
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -426,44 +435,27 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut retained = Vec::with_capacity(items.len());
     for item in std::mem::take(items) {
         match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                id,
-                call_id,
-                output,
-                internal_chat_message_metadata_passthrough,
-            }) => {
-                if function_call_ids.contains(&call_id) || local_shell_call_ids.contains(&call_id) {
-                    retained.push(RolloutItem::ResponseItem(
-                        ResponseItem::FunctionCallOutput {
-                            id,
-                            call_id,
-                            output,
-                            internal_chat_message_metadata_passthrough,
-                        },
-                    ));
-                } else {
-                    repaired.dropped_orphan_function_call_outputs += 1;
-                }
-            }
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
-                id,
-                call_id,
-                name,
-                output,
-                internal_chat_message_metadata_passthrough,
-            }) => {
-                if custom_tool_call_ids.contains(&call_id) {
-                    retained.push(RolloutItem::ResponseItem(
-                        ResponseItem::CustomToolCallOutput {
-                            id,
-                            call_id,
-                            name,
-                            output,
-                            internal_chat_message_metadata_passthrough,
-                        },
-                    ));
-                } else {
-                    repaired.dropped_orphan_custom_tool_call_outputs += 1;
+            RolloutItem::ResponseItem(response_item) => {
+                let keep = match &response_item.item {
+                    ResponseItem::FunctionCallOutput { call_id, .. } => {
+                        let keep = function_call_ids.contains(call_id)
+                            || local_shell_call_ids.contains(call_id);
+                        if !keep {
+                            repaired.dropped_orphan_function_call_outputs += 1;
+                        }
+                        keep
+                    }
+                    ResponseItem::CustomToolCallOutput { call_id, .. } => {
+                        let keep = custom_tool_call_ids.contains(call_id);
+                        if !keep {
+                            repaired.dropped_orphan_custom_tool_call_outputs += 1;
+                        }
+                        keep
+                    }
+                    _ => true,
+                };
+                if keep {
+                    retained.push(RolloutItem::ResponseItem(response_item));
                 }
             }
             RolloutItem::Compacted(mut compacted) => {
@@ -479,18 +471,20 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
+                _ => None,
+            },
             _ => None,
         })
         .collect::<HashSet<_>>();
     let mut custom_output_call_ids = items
         .iter()
         .filter_map(|item| match item {
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, .. }) => {
-                Some(call_id.clone())
-            }
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::CustomToolCallOutput { call_id, .. } => Some(call_id.clone()),
+                _ => None,
+            },
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -498,50 +492,59 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
     let mut synthetic_outputs = Vec::new();
     for (idx, item) in items.iter().enumerate() {
         match item {
-            RolloutItem::ResponseItem(ResponseItem::FunctionCall { call_id, .. })
-                if function_output_call_ids.insert(call_id.clone()) =>
-            {
-                repaired.inserted_function_call_outputs += 1;
-                synthetic_outputs.push((
-                    idx,
-                    RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
-                ));
-            }
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCall { call_id, .. })
-                if custom_output_call_ids.insert(call_id.clone()) =>
-            {
-                repaired.inserted_custom_tool_call_outputs += 1;
-                synthetic_outputs.push((
-                    idx,
-                    RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        name: None,
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
-                ));
-            }
-            RolloutItem::ResponseItem(ResponseItem::LocalShellCall {
-                call_id: Some(call_id),
-                ..
-            }) if function_output_call_ids.insert(call_id.clone()) => {
-                repaired.inserted_function_call_outputs += 1;
-                synthetic_outputs.push((
-                    idx,
-                    RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
-                        id: None,
-                        call_id: call_id.clone(),
-                        output: aborted_call_output(),
-                        internal_chat_message_metadata_passthrough: None,
-                    }),
-                ));
-            }
+            RolloutItem::ResponseItem(item) => match &item.item {
+                ResponseItem::FunctionCall { call_id, .. }
+                    if function_output_call_ids.insert(call_id.clone()) =>
+                {
+                    repaired.inserted_function_call_outputs += 1;
+                    synthetic_outputs.push((
+                        idx,
+                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                            ResponseItem::FunctionCallOutput {
+                                id: None,
+                                call_id: call_id.clone(),
+                                output: aborted_call_output(),
+                                internal_chat_message_metadata_passthrough: None,
+                            },
+                        )),
+                    ));
+                }
+                ResponseItem::CustomToolCall { call_id, .. }
+                    if custom_output_call_ids.insert(call_id.clone()) =>
+                {
+                    repaired.inserted_custom_tool_call_outputs += 1;
+                    synthetic_outputs.push((
+                        idx,
+                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                            ResponseItem::CustomToolCallOutput {
+                                id: None,
+                                call_id: call_id.clone(),
+                                name: None,
+                                output: aborted_call_output(),
+                                internal_chat_message_metadata_passthrough: None,
+                            },
+                        )),
+                    ));
+                }
+                ResponseItem::LocalShellCall {
+                    call_id: Some(call_id),
+                    ..
+                } if function_output_call_ids.insert(call_id.clone()) => {
+                    repaired.inserted_function_call_outputs += 1;
+                    synthetic_outputs.push((
+                        idx,
+                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                            ResponseItem::FunctionCallOutput {
+                                id: None,
+                                call_id: call_id.clone(),
+                                output: aborted_call_output(),
+                                internal_chat_message_metadata_passthrough: None,
+                            },
+                        )),
+                    ));
+                }
+                _ => {}
+            },
             _ => {}
         }
     }
@@ -987,16 +990,16 @@ mod tests {
     use codex_config::types::McpServerTransportConfig;
     use codex_core::RolloutRecorder;
     use codex_core::config::ConfigBuilder;
+    use codex_history::{
+        CompactedItem, InitialHistory, ResponseItemEnvelope, ResumedHistory, RolloutItem,
+    };
     use codex_protocol::{
         ThreadId,
         models::{
             FunctionCallOutputPayload, LocalShellAction, LocalShellExecAction, LocalShellStatus,
             ResponseItem,
         },
-        protocol::{
-            CompactedItem, InitialHistory, ResumedHistory, RolloutItem, SessionMeta,
-            SessionMetaLine, SessionSource,
-        },
+        protocol::{SessionMeta, SessionMetaLine, SessionSource},
     };
     use std::{
         collections::HashMap,
@@ -1128,7 +1131,7 @@ mod tests {
         let thread_id = ThreadId::new();
         let history = InitialHistory::Resumed(ResumedHistory {
             conversation_id: thread_id,
-            history: Arc::new(vec![RolloutItem::ResponseItem(
+            history: Arc::new(vec![RolloutItem::ResponseItem(ResponseItemEnvelope::from(
                 ResponseItem::CustomToolCall {
                     id: None,
                     status: Some("completed".to_string()),
@@ -1138,7 +1141,7 @@ mod tests {
                     input: "{}".to_string(),
                     internal_chat_message_metadata_passthrough: None,
                 },
-            )]),
+            ))]),
             rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
         });
 
@@ -1154,8 +1157,10 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert!(matches!(
             &items[1],
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, output, .. })
-                if call_id == "call-1" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCallOutput { call_id, output, .. },
+                ..
+            }) if call_id == "call-1" && output.text_content() == Some("aborted")
         ));
     }
 
@@ -1179,15 +1184,17 @@ mod tests {
                     },
                     git: None,
                 }),
-                RolloutItem::ResponseItem(ResponseItem::CustomToolCall {
-                    id: None,
-                    status: Some("completed".to_string()),
-                    call_id: "call-persist".to_string(),
-                    name: "actor_send".to_string(),
-                    namespace: None,
-                    input: "{}".to_string(),
-                    internal_chat_message_metadata_passthrough: None,
-                }),
+                RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                    ResponseItem::CustomToolCall {
+                        id: None,
+                        status: Some("completed".to_string()),
+                        call_id: "call-persist".to_string(),
+                        name: "actor_send".to_string(),
+                        namespace: None,
+                        input: "{}".to_string(),
+                        internal_chat_message_metadata_passthrough: None,
+                    },
+                )),
             ]),
             rollout_path: Some(rollout_path.clone()),
         });
@@ -1221,22 +1228,24 @@ mod tests {
         assert!(matches!(&items[0], RolloutItem::SessionMeta(_)));
         assert!(matches!(
             &items[2],
-            RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput { call_id, output, .. })
-                if call_id == "call-persist" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::CustomToolCallOutput { call_id, output, .. },
+                ..
+            }) if call_id == "call-persist" && output.text_content() == Some("aborted")
         ));
     }
 
     #[test]
     fn repair_response_item_history_drops_orphan_outputs() {
         let mut history = vec![
-            ResponseItem::CustomToolCallOutput {
+            ResponseItemEnvelope::from(ResponseItem::CustomToolCallOutput {
                 id: None,
                 call_id: "missing".to_string(),
                 name: None,
                 output: FunctionCallOutputPayload::from_text("ok".to_string()),
                 internal_chat_message_metadata_passthrough: None,
-            },
-            ResponseItem::CustomToolCall {
+            }),
+            ResponseItemEnvelope::from(ResponseItem::CustomToolCall {
                 id: None,
                 status: Some("completed".to_string()),
                 call_id: "call-2".to_string(),
@@ -1244,7 +1253,7 @@ mod tests {
                 namespace: None,
                 input: "{}".to_string(),
                 internal_chat_message_metadata_passthrough: None,
-            },
+            }),
         ];
 
         let repaired = repair_response_item_history(&mut history);
@@ -1258,9 +1267,9 @@ mod tests {
         );
         assert_eq!(history.len(), 2);
         assert!(matches!(
-            &history[1],
+            &history[1].item,
             ResponseItem::CustomToolCallOutput { call_id, output, .. }
-                if call_id == "call-2" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+                if call_id == "call-2" && output.text_content() == Some("aborted")
         ));
     }
 
@@ -1268,19 +1277,22 @@ mod tests {
     fn repair_initial_history_updates_compacted_replacement_history() {
         let history = InitialHistory::Forked(vec![RolloutItem::Compacted(CompactedItem {
             message: "compacted".to_string(),
-            replacement_history: Some(vec![ResponseItem::LocalShellCall {
-                id: None,
-                call_id: Some("shell-1".to_string()),
-                status: LocalShellStatus::Completed,
-                internal_chat_message_metadata_passthrough: None,
-                action: LocalShellAction::Exec(LocalShellExecAction {
-                    command: vec!["echo".to_string(), "hi".to_string()],
-                    timeout_ms: None,
-                    working_directory: Some(".".to_string()),
-                    env: None,
-                    user: None,
-                }),
-            }]),
+            replacement_history: Some(vec![ResponseItemEnvelope::from(
+                ResponseItem::LocalShellCall {
+                    id: None,
+                    call_id: Some("shell-1".to_string()),
+                    status: LocalShellStatus::Completed,
+                    internal_chat_message_metadata_passthrough: None,
+                    action: LocalShellAction::Exec(LocalShellExecAction {
+                        command: vec!["echo".to_string(), "hi".to_string()],
+                        timeout_ms: None,
+                        working_directory: Some(".".to_string()),
+                        env: None,
+                        user: None,
+                    }),
+                },
+            )]),
+            mcp_resource_origins: None,
             window_number: None,
             first_window_id: None,
             previous_window_id: None,
@@ -1304,11 +1316,11 @@ mod tests {
             .as_ref()
             .expect("replacement history");
         assert!(matches!(
-            &replacement_history[1],
+            &replacement_history[1].item,
             ResponseItem::FunctionCallOutput {
                 call_id, output, ..
             }
-                if call_id == "shell-1" && output == &FunctionCallOutputPayload::from_text("aborted".to_string())
+                if call_id == "shell-1" && output.text_content() == Some("aborted")
         ));
     }
 }

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -491,60 +491,60 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
 
     let mut synthetic_outputs = Vec::new();
     for (idx, item) in items.iter().enumerate() {
-        match item {
-            RolloutItem::ResponseItem(item) => match &item.item {
-                ResponseItem::FunctionCall { call_id, .. }
-                    if function_output_call_ids.insert(call_id.clone()) =>
-                {
-                    repaired.inserted_function_call_outputs += 1;
-                    synthetic_outputs.push((
-                        idx,
-                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
-                            ResponseItem::FunctionCallOutput {
-                                id: None,
-                                call_id: call_id.clone(),
-                                output: aborted_call_output(),
-                                internal_chat_message_metadata_passthrough: None,
-                            },
-                        )),
-                    ));
-                }
-                ResponseItem::CustomToolCall { call_id, .. }
-                    if custom_output_call_ids.insert(call_id.clone()) =>
-                {
-                    repaired.inserted_custom_tool_call_outputs += 1;
-                    synthetic_outputs.push((
-                        idx,
-                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
-                            ResponseItem::CustomToolCallOutput {
-                                id: None,
-                                call_id: call_id.clone(),
-                                name: None,
-                                output: aborted_call_output(),
-                                internal_chat_message_metadata_passthrough: None,
-                            },
-                        )),
-                    ));
-                }
-                ResponseItem::LocalShellCall {
-                    call_id: Some(call_id),
-                    ..
-                } if function_output_call_ids.insert(call_id.clone()) => {
-                    repaired.inserted_function_call_outputs += 1;
-                    synthetic_outputs.push((
-                        idx,
-                        RolloutItem::ResponseItem(ResponseItemEnvelope::from(
-                            ResponseItem::FunctionCallOutput {
-                                id: None,
-                                call_id: call_id.clone(),
-                                output: aborted_call_output(),
-                                internal_chat_message_metadata_passthrough: None,
-                            },
-                        )),
-                    ));
-                }
-                _ => {}
-            },
+        let RolloutItem::ResponseItem(item) = item else {
+            continue;
+        };
+        match &item.item {
+            ResponseItem::FunctionCall { call_id, .. }
+                if function_output_call_ids.insert(call_id.clone()) =>
+            {
+                repaired.inserted_function_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                        ResponseItem::FunctionCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        },
+                    )),
+                ));
+            }
+            ResponseItem::CustomToolCall { call_id, .. }
+                if custom_output_call_ids.insert(call_id.clone()) =>
+            {
+                repaired.inserted_custom_tool_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                        ResponseItem::CustomToolCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            name: None,
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        },
+                    )),
+                ));
+            }
+            ResponseItem::LocalShellCall {
+                call_id: Some(call_id),
+                ..
+            } if function_output_call_ids.insert(call_id.clone()) => {
+                repaired.inserted_function_call_outputs += 1;
+                synthetic_outputs.push((
+                    idx,
+                    RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                        ResponseItem::FunctionCallOutput {
+                            id: None,
+                            call_id: call_id.clone(),
+                            output: aborted_call_output(),
+                            internal_chat_message_metadata_passthrough: None,
+                        },
+                    )),
+                ));
+            }
             _ => {}
         }
     }

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -8,14 +8,15 @@ use std::{
 use agent_client_protocol::schema::v1::{
     AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate, ClientCapabilities,
     ConfigOptionUpdate, Content, ContentBlock, ContentChunk, Diff, EmbeddedResource,
-    EmbeddedResourceResource, LoadSessionResponse, Meta, PermissionOption, PermissionOptionKind,
-    Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
-    SessionConfigId, SessionConfigOption, SessionConfigOptionCategory, SessionConfigOptionValue,
-    SessionConfigSelectOption, SessionConfigValueId, SessionId, SessionMode, SessionModeId,
-    SessionModeState, SessionNotification, SessionUpdate, StopReason, Terminal,
-    TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput, UsageUpdate,
+    EmbeddedResourceResource, ImageContent, LoadSessionResponse, Meta, PermissionOption,
+    PermissionOptionKind, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus, PromptRequest,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ResourceLink,
+    SelectedPermissionOutcome, SessionConfigId, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigOptionValue, SessionConfigSelectOption, SessionConfigValueId, SessionId,
+    SessionMode, SessionModeId, SessionModeState, SessionNotification, SessionUpdate, StopReason,
+    Terminal, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+    UsageUpdate,
 };
 use agent_client_protocol::{Client, Error};
 use agenthub_managed_skills::managed_skills_root;
@@ -25,6 +26,7 @@ use codex_core::{
     config::{Config, set_project_trust_level},
     review_prompts::user_facing_hint,
 };
+use codex_history::RolloutItem;
 use codex_login::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::{
@@ -32,6 +34,10 @@ use codex_protocol::{
     config_types::TrustLevel,
     dynamic_tools::{DynamicToolCallOutputContentItem, DynamicToolCallRequest},
     error::CodexErr,
+    items::{
+        AgentMessageDelivery, CollabAgentTool, CollabAgentToolCallItem, CollabAgentToolCallStatus,
+        SubAgentActivityItem, TurnItem,
+    },
     mcp::CallToolResult,
     models::{AdditionalPermissionProfile, ResponseItem, WebSearchAction},
     openai_models::{ModelPreset, ReasoningEffort, ReasoningEffortPreset},
@@ -39,17 +45,18 @@ use codex_protocol::{
     plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs},
     protocol::{
         AgentMessageContentDeltaEvent, AgentMessageEvent, AgentReasoningEvent,
-        AgentReasoningRawContentEvent, AgentReasoningSectionBreakEvent,
+        AgentReasoningRawContentEvent, AgentReasoningSectionBreakEvent, AgentStatus,
         ApplyPatchApprovalRequestEvent, DeprecationNoticeEvent, DynamicToolCallResponseEvent,
         ElicitationAction, ErrorEvent, Event, EventMsg, ExecApprovalRequestEvent,
         ExecCommandBeginEvent, ExecCommandEndEvent, ExecCommandOutputDeltaEvent, ExecCommandStatus,
-        ExitedReviewModeEvent, FileChange, ItemCompletedEvent, ItemStartedEvent, McpInvocation,
-        McpStartupCompleteEvent, McpStartupUpdateEvent, McpToolCallBeginEvent, McpToolCallEndEvent,
-        ModelRerouteEvent, NetworkApprovalContext, NetworkPolicyRuleAction, Op,
-        PatchApplyBeginEvent, PatchApplyEndEvent, PatchApplyStatus, PatchApplyUpdatedEvent,
-        ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent, ReviewDecision,
-        ReviewOutputEvent, ReviewRequest, ReviewTarget, RolloutItem, SandboxPolicy,
-        StreamErrorEvent, TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
+        ExitedReviewModeEvent, FileChange, ImageGenerationBeginEvent, ImageGenerationEndEvent,
+        ItemCompletedEvent, ItemStartedEvent, McpInvocation, McpStartupCompleteEvent,
+        McpStartupUpdateEvent, McpToolCallBeginEvent, McpToolCallEndEvent, ModelRerouteEvent,
+        NetworkApprovalContext, NetworkPolicyRuleAction, Op, PatchApplyBeginEvent,
+        PatchApplyEndEvent, PatchApplyStatus, PatchApplyUpdatedEvent, ReasoningContentDeltaEvent,
+        ReasoningRawContentDeltaEvent, ReviewDecision, ReviewOutputEvent, ReviewRequest,
+        ReviewTarget, SandboxPolicy, StreamErrorEvent, SubAgentActivityKind,
+        TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
         ThreadSettingsOverrides, TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent,
         TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent,
         WebSearchBeginEvent, WebSearchEndEvent,
@@ -62,6 +69,7 @@ use codex_protocol::{
         RequestUserInputResponse,
     },
     review_format::format_review_findings_block,
+    turn_input::{TurnInputMode, TurnInputRequest},
     user_input::UserInput,
 };
 use codex_shell_command::parse_command::parse_command;
@@ -108,6 +116,91 @@ fn format_thread_goal_update(event: &ThreadGoalUpdatedEvent) -> String {
         format!("Goal updated ({status}):\n{objective}")
     } else {
         format!("Goal updated ({status}): {objective}")
+    }
+}
+
+fn collab_agent_tool_name(tool: CollabAgentTool) -> &'static str {
+    match tool {
+        CollabAgentTool::SpawnAgent => "spawn_agent",
+        CollabAgentTool::SendInput => "send_input",
+        CollabAgentTool::ResumeAgent => "resume_agent",
+        CollabAgentTool::Wait => "wait",
+        CollabAgentTool::CloseAgent => "close_agent",
+    }
+}
+
+fn collab_agent_tool_title(tool: CollabAgentTool) -> &'static str {
+    match tool {
+        CollabAgentTool::SpawnAgent => "Spawn subagent",
+        CollabAgentTool::SendInput => "Message subagent",
+        CollabAgentTool::ResumeAgent => "Resume subagent",
+        CollabAgentTool::Wait => "Wait for subagents",
+        CollabAgentTool::CloseAgent => "Close subagent",
+    }
+}
+
+fn collab_agent_raw_input(item: &CollabAgentToolCallItem) -> serde_json::Value {
+    serde_json::json!({
+        "tool": collab_agent_tool_name(item.tool),
+        "prompt": item.prompt,
+        "model": item.model,
+        "reasoning_effort": item.reasoning_effort,
+        "receiver_thread_ids": item.receiver_thread_ids,
+    })
+}
+
+fn collab_agent_meta(item: &CollabAgentToolCallItem) -> Meta {
+    Meta::from_iter([(
+        "agenthub".into(),
+        serde_json::json!({
+            "kind": "codex_collaboration",
+            "tool": collab_agent_tool_name(item.tool),
+            "sender_thread_id": item.sender_thread_id,
+            "receiver_thread_ids": item.receiver_thread_ids,
+        }),
+    )])
+}
+
+fn subagent_tool_call_id(thread_id: &codex_protocol::ThreadId) -> String {
+    format!("codex-subagent:{thread_id}")
+}
+
+fn short_thread_id(thread_id: &codex_protocol::ThreadId) -> String {
+    thread_id.to_string().chars().take(8).collect()
+}
+
+fn subagent_meta(
+    thread_id: &codex_protocol::ThreadId,
+    agent_path: Option<&str>,
+    activity: &str,
+) -> Meta {
+    Meta::from_iter([(
+        "agenthub".into(),
+        serde_json::json!({
+            "kind": "codex_subagent",
+            "thread_id": thread_id,
+            "agent_path": agent_path,
+            "activity": activity,
+        }),
+    )])
+}
+
+fn agent_status_to_tool_call_status(status: &AgentStatus) -> ToolCallStatus {
+    match status {
+        AgentStatus::PendingInit | AgentStatus::Running => ToolCallStatus::InProgress,
+        AgentStatus::Completed(_) | AgentStatus::Shutdown => ToolCallStatus::Completed,
+        AgentStatus::Interrupted | AgentStatus::Errored(_) | AgentStatus::NotFound => {
+            ToolCallStatus::Failed
+        }
+    }
+}
+
+pub(crate) fn user_input_op(items: Vec<UserInput>) -> Op {
+    let (reply, _response) = oneshot::channel();
+    Op::TurnInput {
+        request: Box::new(TurnInputRequest::user_input(items)),
+        mode: TurnInputMode::StartOrSteer,
+        reply,
     }
 }
 
@@ -559,6 +652,7 @@ struct PromptState {
     stream_open: bool,
     response_txs: Vec<oneshot::Sender<Result<StopReason, Error>>>,
     seen_message_deltas: bool,
+    last_agent_message_id: Option<String>,
     seen_reasoning_deltas: bool,
     seen_reasoning_final: bool,
 }
@@ -599,6 +693,7 @@ impl PromptState {
             stream_open: true,
             response_txs: vec![response_tx],
             seen_message_deltas: false,
+            last_agent_message_id: None,
             seen_reasoning_deltas: false,
             seen_reasoning_final: false,
         }
@@ -622,6 +717,7 @@ impl PromptState {
             stream_open: true,
             response_txs: Vec::new(),
             seen_message_deltas: false,
+            last_agent_message_id: None,
             seen_reasoning_deltas: false,
             seen_reasoning_final: false,
         }
@@ -928,6 +1024,9 @@ impl PromptState {
                 started_at_ms: _,
             }) => {
                 info!("Item started with thread_id: {thread_id}, turn_id: {turn_id}, item: {item:?}");
+                if let TurnItem::CollabAgentToolCall(item) = item {
+                    self.start_collab_agent_tool_call(client, item).await;
+                }
             }
             EventMsg::UserMessage(UserMessageEvent {
                 message,
@@ -952,7 +1051,10 @@ impl PromptState {
             }) => {
                 info!("Agent message content delta received: thread_id: {thread_id}, turn_id: {turn_id}, item_id: {item_id}, delta: {delta:?}");
                 self.seen_message_deltas = true;
-                client.send_agent_text(delta).await;
+                self.last_agent_message_id = Some(item_id.clone());
+                client
+                    .send_agent_text_chunk(delta, Some(item_id), None)
+                    .await;
             }
             EventMsg::ReasoningContentDelta(ReasoningContentDeltaEvent {
                 thread_id,
@@ -983,10 +1085,24 @@ impl PromptState {
                 self.seen_reasoning_deltas = true;
                 client.send_agent_thought("\n\n").await;
             }
-            EventMsg::AgentMessage(AgentMessageEvent { message , phase: _, .. }) => {
+            EventMsg::AgentMessage(AgentMessageEvent {
+                message,
+                phase: _,
+                delivery,
+                ..
+            }) => {
                 info!("Agent message (non-delta) received: {message:?}");
-                // We didn't receive this message via streaming
-                if !std::mem::take(&mut self.seen_message_deltas) {
+                let streamed = std::mem::take(&mut self.seen_message_deltas);
+                let message_id = self.last_agent_message_id.take();
+                if delivery == Some(AgentMessageDelivery::Async) {
+                    client
+                        .send_agent_text_chunk(
+                            if streamed { String::new() } else { message },
+                            message_id,
+                            Some("async"),
+                        )
+                        .await;
+                } else if !streamed {
                     client.send_agent_text(message).await;
                 }
             }
@@ -1152,6 +1268,15 @@ impl PromptState {
                 started_at_ms: _,
             }) => {
                 info!("Item completed: thread_id={}, turn_id={}, item={:?}", thread_id, turn_id, item);
+                match item {
+                    TurnItem::CollabAgentToolCall(item) => {
+                        self.finish_collab_agent_tool_call(client, item).await;
+                    }
+                    TurnItem::SubAgentActivity(item) => {
+                        self.update_subagent_activity(client, item).await;
+                    }
+                    _ => {}
+                }
             }
             EventMsg::TurnComplete(TurnCompleteEvent {
                 last_agent_message,
@@ -1216,6 +1341,17 @@ impl PromptState {
                         )
                     )]).locations(vec![ToolCallLocation::new(path)])))
                     .await;
+            }
+            EventMsg::ImageGenerationBegin(event) => {
+                info!("Image generation started: call_id={}", event.call_id);
+                self.start_image_generation(client, event).await;
+            }
+            EventMsg::ImageGenerationEnd(event) => {
+                info!(
+                    "Image generation finished: call_id={}, status={}",
+                    event.call_id, event.status
+                );
+                self.finish_image_generation(client, event).await;
             }
             EventMsg::EnteredReviewMode(review_request) => {
                 info!("Review begin: request={review_request:?}");
@@ -1298,10 +1434,8 @@ impl PromptState {
             // Informational: backend is waiting on a safety review before
             // streaming more output. No user-facing action in the ACP adapter.
             | EventMsg::SafetyBuffering(..)
-            |
-            EventMsg::ImageGenerationBegin(..)
-            | EventMsg::ImageGenerationEnd(..)
             | EventMsg::ThreadRolledBack(..)
+            | EventMsg::ThreadQueueChanged(..)
             | EventMsg::HookStarted(..)
             | EventMsg::HookCompleted(..)
             // we already have a way to diff the turn, so ignore
@@ -1330,6 +1464,175 @@ impl PromptState {
             | EventMsg::EnvironmentDisconnected(..)
             | EventMsg::RawResponseCompleted(..) => {}
             EventMsg::GuardianAssessment(..) => {}
+        }
+    }
+
+    async fn start_collab_agent_tool_call(
+        &self,
+        client: &SessionClient,
+        item: CollabAgentToolCallItem,
+    ) {
+        let tool_call = ToolCall::new(item.id.clone(), collab_agent_tool_title(item.tool))
+            .kind(ToolKind::Think)
+            .status(ToolCallStatus::InProgress)
+            .raw_input(collab_agent_raw_input(&item))
+            .meta(collab_agent_meta(&item));
+        client.send_tool_call(tool_call).await;
+    }
+
+    async fn start_image_generation(
+        &self,
+        client: &SessionClient,
+        event: ImageGenerationBeginEvent,
+    ) {
+        let meta = Meta::from_iter([(
+            "agenthub".into(),
+            serde_json::json!({ "kind": "codex_image_generation" }),
+        )]);
+        client
+            .send_tool_call(
+                ToolCall::new(event.call_id, "Generate image")
+                    .kind(ToolKind::Other)
+                    .status(ToolCallStatus::InProgress)
+                    .meta(meta),
+            )
+            .await;
+    }
+
+    async fn finish_image_generation(
+        &self,
+        client: &SessionClient,
+        event: ImageGenerationEndEvent,
+    ) {
+        let saved_path = event
+            .saved_path
+            .as_ref()
+            .map(|path| path.display().to_string());
+        let failed = event.failure.is_some()
+            || matches!(
+                event.status.trim().to_ascii_lowercase().as_str(),
+                "failed" | "error" | "cancelled" | "canceled"
+            );
+        let completed = matches!(
+            event.status.trim().to_ascii_lowercase().as_str(),
+            "completed" | "succeeded" | "success"
+        );
+        let mut content = Vec::new();
+        if !event.result.is_empty() {
+            content.push(ToolCallContent::Content(Content::new(ContentBlock::Image(
+                ImageContent::new(event.result, "image/png"),
+            ))));
+        }
+        if let Some(path) = saved_path.as_ref() {
+            content.push(ToolCallContent::Content(Content::new(
+                ContentBlock::ResourceLink(ResourceLink::new(path.clone(), path.clone())),
+            )));
+        }
+
+        let mut fields = ToolCallUpdateFields::new()
+            .title("Generate image")
+            .status(if failed {
+                ToolCallStatus::Failed
+            } else if completed {
+                ToolCallStatus::Completed
+            } else {
+                ToolCallStatus::InProgress
+            })
+            .raw_output(serde_json::json!({
+                "status": event.status,
+                "revised_prompt": event.revised_prompt,
+                "transparent_background": event.transparent_background,
+                "failure": event.failure,
+                "saved_path": saved_path,
+            }));
+        if !content.is_empty() {
+            fields = fields.content(content);
+        }
+        let meta = Meta::from_iter([(
+            "agenthub".into(),
+            serde_json::json!({ "kind": "codex_image_generation" }),
+        )]);
+        client
+            .send_tool_call_update(ToolCallUpdate::new(event.call_id, fields).meta(meta))
+            .await;
+    }
+
+    async fn finish_collab_agent_tool_call(
+        &self,
+        client: &SessionClient,
+        item: CollabAgentToolCallItem,
+    ) {
+        let status = match item.status {
+            CollabAgentToolCallStatus::InProgress => ToolCallStatus::InProgress,
+            CollabAgentToolCallStatus::Completed => ToolCallStatus::Completed,
+            CollabAgentToolCallStatus::Failed => ToolCallStatus::Failed,
+        };
+        let fields = ToolCallUpdateFields::new()
+            .title(collab_agent_tool_title(item.tool))
+            .status(status)
+            .raw_output(serde_json::json!({
+                "receiver_thread_ids": &item.receiver_thread_ids,
+                "agent_statuses": &item.agents_states,
+            }));
+        client
+            .send_tool_call_update(
+                ToolCallUpdate::new(item.id.clone(), fields).meta(collab_agent_meta(&item)),
+            )
+            .await;
+
+        for (thread_id, agent_status) in &item.agents_states {
+            let subagent_id = subagent_tool_call_id(thread_id);
+            let fields = ToolCallUpdateFields::new()
+                .title(format!("Subagent {}", short_thread_id(thread_id)))
+                .status(agent_status_to_tool_call_status(agent_status));
+            client
+                .send_tool_call_update(
+                    ToolCallUpdate::new(subagent_id, fields)
+                        .meta(subagent_meta(thread_id, None, "status")),
+                )
+                .await;
+        }
+    }
+
+    async fn update_subagent_activity(&self, client: &SessionClient, item: SubAgentActivityItem) {
+        let tool_call_id = subagent_tool_call_id(&item.agent_thread_id);
+        let title = format!("Subagent {}", item.agent_path);
+        let activity = match item.kind {
+            SubAgentActivityKind::Started => "started",
+            SubAgentActivityKind::Interacted => "interacted",
+            SubAgentActivityKind::Interrupted => "interrupted",
+        };
+        let status = match item.kind {
+            SubAgentActivityKind::Started | SubAgentActivityKind::Interacted => {
+                ToolCallStatus::InProgress
+            }
+            SubAgentActivityKind::Interrupted => ToolCallStatus::Failed,
+        };
+        let meta = subagent_meta(
+            &item.agent_thread_id,
+            Some(item.agent_path.as_str()),
+            activity,
+        );
+
+        if item.kind == SubAgentActivityKind::Started {
+            client
+                .send_tool_call(
+                    ToolCall::new(tool_call_id, title)
+                        .kind(ToolKind::Think)
+                        .status(status)
+                        .meta(meta),
+                )
+                .await;
+        } else {
+            client
+                .send_tool_call_update(
+                    ToolCallUpdate::new(
+                        tool_call_id,
+                        ToolCallUpdateFields::new().title(title).status(status),
+                    )
+                    .meta(meta),
+                )
+                .await;
         }
     }
 
@@ -2420,6 +2723,7 @@ fn build_exec_permission_options(
                 ),
                 decision: ReviewDecision::ApprovedForSession,
             }),
+            ReviewDecision::ApprovedMcpPolicyAmendment => None,
             ReviewDecision::NetworkPolicyAmendment {
                 network_policy_amendment,
             } => Some({
@@ -2857,10 +3161,28 @@ impl SessionClient {
     }
 
     async fn send_agent_text(&self, text: impl Into<String>) {
-        self.send_notification(SessionUpdate::AgentMessageChunk(ContentChunk::new(
-            text.into().into(),
-        )))
-        .await;
+        self.send_agent_text_chunk(text, None, None).await;
+    }
+
+    async fn send_agent_text_chunk(
+        &self,
+        text: impl Into<String>,
+        message_id: Option<String>,
+        delivery: Option<&str>,
+    ) {
+        let mut meta = Meta::new();
+        if let Some(message_id) = message_id {
+            meta.insert("message_id".into(), serde_json::Value::String(message_id));
+        }
+        if let Some(delivery) = delivery {
+            meta.insert(
+                "delivery".into(),
+                serde_json::Value::String(delivery.into()),
+            );
+        }
+        let chunk = ContentChunk::new(text.into().into()).meta((!meta.is_empty()).then_some(meta));
+        self.send_notification(SessionUpdate::AgentMessageChunk(chunk))
+            .await;
     }
 
     async fn send_agent_thought(&self, text: impl Into<String>) {
@@ -3450,16 +3772,10 @@ impl<A: Auth> ThreadActor<A> {
                 "compact" => op = Op::Compact,
                 "undo" => op = Op::ThreadRollback { num_turns: 1 },
                 "init" => {
-                    op = Op::UserInput {
-                        items: vec![UserInput::Text {
-                            text: INIT_COMMAND_PROMPT.into(),
-                            text_elements: vec![],
-                        }],
-                        final_output_json_schema: None,
-                        responsesapi_client_metadata: None,
-                        additional_context: Default::default(),
-                        thread_settings: ThreadSettingsOverrides::default(),
-                    }
+                    op = user_input_op(vec![UserInput::Text {
+                        text: INIT_COMMAND_PROMPT.into(),
+                        text_elements: vec![],
+                    }])
                 }
                 "review" => {
                     let instructions = rest.trim();
@@ -3505,24 +3821,10 @@ impl<A: Auth> ThreadActor<A> {
                     self.auth.logout().await?;
                     return Err(Error::auth_required());
                 }
-                _ => {
-                    op = Op::UserInput {
-                        items,
-                        final_output_json_schema: None,
-                        responsesapi_client_metadata: None,
-                        additional_context: Default::default(),
-                        thread_settings: ThreadSettingsOverrides::default(),
-                    }
-                }
+                _ => op = user_input_op(items),
             }
         } else {
-            op = Op::UserInput {
-                items,
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }
+            op = user_input_op(items)
         }
 
         let submission_seed = Uuid::new_v4().to_string();
@@ -3536,7 +3838,7 @@ impl<A: Auth> ThreadActor<A> {
         );
         let submission_id = self
             .thread
-            .submit(submission_seed, op.clone())
+            .submit(submission_seed, op)
             .instrument(submit_span)
             .await
             .map_err(|e| Error::internal_error().data(e.to_string()))?;
@@ -3678,7 +3980,7 @@ impl<A: Auth> ThreadActor<A> {
                     self.replay_event_msg(&event_msg).await;
                 }
                 RolloutItem::ResponseItem(response_item) => {
-                    self.replay_response_item(&response_item).await;
+                    self.replay_response_item(&response_item.item).await;
                 }
                 // Skip SessionMeta, TurnContext, Compacted
                 _ => {}
@@ -4682,6 +4984,7 @@ mod tests {
     use codex_core::test_support::all_model_presets;
     use codex_protocol::config_types::ModeKind;
     use codex_protocol::protocol::{EnteredReviewModeEvent, ModelVerificationEvent};
+    use codex_protocol::turn_input::TurnInput as ProtocolTurnInput;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use tokio::{
         sync::{Mutex, Notify, mpsc::UnboundedSender},
@@ -4700,6 +5003,16 @@ mod tests {
             duration_ms: None,
             time_to_first_token_ms: None,
         }
+    }
+
+    fn turn_input_items(op: &Op) -> Option<&[UserInput]> {
+        let Op::TurnInput { request, .. } = op else {
+            return None;
+        };
+        let ProtocolTurnInput::UserInput { content, .. } = &request.input else {
+            return None;
+        };
+        Some(content)
     }
 
     #[test]
@@ -4877,6 +5190,144 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_updated_codex_events_preserve_async_subagent_and_image_content()
+    -> anyhow::Result<()> {
+        LocalSet::new()
+            .run_until(async {
+                let session_id = SessionId::new("test");
+                let client = Arc::new(StubClient::new());
+                let session_client =
+                    SessionClient::with_client(session_id, client.clone(), Arc::default());
+                let thread = Arc::new(StubCodexThread::new());
+                let (message_tx, _message_rx) = tokio::sync::mpsc::unbounded_channel();
+                let mut prompt_state =
+                    PromptState::new_detached("submission-id".to_string(), thread, message_tx);
+                let child_thread_id = codex_protocol::ThreadId::new();
+
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::AgentMessage(AgentMessageEvent {
+                            message: "Background result".to_string(),
+                            phase: None,
+                            memory_citation: None,
+                            delivery: Some(AgentMessageDelivery::Async),
+                        }),
+                    )
+                    .await;
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::ItemCompleted(ItemCompletedEvent {
+                            thread_id: codex_protocol::ThreadId::new(),
+                            turn_id: "turn-1".to_string(),
+                            item: TurnItem::SubAgentActivity(SubAgentActivityItem {
+                                id: "activity-1".to_string(),
+                                kind: SubAgentActivityKind::Started,
+                                agent_thread_id: child_thread_id,
+                                agent_path: codex_protocol::AgentPath::root()
+                                    .join("reviewer")
+                                    .expect("reviewer path"),
+                            }),
+                            started_at_ms: None,
+                            completed_at_ms: 42,
+                        }),
+                    )
+                    .await;
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::ImageGenerationBegin(ImageGenerationBeginEvent {
+                            call_id: "image-1".to_string(),
+                        }),
+                    )
+                    .await;
+                prompt_state
+                    .handle_event(
+                        &session_client,
+                        EventMsg::ImageGenerationEnd(ImageGenerationEndEvent {
+                            call_id: "image-1".to_string(),
+                            status: "completed".to_string(),
+                            revised_prompt: Some("A diagram".to_string()),
+                            result: "aW1hZ2U=".to_string(),
+                            transparent_background: Some(false),
+                            failure: None,
+                            saved_path: None,
+                        }),
+                    )
+                    .await;
+
+                let notifications = client.notifications.lock().unwrap();
+                assert_eq!(
+                    notifications.len(),
+                    4,
+                    "notifications don't match {notifications:?}"
+                );
+
+                let async_chunk = match &notifications[0].update {
+                    SessionUpdate::AgentMessageChunk(chunk) => chunk,
+                    other => panic!("expected async agent message, got {other:?}"),
+                };
+                assert!(matches!(
+                    &async_chunk.content,
+                    ContentBlock::Text(TextContent { text, .. }) if text == "Background result"
+                ));
+                assert_eq!(
+                    async_chunk
+                        .meta
+                        .as_ref()
+                        .and_then(|meta| meta.get("delivery"))
+                        .and_then(serde_json::Value::as_str),
+                    Some("async")
+                );
+
+                let subagent_call = match &notifications[1].update {
+                    SessionUpdate::ToolCall(call) => call,
+                    other => panic!("expected subagent tool call, got {other:?}"),
+                };
+                assert_eq!(subagent_call.title, "Subagent /root/reviewer");
+                assert_eq!(
+                    subagent_call
+                        .meta
+                        .as_ref()
+                        .and_then(|meta| meta.get("agenthub"))
+                        .and_then(|value| value.get("kind"))
+                        .and_then(serde_json::Value::as_str),
+                    Some("codex_subagent")
+                );
+
+                assert!(matches!(
+                    &notifications[2].update,
+                    SessionUpdate::ToolCall(call)
+                        if call.title == "Generate image"
+                            && call.status == ToolCallStatus::InProgress
+                ));
+                let image_update = match &notifications[3].update {
+                    SessionUpdate::ToolCallUpdate(update) => update,
+                    other => panic!("expected image tool update, got {other:?}"),
+                };
+                assert_eq!(image_update.fields.status, Some(ToolCallStatus::Completed));
+                assert!(image_update.fields.content.as_ref().is_some_and(|content| {
+                    content.iter().any(|item| {
+                        matches!(
+                            item,
+                            ToolCallContent::Content(Content {
+                                content: ContentBlock::Image(ImageContent { data, mime_type, .. }),
+                                ..
+                            }) if data == "aW1hZ2U=" && mime_type == "image/png"
+                        )
+                    })
+                }));
+                assert!(
+                    !serde_json::to_string(&image_update.fields.raw_output)?.contains("aW1hZ2U=")
+                );
+
+                anyhow::Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test]
     async fn test_compact() -> anyhow::Result<()> {
         let (session_id, client, thread, message_tx, local_set) = setup().await?;
         let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
@@ -4909,7 +5360,7 @@ mod tests {
             }) if text == "Compact task completed"
         ));
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::Compact]);
+        assert!(matches!(ops.as_slice(), [Op::Compact]));
 
         Ok(())
     }
@@ -4959,7 +5410,10 @@ mod tests {
         ));
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::ThreadRollback { num_turns: 1 }]);
+        assert!(matches!(
+            ops.as_slice(),
+            [Op::ThreadRollback { num_turns: 1 }]
+        ));
 
         Ok(())
     }
@@ -4999,18 +5453,16 @@ mod tests {
             "notifications don't match {notifications:?}"
         );
         let ops = thread.ops.lock().unwrap();
+        assert_eq!(ops.len(), 1, "ops don't match {ops:?}");
         assert_eq!(
-            ops.as_slice(),
-            &[Op::UserInput {
-                items: vec![UserInput::Text {
+            turn_input_items(&ops[0]),
+            Some(
+                [UserInput::Text {
                     text: INIT_COMMAND_PROMPT.to_string(),
-                    text_elements: vec![]
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }],
+                    text_elements: vec![],
+                }]
+                .as_slice()
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5054,14 +5506,15 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::UncommittedChanges)),
-                    target: ReviewTarget::UncommittedChanges,
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::UncommittedChanges)),
+                        target: ReviewTarget::UncommittedChanges,
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5109,18 +5562,19 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::Custom {
-                        instructions: instructions.to_owned()
-                    })),
-                    target: ReviewTarget::Custom {
-                        instructions: instructions.to_owned()
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::Custom {
+                            instructions: instructions.to_owned(),
+                        })),
+                        target: ReviewTarget::Custom {
+                            instructions: instructions.to_owned(),
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5164,20 +5618,21 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::Commit {
-                        sha: "123456".to_owned(),
-                        title: None
-                    })),
-                    target: ReviewTarget::Commit {
-                        sha: "123456".to_owned(),
-                        title: None
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::Commit {
+                            sha: "123456".to_owned(),
+                            title: None,
+                        })),
+                        target: ReviewTarget::Commit {
+                            sha: "123456".to_owned(),
+                            title: None,
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5221,18 +5676,19 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(
-            ops.as_slice(),
-            &[Op::Review {
-                review_request: ReviewRequest {
-                    user_facing_hint: Some(user_facing_hint(&ReviewTarget::BaseBranch {
-                        branch: "feature".to_owned()
-                    })),
-                    target: ReviewTarget::BaseBranch {
-                        branch: "feature".to_owned()
-                    },
-                }
-            }],
+        assert!(
+            matches!(
+                ops.as_slice(),
+                [Op::Review { review_request }]
+                    if review_request == &ReviewRequest {
+                        user_facing_hint: Some(user_facing_hint(&ReviewTarget::BaseBranch {
+                            branch: "feature".to_owned(),
+                        })),
+                        target: ReviewTarget::BaseBranch {
+                            branch: "feature".to_owned(),
+                        },
+                    }
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5276,18 +5732,16 @@ mod tests {
         );
 
         let ops = thread.ops.lock().unwrap();
+        assert_eq!(ops.len(), 1, "ops don't match {ops:?}");
         assert_eq!(
-            ops.as_slice(),
-            &[Op::UserInput {
-                items: vec![UserInput::Text {
+            turn_input_items(&ops[0]),
+            Some(
+                [UserInput::Text {
                     text: "/custom foo".into(),
-                    text_elements: vec![]
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: ThreadSettingsOverrides::default(),
-            }],
+                    text_elements: vec![],
+                }]
+                .as_slice()
+            ),
             "ops don't match {ops:?}"
         );
 
@@ -5343,8 +5797,8 @@ mod tests {
 
                 let ops = thread.ops.lock().unwrap();
                 assert_eq!(ops.len(), 2, "ops don't match {ops:?}");
-                assert!(matches!(ops[0], Op::UserInput { .. }));
-                assert!(matches!(ops[1], Op::UserInput { .. }));
+                assert!(matches!(&ops[0], Op::TurnInput { .. }));
+                assert!(matches!(&ops[1], Op::TurnInput { .. }));
 
                 drop(message_tx);
                 anyhow::Ok(())
@@ -5383,6 +5837,7 @@ mod tests {
                             message: "resumed output".to_string(),
                             phase: None,
                             memory_citation: None,
+                            delivery: None,
                         }),
                     })
                     .await;
@@ -5671,7 +6126,7 @@ mod tests {
                 {
                     let ops = thread.ops.lock().unwrap();
                     assert_eq!(ops.len(), 2, "ops don't match {ops:?}");
-                    assert!(matches!(ops[0], Op::UserInput { .. }));
+                    assert!(matches!(&ops[0], Op::TurnInput { .. }));
                     match &ops[1] {
                         Op::UserInputAnswer { id, response } => {
                             assert_eq!(id, "shared-submission");
@@ -5848,15 +6303,17 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(submission_id.clone());
-            self.ops.lock().unwrap().push(op.clone());
 
-            match op {
-                Op::UserInput { items, .. } => {
+            match &op {
+                Op::TurnInput { request, .. } => {
+                    let ProtocolTurnInput::UserInput { content: items, .. } = &request.input else {
+                        unimplemented!()
+                    };
                     *self.active_prompt_id.lock().unwrap() = Some(submission_id.clone());
                     let prompt = items
-                        .into_iter()
+                        .iter()
                         .map(|i| match i {
-                            UserInput::Text { text, .. } => text,
+                            UserInput::Text { text, .. } => text.clone(),
                             _ => unimplemented!(),
                         })
                         .join("\n");
@@ -6016,6 +6473,7 @@ mod tests {
                                     message: prompt,
                                     phase: None,
                                     memory_citation: None,
+                                    delivery: None,
                                 }),
                             })
                             .unwrap();
@@ -6051,6 +6509,7 @@ mod tests {
                                 message: "Compact task completed".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -6071,6 +6530,7 @@ mod tests {
                                 message: "Undo in progress...".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -6082,6 +6542,7 @@ mod tests {
                                 message: "Undo completed.".to_string(),
                                 phase: None,
                                 memory_citation: None,
+                                delivery: None,
                             }),
                         })
                         .unwrap();
@@ -6159,6 +6620,7 @@ mod tests {
                     unimplemented!()
                 }
             }
+            self.ops.lock().unwrap().push(op);
             Ok(submission_id)
         }
 
@@ -7184,6 +7646,7 @@ mod tests {
                             message: "still flowing".to_string(),
                             phase: None,
                             memory_citation: None,
+                            delivery: None,
                         }),
                     )
                     .await;

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -21,7 +21,7 @@ agenthub-codex-acp-runtime = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/hawkingrei/codex", rev = "6ca61345ceb09d76edc3db8c4eb55df18a10888a" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]

--- a/crates/agenthub-acp/src/lib.rs
+++ b/crates/agenthub-acp/src/lib.rs
@@ -15,12 +15,12 @@ use std::sync::{
 use std::time::Duration;
 
 use agent_client_protocol::schema::v1::{
-    CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, Implementation,
-    InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption,
-    PermissionOptionKind, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, SelectedPermissionOutcome, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, TextContent, ToolCall, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields,
+    CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, ImageContent,
+    Implementation, InitializeRequest, LoadSessionRequest, McpServer, NewSessionRequest,
+    PermissionOption, PermissionOptionKind, PromptRequest, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
+    TextContent, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
 };
 // `ProtocolVersion` is version-agnostic in 0.15 — it lives at the schema root, not
 // under the versioned `schema::v1` module.
@@ -737,7 +737,7 @@ fn permission_outcome_allows(
 #[derive(Debug)]
 enum AcpCommand {
     Prompt {
-        input: String,
+        blocks: Vec<ContentBlock>,
         submission_id: String,
     },
     SetMode(String),
@@ -747,6 +747,42 @@ enum AcpCommand {
         value: String,
     },
     Cancel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpPromptImage {
+    pub data: String,
+    pub mime_type: String,
+    pub uri: Option<String>,
+}
+
+impl AcpPromptImage {
+    pub fn new(data: impl Into<String>, mime_type: impl Into<String>) -> Self {
+        Self {
+            data: data.into(),
+            mime_type: mime_type.into(),
+            uri: None,
+        }
+    }
+
+    #[must_use]
+    pub fn uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+
+    fn into_content_block(self) -> ContentBlock {
+        ContentBlock::Image(ImageContent::new(self.data, self.mime_type).uri(self.uri))
+    }
+}
+
+fn build_user_prompt_blocks(input: String, images: Vec<AcpPromptImage>) -> Vec<ContentBlock> {
+    let mut blocks = Vec::with_capacity(images.len() + 1);
+    if !input.is_empty() || images.is_empty() {
+        blocks.push(ContentBlock::Text(TextContent::new(input)));
+    }
+    blocks.extend(images.into_iter().map(AcpPromptImage::into_content_block));
+    blocks
 }
 
 impl AcpCommand {
@@ -965,8 +1001,18 @@ impl AcpHandle {
         input: String,
         submission_id: String,
     ) -> anyhow::Result<()> {
+        self.prompt_with_images_with_submission(input, Vec::new(), submission_id)
+            .await
+    }
+
+    pub async fn prompt_with_images_with_submission(
+        &self,
+        input: String,
+        images: Vec<AcpPromptImage>,
+        submission_id: String,
+    ) -> anyhow::Result<()> {
         self.send(AcpCommand::Prompt {
-            input,
+            blocks: build_user_prompt_blocks(input, images),
             submission_id,
         })
         .await
@@ -1264,7 +1310,7 @@ async fn dispatch_acp_command(
 ) {
     match cmd {
         AcpCommand::Prompt {
-            input,
+            blocks: prompt_blocks,
             submission_id,
         } => {
             context.diagnostics.observe_prompt_start(&submission_id);
@@ -1275,9 +1321,10 @@ async fn dispatch_acp_command(
             let prompt_done_tx = context.prompt_done_tx.clone();
             let diagnostics = context.diagnostics.clone();
             let submission_id_for_task = submission_id.clone();
-            let mut blocks = Vec::with_capacity(context.prompt_prefix_blocks.len() + 1);
+            let mut blocks =
+                Vec::with_capacity(context.prompt_prefix_blocks.len() + prompt_blocks.len());
             blocks.extend(context.prompt_prefix_blocks.iter().cloned());
-            blocks.push(ContentBlock::Text(TextContent::new(input)));
+            blocks.extend(prompt_blocks);
             let task = tokio::task::spawn_local(async move {
                 let request = PromptRequest::new(session_id, blocks);
                 send_acp_prompt(conn, request, event_sink, diagnostics.clone()).await;
@@ -1900,6 +1947,12 @@ fn json_message(kind: &str, chunk: &ContentChunk, chunk_state: &mut AcpChunkStat
         obj.insert(
             "chunk_index".to_string(),
             Value::Number(Number::from(chunk_index)),
+        );
+    }
+    if let Some(meta) = &chunk.meta {
+        obj.insert(
+            "meta".to_string(),
+            serde_json::to_value(meta).unwrap_or(Value::Null),
         );
     }
     Value::Object(obj)
@@ -2598,17 +2651,18 @@ mod tests {
     use super::{
         ACP_PERMISSION_REVIEW_TIMEOUT, AcpActorContinuityEnvelope, AcpActorSkillContext,
         AcpCommand, AcpHandle, AcpPermissionRespondResult, AcpPermissionService,
-        AcpPromptDeliveryPolicy, AcpRuntimeDiagnostics, AcpRuntimeLocation, AcpSendError,
-        acp_pending_tool_call_prompt_block_seconds, acp_permission_review_timeout,
+        AcpPromptDeliveryPolicy, AcpPromptImage, AcpRuntimeDiagnostics, AcpRuntimeLocation,
+        AcpSendError, acp_pending_tool_call_prompt_block_seconds, acp_permission_review_timeout,
         acp_session_start_timeout, acp_stale_provider_prompt_seconds, build_prompt_prefix_blocks,
-        dedupe_skills, format_auth_required_message, handle_auth_required_failure,
-        is_auth_required_error, load_mcp_servers_from_path, load_skills_from_config,
-        load_workdir_skills, permission_outcome_allows, permission_review_failure_outcome,
-        remove_skills_conflicting_with_reserved, should_queue_while_prompts_active,
+        build_user_prompt_blocks, dedupe_skills, format_auth_required_message,
+        handle_auth_required_failure, is_auth_required_error, load_mcp_servers_from_path,
+        load_skills_from_config, load_workdir_skills, permission_outcome_allows,
+        permission_review_failure_outcome, remove_skills_conflicting_with_reserved,
+        should_queue_while_prompts_active,
     };
     use agent_client_protocol::schema::v1::{
         ContentBlock, McpServer, PermissionOption, PermissionOptionKind, RequestPermissionOutcome,
-        SelectedPermissionOutcome,
+        SelectedPermissionOutcome, TextContent,
     };
     use agent_client_protocol::{Error as AcpError, ErrorCode as AcpErrorCode};
     use agenthub_acp_core::build_skill;
@@ -2904,7 +2958,7 @@ mod tests {
             false,
             false,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
@@ -2914,7 +2968,7 @@ mod tests {
             false,
             false,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
@@ -2924,7 +2978,7 @@ mod tests {
             true,
             false,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
@@ -2934,7 +2988,7 @@ mod tests {
             false,
             true,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
@@ -2944,7 +2998,7 @@ mod tests {
             false,
             false,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
@@ -2992,10 +3046,39 @@ mod tests {
             false,
             true,
             &AcpCommand::Prompt {
-                input: "hello".to_string(),
+                blocks: vec![ContentBlock::Text(TextContent::new("hello"))],
                 submission_id: "submission-1".to_string(),
             }
         ));
+    }
+
+    #[test]
+    fn multimodal_prompt_blocks_preserve_text_and_image_order() {
+        let blocks = build_user_prompt_blocks(
+            "describe this image".to_string(),
+            vec![AcpPromptImage::new("aW1hZ2U=", "image/png")],
+        );
+
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::Text(content) if content.text == "describe this image"
+        ));
+        assert!(matches!(
+            &blocks[1],
+            ContentBlock::Image(content)
+                if content.data == "aW1hZ2U=" && content.mime_type == "image/png"
+        ));
+    }
+
+    #[test]
+    fn image_only_prompt_does_not_add_an_empty_text_block() {
+        let blocks = build_user_prompt_blocks(
+            String::new(),
+            vec![AcpPromptImage::new("aW1hZ2U=", "image/png")],
+        );
+
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(blocks[0], ContentBlock::Image(_)));
     }
 
     #[test]

--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -802,8 +802,8 @@ pub fn normalize_optional_codex_acp_mode_id(mode_id: Option<&str>) -> Option<Str
         .map(normalize_codex_acp_mode_id)
 }
 
-/// Provider-neutral thinking levels for the Agent Runtime Profiles feature, ordered low → high.
-pub const AGENT_THINKING_LEVELS: [&str; 4] = ["low", "medium", "high", "max"];
+/// Runtime thinking levels accepted by AgentHub, ordered low → high. Providers may support a subset.
+pub const AGENT_THINKING_LEVELS: [&str; 6] = ["low", "medium", "high", "xhigh", "max", "ultra"];
 
 /// Normalize an operator-provided runtime model override: trim, and treat blank as unset. Unknown model
 /// names are intentionally allowed — provider availability drifts independently of AgentHub releases.
@@ -815,8 +815,9 @@ pub fn normalize_optional_runtime_model(model: Option<&str>) -> Option<String> {
 }
 
 /// Normalize a runtime thinking level: trim, lowercase, and keep only the constrained enum
-/// (`low|medium|high|max`). Blank is unset; an unrecognized value yields `None` so callers can reject
-/// it. Stored provider-neutrally — the launch translation maps it to provider-specific options.
+/// (`low|medium|high|xhigh|max|ultra`). Blank is unset; an unrecognized value yields `None` so callers
+/// can reject it. Provider-specific validation and launch translation happen at the API/runtime
+/// boundary.
 pub fn normalize_optional_thinking_level(level: Option<&str>) -> Option<String> {
     let normalized = level.map(str::trim).filter(|value| !value.is_empty())?;
     let lowered = normalized.to_ascii_lowercase();
@@ -1335,7 +1336,7 @@ mod tests {
     fn normalize_optional_thinking_level_keeps_only_the_enum() {
         assert_eq!(super::normalize_optional_thinking_level(None), None);
         assert_eq!(super::normalize_optional_thinking_level(Some(" ")), None);
-        for level in ["low", "medium", "high", "max"] {
+        for level in ["low", "medium", "high", "xhigh", "max", "ultra"] {
             assert_eq!(
                 super::normalize_optional_thinking_level(Some(level)).as_deref(),
                 Some(level)
@@ -1348,8 +1349,8 @@ mod tests {
         );
         // Unrecognized values are rejected (None) so the API layer can surface an error.
         assert_eq!(
-            super::normalize_optional_thinking_level(Some("ultra")),
-            None
+            super::normalize_optional_thinking_level(Some("  ULTRA ")).as_deref(),
+            Some("ultra")
         );
         assert!(super::is_valid_thinking_level("Max"));
         assert!(!super::is_valid_thinking_level("turbo"));

--- a/docs/features/acp-runtime.md
+++ b/docs/features/acp-runtime.md
@@ -15,6 +15,8 @@ spec is required to keep contracts consistent across providers and UI/runtime la
 - ACP provider compatibility baseline for Codex/Gemini/Kimi/Claude adapters, including
   AgentHub-distributed adapter binaries where available.
 - Codex-specific diagnostic side-channel boundaries for live turn/tool-call integrity.
+- Standalone ACP workbench behavior, including runtime context and Codex subagent visibility.
+- Local ACP multimodal image input and provider-generated image output.
 
 ## Non-Goals
 
@@ -23,6 +25,7 @@ spec is required to keep contracts consistent across providers and UI/runtime la
   protocol calls.
 - Re-documenting every ACP UI polish change as timeline history.
 - Defining Team orchestration semantics beyond ACP interaction boundaries.
+- Extending image attachments to remote agents, stdin-only processes, or Team composers.
 
 ## Architecture
 
@@ -77,6 +80,15 @@ Codex and Claude are special cases inside the provider adapter layer:
 ### 4) Conversation/Debug Surfaces
 
 - Conversation is the primary event timeline with ordered render.
+- The standalone ACP workbench exposes the active run state, model, thinking level, permission mode,
+  and Codex subagent activity without requiring the debug tab.
+- Codex collaboration and subagent events remain ACP tool activity. They must not be projected as
+  AgentHub Team members or mutate Team ownership and execution records.
+- Codex runtime profiles accept `xhigh`, `max`, and `ultra` in addition to the common reasoning
+  levels. The adapter must pass these values through exactly; provider/model validation remains
+  authoritative. Claude retains the common `low`, `medium`, `high`, and `max` profile levels.
+- Asynchronous Codex agent messages remain in the ordered conversation and carry an explicit
+  background-delivery label instead of being mistaken for synchronous turn output.
 - Debug provides advanced state/introspection:
   - permission pending/history
   - runtime metrics
@@ -168,6 +180,9 @@ ACP permission requests are first-class runtime records:
 ### 6) Provider Compatibility Contract
 
 - ACP protocol mapping must stay aligned with upstream provider schemas.
+- The Codex ACP baseline is the official `openai/codex` release source. AgentHub must pin Cargo and
+  Bazel to one reviewed upstream commit and must not require a downstream Codex fork for protocol or
+  dependency compatibility.
 - Codex ACP sync changes should preserve session listing, tool-call payload decode, and event handling contracts.
 - Codex ACP behavior should use upstream Codex TUI/core behavior as the compatibility reference
   when ACP semantics are ambiguous. In particular, a permission denial is a model-visible failed
@@ -222,7 +237,39 @@ ACP permission requests are first-class runtime records:
   Code invocations are not misclassified as interactive ACP sessions.
 - When an ACP provider returns `auth_required`, AgentHub should surface an explicit setup error instead of silently retrying interactive auth flows on behalf of a remote user.
 
-### 7) Placement And Proxy Contract
+### 7) Multimodal Contract
+
+- The standalone browser composer may submit text, images, or both. Image-only prompts must not add
+  an empty text content block.
+- The browser sends validated image attachments through the existing agent input route. AgentHub
+  maps them to ACP `ImageContent`, and the Codex adapter maps that provider-neutral content to Codex
+  image user input.
+- Input is limited to four images, 5 MiB per decoded image, and 10 MiB total decoded image bytes.
+  The input route has a 16 MiB request-body limit to cover JSON and base64 overhead.
+- Accepted formats are PNG, JPEG, WebP, and GIF. The backend must validate standard base64, declared
+  MIME type, and the corresponding file signature before persisting or forwarding an attachment.
+- Multimodal input is currently local-ACP-only. Remote agents and stdin-only processes must reject
+  image attachments deterministically instead of silently dropping them.
+- The normalized user event keeps one bounded attachment copy so SSE replay can reconstruct the
+  conversation. Prompt submission failures must preserve the visible user event and attachments.
+- Provider-generated images are represented as ACP image content with an optional saved-resource
+  link. Raw/debug tool output must not duplicate the base64 payload.
+- The web renderer may display only PNG, JPEG, WebP, and GIF from validated `data:` or HTTP(S)
+  sources. SVG and local-file URI rendering remain disallowed.
+
+### 8) Standalone Workbench Contract
+
+- Image selection, clipboard paste, drag-and-drop, preview, removal, and image-only submission are
+  available in the standalone ACP composer without changing Team composer semantics.
+- Composer validation must mirror backend limits and preserve attachments across failed sends or
+  explicit retries. Successful sends clear text and attachments together.
+- The primary header exposes run state, model, live reasoning effort, effective permission mode, and
+  active versus total Codex subagent counts in a compact, localization-ready presentation. Live ACP
+  config values take precedence over persisted startup defaults.
+- Repeated Codex subagent activity with the same thread identifier updates one deterministic tool
+  card. Live subagent cards must not be closed by generic stale-tool settlement.
+
+### 9) Placement And Proxy Contract
 
 - Provider identity and runtime placement must stay independent axes.
 - Introducing remote-node/P2P execution must not require duplicating Codex/Gemini/Kimi/Claude adapter logic.
@@ -237,6 +284,12 @@ ACP permission requests are first-class runtime records:
 - `cargo test -p agenthub-acp-adapter`
 - `cargo check -p agenthub-codex-acp-runtime`
 - `cargo test -p agenthub-codex-acp-runtime`
+- `cargo test -p agenthub-acp prompt_`
+- `cargo test -p agenthub input_image_validation`
+- `cargo test -p agenthub-config normalize_optional_thinking_level`
+- `cargo test -p agenthub codex_reasoning_effort_maps_thinking_levels`
+- `cargo test -p agenthub create_agent_route_`
+- `pnpm -C web exec vitest run src/acp.test.ts src/components/input_dock.test.tsx src/components/acp_media_gallery.test.tsx src/agents_workbench.test.tsx src/components/use_agents_workbench_panel.test.tsx src/api.test.ts src/create_agent_modal.test.tsx src/pages/team/team_management_modals.test.tsx`
 - Focused `agenthub-codex-acp` tests for live-turn tool-call completeness:
   - a `CustomToolCall` without matching `CustomToolCallOutput` is recorded as diagnostic state
     before turn completion/compaction can panic
@@ -271,6 +324,9 @@ ACP permission requests are first-class runtime records:
 
 - Keep ACP contracts provider-agnostic at system boundary; isolate provider drift in adapter modules.
 - Prefer additive compatibility changes when protocol evolves.
+- Keep the Codex Cargo and Bazel pins on the same official `openai/codex` commit. A dependency graph
+  regression should be tracked and remediated upstream or through ordinary dependency constraints,
+  not by silently switching AgentHub back to a downstream Codex fork.
 - AgentHub owns Codex subagent enablement through `codex_acp.multi_agent_enabled` (default
   `true`). When launching Codex ACP through `agenthub-acp codex`, `agenthub-codex-acp`, or another
   recognized Codex ACP command, AgentHub should pass an explicit
@@ -324,6 +380,11 @@ ACP permission requests are first-class runtime records:
   compaction or resume paths run.
 - Long-session rendering can regress if virtualization/stick-bottom heuristics are bypassed.
 - Permission UX still needs periodic real-browser verification under rapid agent switching.
+- Inline base64 attachment persistence increases SQLite and SSE replay cost near the current input
+  limits. A later storage migration should replace inline event payloads with owner-scoped object
+  references and replay-safe thumbnails without changing the ACP content contract.
+- Official Codex releases can reintroduce older or parallel transitive dependency versions. Each
+  Codex upgrade needs a lockfile audit even when the upstream source itself is current.
 - A provider may still fail to finish after receiving a valid deny response. AgentHub should expose
   that as a stale provider prompt with safe diagnostics; automatic cancel, kill, or prompt
   abandonment remains out of scope unless a future provider-specific contract explicitly requires it.
@@ -353,4 +414,5 @@ ACP permission requests are first-class runtime records:
 - `docs/journal/2026-06-10-claude-acp-provider-support.md`
 - `docs/journal/2026-06-11-generic-codex-acp-entrypoint.md`
 - `docs/journal/2026-07-19-acp-ui-compaction-wave2.md`
+- `docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md`
 - `docs/journal/2026-08-09-feature-docs-compaction-wave2-closeout.md`

--- a/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
+++ b/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
@@ -33,6 +33,18 @@ No downstream Codex fork is used by the Cargo or Bazel Codex source pins.
 - Runtime and test code now use `codex-history` envelopes and `Op::TurnInput` without weakening the
   existing history-repair, prompt-steering, approval, or configuration tests.
 
+### CI Compatibility Repairs
+
+- The official `codex-code-mode-protocol` build script now honors an explicit `PROTOC` executable
+  before falling back to its vendored Cargo executable. Bazel supplies the hermetic protobuf
+  compiler through crate-universe build-script metadata, so the generated protocol remains on the
+  official Codex source graph without depending on an absolute path from another sandbox.
+- The rollout-history repair loop uses an equivalent `let ... else` shape that satisfies the
+  workspace `single_match` lint without changing which response items are repaired.
+- The Team ACP duplicate-send test now follows the successful-send contract: the cleared composer
+  remains disabled until a new prompt is entered, then duplicate triggers are still suppressed
+  while that follow-up prompt is in flight.
+
 ### Updated Codex Capabilities Through ACP
 
 - Asynchronous Codex agent messages retain `delivery = async` metadata through the ACP event path
@@ -77,6 +89,7 @@ The focused checks cover the changed dependency, protocol, API, and UI boundarie
 
 ```bash
 cargo fmt --all --check
+cargo clippy --locked --workspace --all-targets -- -D warnings
 cargo check -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-acp -p agenthub
 cargo test -p agenthub-codex-acp-runtime
 cargo test -p agenthub-acp-adapter
@@ -88,6 +101,7 @@ cargo test -p agenthub create_agent_route_
 npm run lint
 npx tsc --noEmit
 npm run build
+npm run test:coverage
 npx vitest run src/acp.test.ts src/components/input_dock.test.tsx src/components/acp_media_gallery.test.tsx src/agents_workbench.test.tsx src/components/use_agents_workbench_panel.test.tsx src/api.test.ts src/create_agent_modal.test.tsx src/pages/team/team_management_modals.test.tsx
 ```
 
@@ -97,16 +111,20 @@ validator contains two passing tests, and the focused web matrix contains 82 pas
 eight files. The extended reasoning checks add one config normalization test, one Codex mapping
 test, and 13 create-agent route tests.
 
-The focused Bazel command was attempted with the repository's default configuration:
+The CI repair follow-up also passed the full Web coverage matrix: 1,503 tests across 162 core test
+files plus 30 Team smoke tests. The production build, ESLint, TypeScript typecheck, workspace
+all-targets Clippy, and formatting checks completed successfully.
+
+The affected Bazel binaries and test targets passed with Bazel 9.2.0:
 
 ```bash
+bazel build //agenthub-codex-acp:agenthub_codex_acp_bin //crates/agenthub-acp-adapter:agenthub_acp_adapter_bin
 bazel test //agenthub-codex-acp:agenthub_codex_acp_tests //crates/agenthub-acp-adapter:agenthub_acp_adapter_tests
 ```
 
-It stopped before loading AgentHub's targets because the local external repository state reported
-that `@rules_rust+//rust:defs.bzl` had no corresponding Bazel package. No project or user Bazel
-configuration was changed as part of this checkpoint; CI or a repaired local external-repository
-state still needs to provide Bazel compilation evidence.
+The build completed 4,082 actions and both tests passed. The commands used an isolated local output
+root and repository/disk caches to avoid a capacity-limited `/tmp` mount; no project or user Bazel
+configuration was changed.
 
 Chrome DevTools MCP was not available in this environment, so this checkpoint does not claim
 before/after browser evidence. The DOM-level interaction matrix and production web build are the

--- a/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
+++ b/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
@@ -44,6 +44,10 @@ No downstream Codex fork is used by the Cargo or Bazel Codex source pins.
 - The Team ACP duplicate-send test now follows the successful-send contract: the cleared composer
   remains disabled until a new prompt is entered, then duplicate triggers are still suppressed
   while that follow-up prompt is in flight.
+- The Team task handoff CAS regression now prepares the terminal update before either concurrent
+  writer starts. It exercises the complete production transaction through an internal helper, so a
+  stale update still loses while a valid handoff-then-update serial order is no longer misclassified
+  as a concurrency failure under coverage instrumentation.
 
 ### Updated Codex Capabilities Through ACP
 
@@ -98,6 +102,7 @@ cargo test -p agenthub input_image_validation
 cargo test -p agenthub-config normalize_optional_thinking_level
 cargo test -p agenthub codex_reasoning_effort_maps_thinking_levels
 cargo test -p agenthub create_agent_route_
+cargo test --locked -p agenthub concurrent_terminal_status_update_and_handoff_do_not_both_apply -- --nocapture
 npm run lint
 npx tsc --noEmit
 npm run build
@@ -120,10 +125,12 @@ The affected Bazel binaries and test targets passed with Bazel 9.2.0:
 ```bash
 bazel build //agenthub-codex-acp:agenthub_codex_acp_bin //crates/agenthub-acp-adapter:agenthub_acp_adapter_bin
 bazel test //agenthub-codex-acp:agenthub_codex_acp_tests //crates/agenthub-acp-adapter:agenthub_acp_adapter_tests
+bazel test --nocache_test_results --runs_per_test=20 --test_arg=concurrent_terminal_status_update_and_handoff_do_not_both_apply //:agenthub_unit_tests
 ```
 
-The build completed 4,082 actions and both tests passed. The commands used an isolated local output
-root and repository/disk caches to avoid a capacity-limited `/tmp` mount; no project or user Bazel
+The build completed 4,082 actions and both ACP tests passed. The deterministic Team task CAS
+regression also passed 20 independent Bazel runs. The commands used an isolated local output root
+and repository/disk caches to avoid a capacity-limited `/tmp` mount; no project or user Bazel
 configuration was changed.
 
 Chrome DevTools MCP was not available in this environment, so this checkpoint does not claim

--- a/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
+++ b/docs/journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md
@@ -1,0 +1,133 @@
+# Official Codex 0.149.1 ACP Multimodal And Standalone UI
+
+## Summary
+
+AgentHub now pins its Codex ACP runtime to the official `openai/codex` `0.149.1`
+source commit `ff29a44391deccde0aba0f8390337d7f3c319ea4`. The ACP bridge tracks the
+upstream app-server protocol additions for asynchronous agent delivery, collaboration, subagent
+activity, and image generation. The standalone ACP workbench now exposes that runtime state and
+supports bounded image input and output.
+
+No downstream Codex fork is used by the Cargo or Bazel Codex source pins.
+
+## Baseline
+
+- Cargo Codex crates and Bazel `codex_src` previously did not represent the requested official
+  release boundary.
+- Upstream history types moved into `codex-history`, user prompt submission moved from
+  `Op::UserInput` to `Op::TurnInput`, and app-server agent messages gained delivery metadata.
+- Codex collaboration and subagent notifications were available upstream but were not represented
+  consistently in AgentHub's ACP event stream or standalone UI.
+- The standalone ACP composer supported text only, and image-generation payloads were not rendered
+  as image content.
+
+## Implementation
+
+### Official Codex Source
+
+- All direct Codex Cargo git dependencies now use `https://github.com/openai/codex` at
+  `ff29a44391deccde0aba0f8390337d7f3c319ea4`.
+- `MODULE.bazel` uses the same official repository and commit.
+- `Cargo.lock` was refreshed from that source, and the former Codex-specific crate patches were
+  removed where they conflicted with the official release graph.
+- Runtime and test code now use `codex-history` envelopes and `Op::TurnInput` without weakening the
+  existing history-repair, prompt-steering, approval, or configuration tests.
+
+### Updated Codex Capabilities Through ACP
+
+- Asynchronous Codex agent messages retain `delivery = async` metadata through the ACP event path
+  and render with an explicit background-delivery label.
+- Collaboration tool calls and subagent lifecycle activity become deterministic ACP tool calls with
+  `agenthub.kind` metadata.
+- Codex runtime profiles now preserve the upstream `xhigh`, `max`, and `ultra` reasoning efforts
+  instead of reducing AgentHub's `max` profile to `high`. Codex-only levels are rejected for Claude.
+- Codex subagents remain provider-internal ACP activity. They do not create AgentHub Team members or
+  mutate Team control-plane state.
+- Repeated subagent events update one card per Codex thread, and active subagent cards are excluded
+  from generic stale-tool settlement.
+- Image-generation lifecycle events become ACP tool calls whose terminal content contains the image
+  and optional saved-resource link without copying image base64 into raw debug output.
+
+### Local ACP Multimodal Input
+
+- The agent input route accepts text, images, or both for local ACP runtimes.
+- Image attachments are converted to ACP `ImageContent` blocks and then to Codex image user input.
+- Image-only prompts omit an empty text block.
+- Backend validation allows PNG, JPEG, WebP, and GIF, checks declared MIME type against file
+  signatures, and enforces four images, 5 MiB per image, and 10 MiB total decoded bytes.
+- The input route has a 16 MiB request-body limit for JSON and base64 overhead.
+- Remote agents and stdin-only runtimes reject multimodal input explicitly instead of dropping it.
+- Normalized user events retain bounded attachment data so history and SSE replay can reconstruct
+  the conversation after a page reload.
+
+### Standalone ACP Workbench
+
+- The composer supports file selection, clipboard paste, drag-and-drop, thumbnail preview, removal,
+  client-side validation, and image-only sends.
+- Failed sends and retries retain image attachments; successful sends clear text and images
+  together.
+- The workbench header now shows run state, model, live reasoning effort, effective permission mode,
+  and active/total Codex subagent counts. Live ACP values override persisted startup defaults.
+- Message and tool bubbles render only allowlisted raster image formats from safe `data:` or HTTP(S)
+  sources. SVG and local-file URI rendering remain blocked.
+
+## Validation Evidence
+
+The focused checks cover the changed dependency, protocol, API, and UI boundaries:
+
+```bash
+cargo fmt --all --check
+cargo check -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-acp -p agenthub
+cargo test -p agenthub-codex-acp-runtime
+cargo test -p agenthub-acp-adapter
+cargo test -p agenthub-acp prompt_
+cargo test -p agenthub input_image_validation
+cargo test -p agenthub-config normalize_optional_thinking_level
+cargo test -p agenthub codex_reasoning_effort_maps_thinking_levels
+cargo test -p agenthub create_agent_route_
+npm run lint
+npx tsc --noEmit
+npm run build
+npx vitest run src/acp.test.ts src/components/input_dock.test.tsx src/components/acp_media_gallery.test.tsx src/agents_workbench.test.tsx src/components/use_agents_workbench_panel.test.tsx src/api.test.ts src/create_agent_modal.test.tsx src/pages/team/team_management_modals.test.tsx
+```
+
+The Codex runtime suite contains 135 passing tests, and the provider adapter suite contains eight
+passing tests. The multimodal ACP prompt subset contains seven passing tests, the backend image
+validator contains two passing tests, and the focused web matrix contains 82 passing tests across
+eight files. The extended reasoning checks add one config normalization test, one Codex mapping
+test, and 13 create-agent route tests.
+
+The focused Bazel command was attempted with the repository's default configuration:
+
+```bash
+bazel test //agenthub-codex-acp:agenthub_codex_acp_tests //crates/agenthub-acp-adapter:agenthub_acp_adapter_tests
+```
+
+It stopped before loading AgentHub's targets because the local external repository state reported
+that `@rules_rust+//rust:defs.bzl` had no corresponding Bazel package. No project or user Bazel
+configuration was changed as part of this checkpoint; CI or a repaired local external-repository
+state still needs to provide Bazel compilation evidence.
+
+Chrome DevTools MCP was not available in this environment, so this checkpoint does not claim
+before/after browser evidence. The DOM-level interaction matrix and production web build are the
+fallback evidence for this rollout.
+
+## Risks And Follow-Ups
+
+- The official Codex graph reintroduces older or parallel versions of several transitive crates
+  compared with the previous downstream pin. The resolved runtime graph currently includes
+  `gix 0.81.0`, `gix-fs 0.19.2`, `gix-pack 0.68.0`, `hickory-proto 0.25.2`,
+  `jsonwebtoken 9.3.1`, `opentelemetry_sdk 0.31.0`, and `tar 0.4.45`, which match previously
+  fixed Dependabot advisory ranges (`GHSA-fr8x-3vfx-f45h`, `GHSA-pg4w-g64p-qwhj`,
+  `GHSA-f26g-jm89-4g65`, `GHSA-p3hw-mv63-rf9w`, `GHSA-f89h-2fjh-2r9q`,
+  `GHSA-x494-mj8g-cj27`, `GHSA-q2qq-hmj6-3wpp`, `GHSA-3v94-mw7p-v465`,
+  `GHSA-h395-gr6q-cpjc`, `GHSA-w9wp-h8wv-79jx`, and `GHSA-3pv8-6f4r-ffg2`).
+  A direct `cargo update -p tar --precise 0.4.46` check cannot resolve because official
+  `codex-core-plugins 0.149.1` pins `tar = "=0.4.45"`; the other affected lines also require
+  upstream-compatible dependency changes. Keep the official source boundary and address these
+  findings in a newer official release rather than restoring a Codex fork.
+- Inline base64 user-event persistence is intentionally bounded but increases SQLite and SSE replay
+  cost. Migrate attachments to owner-scoped object references and replay-safe thumbnails before
+  raising the current limits.
+- Run an authenticated real-browser pass for image selection, paste, drag/drop, reload replay,
+  generated-image rendering, asynchronous delivery, and concurrent Codex subagent activity.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -188,6 +188,9 @@ Main shape:
   contracts in canonical specs while retaining dated journals only for rollout evidence.
 - Dependabot remediation now removes all 16 open alert versions from the Rust ACP, web, and
   userdocs dependency graphs while retaining explicit upstream dependency migration follow-ups.
+- Codex ACP now pins official `openai/codex` `0.149.1`, forwards asynchronous and subagent activity
+  through ACP metadata, and gives the standalone workbench bounded image input/output plus compact
+  runtime context without projecting Codex subagents into Team membership.
 - User documentation now follows current release artifacts and runtime behavior across installation,
   onboarding, agent lifecycle, streaming, API automation, nodes, security, storage, and operations.
 - Team prompts now separate an idea's validity from requests to propagate or durably encode it, with
@@ -306,6 +309,7 @@ Start with:
 - `2026-08-17-mailbox-reassignment-cas-and-idempotency.md`
 - `2026-08-17-message-index-repair-corruption-visibility.md`
 - `2026-08-19-safe-paths-removal.md`
+- `2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,13 +10,16 @@ Active backlog only. Keep this file small and current.
   validate the formula against the intended formal release, including both binary versions and
   `brew services` startup. Evidence:
   [journal/2026-08-13-user-documentation-release-readiness.md](journal/2026-08-13-user-documentation-release-readiness.md).
-- [ ] `P1` Replace the temporary security pins for
-  `hawkingrei/codex@6ca61345ceb09d76edc3db8c4eb55df18a10888a` and
-  `hawkingrei/symposium-acp@c731bb045d1375af48b0446af728aea52503b30b` with upstream stable
-  releases that resolve the same Dependabot package set, then rerun the AgentHub ACP Cargo and Bazel
-  compatibility suites. Do not move back while the default ACP runtime graph contains an affected
-  `gix`, `hickory-proto`, `jsonwebtoken`, `opentelemetry_sdk`, `rmcp`, or `tar` release. Evidence:
-  [journal/2026-08-12-dependabot-security-remediation.md](journal/2026-08-12-dependabot-security-remediation.md).
+- [ ] `P1` Remediate dependency-graph regressions exposed by returning Codex to official
+  `openai/codex@ff29a44391deccde0aba0f8390337d7f3c319ea4`, and replace the separate
+  `hawkingrei/symposium-acp@c731bb045d1375af48b0446af728aea52503b30b` pin with an upstream stable
+  release. The official 0.149.1 graph currently reintroduces advisory-range `gix 0.81.0`,
+  `gix-fs 0.19.2`, `gix-pack 0.68.0`, `hickory-proto 0.25.2`, `jsonwebtoken 9.3.1`,
+  `opentelemetry_sdk 0.31.0`, and `tar 0.4.45`; even `tar` is pinned exactly by upstream and cannot
+  be updated independently. Do not restore a downstream Codex fork; resolve findings in a newer
+  official Codex release or with ordinary compatible constraints. Evidence:
+  [journal/2026-08-12-dependabot-security-remediation.md](journal/2026-08-12-dependabot-security-remediation.md),
+  [journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md](journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md).
 - [ ] `P1` Verify preview release partial-asset behavior: semver release run `29194967848` for `v0.0.11` proves Linux `x86_64` / `aarch64` release builds used `release-vendored-openssl`, avoided the stale cross-sysroot OpenSSL panic, and published canonical `agenthub` / `agenthub-acp` assets plus Debian packages. Remaining evidence is a preview release run showing successful binary assets publish when one release matrix target fails. Record the preview workflow run ID and release URL in [journal/2026-04-20-release-vendored-openssl-and-partial-assets.md](journal/2026-04-20-release-vendored-openssl-and-partial-assets.md).
 - [ ] `P1` Define and enforce the Linux runtime baseline for official artifacts: the x86_64 prebuild from workflow run `31259043337` starts on Ubuntu 24.04 but requires `GLIBC_2.38` / `GLIBC_2.39` and does not start on Ubuntu 22.04. Pin the supported glibc floor, build against a compatible sysroot, and add a published-binary startup smoke on the oldest supported Linux distribution. Evidence: [journal/2026-08-08-object-store-s3-release-enablement.md](journal/2026-08-08-object-store-s3-release-enablement.md).
 
@@ -67,6 +70,13 @@ Stable contracts:
 
 ## Frontend UI/UX
 
+- [ ] `P1` Replace inline base64 persistence for standalone ACP image attachments with owner-scoped
+  object-store references and replay-safe thumbnails, then capture authenticated Chrome evidence for
+  select, paste, drag/drop, reload replay, generated-image rendering, asynchronous delivery, and
+  concurrent Codex subagent activity. Keep the current four-image, 5 MiB-per-image, 10 MiB-total
+  limits until storage and replay costs are measured. Stable contract:
+  [features/acp-runtime.md](features/acp-runtime.md); evidence:
+  [journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md](journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md).
 - [ ] `P2` Close out the remaining findings from the 2026-08-16 code-only UI/UX review: `team_markdown.ts`
   duplicates `markdown.ts`'s LRU cache/`sanitizeHref`/autolink logic instead of sharing it; `InputDock`
   and `TeamMessageComposer` use two different color-token systems and send-button shapes, contradicting

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -45,7 +45,7 @@ use super::{
 };
 use crate::acp::{
     AcpActorSkillContext, AcpHandle, AcpHandleDiagnostics, AcpPermissionReviewDispatcher,
-    AcpPermissionService, AcpPromptDeliveryPolicy,
+    AcpPermissionService, AcpPromptDeliveryPolicy, AcpPromptImage,
 };
 use crate::auth::AuthService;
 use crate::internal::client::{InternalGrpcMailboxClient, InternalGrpcPeerClientConfig};
@@ -97,6 +97,15 @@ const PER_AGENT_EVENT_SOURCE: &str = "per_agent_agent_events";
 pub enum AgentSendInputError {
     #[error("agent session mismatch: expected={expected} running={running}")]
     SessionMismatch { expected: String, running: String },
+    #[error("image input is only supported by local ACP agents")]
+    MultimodalUnsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentInputImage {
+    pub file_name: String,
+    pub mime_type: String,
+    pub data: String,
 }
 
 #[derive(Debug, Clone)]
@@ -2131,8 +2140,28 @@ impl AgentManager {
         message_id: Option<&str>,
         expected_session_id: Option<&str>,
     ) -> anyhow::Result<()> {
+        self.send_input_with_images(agent_id, input, &[], message_id, expected_session_id)
+            .await
+    }
+
+    #[tracing::instrument(
+        skip(self, input, images, message_id),
+        fields(agent_id = %agent_id, expected_session_id = ?expected_session_id, image_count = images.len()),
+        err
+    )]
+    pub async fn send_input_with_images(
+        &self,
+        agent_id: &str,
+        input: &str,
+        images: &[AgentInputImage],
+        message_id: Option<&str>,
+        expected_session_id: Option<&str>,
+    ) -> anyhow::Result<()> {
         let agent = self.get_agent(agent_id).await?;
         if let Some(target_node_id) = agent.target_node_id.as_deref() {
+            if !images.is_empty() {
+                return Err(AgentSendInputError::MultimodalUnsupported.into());
+            }
             let client = self
                 .remote_control_client_for_target_node(target_node_id)
                 .await?;
@@ -2193,6 +2222,9 @@ impl AgentManager {
         }
 
         if let Some(stdin) = stdin {
+            if !images.is_empty() {
+                return Err(AgentSendInputError::MultimodalUnsupported.into());
+            }
             let mut stdin_guard = stdin.lock().await;
             if let Some(stdin) = stdin_guard.as_mut() {
                 stdin.write_all(format!("{}\n", input).as_bytes()).await?;
@@ -2214,7 +2246,13 @@ impl AgentManager {
             "type": "user_message",
             "text": input,
             "chunk": false,
-            "message_id": message_id
+            "message_id": message_id,
+            "attachments": images.iter().map(|image| serde_json::json!({
+                "type": "image",
+                "file_name": image.file_name,
+                "mime_type": image.mime_type,
+                "data": image.data,
+            })).collect::<Vec<_>>()
         })
         .to_string();
         let ts = Utc::now().timestamp();
@@ -2240,8 +2278,16 @@ impl AgentManager {
         };
         let _ = output_tx.send(output);
 
+        let prompt_images = images
+            .iter()
+            .map(|image| AcpPromptImage::new(image.data.clone(), image.mime_type.clone()))
+            .collect();
         match acp
-            .prompt_with_submission(input.to_string(), message_id.clone())
+            .prompt_with_images_with_submission(
+                input.to_string(),
+                prompt_images,
+                message_id.clone(),
+            )
             .await
         {
             Ok(()) => Ok(()),

--- a/src/agent/manager/acp_provider.rs
+++ b/src/agent/manager/acp_provider.rs
@@ -65,15 +65,16 @@ impl AcpProviderSpec {
     }
 }
 
-/// Map the provider-neutral thinking level to the Codex `reasoning_effort` config value. Codex tops out
-/// at `high`, so `max` maps to `high`; an unrecognized level yields `None` (caller skips the option and
-/// the provider default applies).
+/// Map an AgentHub thinking level to the exact Codex `reasoning_effort` config value. An unrecognized
+/// level yields `None` so the provider default remains authoritative.
 pub(super) fn codex_reasoning_effort_for_thinking_level(level: &str) -> Option<&'static str> {
     match level.trim().to_ascii_lowercase().as_str() {
         "low" => Some("low"),
         "medium" => Some("medium"),
         "high" => Some("high"),
-        "max" => Some("high"),
+        "xhigh" => Some("xhigh"),
+        "max" => Some("max"),
+        "ultra" => Some("ultra"),
         _ => None,
     }
 }
@@ -322,15 +323,22 @@ mod tests {
             codex_reasoning_effort_for_thinking_level("high"),
             Some("high")
         );
-        // Codex tops out at high, so max maps to high.
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("xhigh"),
+            Some("xhigh")
+        );
         assert_eq!(
             codex_reasoning_effort_for_thinking_level("max"),
-            Some("high")
+            Some("max")
+        );
+        assert_eq!(
+            codex_reasoning_effort_for_thinking_level("ultra"),
+            Some("ultra")
         );
         // Case-insensitive + trimmed.
         assert_eq!(
             codex_reasoning_effort_for_thinking_level(" MAX "),
-            Some("high")
+            Some("max")
         );
         // Unknown levels are skipped (provider default applies).
         assert_eq!(codex_reasoning_effort_for_thinking_level("turbo"), None);

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -838,8 +838,8 @@ impl AgentManager {
                             }
                         }
                         None => {
-                            // Phase 1 only persists low|medium|high|max, so an unmapped level means
-                            // manual or stale data; surface it rather than silently using the default.
+                            // An unmapped level means manual or stale data; surface it rather than
+                            // silently using the default.
                             tracing::warn!(
                                 "unmapped thinking level for codex reasoning effort, leaving provider default: agent_id={}, level={}",
                                 agent.id,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,7 +11,7 @@ pub use agenthub_agent_domain::{
     AgentNodeUpdate, AgentOutput, AgentRecord, AgentStatus, OutputStream, WorktreeMode,
 };
 pub(crate) use manager::derive_team_runtime_workdir;
-pub use manager::{AgentManager, AgentSendInputError};
+pub use manager::{AgentInputImage, AgentManager, AgentSendInputError};
 pub use triggers::{
     AgentTimeTriggerCreateInput, AgentTimeTriggerManager, AgentTimeTriggerRecord,
     AgentTimeTriggerWorker, AgentTimeTriggerWorkerSettings,

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -1,10 +1,11 @@
 use axum::{
     Json, Router,
     body::Bytes,
-    extract::{Path, Query, State},
+    extract::{DefaultBodyLimit, Path, Query, State},
     http::HeaderMap,
     routing::{delete, get, post},
 };
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
@@ -19,7 +20,7 @@ use crate::acp::{
     AcpActorSkillContext, AcpPermissionRecord, AcpPermissionRespondResult, DEFAULT_ACTOR_CHANNEL,
 };
 use crate::agent::{
-    AgentConfig, AgentRecord, AgentSendInputError, AgentTimeTriggerCreateInput,
+    AgentConfig, AgentInputImage, AgentRecord, AgentSendInputError, AgentTimeTriggerCreateInput,
     AgentTimeTriggerManager, AgentTimeTriggerRecord, WorktreeMode, normalize_target_node_id,
 };
 use crate::api::authz::require_capability;
@@ -36,6 +37,10 @@ use crate::team::effective_team_member_skills;
 const AGENT_SOURCE_MANUAL: &str = "manual";
 const AGENT_SOURCE_TEAM_FORGE: &str = "team_forge";
 const AGENT_EVENTS_PAGE_LIMIT: i64 = 20;
+const AGENT_INPUT_MAX_IMAGES: usize = 4;
+const AGENT_INPUT_MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
+const AGENT_INPUT_MAX_TOTAL_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+const AGENT_INPUT_BODY_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, serde::Deserialize)]
 pub struct CreateAgentRequest {
@@ -145,6 +150,15 @@ pub struct SendInputRequest {
     pub input: String,
     pub message_id: Option<String>,
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub images: Vec<SendInputImageRequest>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct SendInputImageRequest {
+    pub file_name: String,
+    pub mime_type: String,
+    pub data: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -200,7 +214,10 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/{id}/start", post(start_agent))
         .route("/{id}/stop", post(stop_agent))
-        .route("/{id}/input", post(send_input))
+        .route(
+            "/{id}/input",
+            post(send_input).layer(DefaultBodyLimit::max(AGENT_INPUT_BODY_LIMIT_BYTES)),
+        )
         .route("/{id}/uploads", post(upload_agent_object))
         .route("/{id}/uploads/downloads", post(download_agent_object))
         .route("/{id}/images", post(upload_agent_image))
@@ -447,16 +464,18 @@ async fn send_input(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let _user = require_capability(&headers, &state, UserCapability::RuntimeOperate).await?;
     let input = payload.input;
-    if input.trim().is_empty() {
+    let images = validate_agent_input_images(payload.images)?;
+    if input.trim().is_empty() && images.is_empty() {
         return Err(ApiError::bad_request("input is required"));
     }
     let message_id = normalize_optional_request_field("message_id", payload.message_id)?;
     let session_id = normalize_optional_request_field("session_id", payload.session_id)?;
     match state
         .agents
-        .send_input(
+        .send_input_with_images(
             &agent_id,
             &input,
+            &images,
             message_id.as_deref(),
             session_id.as_deref(),
         )
@@ -464,15 +483,86 @@ async fn send_input(
     {
         Ok(()) => {}
         Err(err) => {
-            if let Some(AgentSendInputError::SessionMismatch { .. }) =
-                err.downcast_ref::<AgentSendInputError>()
-            {
-                return Err(ApiError::conflict(&err.to_string()));
+            if let Some(send_error) = err.downcast_ref::<AgentSendInputError>() {
+                return match send_error {
+                    AgentSendInputError::SessionMismatch { .. } => {
+                        Err(ApiError::conflict(&err.to_string()))
+                    }
+                    AgentSendInputError::MultimodalUnsupported => {
+                        Err(ApiError::bad_request(&err.to_string()))
+                    }
+                };
             }
             return Err(err.into());
         }
     }
     Ok(ok_response())
+}
+
+fn validate_agent_input_images(
+    images: Vec<SendInputImageRequest>,
+) -> Result<Vec<AgentInputImage>, ApiError> {
+    if images.len() > AGENT_INPUT_MAX_IMAGES {
+        return Err(ApiError::bad_request("at most 4 images may be attached"));
+    }
+
+    let mut total_bytes = 0usize;
+    images
+        .into_iter()
+        .map(|image| {
+            let file_name = image.file_name.trim();
+            if file_name.is_empty() || file_name.len() > 255 {
+                return Err(ApiError::bad_request(
+                    "image file_name must be between 1 and 255 bytes",
+                ));
+            }
+            let mime_type = image.mime_type.trim().to_ascii_lowercase();
+            if !matches!(
+                mime_type.as_str(),
+                "image/png" | "image/jpeg" | "image/webp" | "image/gif"
+            ) {
+                return Err(ApiError::bad_request(
+                    "image mime_type must be image/png, image/jpeg, image/webp, or image/gif",
+                ));
+            }
+            let data = image.data.trim();
+            let decoded = STANDARD
+                .decode(data)
+                .map_err(|_| ApiError::bad_request("image data must be valid standard base64"))?;
+            if decoded.is_empty() {
+                return Err(ApiError::bad_request("image data must not be empty"));
+            }
+            if decoded.len() > AGENT_INPUT_MAX_IMAGE_BYTES {
+                return Err(ApiError::bad_request("each image must be 5 MiB or smaller"));
+            }
+            if !image_bytes_match_mime_type(&decoded, &mime_type) {
+                return Err(ApiError::bad_request(
+                    "image data does not match its declared mime_type",
+                ));
+            }
+            total_bytes = total_bytes.saturating_add(decoded.len());
+            if total_bytes > AGENT_INPUT_MAX_TOTAL_IMAGE_BYTES {
+                return Err(ApiError::bad_request(
+                    "attached images must total 10 MiB or less",
+                ));
+            }
+            Ok(AgentInputImage {
+                file_name: file_name.to_string(),
+                mime_type,
+                data: data.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn image_bytes_match_mime_type(bytes: &[u8], mime_type: &str) -> bool {
+    match mime_type {
+        "image/png" => bytes.starts_with(b"\x89PNG\r\n\x1a\n"),
+        "image/jpeg" => bytes.starts_with(&[0xff, 0xd8, 0xff]),
+        "image/webp" => bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP",
+        "image/gif" => bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a"),
+        _ => false,
+    }
 }
 
 async fn upload_agent_object(
@@ -932,28 +1022,41 @@ fn normalize_codex_acp_default_mode_request(
 
 /// Normalize and validate the runtime profile fields from a create/update request, and gate them to
 /// providers that support runtime profiles. `runtime_model` accepts any non-blank string (unknown
-/// model names are allowed); `thinking_level` must be one of `low|medium|high|max`. A profile may only
-/// be set when the agent's derived ACP provider is Codex or Claude — Gemini/Kimi and non-ACP agents are
-/// rejected. Returns the normalized `(runtime_model, thinking_level)`.
+/// model names are allowed). Common thinking levels are `low|medium|high|max`; Codex additionally
+/// accepts `xhigh|ultra`. A profile may only be set when the agent's derived ACP provider is Codex or
+/// Claude — Gemini/Kimi and non-ACP agents are rejected. Returns the normalized
+/// `(runtime_model, thinking_level)`.
 fn normalize_runtime_profile_request(
     provider: Option<&str>,
     runtime_model: Option<&str>,
     thinking_level: Option<&str>,
 ) -> Result<(Option<String>, Option<String>), ApiError> {
     let model = normalize_optional_runtime_model(runtime_model);
-    let level =
-        match thinking_level
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            None => None,
-            Some(value) => Some(normalize_optional_thinking_level(Some(value)).ok_or_else(
-                || ApiError::bad_request("thinking_level must be one of low, medium, high, or max"),
-            )?),
-        };
+    let level = match thinking_level
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        None => None,
+        Some(value) => Some(
+            normalize_optional_thinking_level(Some(value)).ok_or_else(|| {
+                ApiError::bad_request(
+                    "thinking_level must be one of low, medium, high, xhigh, max, or ultra",
+                )
+            })?,
+        ),
+    };
     if (model.is_some() || level.is_some()) && !matches!(provider, Some("codex") | Some("claude")) {
         return Err(ApiError::bad_request(
             "runtime_model and thinking_level require a Codex or Claude ACP agent",
+        ));
+    }
+    if provider == Some("claude")
+        && level
+            .as_deref()
+            .is_some_and(|value| matches!(value, "xhigh" | "ultra"))
+    {
+        return Err(ApiError::bad_request(
+            "thinking_level xhigh and ultra are only supported by Codex ACP agents",
         ));
     }
     Ok((model, level))
@@ -1318,11 +1421,11 @@ mod tests {
     use agenthub_config::{AppConfig, PushConfig, WebConfig};
 
     use super::{
-        StartAgentActorRuntimeRequest, StartAgentRequest, TeamMemberProfileRecord, WorktreeMode,
-        build_agent_discovery_card, map_create_agent_error, parse_agent_source,
-        parse_optional_start_agent_request, parse_start_actor_runtime_context, parse_worktree_mode,
-        resolve_create_agent_workdir, resolve_member_profile_from_spec, router,
-        sanitize_worktree_segment,
+        SendInputImageRequest, StartAgentActorRuntimeRequest, StartAgentRequest,
+        TeamMemberProfileRecord, WorktreeMode, build_agent_discovery_card, map_create_agent_error,
+        parse_agent_source, parse_optional_start_agent_request, parse_start_actor_runtime_context,
+        parse_worktree_mode, resolve_create_agent_workdir, resolve_member_profile_from_spec,
+        router, sanitize_worktree_segment, validate_agent_input_images,
     };
 
     #[test]
@@ -3228,11 +3331,71 @@ mod tests {
                     "workdir": "/tmp/bad-thinking-agent",
                     "command": "agenthub-codex-acp",
                     "args": [],
-                    "thinking_level": "ultra"
+                    "thinking_level": "turbo"
                 })),
             ))
             .await
             .expect("create bad thinking agent");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_agent_route_persists_ultra_thinking_level_for_codex() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = router(state.clone());
+
+        let response = app
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "ultra-thinking-agent",
+                    "workdir": "/tmp/ultra-thinking-agent",
+                    "command": "agenthub-codex-acp",
+                    "args": [],
+                    "thinking_level": "ULTRA"
+                })),
+            ))
+            .await
+            .expect("create ultra thinking agent");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = decode_json_body(response).await;
+        let agent_id = body["id"].as_str().expect("agent id");
+        let thinking_level = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT thinking_level FROM agents WHERE id = ?1",
+        )
+        .bind(agent_id)
+        .fetch_one(&state.db)
+        .await
+        .expect("load created agent thinking level");
+        assert_eq!(thinking_level.as_deref(), Some("ultra"));
+    }
+
+    #[tokio::test]
+    async fn create_agent_route_rejects_codex_only_thinking_level_for_claude() {
+        let state = build_test_state().await;
+        let token = create_auth_token(&state).await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(build_json_request(
+                Method::POST,
+                "/",
+                Some(&token),
+                Some(json!({
+                    "name": "claude-ultra-agent",
+                    "workdir": "/tmp/claude-ultra-agent",
+                    "command": "agenthub-acp",
+                    "args": ["claude"],
+                    "thinking_level": "ultra"
+                })),
+            ))
+            .await
+            .expect("create Claude ultra thinking agent");
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
@@ -5200,5 +5363,32 @@ mod tests {
         assert_eq!(second.status(), StatusCode::OK);
         let second_body = decode_json_body(second).await;
         assert_eq!(second_body["status"], "already_resolved");
+    }
+
+    #[test]
+    fn input_image_validation_accepts_supported_image_data() {
+        let png = b"\x89PNG\r\n\x1a\nminimal";
+        let images = validate_agent_input_images(vec![SendInputImageRequest {
+            file_name: "diagram.png".to_string(),
+            mime_type: "IMAGE/PNG".to_string(),
+            data: STANDARD.encode(png),
+        }])
+        .expect("valid image input");
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].mime_type, "image/png");
+        assert_eq!(images[0].file_name, "diagram.png");
+    }
+
+    #[test]
+    fn input_image_validation_rejects_mismatched_content_type() {
+        let err = validate_agent_input_images(vec![SendInputImageRequest {
+            file_name: "diagram.png".to_string(),
+            mime_type: "image/png".to_string(),
+            data: STANDARD.encode(b"not-a-png"),
+        }])
+        .expect_err("mismatched image data should fail");
+
+        assert_eq!(err.into_response().status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/team/manager/task_updates.rs
+++ b/src/team/manager/task_updates.rs
@@ -100,6 +100,14 @@ impl TeamManager {
         let prepared = self
             .prepare_task_update(task_id, status, assignment, priority, context_patch)
             .await?;
+        self.apply_prepared_task_update(task_id, prepared).await
+    }
+
+    pub(super) async fn apply_prepared_task_update(
+        &self,
+        task_id: &str,
+        prepared: PreparedTeamTaskUpdate,
+    ) -> anyhow::Result<super::TeamTaskRecord> {
         if !prepared.has_changes() {
             return Ok(prepared.current);
         }
@@ -183,7 +191,7 @@ impl TeamManager {
         }
     }
 
-    async fn prepare_task_update(
+    pub(super) async fn prepare_task_update(
         &self,
         task_id: &str,
         status: Option<TeamTaskStatus>,

--- a/src/team/manager/tests/task_cases.rs
+++ b/src/team/manager/tests/task_cases.rs
@@ -1198,16 +1198,11 @@ async fn list_tasks_with_query_keeps_tasks_without_conversation_rows() {
 /// pool (`setup_concurrent_teamspace_db`) because the shared `:memory:` pool used elsewhere is
 /// single-connection and cannot exercise genuine interleaving between two transactions.
 ///
-/// Whether any single attempt actually lands the two operations' internal reads/writes in the
-/// vulnerable order is scheduler-dependent -- empirically only about 1 in 20 single attempts do, even
-/// with a real multi-connection pool, since `update_task_status` reaches its write in fewer awaits than
-/// `handoff_task_execution` and so usually wins outright rather than losing to a stale read. Looping
-/// many fresh task/lease pairs turns that low per-attempt probability into a reliable regression check
-/// (a single-attempt version of this test reliably passed even with the CAS guard reverted).
+/// Prepare the terminal update before either writer starts so it always carries the original CAS token.
+/// This makes the stale-write boundary deterministic without treating a legitimate handoff-then-update
+/// serial order as a concurrency failure.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_terminal_status_update_and_handoff_do_not_both_apply() {
-    const ATTEMPTS: usize = 60;
-
     let (db, dir) = setup_concurrent_teamspace_db().await;
 
     struct CleanupGuard(std::path::PathBuf);
@@ -1222,110 +1217,93 @@ async fn concurrent_terminal_status_update_and_handoff_do_not_both_apply() {
     let _cleanup = CleanupGuard(dir);
 
     let manager = Arc::new(TeamManager::new(db.clone()));
+    let now = Utc::now().timestamp();
+    let team_id = format!("team-{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO team_definitions (id, name, spec_json, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?4)",
+    )
+    .bind(&team_id)
+    .bind(format!("race-team-{}", Uuid::new_v4()))
+    .bind(json!({"entrypoint":"member-a","members":[{"member_id":"member-a"},{"member_id":"member-b"}]}).to_string())
+    .bind(now)
+    .execute(&db)
+    .await
+    .expect("insert team");
 
-    for attempt in 0..ATTEMPTS {
-        let now = Utc::now().timestamp();
-        let team_id = format!("team-{}", Uuid::new_v4());
-        sqlx::query(
-            "INSERT INTO team_definitions (id, name, spec_json, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?4)",
-        )
-        .bind(&team_id)
-        .bind(format!("race-team-{}", Uuid::new_v4()))
-        .bind(json!({"entrypoint":"member-a","members":[{"member_id":"member-a"},{"member_id":"member-b"}]}).to_string())
-        .bind(now)
-        .execute(&db)
+    let task_id = format!("task-{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO team_tasks (id, team_id, title, status, priority, created_by_actor_id, assigned_member_id, context_json, created_at, updated_at) \
+         VALUES (?1, ?2, 'race task', 'in_progress', 'medium', 'user', 'member-a', '{}', ?3, ?3)",
+    )
+    .bind(&task_id)
+    .bind(&team_id)
+    .bind(now)
+    .execute(&db)
+    .await
+    .expect("insert task");
+
+    manager
+        .claim_task_execution(&task_id, "member-a", 300)
         .await
-        .expect("insert team");
-
-        let task_id = format!("task-{}", Uuid::new_v4());
-        sqlx::query(
-            "INSERT INTO team_tasks (id, team_id, title, status, priority, created_by_actor_id, assigned_member_id, context_json, created_at, updated_at) \
-             VALUES (?1, ?2, 'race task', 'in_progress', 'medium', 'user', 'member-a', '{}', ?3, ?3)",
+        .expect("claim initial goal lease");
+    let prepared_completion = manager
+        .prepare_task_update(
+            &task_id,
+            Some(TeamTaskStatus::Completed),
+            TeamTaskAssignmentUpdate::Unchanged,
+            None,
+            None,
         )
-        .bind(&task_id)
-        .bind(&team_id)
-        .bind(now)
-        .execute(&db)
         .await
-        .expect("insert task");
+        .expect("prepare terminal status update");
 
-        manager
-            .claim_task_execution(&task_id, "member-a", 300)
+    let complete_manager = manager.clone();
+    let complete_task_id = task_id.clone();
+    let complete = tokio::spawn(async move {
+        complete_manager
+            .apply_prepared_task_update(&complete_task_id, prepared_completion)
             .await
-            .expect("claim initial goal lease");
+    });
+    let handoff_manager = manager.clone();
+    let handoff_task_id = task_id.clone();
+    let handoff = tokio::spawn(async move {
+        handoff_manager
+            .handoff_task_execution(&handoff_task_id, "member-b", "owner-1", "reassign")
+            .await
+    });
+    let (complete_result, handoff_result) = tokio::join!(complete, handoff);
+    let complete_result = complete_result.expect("complete task did not panic");
+    let handoff_result = handoff_result.expect("handoff task did not panic");
 
-        let complete_manager = manager.clone();
-        let complete_task_id = task_id.clone();
-        let complete = tokio::spawn(async move {
-            complete_manager
-                .update_task_status(&complete_task_id, TeamTaskStatus::Completed)
-                .await
-        });
-        let handoff_manager = manager.clone();
-        let handoff_task_id = task_id.clone();
-        let handoff = tokio::spawn(async move {
-            handoff_manager
-                .handoff_task_execution(&handoff_task_id, "member-b", "owner-1", "reassign")
-                .await
-        });
-        let (complete_result, handoff_result) = tokio::join!(complete, handoff);
-        let complete_result = complete_result.expect("complete task did not panic");
-        let handoff_result = handoff_result.expect("handoff task did not panic");
+    let final_task = manager.get_task(&task_id).await.expect("reload task");
+    let lease_row = sqlx::query(
+        "SELECT released_at, release_reason FROM team_goal_leases WHERE task_id = ?1 AND lease_generation = 1",
+    )
+    .bind(&task_id)
+    .fetch_one(&db)
+    .await
+    .expect("reload goal lease");
+    let released_at: Option<i64> = lease_row.get("released_at");
+    let release_reason: Option<String> = lease_row.get("release_reason");
 
-        let final_task = manager.get_task(&task_id).await.expect("reload task");
-        let lease_row = sqlx::query(
-            "SELECT released_at, release_reason FROM team_goal_leases WHERE task_id = ?1 AND lease_generation = 1",
-        )
-        .bind(&task_id)
-        .fetch_one(&db)
-        .await
-        .expect("reload goal lease");
-        let released_at: Option<i64> = lease_row.get("released_at");
-        let release_reason: Option<String> = lease_row.get("release_reason");
-
-        match (complete_result.is_ok(), handoff_result.is_ok()) {
-            (true, false) => {
-                assert_eq!(
-                    final_task.status,
-                    TeamTaskStatus::Completed,
-                    "attempt {attempt}"
-                );
-                assert_eq!(
-                    final_task.assigned_member_id.as_deref(),
-                    Some("member-a"),
-                    "attempt {attempt}"
-                );
-                assert_eq!(
-                    release_reason.as_deref(),
-                    Some("completed"),
-                    "attempt {attempt}"
-                );
-            }
-            (false, true) => {
-                assert_eq!(
-                    final_task.status,
-                    TeamTaskStatus::InProgress,
-                    "attempt {attempt}"
-                );
-                assert_eq!(
-                    final_task.assigned_member_id.as_deref(),
-                    Some("member-b"),
-                    "attempt {attempt}"
-                );
-                assert_eq!(
-                    release_reason.as_deref(),
-                    Some("handoff"),
-                    "attempt {attempt}"
-                );
-            }
-            other => panic!(
-                "attempt {attempt}: expected exactly one of the two concurrent operations to win, got {:?} (complete={:?}, handoff={:?})",
-                other, complete_result, handoff_result
-            ),
+    match (complete_result.is_ok(), handoff_result.is_ok()) {
+        (true, false) => {
+            assert_eq!(final_task.status, TeamTaskStatus::Completed);
+            assert_eq!(final_task.assigned_member_id.as_deref(), Some("member-a"));
+            assert_eq!(release_reason.as_deref(), Some("completed"));
         }
-        assert!(
-            released_at.is_some(),
-            "attempt {attempt}: the generation-1 goal lease must be released by whichever operation won"
-        );
+        (false, true) => {
+            assert_eq!(final_task.status, TeamTaskStatus::InProgress);
+            assert_eq!(final_task.assigned_member_id.as_deref(), Some("member-b"));
+            assert_eq!(release_reason.as_deref(), Some("handoff"));
+        }
+        other => panic!(
+            "expected exactly one of the two concurrent operations to win, got {:?} (complete={:?}, handoff={:?})",
+            other, complete_result, handoff_result
+        ),
     }
+    assert!(
+        released_at.is_some(),
+        "the generation-1 goal lease must be released by whichever operation won"
+    );
 }

--- a/third_party/codex_code_mode_protocol/BUILD.bazel
+++ b/third_party/codex_code_mode_protocol/BUILD.bazel
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["use_bazel_protoc.patch"])

--- a/third_party/codex_code_mode_protocol/use_bazel_protoc.patch
+++ b/third_party/codex_code_mode_protocol/use_bazel_protoc.patch
@@ -1,0 +1,11 @@
+diff --git a/build.rs b/build.rs
+--- a/build.rs
++++ b/build.rs
+@@ -7,2 +7,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
+     let mut config = tonic_prost_build::Config::new();
+-    config.protoc_executable(protoc_bin_vendored::protoc_bin_path()?);
++    let protoc = match std::env::var_os("PROTOC") {
++        Some(protoc) => PathBuf::from(protoc),
++        None => protoc_bin_vendored::protoc_bin_path()?,
++    };
++    config.protoc_executable(protoc);

--- a/web/src/acp.test.ts
+++ b/web/src/acp.test.ts
@@ -775,4 +775,161 @@ describe("buildAcpView", () => {
       status: "running",
     });
   });
+
+  it("preserves user image attachments and asynchronous message delivery", () => {
+    const view = buildAcpView([
+      {
+        ts: 10,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "user_message",
+          text: "What is shown?",
+          attachments: [
+            {
+              type: "image",
+              file_name: "diagram.png",
+              mime_type: "image/png",
+              data: "aW1hZ2U=",
+            },
+          ],
+        }),
+      },
+      {
+        ts: 20,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "agent_message",
+          text: "Background result",
+          meta: { delivery: "async" },
+        }),
+      },
+    ]);
+
+    expect(view.messages[0].media).toEqual([
+      {
+        type: "image",
+        name: "diagram.png",
+        mime_type: "image/png",
+        data: "aW1hZ2U=",
+        uri: undefined,
+      },
+    ]);
+    expect(view.messages[1].delivery).toBe("async");
+  });
+
+  it("extracts generated images without exposing base64 as tool text", () => {
+    const view = buildAcpView([
+      {
+        ts: 10,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "tool_call_update",
+          id: "image-1",
+          title: "Generate image",
+          status: "completed",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "image",
+                data: "aW1hZ2U=",
+                mimeType: "image/png",
+              },
+            },
+          ],
+          meta: { agenthub: { kind: "codex_image_generation" } },
+        }),
+      },
+    ]);
+
+    expect(view.toolCalls).toHaveLength(1);
+    expect(view.toolCalls[0].content).toBeUndefined();
+    expect(view.toolCalls[0].media?.[0]).toMatchObject({
+      type: "image",
+      mime_type: "image/png",
+      data: "aW1hZ2U=",
+    });
+  });
+
+  it("upserts subagent activity and keeps live subagents open across parent messages", () => {
+    const subagentMeta = { agenthub: { kind: "codex_subagent" } };
+    const view = buildAcpView([
+      {
+        ts: 10,
+        event_id: 1,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "tool_call",
+          id: "codex-subagent:child",
+          title: "Subagent child",
+          status: "in_progress",
+          meta: subagentMeta,
+        }),
+      },
+      {
+        ts: 20,
+        event_id: 2,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "tool_call",
+          id: "codex-subagent:child",
+          title: "Subagent reviewer",
+          status: "in_progress",
+          meta: subagentMeta,
+        }),
+      },
+      {
+        ts: 30,
+        event_id: 3,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "agent_message",
+          text: "Parent turn completed.",
+        }),
+      },
+    ]);
+
+    expect(view.toolCalls).toHaveLength(1);
+    expect(view.toolCalls[0]).toMatchObject({
+      id: "codex-subagent:child",
+      title: "Subagent reviewer",
+      status: "in_progress",
+    });
+  });
+
+  it("settles live subagents when their parent run reaches a terminal state", () => {
+    const view = buildAcpView([
+      {
+        ts: 10,
+        event_id: 1,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "tool_call",
+          id: "codex-subagent:child",
+          title: "Subagent child",
+          status: "in_progress",
+          meta: { agenthub: { kind: "codex_subagent" } },
+        }),
+      },
+      {
+        ts: 20,
+        event_id: 2,
+        stream: "acp",
+        session_id: "s1",
+        message: JSON.stringify({
+          type: "run_status",
+          status: "interrupted",
+        }),
+      },
+    ]);
+
+    expect(view.toolCalls[0].status).toBe("interrupted");
+  });
 });

--- a/web/src/acp.ts
+++ b/web/src/acp.ts
@@ -10,10 +10,20 @@ export type AcpToolCall = {
   raw_output?: unknown;
   terminal_output?: string;
   terminal_activities?: AcpTerminalActivity[];
+  media?: AcpMedia[];
+  meta?: unknown;
   session_id?: string | null;
   seq?: string;
   event_id?: number;
   ts?: number;
+};
+
+export type AcpMedia = {
+  type: "image";
+  data?: string;
+  mime_type: string;
+  uri?: string;
+  name?: string;
 };
 
 export type AcpTerminalActivity = {
@@ -30,6 +40,9 @@ export type AcpMessage = {
   seq?: string;
   event_id?: number;
   chunk: boolean;
+  media?: AcpMedia[];
+  delivery?: string;
+  meta?: unknown;
   ts?: number;
 };
 
@@ -159,6 +172,9 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
       const text = String(parsed.text ?? "");
       const last = messages[messages.length - 1];
       const is_chunk = parsed.chunk === true;
+      const messageMedia = extractAcpMedia(parsed.attachments);
+      const messageMeta = parsed.meta;
+      const delivery = parseMessageDelivery(messageMeta);
       const messageId =
         typeof parsed.message_id === "string" ? parsed.message_id : null;
       const chunkIndex = parseChunkIndex(parsed.chunk_index);
@@ -199,6 +215,9 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
             existing.message_id = messageId;
           }
           existing.chunk_index = chunkIndex;
+          existing.media = mergeAcpMedia(existing.media, messageMedia);
+          if (messageMeta !== undefined) existing.meta = messageMeta;
+          if (delivery) existing.delivery = delivery;
         } else {
           const chunks = new Map<number, string>();
           chunks.set(chunkIndex, text);
@@ -212,6 +231,9 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
             seq: event.seq,
             event_id: event.event_id,
             chunk: true,
+            media: messageMedia,
+            delivery,
+            meta: messageMeta,
             ts: event.ts,
           } satisfies AcpMessage;
           messages.push(next);
@@ -235,6 +257,9 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
           if (messageId && last.message_id == null) {
             last.message_id = messageId;
           }
+          last.media = mergeAcpMedia(last.media, messageMedia);
+          if (messageMeta !== undefined) last.meta = messageMeta;
+          if (delivery) last.delivery = delivery;
         } else {
           messages.push({
             kind: parsed.type,
@@ -245,6 +270,9 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
             seq: event.seq,
             event_id: event.event_id,
             chunk: is_chunk,
+            media: messageMedia,
+            delivery,
+            meta: messageMeta,
             ts: event.ts,
           });
         }
@@ -272,14 +300,30 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
         status: parsed.status ? String(parsed.status) : "in_progress",
         content: parsed.content ? formatAcpContent(parsed.content) : undefined,
         raw_input: parsed.raw_input,
+        media: extractAcpMedia(parsed.content),
+        meta: parsed.meta,
         session_id: event.session_id ?? null,
         seq: event.seq,
         event_id: event.event_id,
         ts: event.ts,
       };
       if (!call.id) continue;
-      toolCallMap.set(call.id, call);
-      toolCalls.push(call);
+      const existing = toolCallMap.get(call.id);
+      if (existing) {
+        existing.title = call.title;
+        existing.kind = call.kind;
+        existing.status = call.status;
+        existing.content = mergeToolCallContent(existing.content, call.content ?? "");
+        existing.raw_input = call.raw_input ?? existing.raw_input;
+        existing.media = mergeAcpMedia(existing.media, call.media);
+        existing.meta = call.meta ?? existing.meta;
+        existing.seq = call.seq;
+        existing.event_id = call.event_id;
+        existing.ts = call.ts;
+      } else {
+        toolCallMap.set(call.id, call);
+        toolCalls.push(call);
+      }
       continue;
     }
     if (parsed.type === "tool_call_update") {
@@ -300,6 +344,8 @@ export function buildAcpView(events: AcpEventLine[]): AcpView {
       if (parsed.kind) call.kind = String(parsed.kind);
       if (parsed.raw_input) call.raw_input = parsed.raw_input;
       if (parsed.raw_output) call.raw_output = parsed.raw_output;
+      if (parsed.meta !== undefined) call.meta = parsed.meta;
+      call.media = mergeAcpMedia(call.media, extractAcpMedia(parsed.content));
       if (parsed.content) {
         const nextContent = formatAcpContent(parsed.content);
         if (nextContent) {
@@ -442,6 +488,9 @@ function closeStaleLiveToolCalls(
     }
     if (terminalRunStatus && isRunStatusForToolCall(runStatus, call)) {
       call.status = terminalRunStatus;
+      continue;
+    }
+    if (readAgentHubMetaKind(call.meta) === "codex_subagent") {
       continue;
     }
     const latestMessageOrder = latestMessageOrderBySession.get(
@@ -624,6 +673,78 @@ function parseAcpConfigValueId(value: unknown): string | null {
   return null;
 }
 
+function parseMessageDelivery(meta: unknown): string | undefined {
+  if (!meta || typeof meta !== "object") return undefined;
+  const delivery = (meta as Record<string, unknown>).delivery;
+  return typeof delivery === "string" && delivery.trim() ? delivery.trim() : undefined;
+}
+
+export function readAgentHubMetaKind(meta: unknown): string | null {
+  if (!meta || typeof meta !== "object") return null;
+  const agenthub = (meta as Record<string, unknown>).agenthub;
+  if (!agenthub || typeof agenthub !== "object") return null;
+  const kind = (agenthub as Record<string, unknown>).kind;
+  return typeof kind === "string" ? kind : null;
+}
+
+function isSameAcpMedia(left: AcpMedia, right: AcpMedia): boolean {
+  return (
+    left.mime_type === right.mime_type &&
+    left.uri === right.uri &&
+    left.data === right.data
+  );
+}
+
+function mergeAcpMedia(
+  previous: AcpMedia[] | undefined,
+  next: AcpMedia[] | undefined
+): AcpMedia[] | undefined {
+  if (!previous?.length) return next?.length ? next : undefined;
+  if (!next?.length) return previous;
+  const merged = [...previous];
+  for (const media of next) {
+    if (merged.some((candidate) => isSameAcpMedia(candidate, media))) continue;
+    merged.push(media);
+  }
+  return merged;
+}
+
+export function extractAcpMedia(content: unknown): AcpMedia[] | undefined {
+  const media: AcpMedia[] = [];
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const obj = value as Record<string, unknown>;
+    if (obj.type === "image") {
+      const data = typeof obj.data === "string" ? obj.data : undefined;
+      const uri = typeof obj.uri === "string" ? obj.uri : undefined;
+      const mimeTypeValue = obj.mimeType ?? obj.mime_type;
+      const mimeType =
+        typeof mimeTypeValue === "string" ? mimeTypeValue.toLowerCase() : "image/png";
+      if (!mimeType.startsWith("image/") || (!data && !uri)) return;
+      const nameValue = obj.name ?? obj.file_name;
+      const candidate: AcpMedia = {
+        type: "image",
+        data,
+        uri,
+        mime_type: mimeType,
+        name: typeof nameValue === "string" ? nameValue : undefined,
+      };
+      if (!media.some((item) => isSameAcpMedia(item, candidate))) {
+        media.push(candidate);
+      }
+      return;
+    }
+    if (obj.content !== undefined) visit(obj.content);
+    if (obj.attachments !== undefined) visit(obj.attachments);
+  };
+  visit(content);
+  return media.length > 0 ? media : undefined;
+}
+
 function formatAcpContent(content: unknown): string {
   if (Array.isArray(content)) {
     return content
@@ -634,6 +755,7 @@ function formatAcpContent(content: unknown): string {
   if (typeof content === "string") return content;
   if (content && typeof content === "object") {
     const obj = content as Record<string, unknown>;
+    if (obj.type === "image") return "";
     if (typeof obj.text === "string") return obj.text;
     if (obj.type === "content" && obj.content) {
       return formatAcpContent(obj.content);

--- a/web/src/agents_workbench.test.tsx
+++ b/web/src/agents_workbench.test.tsx
@@ -97,6 +97,52 @@ describe("AgentsWorkbench", () => {
     expect(html).toContain("Send");
     expect(html).toContain("Thread");
     expect(html).toContain("/repo/workdir");
+    expect(html).toContain('data-standalone-acp-context="true"');
+    expect(html).toContain('aria-label="Attach images"');
+  });
+
+  it("summarizes active Codex subagents in the standalone header", () => {
+    const html = renderWorkbench({
+      acpView: {
+        ...baseView,
+        toolCalls: [
+          {
+            id: "codex-subagent:child",
+            title: "Subagent child",
+            status: "in_progress",
+            meta: { agenthub: { kind: "codex_subagent" } },
+          },
+        ],
+      },
+    });
+
+    expect(html).toContain("1 active / 1 total");
+  });
+
+  it("prefers live Codex reasoning and mode context in the standalone header", () => {
+    const html = renderWorkbench({
+      activeAgentRecord: {
+        ...createProps().activeAgentRecord!,
+        thinking_level: "high",
+        codex_acp_default_mode: "full-access",
+      },
+      acpView: {
+        ...baseView,
+        currentMode: "read-only",
+        configOptions: [
+          {
+            id: "reasoning_effort",
+            label: "Reasoning effort",
+            currentValueId: "ultra",
+            selectOptions: [],
+          },
+        ],
+      },
+    });
+
+    expect(html).toContain("Ultra");
+    expect(html).toContain("Read Only");
+    expect(html).not.toContain("Full Access");
   });
 
   it("hides the input dock when ACP debug owns the footer", () => {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -936,7 +936,12 @@ describe("api request headers", () => {
         call: () => api.sendInput(token, agentId, "hello", "message-1", "session-1"),
         url: "/api/agents/agent%2Fone/input",
         method: "POST",
-        body: { input: "hello", message_id: "message-1", session_id: "session-1" },
+        body: {
+          input: "hello",
+          message_id: "message-1",
+          session_id: "session-1",
+          images: [],
+        },
       },
       {
         call: () =>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -57,6 +57,13 @@ export type AgentRecord = {
   updated_at: number;
 };
 
+export type AgentInputImage = {
+  id: string;
+  file_name: string;
+  mime_type: string;
+  data: string;
+};
+
 export type AgentTimeTriggerRecord = {
   id: string;
   agent_id: string;
@@ -1488,11 +1495,12 @@ export const api = {
     id: string,
     input: string,
     message_id?: string,
-    session_id?: string
+    session_id?: string,
+    images: AgentInputImage[] = []
   ) =>
     apiFetch<{ status: string }>(`/api/agents/${encodePathSegment(id)}/input`, token, {
       method: "POST",
-      body: JSON.stringify({ input, message_id, session_id }),
+      body: JSON.stringify({ input, message_id, session_id, images }),
     }),
   createAgent: (token: string, payload: AgentConfig) =>
     apiFetch<AgentRecord>("/api/agents", token, {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -3,6 +3,7 @@ import {
   api,
   parseApiErrorMessage,
   stringifyApiError,
+  type AgentInputImage,
 } from "./api";
 import {
   AGENT_NOT_RUNNING_ERROR,
@@ -392,6 +393,7 @@ export function App() {
   );
 
   const [input, setInput] = useState("");
+  const [inputImages, setInputImages] = useState<AgentInputImage[]>([]);
   const [inputHistory, setInputHistory] = useState<string[]>(() =>
     parseInputHistory(getLocalStorageItemSafe(INPUT_HISTORY_STORAGE_KEY))
   );
@@ -421,6 +423,10 @@ export function App() {
       JSON.stringify(inputHistory)
     );
   }, [inputHistory]);
+
+  useEffect(() => {
+    setInputImages([]);
+  }, [activeAgent]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -564,10 +570,12 @@ export function App() {
     options?: {
       recordHistory?: boolean;
       clearComposer?: boolean;
+      images?: AgentInputImage[];
     }
   ) => {
     const text = rawText.trim();
-    if (!text) return;
+    const images = options?.images ?? [];
+    if (!text && images.length === 0) return;
     if (!auth?.token || !activeAgent) return;
     
     let messageId: string | null = null;
@@ -583,17 +591,19 @@ export function App() {
         activeAgent,
         text,
         messageId ?? undefined,
-        sessionId ?? undefined
+        sessionId ?? undefined,
+        images
       );
     try {
       await sendInputForSession(activeSessionId);
-      if (options?.recordHistory) {
+      if (options?.recordHistory && text) {
         setInputHistory((prev) => pushInputHistory(prev, text));
         setInputHistoryCursor(-1);
       }
       if (options?.clearComposer) {
         inputHistoryDraftRef.current = "";
         setInput("");
+        setInputImages([]);
       }
       } catch (err: unknown) {
         const msg = parseApiErrorMessage(err) ?? String(err || "websocket not connected");
@@ -605,13 +615,14 @@ export function App() {
           await loadAgentEvents(activeAgent, runningSessionId);
           try {
             await sendInputForSession(runningSessionId);
-            if (options?.recordHistory) {
+            if (options?.recordHistory && text) {
               setInputHistory((prev) => pushInputHistory(prev, text));
               setInputHistoryCursor(-1);
             }
             if (options?.clearComposer) {
               inputHistoryDraftRef.current = "";
               setInput("");
+              setInputImages([]);
             }
             return;
           } catch (retryErr: unknown) {
@@ -888,6 +899,7 @@ export function App() {
         isConversationLoading,
         terminalRef,
         input,
+        inputImages,
         inputHistory,
         ansi,
         canControlAcp,
@@ -910,6 +922,7 @@ export function App() {
         onAcpCancel: onAcpCancel,
         onAcpClearSession: onAcpClearSession,
         onInputChange: onInputChange,
+        onInputImagesChange: setInputImages,
         onSelectInputHistory: onSelectInputHistory,
         onNavigateInputHistory: onNavigateInputHistory,
         onSendAcpInput: sendAcpInput,
@@ -932,6 +945,7 @@ export function App() {
       isConversationLoading,
       terminalRef,
       input,
+      inputImages,
       inputHistory,
       ansi,
       canControlAcp,

--- a/web/src/components/acp_conversation_bubble.tsx
+++ b/web/src/components/acp_conversation_bubble.tsx
@@ -154,6 +154,8 @@ export const AcpConversationBubble = React.memo(
         <MarkdownBubble
           className="agent_message"
           text={msg.text}
+          media={msg.media}
+          delivery={msg.delivery}
           markdownRenderVersion={markdownRenderVersion}
         />
       );
@@ -163,6 +165,7 @@ export const AcpConversationBubble = React.memo(
       <MarkdownBubble
         className="user_message"
         text={msg.text}
+        media={msg.media}
         markdownRenderVersion={markdownRenderVersion}
       />
     );

--- a/web/src/components/acp_media_gallery.test.tsx
+++ b/web/src/components/acp_media_gallery.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AcpMediaGallery, resolveAcpMediaSource } from "./acp_media_gallery";
+
+describe("AcpMediaGallery", () => {
+  it("renders supported inline images", () => {
+    const html = renderToStaticMarkup(
+      <AcpMediaGallery
+        media={[
+          {
+            type: "image",
+            name: "result.png",
+            mime_type: "image/png",
+            data: "aW1hZ2U=",
+          },
+        ]}
+      />
+    );
+
+    expect(html).toContain('data-acp-media-gallery="true"');
+    expect(html).toContain("data:image/png;base64,aW1hZ2U=");
+    expect(html).toContain('alt="result.png"');
+  });
+
+  it("rejects unsupported or unsafe image sources", () => {
+    expect(
+      resolveAcpMediaSource({
+        type: "image",
+        mime_type: "image/svg+xml",
+        data: "PHN2Zz4=",
+      })
+    ).toBeNull();
+    expect(
+      resolveAcpMediaSource({
+        type: "image",
+        mime_type: "image/png",
+        uri: "file:///tmp/image.png",
+      })
+    ).toBeNull();
+  });
+});

--- a/web/src/components/acp_media_gallery.tsx
+++ b/web/src/components/acp_media_gallery.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import type { AcpMedia } from "../acp";
+
+const SAFE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+export function resolveAcpMediaSource(media: AcpMedia): string | null {
+  const mimeType = media.mime_type.trim().toLowerCase();
+  if (!SAFE_IMAGE_MIME_TYPES.has(mimeType)) return null;
+  if (media.data) return `data:${mimeType};base64,${media.data}`;
+  if (!media.uri) return null;
+  if (/^https?:\/\//i.test(media.uri)) return media.uri;
+  if (media.uri.startsWith(`data:${mimeType};base64,`)) return media.uri;
+  return null;
+}
+
+export const AcpMediaGallery = React.memo(function AcpMediaGallery({
+  media,
+  compact = false,
+}: {
+  media?: AcpMedia[];
+  compact?: boolean;
+}) {
+  const items = (media ?? [])
+    .map((item) => ({ item, source: resolveAcpMediaSource(item) }))
+    .filter((entry): entry is { item: AcpMedia; source: string } => Boolean(entry.source));
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className={`grid gap-2 ${compact ? "grid-cols-[repeat(auto-fill,minmax(7rem,10rem))]" : "grid-cols-[repeat(auto-fill,minmax(10rem,16rem))]"}`}
+      data-acp-media-gallery="true"
+    >
+      {items.map(({ item, source }, index) => (
+        <a
+          key={`${source.slice(0, 80)}:${index}`}
+          href={source}
+          target="_blank"
+          rel="noreferrer"
+          className="block overflow-hidden rounded-xl border border-black/10 bg-slate-50 shadow-sm transition hover:border-black/20"
+          title={item.name ? `Open ${item.name}` : "Open image"}
+        >
+          <img
+            src={source}
+            alt={item.name ?? `Image ${index + 1}`}
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            className={`w-full object-contain ${compact ? "max-h-40" : "max-h-72"}`}
+          />
+        </a>
+      ))}
+    </div>
+  );
+});

--- a/web/src/components/acp_tool_call_bubble.tsx
+++ b/web/src/components/acp_tool_call_bubble.tsx
@@ -29,6 +29,7 @@ import {
   resolveEffectiveToolCallStatus,
 } from "./acp_tool_bubble_shared";
 import { formatConversationPreview, unescapeLineBreaks } from "../conversation";
+import { AcpMediaGallery } from "./acp_media_gallery";
 
 export const ToolCallBubble = React.memo(
   function ToolCallBubble({
@@ -182,6 +183,11 @@ export const ToolCallBubble = React.memo(
             ) : null}
           </summary>
           <div className="px-2 pb-2">
+            {msg.media?.length ? (
+              <div className="pb-2">
+                <AcpMediaGallery media={msg.media} compact={true} />
+              </div>
+            ) : null}
             {showPendingRequestUserInputCard && requestUserInputQuestions ? (
               <RequestUserInputCard
                 toolCallId={msg.id}

--- a/web/src/components/agents_workbench.tsx
+++ b/web/src/components/agents_workbench.tsx
@@ -20,6 +20,7 @@ function AgentsWorkbenchView({
   isConversationLoading,
   terminalRef,
   input,
+  inputImages,
   inputHistory,
   ansi,
   canControlAcp,
@@ -42,6 +43,7 @@ function AgentsWorkbenchView({
   onAcpCancel,
   onAcpClearSession,
   onInputChange,
+  onInputImagesChange,
   onSelectInputHistory,
   onNavigateInputHistory,
   onSendAcpInput,
@@ -70,6 +72,7 @@ function AgentsWorkbenchView({
     isConversationLoading,
     terminalRef,
     input,
+    inputImages,
     inputHistory,
     ansi,
     canControlAcp,
@@ -112,12 +115,16 @@ function AgentsWorkbenchView({
       />
       {showInputDock ? (
         <InputDock
+          key={activeAgent ?? "standalone-acp"}
           input={input}
+          images={inputImages}
+          enableImages={true}
           historyCommands={inputHistory}
           showInterrupt={acpView.hasAcp}
           canInterrupt={canInterruptAcpRun}
           onHeightChange={setInputDockHeight}
           onInputChange={onInputChange}
+          onImagesChange={onInputImagesChange}
           onSendInput={onSendInput}
           onInterrupt={onAcpCancel}
           onNavigateHistory={onNavigateInputHistory}

--- a/web/src/components/agents_workbench_types.ts
+++ b/web/src/components/agents_workbench_types.ts
@@ -1,12 +1,13 @@
 import React from "react";
 import { AcpView } from "../acp";
-import { AcpPermissionRecord, AgentRecord } from "../api";
+import { AcpPermissionRecord, AgentInputImage, AgentRecord } from "../api";
 import { OutputLine } from "../output_cache";
 import { AcpConversationEventMeta } from "../hooks/use_acp_conversation";
 
 export type SendAcpInputOptions = {
   recordHistory?: boolean;
   clearComposer?: boolean;
+  images?: AgentInputImage[];
 };
 
 export type AgentsWorkbenchProps = {
@@ -25,6 +26,7 @@ export type AgentsWorkbenchProps = {
   isConversationLoading: boolean;
   terminalRef: React.RefObject<HTMLDivElement | null>;
   input: string;
+  inputImages?: AgentInputImage[];
   inputHistory: string[];
   ansi: (input: string) => string;
   canControlAcp: boolean;
@@ -47,6 +49,7 @@ export type AgentsWorkbenchProps = {
   onAcpCancel: () => void;
   onAcpClearSession: () => void;
   onInputChange: (value: string) => void;
+  onInputImagesChange?: (images: AgentInputImage[]) => void;
   onSelectInputHistory: (value: string) => void;
   onNavigateInputHistory: (direction: "up" | "down") => void;
   onSendAcpInput: (

--- a/web/src/components/bubbles/markdown_bubble.tsx
+++ b/web/src/components/bubbles/markdown_bubble.tsx
@@ -5,16 +5,22 @@ import {
   ACP_MESSAGE_BUBBLE_USER_CLASS,
 } from "../../ui/tailwind_classes";
 import { ThreadRichText } from "../thread_rich_text";
+import type { AcpMedia } from "../../acp";
+import { AcpMediaGallery } from "../acp_media_gallery";
 
 export type MarkdownBubbleProps = {
   className: "agent_message" | "user_message";
   text: string;
+  media?: AcpMedia[];
+  delivery?: string;
   markdownRenderVersion: number;
 };
 
 export const MarkdownBubble = React.memo(function MarkdownBubble({
   className,
   text,
+  media,
+  delivery,
   markdownRenderVersion,
 }: MarkdownBubbleProps) {
   const isAgent = className === "agent_message";
@@ -27,7 +33,15 @@ export const MarkdownBubble = React.memo(function MarkdownBubble({
         data-markdown-render-version={markdownRenderVersion}
         className={isAgent ? ACP_MESSAGE_BUBBLE_AGENT_CLASS : ACP_MESSAGE_BUBBLE_USER_CLASS}
       >
-        <ThreadRichText text={text} />
+        {delivery === "async" ? (
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-indigo-600">
+            Background update
+          </div>
+        ) : null}
+        <div className="space-y-2">
+          {text ? <ThreadRichText text={text} /> : null}
+          <AcpMediaGallery media={media} />
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/create_agent_modal.tsx
+++ b/web/src/components/create_agent_modal.tsx
@@ -88,6 +88,14 @@ export const THINKING_LEVEL_OPTIONS = [
   { value: "high", label: "High" },
   { value: "max", label: "Max" },
 ];
+export const CODEX_THINKING_LEVEL_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "XHigh" },
+  { value: "max", label: "Max" },
+  { value: "ultra", label: "Ultra" },
+];
 export const CODEX_RUNTIME_MODEL_OPTIONS = [
   { value: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
   { value: "gpt-5.6-terra", label: "GPT-5.6-Terra" },
@@ -334,7 +342,7 @@ export function CreateAgentModal({
                 description="Applied when the next session starts."
                 placeholder="Provider default"
                 value={thinkingLevel || null}
-                data={THINKING_LEVEL_OPTIONS}
+                data={isCodexPreset ? CODEX_THINKING_LEVEL_OPTIONS : THINKING_LEVEL_OPTIONS}
                 clearable
                 onChange={(value) => setThinkingLevel?.(value ?? "")}
               />

--- a/web/src/components/input_dock.test.tsx
+++ b/web/src/components/input_dock.test.tsx
@@ -2,7 +2,11 @@
 import { MantineProvider } from "@mantine/core";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { InputDock } from "./input_dock";
+import {
+  ACP_INPUT_MAX_IMAGE_BYTES,
+  InputDock,
+  validateInputImageFiles,
+} from "./input_dock";
 import {
   INPUT_DOCK_ROOT_CLASS,
   INPUT_DOCK_SEND_BUTTON_CLASS,
@@ -51,5 +55,61 @@ describe("InputDock", () => {
     expectStaticClassTokens(html, TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS);
     expectStaticClassTokens(html, INPUT_DOCK_TEXTAREA_CLASS);
     expectStaticClassTokens(html, INPUT_DOCK_SEND_BUTTON_CLASS);
+  });
+
+  it("renders standalone image attachments and attachment controls", () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <InputDock
+          input=""
+          images={[
+            {
+              id: "image-1",
+              file_name: "diagram.png",
+              mime_type: "image/png",
+              data: "aW1hZ2U=",
+            },
+          ]}
+          enableImages={true}
+          historyCommands={[]}
+          showInterrupt={false}
+          canInterrupt={false}
+          onInputChange={vi.fn()}
+          onImagesChange={vi.fn()}
+          onSendInput={vi.fn()}
+          onInterrupt={vi.fn()}
+          onNavigateHistory={vi.fn()}
+          onSelectHistoryCommand={vi.fn()}
+          onJumpToBottom={vi.fn()}
+          showConversationJump={false}
+          isComposingRef={{ current: false }}
+        />
+      </MantineProvider>
+    );
+
+    expect(html).toContain('data-acp-input-images="true"');
+    expect(html).toContain('aria-label="Attach images"');
+    expect(html).toContain('aria-label="Remove diagram.png"');
+    expect(html).toContain("data:image/png;base64,aW1hZ2U=");
+  });
+
+  it("validates image type, count, and size before reading files", () => {
+    expect(
+      validateInputImageFiles([], [
+        new File([new Uint8Array([1])], "diagram.png", { type: "image/png" }),
+      ])
+    ).toBeNull();
+    expect(
+      validateInputImageFiles([], [
+        new File([new Uint8Array([1])], "diagram.svg", { type: "image/svg+xml" }),
+      ])
+    ).toContain("PNG");
+    expect(
+      validateInputImageFiles([], [
+        new File([new Uint8Array(ACP_INPUT_MAX_IMAGE_BYTES + 1)], "large.png", {
+          type: "image/png",
+        }),
+      ])
+    ).toContain("5 MiB");
   });
 });

--- a/web/src/components/input_dock.tsx
+++ b/web/src/components/input_dock.tsx
@@ -14,15 +14,29 @@ import {
   TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS,
 } from "../ui/tailwind_classes";
 import { isImeComposing } from "../input_ime";
+import type { AgentInputImage } from "../api";
+
+export const ACP_INPUT_MAX_IMAGES = 4;
+export const ACP_INPUT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const ACP_INPUT_MAX_TOTAL_IMAGE_BYTES = 10 * 1024 * 1024;
+const ACP_INPUT_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
 
 type InputDockProps = {
   input: string;
+  images?: AgentInputImage[];
+  enableImages?: boolean;
   historyCommands: string[];
   showInterrupt: boolean;
   canInterrupt: boolean;
   sendDisabled?: boolean;
   onHeightChange?: (height: number) => void;
   onInputChange: (value: string) => void;
+  onImagesChange?: (images: AgentInputImage[]) => void;
   onSendInput: () => void;
   onInterrupt: () => void;
   onNavigateHistory: (direction: "up" | "down") => void;
@@ -31,6 +45,75 @@ type InputDockProps = {
   showConversationJump: boolean;
   isComposingRef: React.MutableRefObject<boolean>;
 };
+
+function approximateBase64Bytes(data: string): number {
+  const normalized = data.replace(/\s/g, "");
+  if (!normalized) return 0;
+  const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
+}
+
+export function validateInputImageFiles(
+  existing: AgentInputImage[],
+  files: File[]
+): string | null {
+  if (existing.length + files.length > ACP_INPUT_MAX_IMAGES) {
+    return `Attach up to ${ACP_INPUT_MAX_IMAGES} images.`;
+  }
+  for (const file of files) {
+    if (!ACP_INPUT_IMAGE_TYPES.has(file.type.toLowerCase())) {
+      return "Use PNG, JPEG, WebP, or GIF images.";
+    }
+    if (file.size <= 0) return "Empty images cannot be attached.";
+    if (file.size > ACP_INPUT_MAX_IMAGE_BYTES) {
+      return "Each image must be 5 MiB or smaller.";
+    }
+  }
+  const existingBytes = existing.reduce(
+    (total, image) => total + approximateBase64Bytes(image.data),
+    0
+  );
+  const nextBytes = files.reduce((total, file) => total + file.size, existingBytes);
+  if (nextBytes > ACP_INPUT_MAX_TOTAL_IMAGE_BYTES) {
+    return "Attached images must total 10 MiB or less.";
+  }
+  return null;
+}
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error(`Failed to read ${file.name || "image"}.`));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      const separator = result.indexOf(",");
+      if (separator < 0) {
+        reject(new Error(`Failed to encode ${file.name || "image"}.`));
+        return;
+      }
+      resolve(result.slice(separator + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function createInputImageId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `image-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export async function buildInputImages(files: File[]): Promise<AgentInputImage[]> {
+  return Promise.all(
+    files.map(async (file) => ({
+      id: createInputImageId(),
+      file_name: file.name || "pasted-image",
+      mime_type: file.type.toLowerCase(),
+      data: await readFileAsBase64(file),
+    }))
+  );
+}
 
 type VerticalRect = {
   top: number;
@@ -235,12 +318,15 @@ export function deriveInputDockKeyAction(
 
 export function InputDock({
   input,
+  images = [],
+  enableImages = false,
   historyCommands,
   showInterrupt,
   canInterrupt,
   sendDisabled = false,
   onHeightChange,
   onInputChange,
+  onImagesChange,
   onSendInput,
   onInterrupt,
   onNavigateHistory,
@@ -255,11 +341,58 @@ export function InputDock({
   const historyContainerRef = React.useRef<HTMLDivElement | null>(null);
   const inputDockRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const imageInputRef = React.useRef<HTMLInputElement | null>(null);
+  const imagesRef = React.useRef(images);
+  const mountedRef = React.useRef(true);
   const lastReportedHeightRef = React.useRef<number | null>(null);
+  const [attachmentError, setAttachmentError] = React.useState<string | null>(null);
   const visibleHistory = historyCommands.slice(0, 12);
   const mobileInputViewport = useMobileInputViewport();
   const inputPlaceholder = deriveInputPlaceholder(mobileInputViewport);
   const inputHelperText = deriveInputHelperText(mobileInputViewport);
+  const effectiveSendDisabled =
+    sendDisabled || (input.trim().length === 0 && images.length === 0);
+
+  React.useEffect(() => {
+    imagesRef.current = images;
+  }, [images]);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const addImageFiles = React.useCallback(
+    async (fileList: FileList | File[]) => {
+      if (!enableImages || !onImagesChange) return;
+      const files = Array.from(fileList).filter((file) => file.type.startsWith("image/"));
+      if (files.length === 0) return;
+      const validationError = validateInputImageFiles(imagesRef.current, files);
+      if (validationError) {
+        setAttachmentError(validationError);
+        return;
+      }
+      try {
+        const next = await buildInputImages(files);
+        if (!mountedRef.current) return;
+        const latestImages = imagesRef.current;
+        const completionError = validateInputImageFiles(latestImages, files);
+        if (completionError) {
+          setAttachmentError(completionError);
+          return;
+        }
+        const mergedImages = [...latestImages, ...next];
+        imagesRef.current = mergedImages;
+        onImagesChange(mergedImages);
+        setAttachmentError(null);
+      } catch (error) {
+        setAttachmentError(error instanceof Error ? error.message : "Failed to read image.");
+      }
+    },
+    [enableImages, onImagesChange]
+  );
 
   const reportDockHeight = React.useCallback(() => {
     if (!onHeightChange) return;
@@ -386,9 +519,49 @@ export function InputDock({
         </UnstyledButton>
       )}
       <div className={INPUT_DOCK_ROOT_CLASS}>
+        {enableImages && images.length > 0 ? (
+          <div
+            className="flex flex-wrap gap-2 border-b border-notion-border/70 px-2 pb-2"
+            data-acp-input-images="true"
+          >
+            {images.map((image) => (
+              <div
+                key={image.id}
+                className="group relative h-16 w-16 overflow-hidden rounded-lg border border-notion-border bg-notion-hover"
+              >
+                <img
+                  src={`data:${image.mime_type};base64,${image.data}`}
+                  alt={image.file_name}
+                  className="h-full w-full object-cover"
+                />
+                <UnstyledButton
+                  type="button"
+                  className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-950/75 text-xs text-white opacity-80 transition hover:opacity-100"
+                  onClick={() => {
+                    onImagesChange?.(images.filter((candidate) => candidate.id !== image.id));
+                    setAttachmentError(null);
+                  }}
+                  aria-label={`Remove ${image.file_name}`}
+                  title={`Remove ${image.file_name}`}
+                >
+                  <i className="bi bi-x" aria-hidden="true" />
+                </UnstyledButton>
+              </div>
+            ))}
+          </div>
+        ) : null}
         <div
           className={`input-editor-row ${TEAM_MESSAGE_COMPOSER_EDITOR_ROW_CLASS}`}
           data-input-editor-row="true"
+          onDragOver={(event) => {
+            if (!enableImages) return;
+            event.preventDefault();
+          }}
+          onDrop={(event) => {
+            if (!enableImages) return;
+            event.preventDefault();
+            void addImageFiles(event.dataTransfer.files);
+          }}
         >
           <textarea
             id={textareaId}
@@ -408,6 +581,17 @@ export function InputDock({
               setShowHistory(false);
               onInputChange(e.target.value);
               ensureInputVisible();
+            }}
+            onPaste={(event) => {
+              if (!enableImages) return;
+              const imageFiles = Array.from(event.clipboardData.files).filter((file) =>
+                file.type.startsWith("image/")
+              );
+              if (imageFiles.length === 0) return;
+              if (!event.clipboardData.getData("text/plain")) {
+                event.preventDefault();
+              }
+              void addImageFiles(imageFiles);
             }}
             onCompositionStart={() => {
               isComposingRef.current = true;
@@ -441,7 +625,7 @@ export function InputDock({
                 return;
               }
               if (action.type === "send") {
-                if (sendDisabled) {
+                if (effectiveSendDisabled) {
                   return;
                 }
                 e.preventDefault();
@@ -461,7 +645,7 @@ export function InputDock({
             type="button"
             className={INPUT_DOCK_SEND_BUTTON_CLASS}
             onClick={onSendInput}
-            disabled={sendDisabled}
+            disabled={effectiveSendDisabled}
             aria-label="Send input"
             title="Send input"
           >
@@ -475,7 +659,38 @@ export function InputDock({
           data-input-actions-row="true"
         >
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>{inputHelperText}</span>
+            {enableImages ? (
+              <>
+                <input
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  multiple
+                  className="hidden"
+                  onChange={(event) => {
+                    if (event.target.files) {
+                      void addImageFiles(event.target.files);
+                    }
+                    event.target.value = "";
+                  }}
+                />
+                <UnstyledButton
+                  type="button"
+                  className={INPUT_DOCK_HISTORY_BUTTON_CLASS}
+                  onClick={() => imageInputRef.current?.click()}
+                  disabled={images.length >= ACP_INPUT_MAX_IMAGES}
+                  title="Attach images"
+                  aria-label="Attach images"
+                >
+                  <i className="bi bi-image text-[12px]" aria-hidden="true" />
+                  <span>Images</span>
+                  {images.length > 0 ? <span>{images.length}</span> : null}
+                </UnstyledButton>
+              </>
+            ) : null}
+            <span className={TEAM_MESSAGE_COMPOSER_HELPER_TEXT_CLASS}>
+              {inputHelperText}{enableImages ? " · paste or drop images" : ""}
+            </span>
             {historyCommands.length > 0 && (
               <div className="input-history relative" ref={historyContainerRef}>
                 <UnstyledButton
@@ -536,6 +751,11 @@ export function InputDock({
             </UnstyledButton>
           )}
         </div>
+        {attachmentError ? (
+          <div className="px-2 pb-1 text-[11px] font-medium text-rose-600" role="alert">
+            {attachmentError}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/standalone_acp_header_context.tsx
+++ b/web/src/components/standalone_acp_header_context.tsx
@@ -1,0 +1,84 @@
+import { readAgentHubMetaKind, type AcpView } from "../acp";
+import type { AgentRecord } from "../api";
+import { isToolCallLive } from "../conversation";
+
+function formatRuntimeLabel(value: string): string {
+  return value
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function StatusPill({
+  icon,
+  label,
+  tone = "neutral",
+}: {
+  icon: string;
+  label: string;
+  tone?: "neutral" | "active" | "warning";
+}) {
+  const toneClass =
+    tone === "active"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : tone === "warning"
+        ? "border-amber-200 bg-amber-50 text-amber-700"
+        : "border-notion-border bg-white text-notion-text-muted";
+  return (
+    <span
+      className={`inline-flex min-w-0 items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium ${toneClass}`}
+    >
+      <i className={`bi ${icon} shrink-0 text-[10px]`} aria-hidden="true" />
+      <span className="max-w-44 truncate">{label}</span>
+    </span>
+  );
+}
+
+export function StandaloneAcpHeaderContext({
+  acpView,
+  agent,
+}: {
+  acpView: AcpView;
+  agent: AgentRecord | null;
+}) {
+  const subagents = acpView.toolCalls.filter(
+    (call) => readAgentHubMetaKind(call.meta) === "codex_subagent"
+  );
+  const activeSubagents = subagents.filter((call) => isToolCallLive(call.status)).length;
+  const configuredModel = acpView.configOptions.find((option) => option.id === "model");
+  const configuredReasoning = acpView.configOptions.find(
+    (option) => option.id === "reasoning_effort"
+  );
+  const model = configuredModel?.currentValueId ?? agent?.runtime_model ?? null;
+  const reasoning = configuredReasoning?.currentValueId ?? agent?.thinking_level ?? null;
+  const mode = acpView.currentMode ?? agent?.codex_acp_default_mode ?? null;
+  const runStatus = acpView.runStatus?.status ?? agent?.status ?? "idle";
+  const normalizedStatus = runStatus.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const statusTone = ["running", "starting", "in_progress", "waiting_permission"].includes(
+    normalizedStatus
+  )
+    ? "active"
+    : normalizedStatus === "failed" || normalizedStatus === "error"
+      ? "warning"
+      : "neutral";
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1.5" data-standalone-acp-context="true">
+      <StatusPill icon="bi-activity" label={formatRuntimeLabel(runStatus)} tone={statusTone} />
+      {model ? <StatusPill icon="bi-cpu" label={model} /> : null}
+      {reasoning ? (
+        <StatusPill icon="bi-lightbulb" label={formatRuntimeLabel(reasoning)} />
+      ) : null}
+      {mode ? (
+        <StatusPill icon="bi-shield-check" label={formatRuntimeLabel(mode)} />
+      ) : null}
+      {subagents.length > 0 ? (
+        <StatusPill
+          icon="bi-diagram-3"
+          label={`${activeSubagents} active / ${subagents.length} total`}
+          tone={activeSubagents > 0 ? "active" : "neutral"}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/use_agents_workbench_panel.ts
+++ b/web/src/components/use_agents_workbench_panel.ts
@@ -7,6 +7,7 @@ import { useAgentsPermissionJump } from "./use_agents_permission_jump";
 import { resolveAcpInputDockConversationClearance } from "./acp_input_dock_clearance";
 import { resolveInputDockJumpMode } from "./acp_panel_helpers";
 import type { AgentsWorkbenchProps } from "./agents_workbench_types";
+import { StandaloneAcpHeaderContext } from "./standalone_acp_header_context";
 
 type UseAgentsWorkbenchPanelResult = {
   acpPanelProps: AcpPanelProps;
@@ -30,6 +31,7 @@ export function useAgentsWorkbenchPanel({
   scopedAcpPermissionHistory,
   terminalRef,
   input,
+  inputImages,
   ansi,
   canControlAcp,
   canInterruptAcpRun,
@@ -91,8 +93,9 @@ export function useAgentsWorkbenchPanel({
     await onSendAcpInput(input, {
       recordHistory: true,
       clearComposer: true,
+      images: inputImages,
     });
-  }, [jumpToConversationBottom, input, onSendAcpInput]);
+  }, [jumpToConversationBottom, input, inputImages, onSendAcpInput]);
 
   const onSubmitRequestUserInput = React.useCallback(
     async (text: string) => {
@@ -247,6 +250,10 @@ export function useAgentsWorkbenchPanel({
       acpView,
       subtitle: activeAgentRecord?.workdir ?? null,
       mobileTitle: activeAgentRecord?.name ?? null,
+      headerContext: React.createElement(StandaloneAcpHeaderContext, {
+        acpView,
+        agent: activeAgentRecord,
+      }),
       acpTab: !developerMode && acpTab === "debug" ? "conversation" : acpTab,
       developerMode,
       conversationBottomClearance,
@@ -263,8 +270,7 @@ export function useAgentsWorkbenchPanel({
     }),
     [
       acpView,
-      activeAgentRecord?.workdir,
-      activeAgentRecord?.name,
+      activeAgentRecord,
       developerMode,
       acpTab,
       conversationBottomClearance,

--- a/web/src/conversation.ts
+++ b/web/src/conversation.ts
@@ -1,5 +1,6 @@
 import type {
   AcpMessage,
+  AcpMedia,
   AcpPlanEntry,
   AcpPlanView,
   AcpTerminalActivity,
@@ -14,6 +15,8 @@ export type MessageConversationItem = {
   text: string;
   plan_entries?: PlanEntryView[];
   live?: boolean;
+  media?: AcpMedia[];
+  delivery?: string;
   seq?: string;
   event_id?: number;
   ts?: number;
@@ -29,6 +32,8 @@ export type ToolCallConversationItem = {
   raw_output?: unknown;
   terminal_output?: string;
   terminal_activities?: AcpTerminalActivity[];
+  media?: AcpMedia[];
+  meta?: unknown;
   seq?: string;
   event_id?: number;
   ts?: number;
@@ -226,6 +231,8 @@ export function buildConversationMessages(
         items.push({
           kind: "agent_message",
           text: msg.text,
+          media: msg.media,
+          delivery: msg.delivery,
           seq: msg.seq,
           event_id: msg.event_id,
           ts: msg.ts,
@@ -235,6 +242,7 @@ export function buildConversationMessages(
       items.push({
         kind: "user_message",
         text: msg.text,
+        media: msg.media,
         seq: msg.seq,
         event_id: msg.event_id,
         ts: msg.ts,
@@ -299,6 +307,8 @@ export function buildConversationMessages(
       raw_output: call.raw_output,
       terminal_output: call.terminal_output,
       terminal_activities: call.terminal_activities,
+      media: call.media,
+      meta: call.meta,
       seq: call.seq,
       event_id: call.event_id,
       ts: call.ts,

--- a/web/src/create_agent_modal.test.tsx
+++ b/web/src/create_agent_modal.test.tsx
@@ -4,6 +4,8 @@ import { MantineProvider } from "@mantine/core";
 import {
   CreateAgentModal,
   CODEX_RUNTIME_MODEL_OPTIONS,
+  CODEX_THINKING_LEVEL_OPTIONS,
+  THINKING_LEVEL_OPTIONS,
   listCodexRuntimeModelOptions,
   type CreateAgentModalProps,
   resolveCreateAgentPresetId,
@@ -114,6 +116,23 @@ describe("CreateAgentModal", () => {
     expect(renderModal()).toContain("Thinking level");
     expect(renderModal({ agentPresetId: "claude" })).toContain("Runtime model");
     expect(renderModal({ agentPresetId: "gemini" })).not.toContain("Runtime model");
+  });
+
+  it("exposes extended Codex reasoning efforts without changing Claude levels", () => {
+    expect(CODEX_THINKING_LEVEL_OPTIONS.map((option) => option.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(THINKING_LEVEL_OPTIONS.map((option) => option.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
   });
 
   it("renders the Codex runtime model selector with bundled model presets", () => {

--- a/web/src/pages/team/team_management_modals.test.tsx
+++ b/web/src/pages/team/team_management_modals.test.tsx
@@ -4,6 +4,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../components/create_agent_modal", () => ({
+  CODEX_THINKING_LEVEL_OPTIONS: [
+    { value: "low", label: "Low" },
+    { value: "medium", label: "Medium" },
+    { value: "high", label: "High" },
+    { value: "xhigh", label: "XHigh" },
+    { value: "max", label: "Max" },
+    { value: "ultra", label: "Ultra" },
+  ],
   THINKING_LEVEL_OPTIONS: [
     { value: "low", label: "Low" },
     { value: "medium", label: "Medium" },
@@ -118,6 +126,7 @@ describe("Team management modals", () => {
           onSave={vi.fn()}
           chrome={chrome}
           supportsRuntimeProfile
+          isCodexProvider
         />
       </MantineProvider>
     );

--- a/web/src/pages/team/team_management_modals.tsx
+++ b/web/src/pages/team/team_management_modals.tsx
@@ -10,6 +10,7 @@ import {
   normalizeCodexAcpModeId,
 } from "../../codex_acp_modes";
 import {
+  CODEX_THINKING_LEVEL_OPTIONS,
   CreateAgentModal,
   THINKING_LEVEL_OPTIONS,
   type CreateAgentModalProps,
@@ -203,6 +204,7 @@ export const TeamEditMemberDialog = React.memo(function TeamEditMemberDialog({
   onSave,
   chrome,
   supportsRuntimeProfile,
+  isCodexProvider = false,
 }: {
   open: boolean;
   busy: string | null;
@@ -213,6 +215,7 @@ export const TeamEditMemberDialog = React.memo(function TeamEditMemberDialog({
   onSave: () => void;
   chrome: TeamModalChrome;
   supportsRuntimeProfile: boolean;
+  isCodexProvider?: boolean;
 }) {
   const dialogActive = open && Boolean(draft);
   const focusTrapRef = useFocusTrap(dialogActive);
@@ -299,7 +302,11 @@ export const TeamEditMemberDialog = React.memo(function TeamEditMemberDialog({
                   description="Applies to future sessions."
                   placeholder="Provider default"
                   value={draft.thinking_level || null}
-                  data={THINKING_LEVEL_OPTIONS}
+                  data={
+                    isCodexProvider
+                      ? CODEX_THINKING_LEVEL_OPTIONS
+                      : THINKING_LEVEL_OPTIONS
+                  }
                   clearable
                   onChange={(value) => onPatchDraft({ thinking_level: value ?? "" })}
                 />

--- a/web/src/pages/team/team_page_modals.tsx
+++ b/web/src/pages/team/team_page_modals.tsx
@@ -39,6 +39,7 @@ export type TeamPageModalsProps = {
   closeTeamMemberEditModal: () => void;
   onSaveTeamMemberProfile: () => void;
   selectedAgentSupportsRuntimeProfile: boolean;
+  selectedAgentIsCodex: boolean;
   createChrome: TeamModalChrome;
   forgeChrome: TeamModalChrome;
   editChrome: TeamModalChrome;
@@ -72,6 +73,7 @@ export const TeamPageModals = React.memo(function TeamPageModals({
   closeTeamMemberEditModal,
   onSaveTeamMemberProfile,
   selectedAgentSupportsRuntimeProfile,
+  selectedAgentIsCodex,
   createChrome,
   forgeChrome,
   editChrome,
@@ -121,6 +123,7 @@ export const TeamPageModals = React.memo(function TeamPageModals({
         onSave={onSaveTeamMemberProfile}
         chrome={editChrome}
         supportsRuntimeProfile={selectedAgentSupportsRuntimeProfile}
+        isCodexProvider={selectedAgentIsCodex}
       />
     </>
   );

--- a/web/src/pages/team_page.tsx
+++ b/web/src/pages/team_page.tsx
@@ -2953,6 +2953,12 @@ export function TeamPage(props: TeamPageProps) {
           selectedAgentWorkspaceAgent.args
         ) ?? ""
       ),
+    selectedAgentIsCodex:
+      selectedAgentWorkspaceAgent != null &&
+      resolveAcpProviderForAgent(
+        selectedAgentWorkspaceAgent.command,
+        selectedAgentWorkspaceAgent.args
+      ) === "codex",
     createChrome: modalChrome,
     forgeChrome: modalChrome,
     editChrome: modalChrome,

--- a/web/src/pages/team_panels.test.tsx
+++ b/web/src/pages/team_panels.test.tsx
@@ -8327,7 +8327,28 @@ describe("team panels interactions", () => {
       resolveSend?.();
       await Promise.resolve();
     });
+
+    expect(sendButton.disabled).toBe(true);
+    changeInputValue(input, "follow-up from team acp");
     expect(sendButton.disabled).toBe(false);
+
+    await act(async () => {
+      sendButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(onSendInput).toHaveBeenCalledTimes(2);
+    expect(onSendInput).toHaveBeenLastCalledWith(
+      "follow-up from team acp",
+      "runtime-session-1"
+    );
+    expect(sendButton.disabled).toBe(true);
+
+    await act(async () => {
+      resolveSend?.();
+      await Promise.resolve();
+    });
+    expect(sendButton.disabled).toBe(true);
   });
 
   it("TeamMailboxPanel handles member chat, accept, and advanced mailbox controls", () => {


### PR DESCRIPTION
feat(acp): support official Codex multimodal workflows

## What changed

- Pin Codex dependencies and Bazel source metadata to the official OpenAI Codex 0.149.1 commit `ff29a44391deccde0aba0f8390337d7f3c319ea4`.
- Remove the downstream Codex fork override while retaining the independent ACP provider dependency.
- Adapt the ACP runtime to current Codex turn input, history, item lifecycle, asynchronous delivery, collaboration, subagent, and image-generation events.
- Preserve Codex reasoning levels through `xhigh`, `max`, and `ultra` without widening Claude-specific values.
- Add bounded multimodal image input for local ACP agents, including select, paste, drag/drop, preview, retry, and image-only prompts.
- Render allowlisted generated and referenced images without leaking base64 payloads into raw output.
- Improve the standalone ACP workbench with live model, reasoning, mode, run, and subagent context.
- Keep Codex subagents inside the ACP execution surface instead of projecting them into Team membership.
- Update the canonical ACP contract, rollout journal, journal index, and follow-up backlog.

## Why

AgentHub's Codex integration had drifted behind the official protocol and depended on a downstream Codex fork. The upgrade restores an official-only Codex dependency path while exposing the newer asynchronous, collaboration, subagent, reasoning, and multimodal capabilities through ACP. The standalone workbench now presents those capabilities directly without changing Team membership semantics.

## Related issue

None.

## Validation

- `cargo fmt --all --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo check -p agenthub-config -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-acp -p agenthub`
- Focused Rust tests: 167 passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Focused Vitest suite: 8 files and 82 tests passed
- `git diff --check`

The focused Bazel invocation was attempted but stopped during repository loading because the local `@rules_rust+//rust:defs.bzl` package was unavailable, before either requested test target ran. No Bazel configuration was changed.

Chrome DevTools MCP was unavailable in this environment. DOM-focused tests and the production web build provide the current frontend evidence; authenticated browser evidence remains tracked in `docs/todo.md`.

## Known dependency constraint

The official Codex 0.149.1 graph reintroduces advisory-range `gix`, `gix-fs`, `gix-pack`, `hickory-proto`, `jsonwebtoken`, `opentelemetry_sdk`, and `tar` versions. In particular, upstream pins `tar = 0.4.45` exactly, so it cannot be updated independently. The follow-up is recorded as P1 and must be resolved through a newer official Codex release or ordinary compatible constraints, not by restoring a downstream Codex fork.
