### PR TITLE
chore(acp): upgrade official Codex to 0.150.1

### DIFF
--- a/.github/workflows/distributed-p2p.yml
+++ b/.github/workflows/distributed-p2p.yml
@@ -9,7 +9,7 @@ jobs:
   distributed-p2p:
     name: Distributed P2P Pipeline
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,8 +2878,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-core",
  "codex-protocol",
@@ -2887,8 +2887,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -2898,8 +2898,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2917,9 +2917,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-agent-roles"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
+dependencies = [
+ "codex-config",
+ "codex-file-system",
+ "codex-utils-absolute-path",
+ "codex-utils-path-uri",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "codex-analytics"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -2938,8 +2952,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2969,8 +2983,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "axum",
@@ -2982,6 +2996,7 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-app-server-transport",
  "codex-arg0",
+ "codex-aws-auth",
  "codex-backend-client",
  "codex-chatgpt",
  "codex-cloud-config",
@@ -3002,6 +3017,7 @@ dependencies = [
  "codex-git-utils",
  "codex-goal-extension",
  "codex-guardian-v2",
+ "codex-history-notes-extension",
  "codex-home",
  "codex-hooks",
  "codex-http-client",
@@ -3052,8 +3068,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-app-server",
  "codex-app-server-protocol",
@@ -3078,8 +3094,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -3092,8 +3108,9 @@ dependencies = [
  "codex-shell-command",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "inventory",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -3106,13 +3123,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 
 [[package]]
 name = "codex-app-server-transport"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "axum",
@@ -3149,8 +3166,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -3165,8 +3182,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -3179,14 +3196,15 @@ dependencies = [
  "codex-utils-home-dir",
  "codex-windows-sandbox",
  "dotenvy",
+ "pathdiff",
  "tempfile",
  "tokio",
 ]
 
 [[package]]
 name = "codex-async-utils"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -3194,8 +3212,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -3208,8 +3226,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -3226,8 +3244,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "serde",
  "serde_json",
@@ -3236,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3255,8 +3273,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -3269,8 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-config"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3292,8 +3310,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -3316,8 +3334,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -3334,13 +3352,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 
 [[package]]
 name = "codex-config"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3354,6 +3372,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-path",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "core-foundation 0.9.4",
  "dns-lookup",
  "dunce",
@@ -3384,8 +3403,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3406,8 +3425,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-connectors",
  "codex-core-plugins",
@@ -3421,8 +3440,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3430,8 +3449,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3441,6 +3460,7 @@ dependencies = [
  "chrono",
  "clap",
  "codex-agent-graph-store",
+ "codex-agent-roles",
  "codex-analytics",
  "codex-api",
  "codex-app-server-protocol",
@@ -3515,7 +3535,7 @@ dependencies = [
  "openssl-sys",
  "rand 0.9.4",
  "regex-lite",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3537,8 +3557,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3588,16 +3608,16 @@ dependencies = [
 
 [[package]]
 name = "codex-diagnostics"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "arc-swap",
  "axum",
@@ -3613,6 +3633,7 @@ dependencies = [
  "codex-otel",
  "codex-protocol",
  "codex-sandboxing",
+ "codex-shell-command",
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
  "codex-utils-path-uri",
@@ -3640,8 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -3655,8 +3676,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3673,8 +3694,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3683,8 +3704,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -3699,8 +3720,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -3711,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "codex-external-agent-migration"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "chrono",
  "codex-analytics",
@@ -3739,8 +3760,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -3752,8 +3773,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-http-client",
@@ -3767,8 +3788,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3782,8 +3803,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -3795,8 +3816,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-watcher"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "notify",
  "tokio",
@@ -3805,8 +3826,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -3818,8 +3839,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3844,8 +3865,8 @@ dependencies = [
 
 [[package]]
 name = "codex-goal-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-analytics",
  "codex-core",
@@ -3864,8 +3885,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian-v2"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -3879,12 +3900,13 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-history"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "schemars 0.8.22",
@@ -3892,9 +3914,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-history-notes-extension"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
+dependencies = [
+ "codex-api",
+ "codex-client",
+ "codex-core",
+ "codex-extension-api",
+ "codex-login",
+ "codex-model-provider",
+ "codex-protocol",
+ "codex-tools",
+ "codex-utils-output-truncation",
+ "http 1.4.0",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-home"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -3903,8 +3943,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3914,6 +3954,7 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
+ "codex-utils-path-uri",
  "codex-utils-pty",
  "futures",
  "regex",
@@ -3927,8 +3968,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -3954,8 +3995,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3980,8 +4021,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3992,8 +4033,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "keyring",
  "tracing",
@@ -4001,8 +4042,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -4023,8 +4064,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4057,8 +4098,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4079,7 +4120,7 @@ dependencies = [
  "futures",
  "lru",
  "regex-lite",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -4092,8 +4133,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-config",
  "codex-connectors",
@@ -4116,8 +4157,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -4135,7 +4176,7 @@ dependencies = [
  "codex-skills-extension",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -4147,8 +4188,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4167,8 +4208,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4177,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-write"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4209,8 +4250,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -4230,11 +4271,12 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-api",
  "codex-protocol",
+ "codex-utils-redacted-string",
  "http 1.4.0",
  "schemars 0.8.22",
  "serde",
@@ -4242,8 +4284,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -4261,8 +4303,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4297,8 +4339,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "chrono",
  "codex-api",
@@ -4328,8 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -4341,16 +4383,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -4363,8 +4405,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "chardetng",
  "chrono",
@@ -4376,6 +4418,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "codex-utils-string",
  "encoding_rs",
  "globset",
@@ -4403,8 +4446,8 @@ dependencies = [
 
 [[package]]
 name = "codex-queue-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-core",
  "codex-extension-api",
@@ -4419,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -4430,8 +4473,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "axum",
@@ -4454,7 +4497,7 @@ dependencies = [
  "libc",
  "memchr",
  "oauth2",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4472,8 +4515,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4499,8 +4542,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -4514,8 +4557,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -4536,8 +4579,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "age",
  "anyhow",
@@ -4555,8 +4598,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4576,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -4595,8 +4638,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -4612,8 +4655,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-analytics",
  "codex-config",
@@ -4642,8 +4685,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4664,16 +4707,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -4700,8 +4743,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -4712,10 +4755,9 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
- "codex-utils-pty",
  "codex-utils-string",
  "jsonptr",
- "rmcp 3.1.2",
+ "rmcp 3.1.3",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -4725,8 +4767,8 @@ dependencies = [
 
 [[package]]
 name = "codex-uds"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "async-io",
  "tokio",
@@ -4736,8 +4778,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "dirs",
  "dunce",
@@ -4748,16 +4790,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -4770,8 +4812,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "lru",
  "sha1 0.10.6",
@@ -4780,8 +4822,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -4792,8 +4834,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -4801,8 +4843,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -4814,8 +4856,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -4823,8 +4865,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -4832,8 +4874,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -4842,8 +4884,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -4857,8 +4899,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -4870,8 +4912,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -4885,22 +4927,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-utils-redacted-string"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
+dependencies = [
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
 name = "codex-utils-rustls-provider"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "regex-lite",
  "serde",
@@ -4909,13 +4960,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 
 [[package]]
 name = "codex-web-search-extension"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-api",
  "codex-core",
@@ -4935,8 +4986,8 @@ dependencies = [
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -4949,8 +5000,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4975,8 +5026,8 @@ dependencies = [
 
 [[package]]
 name = "codex-workload-identity"
-version = "0.149.1"
-source = "git+https://github.com/openai/codex?rev=ff29a44391deccde0aba0f8390337d7f3c319ea4#ff29a44391deccde0aba0f8390337d7f3c319ea4"
+version = "0.150.1"
+source = "git+https://github.com/openai/codex?rev=90854393966b21e9ebfd21b122334eb09a20c93d#90854393966b21e9ebfd21b122334eb09a20c93d"
 dependencies = [
  "codex-http-client",
  "serde",
@@ -12548,6 +12599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13077,7 +13134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -13098,7 +13155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14284,9 +14341,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+checksum = "5f17072af977b0f86f714dbd64b3d37d0715bb63064f9d13483f0a1775813374"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -14296,13 +14353,14 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "indexmap 2.14.0",
  "oauth2",
  "pastey 0.2.2",
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.2",
  "reqwest 0.13.4",
- "rmcp-macros 3.1.2",
+ "rmcp-macros 3.1.4",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -14332,9 +14390,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,8 +12,8 @@ bazel_dep(name = "rules_rust", version = "0.67.0")
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "codex_src",
-    # Official Codex 0.149.1 commit shared with the Cargo codex-* dependencies.
-    commit = "ff29a44391deccde0aba0f8390337d7f3c319ea4",
+    # Official Codex 0.150.1 commit shared with the Cargo codex-* dependencies.
+    commit = "90854393966b21e9ebfd21b122334eb09a20c93d",
     remote = "https://github.com/openai/codex",
 )
 

--- a/agenthub-codex-acp/Cargo.toml
+++ b/agenthub-codex-acp/Cargo.toml
@@ -22,27 +22,27 @@ agenthub-managed-skills = { path = "../crates/agenthub-managed-skills" }
 anyhow = "1"
 async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-config = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-arg0 = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-app-server-client = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-core = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-exec-server = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-extension-api = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-features = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-feedback = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-http-client = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-history = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-mcp-server = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-protocol = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-login = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-models-manager = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-shell-command = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-utils-cli = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
-codex-utils-path-uri = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-apply-patch = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-config = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-app-server-client = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-core = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-exec-server = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-extension-api = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-features = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-feedback = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-http-client = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-history = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-mcp-server = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-login = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-models-manager = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-shell-command = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
 heck = "0.5.0"
 itertools = "0.15.0"
 libc = "0.2"

--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -961,6 +961,7 @@ impl AppServerCodexThread {
                 Ok(Some(Event {
                     id: submission_id,
                     msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                        kind: codex_protocol::approvals::ExecApprovalKind::Command,
                         call_id: params.item_id,
                         plugin_id: None,
                         script_path: None,
@@ -1149,7 +1150,11 @@ impl AppServerCodexThread {
             | ServerNotification::TurnModerationMetadata(_)
             | ServerNotification::EnvironmentConnected(_)
             | ServerNotification::EnvironmentDisconnected(_)
-            | ServerNotification::RawResponseCompleted(_) => Ok(None),
+            | ServerNotification::RawResponseCompleted(_)
+            | ServerNotification::McpServerEventStream(_)
+            | ServerNotification::ThreadRealtimeItemStarted(_)
+            | ServerNotification::ThreadRealtimeItemTranscriptDelta(_)
+            | ServerNotification::ThreadRealtimeItemCompleted(_) => Ok(None),
             ServerNotification::FileChangePatchUpdated(payload) => {
                 let submission_id = active_submission_id_for_turn(self, &payload.turn_id).await;
                 Ok(submission_id.map(|id| Event {
@@ -2572,6 +2577,18 @@ fn app_server_collab_item_to_core(item: ThreadItem) -> Option<CoreTurnItem> {
                         codex_app_server_protocol::CollabAgentTool::CloseAgent => {
                             CoreCollabAgentTool::CloseAgent
                         }
+                        codex_app_server_protocol::CollabAgentTool::SendMessage => {
+                            CoreCollabAgentTool::SendMessage
+                        }
+                        codex_app_server_protocol::CollabAgentTool::FollowupTask => {
+                            CoreCollabAgentTool::FollowupTask
+                        }
+                        codex_app_server_protocol::CollabAgentTool::InterruptAgent => {
+                            CoreCollabAgentTool::InterruptAgent
+                        }
+                        codex_app_server_protocol::CollabAgentTool::ListAgents => {
+                            CoreCollabAgentTool::ListAgents
+                        }
                     },
                     status: match status {
                         codex_app_server_protocol::CollabAgentToolCallStatus::InProgress => {
@@ -2582,6 +2599,9 @@ fn app_server_collab_item_to_core(item: ThreadItem) -> Option<CoreTurnItem> {
                         }
                         codex_app_server_protocol::CollabAgentToolCallStatus::Failed => {
                             CoreCollabAgentToolCallStatus::Failed
+                        }
+                        codex_app_server_protocol::CollabAgentToolCallStatus::Interrupted => {
+                            CoreCollabAgentToolCallStatus::Interrupted
                         }
                     },
                     sender_thread_id: ThreadId::from_string(&sender_thread_id).ok()?,
@@ -2610,6 +2630,9 @@ fn app_server_collab_item_to_core(item: ThreadItem) -> Option<CoreTurnItem> {
                 }
                 codex_app_server_protocol::SubAgentActivityKind::Interrupted => {
                     CoreSubAgentActivityKind::Interrupted
+                }
+                codex_app_server_protocol::SubAgentActivityKind::Completed => {
+                    CoreSubAgentActivityKind::Completed
                 }
             },
             agent_thread_id: ThreadId::from_string(&agent_thread_id).ok()?,
@@ -3498,6 +3521,68 @@ mod tests {
         assert_eq!(item.agent_thread_id, child_thread_id);
         assert_eq!(item.agent_path.as_str(), "/root/reviewer");
         assert_eq!(item.kind, CoreSubAgentActivityKind::Started);
+    }
+
+    #[test]
+    fn completed_subagent_activity_translates_to_core_completion() {
+        let child_thread_id = ThreadId::new();
+        let item = app_server_collab_item_to_core(ThreadItem::SubAgentActivity {
+            id: "activity-completed".to_string(),
+            kind: codex_app_server_protocol::SubAgentActivityKind::Completed,
+            agent_thread_id: child_thread_id.to_string(),
+            agent_path: "/root/reviewer".to_string(),
+        })
+        .expect("completed subagent activity");
+
+        let CoreTurnItem::SubAgentActivity(item) = item else {
+            panic!("expected subagent activity");
+        };
+        assert_eq!(item.agent_thread_id, child_thread_id);
+        assert_eq!(item.kind, CoreSubAgentActivityKind::Completed);
+    }
+
+    #[test]
+    fn control_agent_tools_and_interrupted_status_translate_to_core() {
+        let sender_thread_id = ThreadId::new();
+        let cases = [
+            (
+                codex_app_server_protocol::CollabAgentTool::SendMessage,
+                CoreCollabAgentTool::SendMessage,
+            ),
+            (
+                codex_app_server_protocol::CollabAgentTool::FollowupTask,
+                CoreCollabAgentTool::FollowupTask,
+            ),
+            (
+                codex_app_server_protocol::CollabAgentTool::InterruptAgent,
+                CoreCollabAgentTool::InterruptAgent,
+            ),
+            (
+                codex_app_server_protocol::CollabAgentTool::ListAgents,
+                CoreCollabAgentTool::ListAgents,
+            ),
+        ];
+
+        for (tool, expected_tool) in cases {
+            let item = app_server_collab_item_to_core(ThreadItem::CollabAgentToolCall {
+                id: "control-call".to_string(),
+                tool,
+                status: codex_app_server_protocol::CollabAgentToolCallStatus::Interrupted,
+                sender_thread_id: sender_thread_id.to_string(),
+                receiver_thread_ids: Vec::new(),
+                prompt: None,
+                model: None,
+                reasoning_effort: None,
+                agents_states: HashMap::new(),
+            })
+            .expect("control-agent tool call");
+
+            let CoreTurnItem::CollabAgentToolCall(item) = item else {
+                panic!("expected collab-agent tool call");
+            };
+            assert_eq!(item.tool, expected_tool);
+            assert_eq!(item.status, CoreCollabAgentToolCallStatus::Interrupted);
+        }
     }
 
     #[test]

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -308,8 +308,9 @@ fn repair_response_item_history(items: &mut Vec<ResponseItemEnvelope>) -> Histor
     let mut repaired = HistoryRepairStats::default();
     items.retain(|item| match &item.item {
         ResponseItem::FunctionCallOutput { call_id, .. } => {
-            let keep =
-                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id);
+            let keep = call_id.as_ref().is_none_or(|call_id| {
+                function_call_ids.contains(call_id) || local_shell_call_ids.contains(call_id)
+            });
             if !keep {
                 repaired.dropped_orphan_function_call_outputs += 1;
             }
@@ -327,7 +328,10 @@ fn repair_response_item_history(items: &mut Vec<ResponseItemEnvelope>) -> Histor
     let mut function_output_call_ids = items
         .iter()
         .filter_map(|item| match &item.item {
-            ResponseItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
+            ResponseItem::FunctionCallOutput {
+                call_id: Some(call_id),
+                ..
+            } => Some(call_id.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -350,7 +354,9 @@ fn repair_response_item_history(items: &mut Vec<ResponseItemEnvelope>) -> Histor
                     idx,
                     ResponseItemEnvelope::from(ResponseItem::FunctionCallOutput {
                         id: None,
-                        call_id: call_id.clone(),
+                        call_id: Some(call_id.clone()),
+                        name: None,
+                        namespace: None,
                         output: aborted_call_output(),
                         internal_chat_message_metadata_passthrough: None,
                     }),
@@ -380,7 +386,9 @@ fn repair_response_item_history(items: &mut Vec<ResponseItemEnvelope>) -> Histor
                     idx,
                     ResponseItemEnvelope::from(ResponseItem::FunctionCallOutput {
                         id: None,
-                        call_id: call_id.clone(),
+                        call_id: Some(call_id.clone()),
+                        name: None,
+                        namespace: None,
                         output: aborted_call_output(),
                         internal_chat_message_metadata_passthrough: None,
                     }),
@@ -438,8 +446,10 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
             RolloutItem::ResponseItem(response_item) => {
                 let keep = match &response_item.item {
                     ResponseItem::FunctionCallOutput { call_id, .. } => {
-                        let keep = function_call_ids.contains(call_id)
-                            || local_shell_call_ids.contains(call_id);
+                        let keep = call_id.as_ref().is_none_or(|call_id| {
+                            function_call_ids.contains(call_id)
+                                || local_shell_call_ids.contains(call_id)
+                        });
                         if !keep {
                             repaired.dropped_orphan_function_call_outputs += 1;
                         }
@@ -472,7 +482,10 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
         .iter()
         .filter_map(|item| match item {
             RolloutItem::ResponseItem(item) => match &item.item {
-                ResponseItem::FunctionCallOutput { call_id, .. } => Some(call_id.clone()),
+                ResponseItem::FunctionCallOutput {
+                    call_id: Some(call_id),
+                    ..
+                } => Some(call_id.clone()),
                 _ => None,
             },
             _ => None,
@@ -504,7 +517,9 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                     RolloutItem::ResponseItem(ResponseItemEnvelope::from(
                         ResponseItem::FunctionCallOutput {
                             id: None,
-                            call_id: call_id.clone(),
+                            call_id: Some(call_id.clone()),
+                            name: None,
+                            namespace: None,
                             output: aborted_call_output(),
                             internal_chat_message_metadata_passthrough: None,
                         },
@@ -538,7 +553,9 @@ fn repair_rollout_items(items: &mut Vec<RolloutItem>) -> HistoryRepairStats {
                     RolloutItem::ResponseItem(ResponseItemEnvelope::from(
                         ResponseItem::FunctionCallOutput {
                             id: None,
-                            call_id: call_id.clone(),
+                            call_id: Some(call_id.clone()),
+                            name: None,
+                            namespace: None,
                             output: aborted_call_output(),
                             internal_chat_message_metadata_passthrough: None,
                         },
@@ -1274,6 +1291,36 @@ mod tests {
     }
 
     #[test]
+    fn repair_response_item_history_preserves_external_function_outputs() {
+        let mut history = vec![ResponseItemEnvelope::from(
+            ResponseItem::FunctionCallOutput {
+                id: None,
+                call_id: None,
+                name: Some("history.read_item".to_string()),
+                namespace: Some("history".to_string()),
+                output: FunctionCallOutputPayload::from_text("ok".to_string()),
+                internal_chat_message_metadata_passthrough: None,
+            },
+        )];
+
+        let repaired = repair_response_item_history(&mut history);
+
+        assert_eq!(repaired, HistoryRepairStats::default());
+        assert!(matches!(
+            &history[0].item,
+            ResponseItem::FunctionCallOutput {
+                call_id: None,
+                name: Some(name),
+                namespace: Some(namespace),
+                output,
+                ..
+            } if name == "history.read_item"
+                && namespace == "history"
+                && output.text_content() == Some("ok")
+        ));
+    }
+
+    #[test]
     fn repair_initial_history_updates_compacted_replacement_history() {
         let history = InitialHistory::Forked(vec![RolloutItem::Compacted(CompactedItem {
             message: "compacted".to_string(),
@@ -1320,7 +1367,8 @@ mod tests {
             ResponseItem::FunctionCallOutput {
                 call_id, output, ..
             }
-                if call_id == "shell-1" && output.text_content() == Some("aborted")
+                if call_id.as_deref() == Some("shell-1")
+                    && output.text_content() == Some("aborted")
         ));
     }
 }

--- a/agenthub-codex-acp/src/codex_agent.rs
+++ b/agenthub-codex-acp/src/codex_agent.rs
@@ -999,7 +999,7 @@ impl CodexAgent {
 mod tests {
     use super::{
         HistoryRepairStats, codex_mcp_server_config, persist_repaired_initial_history,
-        repair_initial_history, repair_response_item_history,
+        repair_initial_history, repair_response_item_history, repair_rollout_items,
     };
     use agent_client_protocol::schema::v1::{
         EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio,
@@ -1317,6 +1317,88 @@ mod tests {
             } if name == "history.read_item"
                 && namespace == "history"
                 && output.text_content() == Some("ok")
+        ));
+    }
+
+    #[test]
+    fn repair_rollout_items_preserves_paired_and_external_function_outputs() {
+        let mut items = vec![
+            RolloutItem::ResponseItem(ResponseItemEnvelope::from(ResponseItem::FunctionCall {
+                id: None,
+                name: "history.read_item".to_string(),
+                namespace: Some("history".to_string()),
+                arguments: "{}".to_string(),
+                call_id: "paired".to_string(),
+                encrypted_function_args: None,
+                internal_chat_message_metadata_passthrough: None,
+            })),
+            RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                ResponseItem::FunctionCallOutput {
+                    id: None,
+                    call_id: Some("paired".to_string()),
+                    name: None,
+                    namespace: None,
+                    output: FunctionCallOutputPayload::from_text("paired output".to_string()),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+            )),
+            RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                ResponseItem::FunctionCallOutput {
+                    id: None,
+                    call_id: None,
+                    name: Some("history.read_item".to_string()),
+                    namespace: Some("history".to_string()),
+                    output: FunctionCallOutputPayload::from_text("external output".to_string()),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+            )),
+            RolloutItem::ResponseItem(ResponseItemEnvelope::from(
+                ResponseItem::FunctionCallOutput {
+                    id: None,
+                    call_id: Some("orphan".to_string()),
+                    name: None,
+                    namespace: None,
+                    output: FunctionCallOutputPayload::from_text("orphan output".to_string()),
+                    internal_chat_message_metadata_passthrough: None,
+                },
+            )),
+        ];
+
+        let repaired = repair_rollout_items(&mut items);
+
+        assert_eq!(
+            repaired,
+            HistoryRepairStats {
+                dropped_orphan_function_call_outputs: 1,
+                ..HistoryRepairStats::default()
+            }
+        );
+        assert_eq!(items.len(), 3);
+        assert!(matches!(
+            &items[1],
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::FunctionCallOutput {
+                    call_id: Some(call_id),
+                    output,
+                    ..
+                },
+                ..
+            }) if call_id == "paired" && output.text_content() == Some("paired output")
+        ));
+        assert!(matches!(
+            &items[2],
+            RolloutItem::ResponseItem(ResponseItemEnvelope {
+                item: ResponseItem::FunctionCallOutput {
+                    call_id: None,
+                    name: Some(name),
+                    namespace: Some(namespace),
+                    output,
+                    ..
+                },
+                ..
+            }) if name == "history.read_item"
+                && namespace == "history"
+                && output.text_content() == Some("external output")
         ));
     }
 

--- a/agenthub-codex-acp/src/thread.rs
+++ b/agenthub-codex-acp/src/thread.rs
@@ -126,6 +126,10 @@ fn collab_agent_tool_name(tool: CollabAgentTool) -> &'static str {
         CollabAgentTool::ResumeAgent => "resume_agent",
         CollabAgentTool::Wait => "wait",
         CollabAgentTool::CloseAgent => "close_agent",
+        CollabAgentTool::SendMessage => "send_message",
+        CollabAgentTool::FollowupTask => "followup_task",
+        CollabAgentTool::InterruptAgent => "interrupt_agent",
+        CollabAgentTool::ListAgents => "list_agents",
     }
 }
 
@@ -136,6 +140,10 @@ fn collab_agent_tool_title(tool: CollabAgentTool) -> &'static str {
         CollabAgentTool::ResumeAgent => "Resume subagent",
         CollabAgentTool::Wait => "Wait for subagents",
         CollabAgentTool::CloseAgent => "Close subagent",
+        CollabAgentTool::SendMessage => "Message agent",
+        CollabAgentTool::FollowupTask => "Follow up agent task",
+        CollabAgentTool::InterruptAgent => "Interrupt agent",
+        CollabAgentTool::ListAgents => "List agents",
     }
 }
 
@@ -1566,6 +1574,7 @@ impl PromptState {
             CollabAgentToolCallStatus::InProgress => ToolCallStatus::InProgress,
             CollabAgentToolCallStatus::Completed => ToolCallStatus::Completed,
             CollabAgentToolCallStatus::Failed => ToolCallStatus::Failed,
+            CollabAgentToolCallStatus::Interrupted => ToolCallStatus::Failed,
         };
         let fields = ToolCallUpdateFields::new()
             .title(collab_agent_tool_title(item.tool))
@@ -1601,12 +1610,14 @@ impl PromptState {
             SubAgentActivityKind::Started => "started",
             SubAgentActivityKind::Interacted => "interacted",
             SubAgentActivityKind::Interrupted => "interrupted",
+            SubAgentActivityKind::Completed => "completed",
         };
         let status = match item.kind {
             SubAgentActivityKind::Started | SubAgentActivityKind::Interacted => {
                 ToolCallStatus::InProgress
             }
             SubAgentActivityKind::Interrupted => ToolCallStatus::Failed,
+            SubAgentActivityKind::Completed => ToolCallStatus::Completed,
         };
         let meta = subagent_meta(
             &item.agent_thread_id,
@@ -1981,6 +1992,7 @@ impl PromptState {
         let available_decisions = event.effective_available_decisions();
         let raw_input = serde_json::json!(&event);
         let ExecApprovalRequestEvent {
+            kind: _,
             call_id,
             plugin_id: _,
             script_path: _,
@@ -4194,7 +4206,9 @@ impl<A: Auth> ThreadActor<A> {
                     .await;
             }
             ResponseItem::FunctionCallOutput {
-                call_id, output, ..
+                call_id: Some(call_id),
+                output,
+                ..
             } => {
                 self.client
                     .send_tool_call_completed(call_id.clone(), serde_json::to_value(output).ok())
@@ -5031,6 +5045,33 @@ mod tests {
         ]);
 
         assert_eq!(message, "Model verification: trusted_access_for_cyber");
+    }
+
+    #[test]
+    fn collab_agent_tool_labels_cover_control_tools() {
+        let cases = [
+            (
+                CollabAgentTool::SendMessage,
+                "send_message",
+                "Message agent",
+            ),
+            (
+                CollabAgentTool::FollowupTask,
+                "followup_task",
+                "Follow up agent task",
+            ),
+            (
+                CollabAgentTool::InterruptAgent,
+                "interrupt_agent",
+                "Interrupt agent",
+            ),
+            (CollabAgentTool::ListAgents, "list_agents", "List agents"),
+        ];
+
+        for (tool, expected_name, expected_title) in cases {
+            assert_eq!(collab_agent_tool_name(tool), expected_name);
+            assert_eq!(collab_agent_tool_title(tool), expected_title);
+        }
     }
 
     #[test]
@@ -6436,6 +6477,7 @@ mod tests {
                             .send(Event {
                                 id: submission_id.clone(),
                                 msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                                    kind: Default::default(),
                                     call_id: "call-id".to_string(),
                                     plugin_id: None,
                                     script_path: None,
@@ -6855,6 +6897,7 @@ mod tests {
                     .exec_approval(
                         &session_client,
                         ExecApprovalRequestEvent {
+                            kind: Default::default(),
                             call_id: "call-id".to_string(),
                             plugin_id: None,
                             script_path: None,
@@ -6945,6 +6988,7 @@ mod tests {
                     .exec_approval(
                         &session_client,
                         ExecApprovalRequestEvent {
+                            kind: Default::default(),
                             call_id: "call-id".to_string(),
                             plugin_id: None,
                             script_path: None,
@@ -7275,6 +7319,7 @@ mod tests {
                     .exec_approval(
                         &session_client,
                         ExecApprovalRequestEvent {
+                            kind: Default::default(),
                             call_id: "call-id".to_string(),
                             plugin_id: None,
                             script_path: None,
@@ -7359,6 +7404,7 @@ mod tests {
                     .exec_approval(
                         &session_client,
                         ExecApprovalRequestEvent {
+                            kind: Default::default(),
                             call_id: "call-id".to_string(),
                             plugin_id: None,
                             script_path: None,
@@ -7623,6 +7669,7 @@ mod tests {
                     .handle_event(
                         &session_client,
                         EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                            kind: Default::default(),
                             call_id: "call-id".to_string(),
                             plugin_id: None,
                             script_path: None,

--- a/crates/agenthub-acp-adapter/Cargo.toml
+++ b/crates/agenthub-acp-adapter/Cargo.toml
@@ -17,7 +17,7 @@ agenthub-codex-acp-runtime = { path = "../../agenthub-codex-acp" }
 anyhow = "1"
 claude-code-acp-rs = { version = "0.1.22", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
-codex-utils-cli = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-utils-cli = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [features]

--- a/crates/agenthub-daemon/Cargo.toml
+++ b/crates/agenthub-daemon/Cargo.toml
@@ -30,7 +30,7 @@ agenthub = { path = "../.." }
 agenthub-acp-adapter = { path = "../agenthub-acp-adapter" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-codex-arg0 = { git = "https://github.com/openai/codex", rev = "ff29a44391deccde0aba0f8390337d7f3c319ea4" }
+codex-arg0 = { git = "https://github.com/openai/codex", rev = "90854393966b21e9ebfd21b122334eb09a20c93d" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [lints.rust]

--- a/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
+++ b/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
@@ -1,0 +1,57 @@
+# Official Codex 0.150.1 Upgrade
+
+## Summary
+
+AgentHub now pins the official `openai/codex` 0.150.1 release commit
+`90854393966b21e9ebfd21b122334eb09a20c93d` for both Cargo and Bazel. The ACP bridge
+adapts the protocol additions introduced since 0.149.1 without restoring a downstream Codex fork
+or changing the two-binary runtime contract.
+
+## Background
+
+The previous baseline was official Codex 0.149.1 at
+`ff29a44391deccde0aba0f8390337d7f3c319ea4`. The official 0.150.1 release was published on
+2026-08-27 and includes the 0.150 line plus a retained-image compaction budgeting fix.
+
+## Scope
+
+- Align every direct Codex Cargo dependency and the Bazel `codex_src` repository on the 0.150.1
+  release commit.
+- Refresh the workspace lockfile for the 0.150.1 dependency graph.
+- Preserve external function outputs whose new optional `call_id` is absent, while continuing to
+  repair paired function and shell outputs.
+- Translate the new control-agent tools, interrupted tool status, completed subagent activity, and
+  command approval kind across the in-process and app-server ACP paths.
+- Explicitly ignore experimental MCP event-stream and realtime timeline notifications until ACP has
+  a corresponding user-facing event contract.
+
+## Key Decisions
+
+- Keep `openai/codex` as the only Codex source; do not reintroduce `hawkingrei/codex`.
+- Pin the immutable release commit rather than the symbolic tag.
+- Map interrupted collaboration calls to ACP failure state and completed subagent activity to ACP
+  completion state.
+- Preserve `FunctionCallOutput` entries without a `call_id`, matching upstream history semantics for
+  external tool outputs.
+
+## Validation
+
+- `cargo check --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon`
+- `cargo test --locked -p agenthub-codex-acp-runtime --lib` (139 passed)
+- `cargo clippy --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo metadata --locked --format-version 1 --no-deps` reports only the `agenthub` and
+  `agenthubd` binary targets.
+- `bazel mod deps --lockfile_mode=update` resolves the new Codex source without changing the module
+  lockfile.
+- `bazel query 'kind("rust_binary", //...)'` reports only `//:agenthub` and
+  `//crates/agenthub-daemon:agenthubd`.
+- Local macOS Bazel builds remain incomplete: `agenthubd` correctly rejects the Linux-only
+  `vendored_bwrap_ffi` dependency on the host platform, while `agenthub` reaches the existing
+  `lance-datafusion` build script and stops because the host does not provide `protoc`.
+
+## Follow-Ups
+
+- Let Linux CI validate both Bazel binary targets against the new `codex_src` commit.
+- The advisory-range dependency versions tracked in `docs/todo.md` remain present in 0.150.1 and
+  still require a future official Codex release or ordinary compatible constraints.

--- a/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
+++ b/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
@@ -37,7 +37,7 @@ The previous baseline was official Codex 0.149.1 at
 ## Validation
 
 - `cargo check --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon`
-- `cargo test --locked -p agenthub-codex-acp-runtime --lib` (139 passed)
+- `cargo test --locked -p agenthub-codex-acp-runtime --lib` (140 passed)
 - `cargo clippy --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon --all-targets -- -D warnings`
 - `cargo fmt --all -- --check`
 - `cargo metadata --locked --format-version 1 --no-deps` reports only the `agenthub` and

--- a/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
+++ b/docs/journal/2026-08-27-official-codex-0-150-1-upgrade.md
@@ -24,6 +24,8 @@ The previous baseline was official Codex 0.149.1 at
   command approval kind across the in-process and app-server ACP paths.
 - Explicitly ignore experimental MCP event-stream and realtime timeline notifications until ACP has
   a corresponding user-facing event contract.
+- Raise the distributed P2P workflow timeout from 20 to 30 minutes so a clean daemon build, the
+  blackbox integration, and post-job cache handling can all reach terminal state.
 
 ## Key Decisions
 
@@ -33,6 +35,9 @@ The previous baseline was official Codex 0.149.1 at
   completion state.
 - Preserve `FunctionCallOutput` entries without a `call_id`, matching upstream history semantics for
   external tool outputs.
+- Keep the P2P test scope unchanged and expand only its time budget. Both the exact-base run and the
+  first 0.150.1 run exhausted 20 minutes after successful daemon builds; the latter also completed
+  the blackbox integration before cancellation during post-job cache handling.
 
 ## Validation
 

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -188,7 +188,7 @@ Main shape:
   contracts in canonical specs while retaining dated journals only for rollout evidence.
 - Dependabot remediation now removes all 16 open alert versions from the Rust ACP, web, and
   userdocs dependency graphs while retaining explicit upstream dependency migration follow-ups.
-- Codex ACP now pins official `openai/codex` `0.149.1`, forwards asynchronous and subagent activity
+- Codex ACP now pins official `openai/codex` `0.150.1`, forwards asynchronous and subagent activity
   through ACP metadata, and gives the standalone workbench bounded image input/output plus compact
   runtime context without projecting Codex subagents into Team membership.
 - User documentation now follows current release artifacts and runtime behavior across installation,
@@ -311,6 +311,7 @@ Start with:
 - `2026-08-19-safe-paths-removal.md`
 - `2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md`
 - `2026-08-27-two-binary-runtime-consolidation.md`
+- `2026-08-27-official-codex-0-150-1-upgrade.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,15 +10,16 @@ Active backlog only. Keep this file small and current.
   install `agenthub` plus `agenthubd`, and run `agenthubd` under `brew services`. Evidence:
   [journal/2026-08-13-user-documentation-release-readiness.md](journal/2026-08-13-user-documentation-release-readiness.md).
 - [ ] `P1` Remediate dependency-graph regressions exposed by returning Codex to official
-  `openai/codex@ff29a44391deccde0aba0f8390337d7f3c319ea4`, and replace the separate
+  `openai/codex@90854393966b21e9ebfd21b122334eb09a20c93d`, and replace the separate
   `hawkingrei/symposium-acp@c731bb045d1375af48b0446af728aea52503b30b` pin with an upstream stable
-  release. The official 0.149.1 graph currently reintroduces advisory-range `gix 0.81.0`,
+  release. The official 0.150.1 graph currently retains advisory-range `gix 0.81.0`,
   `gix-fs 0.19.2`, `gix-pack 0.68.0`, `hickory-proto 0.25.2`, `jsonwebtoken 9.3.1`,
   `opentelemetry_sdk 0.31.0`, and `tar 0.4.45`; even `tar` is pinned exactly by upstream and cannot
   be updated independently. Do not restore a downstream Codex fork; resolve findings in a newer
   official Codex release or with ordinary compatible constraints. Evidence:
   [journal/2026-08-12-dependabot-security-remediation.md](journal/2026-08-12-dependabot-security-remediation.md),
-  [journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md](journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md).
+  [journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md](journal/2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md),
+  [journal/2026-08-27-official-codex-0-150-1-upgrade.md](journal/2026-08-27-official-codex-0-150-1-upgrade.md).
 - [ ] `P1` Verify preview release partial-asset behavior: semver release run `29194967848` for `v0.0.11` proves Linux `x86_64` / `aarch64` release builds used `release-vendored-openssl`, avoided the stale cross-sysroot OpenSSL panic, and published canonical `agenthub` / `agenthub-acp` assets plus Debian packages. Remaining evidence is a preview release run showing successful binary assets publish when one release matrix target fails. Record the preview workflow run ID and release URL in [journal/2026-04-20-release-vendored-openssl-and-partial-assets.md](journal/2026-04-20-release-vendored-openssl-and-partial-assets.md).
 - [ ] `P1` Define and enforce the Linux runtime baseline for official artifacts: the x86_64 prebuild from workflow run `31259043337` starts on Ubuntu 24.04 but requires `GLIBC_2.38` / `GLIBC_2.39` and does not start on Ubuntu 22.04. Pin the supported glibc floor, build against a compatible sysroot, and add a published-binary startup smoke on the oldest supported Linux distribution. Evidence: [journal/2026-08-08-object-store-s3-release-enablement.md](journal/2026-08-08-object-store-s3-release-enablement.md).
 


### PR DESCRIPTION
## Summary

- upgrade every direct Cargo and Bazel `openai/codex` pin from official 0.149.1 to official 0.150.1 commit `90854393966b21e9ebfd21b122334eb09a20c93d`
- adapt the ACP bridge to optional external function-output call IDs, new control-agent lifecycle events, and the command approval kind
- keep experimental MCP event-stream and realtime notifications explicitly ignored until ACP has a matching user-facing contract
- preserve the two-binary runtime contract: `agenthub` and `agenthubd`
- extend the distributed P2P workflow timeout from 20 to 30 minutes without changing its test scope
- record the upgrade decisions, local validation, and remaining upstream advisory-range dependencies

## Why

Codex 0.150.1 is the latest official stable release and includes the 0.150 changes plus the retained-image compaction budgeting fix. Pinning its immutable release commit keeps AgentHub on upstream Codex without restoring a downstream fork.

Official release: https://github.com/openai/codex/releases/tag/rust-v0.150.1

## Related issue

None.

## Validation

- `cargo check --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon`
- `cargo test --locked -p agenthub-codex-acp-runtime --lib` (140 passed)
- `cargo clippy --locked -p agenthub-codex-acp-runtime -p agenthub-acp-adapter -p agenthub-daemon --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --format-version 1 --no-deps` reports only `agenthub` and `agenthubd` binary targets
- `bazel mod deps --lockfile_mode=update`
- `bazel query 'kind("rust_binary", //...)'` reports only `//:agenthub` and `//crates/agenthub-daemon:agenthubd`
- exact-base and initial PR P2P runs both exhausted the old 20-minute timeout after successful daemon builds; the PR run also completed the blackbox integration before cancellation during post-job cache handling
- exact-head `f9a22cfca1c672057b71e787d3f80b0de428e98b` CI is terminal green, including Bazel run `33091101761` and distributed P2P run `33091101891`

## Bazel host notes

- local macOS `agenthubd` build stops at the expected Linux-only `vendored_bwrap_ffi` platform constraint
- local macOS `agenthub` build reaches the existing `lance-datafusion` build script and stops because the host does not provide `protoc`
- Linux CI remains the terminal Bazel build proof for both binary targets

## Follow-up

The advisory-range dependency versions already tracked in `docs/todo.md` remain in official Codex 0.150.1 and require a future upstream release or ordinary compatible constraints.
