### PR TITLE
fix(runtime): supervise agent process shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "jwt-simple",
  "mime_guess",
  "openssl",
+ "process-wrap",
  "prost",
  "protoc-bin-vendored",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ axum = { version = "0.8", features = ["ws"] }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
+process-wrap = { version = "9.1.0", default-features = false, features = ["job-object", "kill-on-drop", "process-group", "tokio1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -103,6 +103,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/npm-binary-distribution.md`
 - `docs/features/debian-systemd-distribution.md`
 - `docs/features/two-binary-runtime.md`
+- `docs/features/daemon-process-supervision.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`
 

--- a/docs/features/daemon-process-supervision.md
+++ b/docs/features/daemon-process-supervision.md
@@ -1,0 +1,116 @@
+# Daemon Process Supervision
+
+## Problem
+
+The daemon owns long-lived local agent subprocesses, but runtime state previously lived only in
+per-agent handles. Shutdown marked SQLite sessions as exited before child termination, explicit stop
+killed only the direct process, and dropping a Tokio child did not prove that descendants had exited.
+That ordering could leave live provider or tool processes behind while the control plane reported a
+terminal state.
+
+## Scope
+
+- Define daemon ownership for every local agent process from spawn through final reap.
+- Stop the entire process tree with a bounded graceful deadline and force-kill fallback.
+- Cover processes that are still starting and have not yet entered the active handle map.
+- Serialize the final shutdown snapshot against concurrent local starts.
+- Persist shutdown or cancellation terminal state only after process exit is proven.
+
+## Non-Goals
+
+- Replacing ACP as the provider integration boundary.
+- Moving provider workers into the daemon process.
+- Changing remote-node process ownership; a remote daemon supervises its own local children.
+- Defining global start admission, retry backoff, durable mailbox delivery receipts, or unified task
+  cancellation. Those are separate runtime-reliability phases.
+
+## Architecture
+
+`AgentProcessSupervisor` is daemon-local and shared by `AgentManager` and `LocalExecutor`.
+
+1. `LocalExecutor` wraps every command with kill-on-drop plus a Unix process group or Windows Job
+   Object before spawn.
+2. The supervisor immediately registers the child by AgentHub session ID, before session setup can
+   fail or be cancelled.
+3. A pending registration is committed only after the active `AgentHandle` is installed. Dropping an
+   uncommitted registration schedules bounded stop and reap.
+4. Natural exit, explicit stop, and daemon shutdown all converge on the same supervised child.
+5. Shutdown takes the exclusive lifecycle gate, preventing new local starts and waiting for in-flight
+   starts to publish their registrations before `stop_all()` snapshots the registry.
+6. SQLite terminal state is written after every targeted process tree has exited and been reaped.
+
+The supervisor uses a shared child mutex to make natural-exit polling, explicit stop, pending-start
+cleanup, and daemon shutdown mutually exclusive for one process.
+
+## Contracts
+
+### Ownership Contract
+
+- Every successfully spawned local child is registered under its runtime session ID immediately.
+- A start future cannot abandon an uncommitted process; registration drop triggers cleanup.
+- The registry entry remains until natural exit finalization or a successful supervised stop.
+- A daemon shutdown failure must retain non-terminal database state rather than claim an unproven
+  exit.
+
+### Stop Contract
+
+- Unix children run as leaders of dedicated process groups; Windows children run in dedicated Job
+  Objects.
+- Graceful stop sends `SIGTERM` to the Unix process group and waits up to five seconds.
+- If the graceful deadline expires, the supervisor force-kills the process group or Job Object and
+  waits up to five seconds.
+- A final kill-and-wait pass acts as the orphan reaper. A stop succeeds only when the wrapped process
+  tree wait completes.
+- All registered processes are stopped concurrently during daemon shutdown.
+
+### State Ordering Contract
+
+- Explicit `stop_agent` writes `cancelled`/`stopped` only after supervised exit.
+- Daemon shutdown bulk-marks remaining running sessions and agents as `exited` only after
+  `stop_all()` succeeds.
+- Natural exits keep their existing `completed`/`failed` finalization path.
+- If process exit cannot be proven, the stop call returns an error and does not write a terminal
+  state for that stop path.
+
+### Lifecycle Gate Contract
+
+- Local starts hold a shared lifecycle permit until their active handle and committed registration
+  exist or startup fails.
+- Shutdown holds the exclusive lifecycle permit for the rest of daemon teardown.
+- Once shutdown begins, new local start permits are rejected.
+
+## Validation Matrix
+
+| Boundary | Required evidence |
+| --- | --- |
+| Process-tree escalation | A child tree that ignores `SIGTERM` crosses the graceful deadline, is force-killed, and its descendant PID no longer exists. |
+| State ordering | A process that delays its `SIGTERM` exit leaves its session `running` during the delay and becomes `exited` only after supervised shutdown completes. |
+| Start/shutdown race | Shutdown waits for an active start permit and every later start-permit request fails. |
+| Existing explicit stop | Existing stop regression coverage still proves idle-GC cleanup after the child exits. |
+| Build boundaries | `cargo fmt`, focused Cargo tests, Cargo check, and the relevant Bazel library/test targets pass on the exact change head. |
+
+## Operational Notes
+
+- The graceful and force deadlines are per process tree; `stop_all()` waits for trees concurrently.
+- A process that deliberately creates a new OS session escapes ordinary process-group membership.
+  Provider and tool subprocesses must not detach from the daemon-owned group/job boundary.
+- Shutdown errors are intentionally loud and leave recoverable `running` rows for startup
+  reconciliation instead of publishing a false terminal state.
+- Built-in ACP workers remain child processes of `agenthubd`; this contract does not add release
+  binaries.
+
+## Open Risks
+
+- Daemon instance locking and generation fencing are not yet implemented, so two daemon processes
+  can still contend for one database/node identity.
+- Start admission is still per-agent rather than globally bounded, and spawn failures have no shared
+  backoff policy.
+- Team mailbox runtime delivery still lacks durable delivery receipts.
+- Background tasks still use independent Tokio tasks rather than one cancellation-aware daemon task
+  group.
+- Cross-platform CI must exercise the Windows Job Object path; local Unix tests cover process groups.
+
+## Source Journals
+
+- [Daemon process supervision](../journal/2026-08-28-daemon-process-supervision.md)
+- [Two-binary runtime consolidation](../journal/2026-08-27-two-binary-runtime-consolidation.md)

--- a/docs/features/two-binary-runtime.md
+++ b/docs/features/two-binary-runtime.md
@@ -93,6 +93,8 @@ or re-executions of that file, not additional release artifacts.
   separately supervised service.
 - External provider commands continue to be discovered through their existing configured path or PATH.
 - Temporary Codex helper aliases do not change the release artifact count.
+- Daemon-owned local children follow the process-tree and shutdown ordering contract in
+  [Daemon Process Supervision](daemon-process-supervision.md).
 
 ## Open Risks
 

--- a/docs/journal/2026-08-28-daemon-process-supervision.md
+++ b/docs/journal/2026-08-28-daemon-process-supervision.md
@@ -1,0 +1,71 @@
+# Daemon Process Supervision
+
+## Summary
+
+Added daemon-owned local agent process supervision with process-tree shutdown, bounded graceful and
+force deadlines, pending-start cleanup, and database terminal-state ordering after verified exit.
+
+## Background
+
+Local agent children were stored only in `AgentHandle`. Daemon shutdown updated all running rows to
+`exited` without first stopping children, while explicit stop updated the session and agent before
+killing only the direct Tokio child. Since Tokio children continue running when dropped by default,
+startup cancellation and daemon teardown could leave provider descendants alive beyond the state
+that claimed to own them.
+
+## Scope
+
+- Added `AgentProcessSupervisor` as the owner of spawned local process registrations.
+- Wrapped Unix children in dedicated process groups and Windows children in Job Objects.
+- Added `SIGTERM`, deadline, force-kill, and final reaper behavior.
+- Added an exclusive shutdown gate against concurrent local starts.
+- Reordered explicit stop and daemon shutdown persistence after verified child exit.
+- Preserved ACP provider/session behavior and the two-native-binary artifact contract.
+
+## Key Decisions
+
+- Kept ACP as the stable provider boundary instead of introducing provider-specific runtime drivers.
+- Registered processes immediately at spawn, before ACP/session initialization, so cancellation of a
+  pending start remains recoverable by the supervisor.
+- Used a pending-registration RAII guard. A registration becomes durable only after the active handle
+  is installed; otherwise guard drop schedules stop and reap.
+- Kept database rows non-terminal when shutdown cannot prove that all targeted process trees exited.
+- Used the existing transitive `process-wrap` version as a direct dependency to share its Unix process
+  group and Windows Job Object behavior.
+
+## Validation
+
+Executed on the implementation worktree:
+
+```bash
+cargo fmt --all
+cargo check -p agenthub --lib
+cargo clippy -p agenthub --lib -- -D warnings
+cargo test -p agenthub agent::manager::supervisor::tests::shutdown_waits_for_active_start_and_rejects_new_starts -- --exact
+cargo test -p agenthub agent::manager::supervisor::tests::stop_all_force_kills_and_reaps_process_groups -- --exact
+cargo test -p agenthub agent::manager::runtime::tests::shutdown_marks_terminal_state_only_after_process_tree_exits -- --exact
+cargo test -p agenthub agent::manager::runtime::tests::stop_agent_removes_idle_gc_state_even_when_exit_watcher_exits_early -- --exact
+cargo test -p agenthub --lib
+bazel build //:agenthub_lib
+```
+
+The focused process-tree test proved force escalation and descendant reaping. The shutdown ordering
+test observed `running` while the child delayed exit, then `exited` after `stop_all_on_shutdown()`.
+The existing explicit-stop regression remained green. The full library suite passed 779 tests and
+failed three pre-existing `state::tests::initialize_services_*` cases before reaching daemon behavior;
+all three panic inside `lance-namespace-impls 8.0.0` because the directory-manifest dataset enables
+old-version cleanup. Re-running those three serially produced the same dependency assertion.
+
+The Bazel command reached the unchanged `lance-file 8.0.0` build script and then failed before
+compiling the root target because the sandbox could not find `protoc`, even though the host has
+`/opt/homebrew/bin/protoc`. No Bazel configuration was changed for this checkpoint. Exact-head Bazel
+success remains a follow-up after the repository supplies the build script with a hermetic `protoc`
+tool, as it already does for the patched Codex code-mode protocol crate.
+
+## Follow-Ups
+
+- Add database-path plus node-ID instance locking and daemon generation fencing.
+- Add globally bounded start admission, timeout, and spawn-failure backoff.
+- Add durable Team mailbox runtime delivery receipts.
+- Move daemon background work into a unified cancellation-aware task group.
+- Run exact-head Bazel validation and cross-platform CI, including Windows Job Object coverage.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -34,6 +34,7 @@ rg -n "Validation|Follow-Ups|Key Decisions" docs/journal/2026-06-*.md
 | Frontend, UI, and mobile surfaces | `docs/features/frontend-design.md`, `docs/features/workspace-unified-ia.md` | `*-web-*.md`, `*-frontend-*.md`, `*-mobile-*.md`, `*-ui-*.md` |
 | Agent nodes and distributed execution | `docs/features/agent-nodes.md`, `docs/features/distributed-node-architecture.md` | `*-node-*.md`, `*-distributed-*.md`, `*-p2p-*.md` |
 | Release, packaging, and install paths | `docs/features/two-binary-runtime.md`, `docs/features/npm-binary-distribution.md`, `docs/features/debian-systemd-distribution.md` | `*-release-*.md`, `*-binary-*.md`, `*-npm-*.md`, `*-debian-*.md`, `*-homebrew-*.md` |
+| Daemon lifecycle and process ownership | `docs/features/daemon-process-supervision.md`, `docs/features/two-binary-runtime.md` | `*-daemon-*.md`, `*-process-supervision*.md` |
 | CI, Bazel, coverage, and dependencies | `docs/developer-setup.md` | `*-ci-*.md`, `*-bazel-*.md`, `*-codecov-*.md`, `*-dependabot-*.md` |
 | Access control, auth, and permissions | `docs/features/access-control-and-roles.md`, `docs/features/acp-runtime.md` | `*-auth-*.md`, `*-access-control-*.md`, `*-permission-*.md` |
 | Message archive, metadata, and object storage | `docs/features/logical-message-metadata-contract.md`, `docs/features/message-archive-lancedb.md`, `docs/features/object-storage-opendal.md` | `*-message-*.md`, `*-metadata-*.md`, `*-lancedb-*.md`, `*-object-storage-*.md` |
@@ -312,6 +313,7 @@ Start with:
 - `2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md`
 - `2026-08-27-two-binary-runtime-consolidation.md`
 - `2026-08-27-official-codex-0-150-1-upgrade.md`
+- `2026-08-28-daemon-process-supervision.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -90,6 +90,18 @@ Stable contracts:
   `acp_tool_fold.tsx`'s `IntersectionObserver` auto-collapse silently closes a manually-opened tool card
   when it scrolls out of view. Evidence: [journal/2026-08-16-frontend-uiux-review-round1-fixes.md](journal/2026-08-16-frontend-uiux-review-round1-fixes.md).
 
+## Daemon Runtime Reliability
+
+- [ ] `P0` Add an exclusive daemon instance lock scoped by canonical database path plus node ID, and
+  persist a daemon generation so stale owners cannot publish runtime state after replacement. Stable
+  process ownership contract: [features/daemon-process-supervision.md](features/daemon-process-supervision.md).
+- [ ] `P1` Add globally bounded local-start admission with queue timeout, spawn timeout, and
+  failure-class backoff. Preserve the supervisor lifecycle gate and per-agent duplicate-start guard.
+- [ ] `P1` Add durable Team mailbox delivery receipts for runtime-bound messages, including stable
+  delivery IDs, idempotent acknowledgement, retry state, and restart recovery.
+- [ ] `P2` Move daemon background workers and runtime watchers into one cancellation-aware task group
+  with ordered shutdown, bounded joins, and surfaced teardown failures.
+
 ## Backend Correctness
 
 - [ ] `P1` Close out the remaining findings from the 2026-08-16 code-only Rust backend review: the

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -7,6 +7,7 @@ mod runtime;
 mod session;
 mod start_plan;
 mod store;
+mod supervisor;
 mod worktree;
 
 #[cfg(test)]
@@ -21,7 +22,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 use tokio::io::AsyncWriteExt;
-use tokio::process::{Child, ChildStdin, Command};
+use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use uuid::Uuid;
 
@@ -36,6 +37,7 @@ use self::store::{
     AgentInsertRecord, AgentSchemaCaps, RemoteManagedAgentUpsert, decode_agent_record,
     get_agent_row, insert_agent_record, list_agent_rows, upsert_remote_managed_agent_record,
 };
+use self::supervisor::{AgentProcessSupervisor, SharedSupervisedChild};
 use self::worktree::git_command_without_fsmonitor;
 use super::event_message_codec::{decode_message_from_storage, persist_agent_event};
 use super::{
@@ -69,6 +71,7 @@ pub struct AgentManager {
     push: Arc<PushService>,
     auth: Arc<AuthService>,
     local_executor: Arc<dyn AgentExecutor>,
+    process_supervisor: AgentProcessSupervisor,
     codex_acp_binary: String,
     acp_default_mode: Option<String>,
     codex_acp_multi_agent_enabled: bool,
@@ -85,7 +88,6 @@ const ACTOR_RUNTIME_TEAM_ID_ENV: &str = "AGENTHUB_ACTOR_TEAM_ID";
 const ACTOR_RUNTIME_CURRENT_RUN_ID_ENV: &str = "AGENTHUB_ACTOR_CURRENT_RUN_ID";
 const ACTOR_RUNTIME_ACTOR_ID_ENV: &str = "AGENTHUB_ACTOR_ID";
 const ACTOR_RUNTIME_CHANNEL_ENV: &str = "AGENTHUB_ACTOR_CHANNEL";
-const AGENT_STOP_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 const AGENT_SOURCE_MANUAL: &str = "manual";
 const AGENT_SOURCE_TEAM_FORGE: &str = "team_forge";
 const INTERNAL_AGENT_MANAGE_PERMISSION: &str = "agent:manage";
@@ -701,7 +703,7 @@ fn spawn_agent_loop_controller(
 }
 
 pub struct AgentHandle {
-    child: Arc<Mutex<Option<Child>>>,
+    child: SharedSupervisedChild,
     output_tx: broadcast::Sender<AgentOutput>,
     input: AgentInput,
     session_id: String,
@@ -787,13 +789,18 @@ impl AgentManager {
         auth: Arc<AuthService>,
         internal_peer_client: Option<InternalGrpcPeerClientConfig>,
     ) -> Self {
+        let process_supervisor = AgentProcessSupervisor::default();
         Self {
             db,
             event_dbs,
             idle_gc,
             push,
             auth,
-            local_executor: Arc::new(LocalExecutor::new(ProxyPolicy::new(proxy_env))),
+            local_executor: Arc::new(LocalExecutor::new(
+                ProxyPolicy::new(proxy_env),
+                process_supervisor.clone(),
+            )),
+            process_supervisor,
             codex_acp_binary,
             acp_default_mode,
             codex_acp_multi_agent_enabled,

--- a/src/agent/manager/executor.rs
+++ b/src/agent/manager/executor.rs
@@ -3,10 +3,13 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 
 use crate::acp::{AcpActorSkillContext, AcpRuntimeLocation};
 
+use super::supervisor::{
+    AgentProcessSupervisor, PendingProcessRegistration, SharedSupervisedChild,
+};
 use super::{
     ACTOR_RUNTIME_ACTOR_ID_ENV, ACTOR_RUNTIME_CHANNEL_ENV, ACTOR_RUNTIME_CURRENT_RUN_ID_ENV,
     ACTOR_RUNTIME_TEAM_ID_ENV, ProxyPolicy,
@@ -14,6 +17,8 @@ use super::{
 
 #[derive(Debug, Clone)]
 pub(super) struct LocalExecutionRequest {
+    pub agent_id: String,
+    pub session_id: String,
     pub command_path: String,
     pub args: Vec<String>,
     pub workdir: String,
@@ -22,7 +27,8 @@ pub(super) struct LocalExecutionRequest {
 }
 
 pub(super) struct SpawnedLocalProcess {
-    pub child: Child,
+    pub child: SharedSupervisedChild,
+    pub registration: PendingProcessRegistration,
     pub runtime_location: AcpRuntimeLocation,
 }
 
@@ -37,11 +43,18 @@ pub(super) trait AgentExecutor: Send + Sync {
 #[derive(Debug, Clone)]
 pub(super) struct LocalExecutor {
     proxy_policy: ProxyPolicy,
+    process_supervisor: AgentProcessSupervisor,
 }
 
 impl LocalExecutor {
-    pub(super) fn new(proxy_policy: ProxyPolicy) -> Self {
-        Self { proxy_policy }
+    pub(super) fn new(
+        proxy_policy: ProxyPolicy,
+        process_supervisor: AgentProcessSupervisor,
+    ) -> Self {
+        Self {
+            proxy_policy,
+            process_supervisor,
+        }
     }
 }
 
@@ -93,9 +106,13 @@ impl AgentExecutor for LocalExecutor {
             }
         }
 
-        let child = command.spawn()?;
+        let (child, registration) = self
+            .process_supervisor
+            .spawn(request.agent_id, request.session_id, command)
+            .await?;
         Ok(SpawnedLocalProcess {
             child,
+            registration,
             runtime_location: AcpRuntimeLocation::LocalProcess,
         })
     }
@@ -154,6 +171,7 @@ mod tests {
         synthesized_child_path,
     };
     use crate::agent::manager::ProxyPolicy;
+    use crate::agent::manager::supervisor::AgentProcessSupervisor;
 
     fn temp_workdir(prefix: &str) -> std::path::PathBuf {
         let unique = Uuid::new_v4();
@@ -166,8 +184,11 @@ mod tests {
         let workdir = temp_workdir("agenthub-executor-extra-env");
         std::fs::create_dir_all(&workdir).expect("create temp workdir");
 
-        let executor = LocalExecutor::new(ProxyPolicy::default());
+        let process_supervisor = AgentProcessSupervisor::default();
+        let executor = LocalExecutor::new(ProxyPolicy::default(), process_supervisor.clone());
         let request = LocalExecutionRequest {
+            agent_id: "agent-executor-test".to_string(),
+            session_id: "session-executor-test".to_string(),
             command_path: "/bin/sh".to_string(),
             args: vec![
                 "-c".to_string(),
@@ -182,15 +203,16 @@ mod tests {
             .spawn_process(request)
             .await
             .expect("spawn process");
-        let output = spawned
-            .child
-            .wait_with_output()
+        spawned.registration.commit();
+        let child = spawned.child.lock().await.take().expect("take child");
+        let output = Box::into_pin(child.wait_with_output())
             .await
             .expect("wait for process output");
 
         assert!(output.status.success(), "process should exit successfully");
         let stdout = String::from_utf8(output.stdout).expect("decode stdout");
         assert_eq!(stdout.trim(), "RUST_BACKTRACE=1");
+        process_supervisor.forget("session-executor-test").await;
 
         let _ = std::fs::remove_dir_all(&workdir);
     }

--- a/src/agent/manager/process.rs
+++ b/src/agent/manager/process.rs
@@ -16,7 +16,7 @@ use crate::push::PushService;
 use agenthub_db::{AgentEventDbRouter, AgentEventIdleGc};
 
 impl AgentManager {
-    fn handle_matches_session(handle: Option<&AgentHandle>, session_id: &str) -> bool {
+    pub(super) fn handle_matches_session(handle: Option<&AgentHandle>, session_id: &str) -> bool {
         handle
             .map(|handle| handle.session_id.as_str() == session_id)
             .unwrap_or(false)
@@ -141,6 +141,7 @@ impl AgentManager {
         let idle_gc = self.idle_gc.clone();
         let inner = self.inner.clone();
         let push = self.push.clone();
+        let process_supervisor = self.process_supervisor.clone();
         let agent_id_clone = agent_id.clone();
         tokio::spawn(async move {
             let child = {
@@ -185,6 +186,7 @@ impl AgentManager {
                     success,
                 )
                 .await;
+                process_supervisor.forget(&session_id).await;
             }
         });
     }
@@ -623,7 +625,7 @@ mod tests {
             .expect("spawn newer child");
         let (output_tx, _rx) = broadcast::channel::<AgentOutput>(8);
         let handle = AgentHandle {
-            child: std::sync::Arc::new(Mutex::new(Some(child))),
+            child: std::sync::Arc::new(Mutex::new(Some(Box::new(child)))),
             output_tx,
             input: AgentInput::Stdin(std::sync::Arc::new(Mutex::new(None))),
             session_id: new_session_id.clone(),
@@ -665,7 +667,7 @@ mod tests {
         if let Some(handle) = state.agents.inner.write().await.remove(&agent_id) {
             let mut child_guard = handle.child.lock().await;
             if let Some(mut child) = child_guard.take() {
-                let _ = child.kill().await;
+                let _ = child.start_kill();
                 let _ = child.wait().await;
             }
         }
@@ -700,7 +702,7 @@ mod tests {
             .expect("spawn newer child");
         let (output_tx, _rx) = broadcast::channel::<AgentOutput>(8);
         let handle = AgentHandle {
-            child: std::sync::Arc::new(Mutex::new(Some(child))),
+            child: std::sync::Arc::new(Mutex::new(Some(Box::new(child)))),
             output_tx,
             input: AgentInput::Stdin(std::sync::Arc::new(Mutex::new(None))),
             session_id: new_session_id.clone(),
@@ -747,7 +749,7 @@ mod tests {
         if let Some(handle) = state.agents.inner.write().await.remove(&agent_id) {
             let mut child_guard = handle.child.lock().await;
             if let Some(mut child) = child_guard.take() {
-                let _ = child.kill().await;
+                let _ = child.start_kill();
                 let _ = child.wait().await;
             }
         }

--- a/src/agent/manager/runtime.rs
+++ b/src/agent/manager/runtime.rs
@@ -474,6 +474,26 @@ impl AgentManager {
     }
 
     #[tracing::instrument(skip(self), err)]
+    pub async fn stop_all_on_shutdown(&self) -> anyhow::Result<AgentSessionExitMarkSummary> {
+        let _shutdown_guard = self.process_supervisor.begin_shutdown().await;
+        self.process_supervisor.stop_all().await?;
+
+        let stopped_handles = {
+            let mut guard = self.inner.write().await;
+            guard.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
+        };
+        for handle in stopped_handles {
+            if let Some(controller) = handle.loop_controller {
+                controller.stop();
+            }
+        }
+
+        // Persist terminal state only after every supervised local process tree
+        // has been reaped successfully.
+        self.mark_exited_on_shutdown().await
+    }
+
+    #[tracing::instrument(skip(self), err)]
     pub async fn mark_exited_on_shutdown(&self) -> anyhow::Result<AgentSessionExitMarkSummary> {
         self.mark_running_agents_exited(AgentSessionExitMarkReason::Shutdown)
             .await
@@ -617,8 +637,12 @@ impl AgentManager {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Stdio;
+
     use chrono::Utc;
     use sqlx::{Row, SqlitePool};
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::process::Command;
     use tokio::time::Duration;
     use uuid::Uuid;
 
@@ -715,7 +739,7 @@ mod tests {
         let stdin = child.stdin.take();
         let (output_tx, _output_rx) = tokio::sync::broadcast::channel(8);
         let handle = super::super::AgentHandle {
-            child: std::sync::Arc::new(tokio::sync::Mutex::new(Some(child))),
+            child: std::sync::Arc::new(tokio::sync::Mutex::new(Some(Box::new(child)))),
             output_tx,
             input: super::super::AgentInput::Stdin(std::sync::Arc::new(tokio::sync::Mutex::new(
                 stdin,
@@ -1210,6 +1234,90 @@ mod tests {
         .await
         .expect("count running agents after cleanup");
         assert_eq!(running_agents, 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_marks_terminal_state_only_after_process_tree_exits() {
+        let state = crate::api::team_tests::build_test_state().await;
+        let (agent_id, session_id) =
+            insert_agent_and_session(&state.db, "shutdown-process-ordering").await;
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("trap 'sleep 1; exit 0' TERM; printf 'ready\\n'; while :; do sleep 10; done")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut process = super::super::supervisor::spawn_supervised(command)
+            .expect("spawn supervised shutdown test process");
+        let stdout = process.stdout().take().expect("take process stdout");
+        let mut lines = BufReader::new(stdout).lines();
+        assert_eq!(
+            lines
+                .next_line()
+                .await
+                .expect("read readiness line")
+                .as_deref(),
+            Some("ready")
+        );
+
+        let (output_tx, _output_rx) = tokio::sync::broadcast::channel(8);
+        let child = std::sync::Arc::new(tokio::sync::Mutex::new(Some(process)));
+        state
+            .agents
+            .process_supervisor
+            .track_test_process(super::super::supervisor::StopTarget {
+                agent_id: agent_id.clone(),
+                session_id: session_id.clone(),
+                child: child.clone(),
+            })
+            .await
+            .expect("track supervised shutdown test process");
+        let handle = super::super::AgentHandle {
+            child,
+            output_tx,
+            input: super::super::AgentInput::Stdin(std::sync::Arc::new(tokio::sync::Mutex::new(
+                None,
+            ))),
+            session_id: session_id.clone(),
+            actor_context: None,
+            acp_prompt_delivery_policy: None,
+            loop_controller: None,
+        };
+        state
+            .agents
+            .inner
+            .write()
+            .await
+            .insert(agent_id.clone(), handle);
+
+        let agents = state.agents.clone();
+        let shutdown = tokio::spawn(async move { agents.stop_all_on_shutdown().await });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let status_during_stop: String =
+            sqlx::query_scalar("SELECT status FROM agent_sessions WHERE id = ?1")
+                .bind(&session_id)
+                .fetch_one(&state.db)
+                .await
+                .expect("load session status during supervised stop");
+        assert_eq!(status_during_stop, "running");
+
+        let summary = shutdown
+            .await
+            .expect("join shutdown task")
+            .expect("stop all supervised processes");
+        assert_eq!(summary.sessions_marked_exited, 1);
+        assert_eq!(summary.agents_marked_exited, 1);
+
+        let session_row = sqlx::query("SELECT status, ended_at FROM agent_sessions WHERE id = ?1")
+            .bind(&session_id)
+            .fetch_one(&state.db)
+            .await
+            .expect("load terminal session state");
+        assert_eq!(session_row.get::<String, _>("status"), "exited");
+        assert!(session_row.get::<Option<i64>, _>("ended_at").is_some());
     }
 
     #[tokio::test]

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use chrono::Utc;
 use sqlx::Row;
 use tokio::sync::{Mutex, broadcast};
@@ -10,10 +11,11 @@ use super::acp_provider::{
     ACP_PROVIDER_CODEX, AcpDefaultModeBehavior, AcpProviderSpec,
     codex_reasoning_effort_for_thinking_level, default_env_for_acp_provider,
 };
-use super::executor::LocalExecutionRequest;
+use super::executor::{LocalExecutionRequest, SpawnedLocalProcess};
 use super::start_plan::{AgentStartPlan, build_agent_start_plan};
+use super::supervisor::SharedSupervisedChild;
 use super::{
-    AGENT_STOP_WAIT_TIMEOUT, AgentHandle, AgentInput, AgentManager, build_runtime_start_policy,
+    AgentHandle, AgentInput, AgentManager, build_runtime_start_policy,
     ensure_team_runtime_workspace_layout, normalize_agent_loop_config, spawn_agent_loop_controller,
 };
 use crate::acp::{
@@ -69,7 +71,7 @@ pub(super) fn effective_acp_default_mode<'a>(
 }
 
 async fn observe_resumed_session_startup(
-    child: &Arc<Mutex<Option<tokio::process::Child>>>,
+    child: &SharedSupervisedChild,
     grace_period: Duration,
     poll_interval: Duration,
 ) -> ResumedSessionStartupState {
@@ -375,6 +377,7 @@ impl AgentManager {
                 agent,
                 actor_context,
             } => {
+                let _start_permit = self.process_supervisor.acquire_start_permit().await?;
                 self.reserve_agent_start(agent_id).await?;
                 let result = self.start_local_agent(agent, actor_context).await;
                 self.release_agent_start(agent_id).await;
@@ -540,6 +543,8 @@ impl AgentManager {
             command_path, start_policy.workdir, command_args
         );
         let local_execution_request = LocalExecutionRequest {
+            agent_id: agent.id.clone(),
+            session_id: session_id.clone(),
             command_path: command_path.clone(),
             args: command_args,
             workdir: start_policy.workdir.clone(),
@@ -588,13 +593,24 @@ impl AgentManager {
                 ));
             }
         };
-        let mut child = local_execution.child;
-        let mut stdout = child.stdout.take();
-        let stderr = child.stderr.take();
-        let stdin = child.stdin.take();
+        let SpawnedLocalProcess {
+            child,
+            registration,
+            runtime_location,
+        } = local_execution;
+        let (mut stdout, stderr, stdin) = {
+            let mut child_guard = child.lock().await;
+            let process = child_guard
+                .as_mut()
+                .ok_or_else(|| anyhow::anyhow!("spawned agent process is missing"))?;
+            (
+                process.stdout().take(),
+                process.stderr().take(),
+                process.stdin().take(),
+            )
+        };
 
         let (output_tx, _rx) = broadcast::channel(256);
-        let child = Arc::new(Mutex::new(Some(child)));
         let stdin = Arc::new(Mutex::new(stdin));
 
         let now = Utc::now().timestamp();
@@ -639,11 +655,31 @@ impl AgentManager {
                     "failed to update agent status after session-insert failure"
                 );
             }
+            if let Err(stop_err) = self.process_supervisor.stop_session(&session_id).await {
+                tracing::error!(
+                    agent_id = %agent.id,
+                    session_id = %session_id,
+                    error = %stop_err,
+                    "failed to stop agent process after session-insert failure"
+                );
+            }
             return Err(err.into());
         }
 
-        self.update_agent_status(&agent.id, AgentStatus::Running)
-            .await?;
+        if let Err(err) = self
+            .update_agent_status(&agent.id, AgentStatus::Running)
+            .await
+        {
+            if let Err(stop_err) = self.process_supervisor.stop_session(&session_id).await {
+                tracing::error!(
+                    agent_id = %agent.id,
+                    session_id = %session_id,
+                    error = %stop_err,
+                    "failed to stop agent process after running-status update failure"
+                );
+            }
+            return Err(err);
+        }
 
         let mut loop_controller = None;
         let mut resumed_provider_id = None::<String>;
@@ -654,7 +690,14 @@ impl AgentManager {
             acp_prompt_delivery_policy = Some(provider.prompt_delivery_policy);
             // Provider continuity is stored separately from the AgentHub runtime launch id
             // above so restarts can keep ACP memory while still recording a new local start.
-            let resume_session_id = self.get_persistent_session(&agent.id, provider.id).await?;
+            let resume_session_id = match self.get_persistent_session(&agent.id, provider.id).await
+            {
+                Ok(session_id) => session_id,
+                Err(err) => {
+                    let _ = self.process_supervisor.stop_session(&session_id).await;
+                    return Err(err);
+                }
+            };
             resumed_provider_id = Some(provider.id.to_string());
             let stdout = match stdout.take() {
                 Some(stdout) => stdout,
@@ -681,6 +724,7 @@ impl AgentManager {
                             "failed to update agent status after missing acp stdout"
                         );
                     }
+                    let _ = self.process_supervisor.stop_session(&session_id).await;
                     return Err(anyhow::anyhow!("acp stdout missing"));
                 }
             };
@@ -709,6 +753,7 @@ impl AgentManager {
                             "failed to update agent status after missing acp stdin"
                         );
                     }
+                    let _ = self.process_supervisor.stop_session(&session_id).await;
                     return Err(anyhow::anyhow!("acp stdin missing"));
                 }
             };
@@ -739,7 +784,7 @@ impl AgentManager {
                 stdin,
                 actor_context: actor_context.clone(),
                 prompt_delivery_policy: provider.prompt_delivery_policy,
-                runtime_location: local_execution.runtime_location,
+                runtime_location,
             })
             .await
             {
@@ -768,6 +813,7 @@ impl AgentManager {
                             "failed to update agent status after acp session spawn failure"
                         );
                     }
+                    let _ = self.process_supervisor.stop_session(&session_id).await;
                     return Err(err);
                 }
             };
@@ -884,6 +930,7 @@ impl AgentManager {
             let mut guard = self.inner.write().await;
             guard.insert(agent.id.clone(), handle);
         }
+        registration.commit();
 
         if !is_acp && let Some(stdout) = stdout {
             self.spawn_output_reader(
@@ -1020,12 +1067,39 @@ impl AgentManager {
                 .await?;
             return Ok(());
         }
-        let handle = {
-            let mut guard = self.inner.write().await;
-            guard.remove(agent_id)
+        let process = {
+            let guard = self.inner.read().await;
+            guard.get(agent_id).map(|handle| {
+                (
+                    handle.child.clone(),
+                    handle.output_tx.clone(),
+                    handle.session_id.clone(),
+                )
+            })
         };
-        if let Some(handle) = handle {
-            let session_id = handle.session_id.clone();
+        if let Some((child, output_tx, session_id)) = process {
+            self.process_supervisor
+                .stop_session_or_child(&session_id, &child)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to stop agent process: agent_id={agent_id} session_id={session_id}"
+                    )
+                })?;
+
+            let removed = {
+                let mut guard = self.inner.write().await;
+                if AgentManager::handle_matches_session(guard.get(agent_id), &session_id) {
+                    guard.remove(agent_id)
+                } else {
+                    None
+                }
+            };
+            if let Some(handle) = removed
+                && let Some(controller) = handle.loop_controller
+            {
+                controller.stop();
+            }
             let now = Utc::now().timestamp();
             if let Err(err) = sqlx::query(
                 r#"
@@ -1058,41 +1132,14 @@ impl AgentManager {
                 );
             }
             self.emit_run_status(
-                handle.output_tx.clone(),
+                output_tx,
                 agent_id.to_string(),
-                session_id,
+                session_id.clone(),
                 "cancelled",
             )
             .await;
             if let Some(idle_gc) = &self.idle_gc {
                 idle_gc.remove_agent(agent_id).await;
-            }
-            let mut child_guard = handle.child.lock().await;
-            if let Some(mut child) = child_guard.take() {
-                if let Err(err) = child.kill().await {
-                    tracing::warn!(
-                        agent_id = %agent_id,
-                        error = %err,
-                        "failed to kill agent child process during stop"
-                    );
-                }
-                match tokio::time::timeout(AGENT_STOP_WAIT_TIMEOUT, child.wait()).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(err)) => {
-                        tracing::warn!(
-                            agent_id = %agent_id,
-                            error = %err,
-                            "failed to wait for agent child process during stop"
-                        );
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            agent_id = %agent_id,
-                            timeout_secs = AGENT_STOP_WAIT_TIMEOUT.as_secs(),
-                            "timed out waiting for agent child process during stop"
-                        );
-                    }
-                }
             }
         }
         Ok(())
@@ -1180,6 +1227,7 @@ mod tests {
         observe_resumed_session_startup, should_force_fresh_session_after_resume_failures,
         should_retry_resumed_acp_session,
     };
+    use crate::agent::manager::supervisor::SharedSupervisedChild;
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::process::Command;
@@ -1236,7 +1284,7 @@ mod tests {
             .arg("exit 1")
             .spawn()
             .expect("spawn failing child");
-        let child = Arc::new(Mutex::new(Some(child)));
+        let child: SharedSupervisedChild = Arc::new(Mutex::new(Some(Box::new(child))));
 
         let startup_state = observe_resumed_session_startup(
             &child,
@@ -1258,7 +1306,7 @@ mod tests {
             .arg("sleep 1")
             .spawn()
             .expect("spawn sleeping child");
-        let child = Arc::new(Mutex::new(Some(child)));
+        let child: SharedSupervisedChild = Arc::new(Mutex::new(Some(Box::new(child))));
 
         let startup_state = observe_resumed_session_startup(
             &child,
@@ -1270,7 +1318,7 @@ mod tests {
 
         let mut child_guard = child.lock().await;
         if let Some(mut child) = child_guard.take() {
-            let _ = child.kill().await;
+            let _ = child.start_kill();
             let _ = child.wait().await;
         }
     }

--- a/src/agent/manager/supervisor.rs
+++ b/src/agent/manager/supervisor.rs
@@ -352,7 +352,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn stop_all_force_kills_and_reaps_process_groups() {
+    async fn stop_all_force_kills_process_groups_and_reaps_leaders() {
         let supervisor =
             AgentProcessSupervisor::new(Duration::from_millis(100), Duration::from_secs(2));
         let mut command = Command::new("sh");
@@ -386,12 +386,16 @@ mod tests {
 
         let status = Command::new("sh")
             .arg("-c")
-            .arg("kill -0 \"$1\" 2>/dev/null")
+            .arg(
+                "kill -0 \"$1\" 2>/dev/null || exit 1; \
+                 state=$(ps -o stat= -p \"$1\" | tr -d '[:space:]'); \
+                 test -n \"$state\" && case \"$state\" in Z*) exit 1;; esac",
+            )
             .arg("agenthub-supervisor-test")
             .arg(descendant_pid)
             .status()
             .await
             .expect("probe descendant process");
-        assert!(!status.success(), "descendant process should be reaped");
+        assert!(!status.success(), "descendant process should be terminated");
     }
 }

--- a/src/agent/manager/supervisor.rs
+++ b/src/agent/manager/supervisor.rs
@@ -1,0 +1,397 @@
+use std::collections::HashMap;
+use std::process::ExitStatus;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Context;
+use futures::future::join_all;
+#[cfg(windows)]
+use process_wrap::tokio::JobObject;
+#[cfg(unix)]
+use process_wrap::tokio::ProcessGroup;
+use process_wrap::tokio::{ChildWrapper, CommandWrap, KillOnDrop};
+use tokio::process::Command;
+use tokio::sync::{Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+
+pub(super) type SupervisedChild = Box<dyn ChildWrapper>;
+pub(super) type SharedSupervisedChild = Arc<Mutex<Option<SupervisedChild>>>;
+
+const DEFAULT_GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_FORCE_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug)]
+pub(super) struct AgentProcessSupervisor {
+    graceful_stop_timeout: Duration,
+    force_stop_timeout: Duration,
+    lifecycle: Arc<RwLock<()>>,
+    shutting_down: Arc<AtomicBool>,
+    processes: Arc<RwLock<HashMap<String, StopTarget>>>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct StopTarget {
+    pub agent_id: String,
+    pub session_id: String,
+    pub child: SharedSupervisedChild,
+}
+
+pub(super) struct PendingProcessRegistration {
+    supervisor: AgentProcessSupervisor,
+    session_id: String,
+    child: SharedSupervisedChild,
+    committed: bool,
+}
+
+impl PendingProcessRegistration {
+    pub(super) fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PendingProcessRegistration {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        let supervisor = self.supervisor.clone();
+        let session_id = self.session_id.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                if let Err(error) = supervisor.stop_session(&session_id).await {
+                    tracing::error!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed to stop uncommitted supervised process"
+                    );
+                }
+            });
+        } else if let Ok(mut guard) = self.child.try_lock()
+            && let Some(process) = guard.as_mut()
+            && let Err(error) = process.start_kill()
+        {
+            tracing::error!(
+                session_id = %self.session_id,
+                error = %error,
+                "failed to synchronously kill uncommitted supervised process"
+            );
+        }
+    }
+}
+
+impl Default for AgentProcessSupervisor {
+    fn default() -> Self {
+        Self::new(DEFAULT_GRACEFUL_STOP_TIMEOUT, DEFAULT_FORCE_STOP_TIMEOUT)
+    }
+}
+
+impl AgentProcessSupervisor {
+    fn new(graceful_stop_timeout: Duration, force_stop_timeout: Duration) -> Self {
+        Self {
+            graceful_stop_timeout,
+            force_stop_timeout,
+            lifecycle: Arc::new(RwLock::new(())),
+            shutting_down: Arc::new(AtomicBool::new(false)),
+            processes: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub(super) async fn spawn(
+        &self,
+        agent_id: String,
+        session_id: String,
+        command: Command,
+    ) -> anyhow::Result<(SharedSupervisedChild, PendingProcessRegistration)> {
+        if self.shutting_down.load(Ordering::Acquire) {
+            anyhow::bail!("agent process supervisor is shutting down");
+        }
+        let child = Arc::new(Mutex::new(Some(
+            spawn_supervised(command).context("failed to spawn supervised agent process")?,
+        )));
+        let target = StopTarget {
+            agent_id,
+            session_id: session_id.clone(),
+            child: child.clone(),
+        };
+        if self.track(target).await.is_err() {
+            let _ = self.stop(&child).await;
+            anyhow::bail!("duplicate supervised agent session: {session_id}");
+        }
+
+        Ok((
+            child.clone(),
+            PendingProcessRegistration {
+                supervisor: self.clone(),
+                session_id,
+                child,
+                committed: false,
+            },
+        ))
+    }
+
+    pub(super) async fn acquire_start_permit(&self) -> anyhow::Result<OwnedRwLockReadGuard<()>> {
+        if self.shutting_down.load(Ordering::Acquire) {
+            anyhow::bail!("agent process supervisor is shutting down");
+        }
+        let guard = self.lifecycle.clone().read_owned().await;
+        if self.shutting_down.load(Ordering::Acquire) {
+            anyhow::bail!("agent process supervisor is shutting down");
+        }
+        Ok(guard)
+    }
+
+    pub(super) async fn begin_shutdown(&self) -> OwnedRwLockWriteGuard<()> {
+        let guard = self.lifecycle.clone().write_owned().await;
+        self.shutting_down.store(true, Ordering::Release);
+        guard
+    }
+
+    pub(super) async fn stop_all(&self) -> anyhow::Result<()> {
+        let targets = self
+            .processes
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let results = join_all(targets.into_iter().map(|target| async move {
+            let result = self.stop(&target.child).await;
+            (target, result)
+        }))
+        .await;
+
+        let mut failures = Vec::new();
+        for (target, result) in results {
+            match result {
+                Ok(_) => self.forget(&target.session_id).await,
+                Err(error) => failures.push(format!(
+                    "agent_id={} session_id={}: {error:#}",
+                    target.agent_id, target.session_id
+                )),
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "failed to stop {} supervised agent process(es): {}",
+                failures.len(),
+                failures.join("; ")
+            )
+        }
+    }
+
+    pub(super) async fn stop_session(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<ExitStatus>> {
+        let target = self.processes.read().await.get(session_id).cloned();
+        let Some(target) = target else {
+            return Ok(None);
+        };
+        let status = self.stop(&target.child).await?;
+        self.forget(session_id).await;
+        Ok(status)
+    }
+
+    pub(super) async fn stop_session_or_child(
+        &self,
+        session_id: &str,
+        child: &SharedSupervisedChild,
+    ) -> anyhow::Result<Option<ExitStatus>> {
+        if self.processes.read().await.contains_key(session_id) {
+            self.stop_session(session_id).await
+        } else {
+            self.stop(child).await
+        }
+    }
+
+    async fn track(&self, target: StopTarget) -> anyhow::Result<()> {
+        let session_id = target.session_id.clone();
+        let mut processes = self.processes.write().await;
+        match processes.entry(session_id.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(target);
+                Ok(())
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {
+                anyhow::bail!("duplicate supervised agent session: {session_id}")
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) async fn track_test_process(&self, target: StopTarget) -> anyhow::Result<()> {
+        self.track(target).await
+    }
+
+    pub(super) async fn forget(&self, session_id: &str) {
+        self.processes.write().await.remove(session_id);
+    }
+
+    pub(super) async fn stop(
+        &self,
+        child: &SharedSupervisedChild,
+    ) -> anyhow::Result<Option<ExitStatus>> {
+        let mut guard = child.lock().await;
+        let Some(process) = guard.as_mut() else {
+            return Ok(None);
+        };
+
+        if let Some(status) = process
+            .try_wait()
+            .context("failed to poll supervised process before stop")?
+        {
+            *guard = None;
+            return Ok(Some(status));
+        }
+
+        // The pipe may already have been handed to an ACP transport. Taking the
+        // child-owned copy still helps plain stdin agents observe EOF promptly.
+        process.stdin().take();
+
+        #[cfg(unix)]
+        {
+            if let Err(error) = process.signal(15) {
+                tracing::debug!(error = %error, "failed to send SIGTERM to supervised process group");
+            }
+
+            match tokio::time::timeout(self.graceful_stop_timeout, process.wait()).await {
+                Ok(Ok(status)) => {
+                    *guard = None;
+                    return Ok(Some(status));
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(error = %error, "failed to wait for graceful supervised process exit");
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        timeout_secs = self.graceful_stop_timeout.as_secs(),
+                        "supervised process exceeded graceful stop deadline"
+                    );
+                }
+            }
+        }
+
+        process
+            .start_kill()
+            .context("failed to force-kill supervised process tree")?;
+        match tokio::time::timeout(self.force_stop_timeout, process.wait()).await {
+            Ok(Ok(status)) => {
+                *guard = None;
+                return Ok(Some(status));
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(error = %error, "failed to reap force-killed supervised process tree");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_secs = self.force_stop_timeout.as_secs(),
+                    "supervised process tree exceeded force-stop deadline"
+                );
+            }
+        }
+
+        // One final kill-and-wait pass is the orphan reaper. A successful
+        // process-wrap wait proves the process group/job object is empty.
+        process
+            .start_kill()
+            .context("final orphan reaper failed to kill supervised process tree")?;
+        let status = tokio::time::timeout(self.force_stop_timeout, process.wait())
+            .await
+            .context("final orphan reaper timed out")?
+            .context("final orphan reaper failed to wait for process tree")?;
+        *guard = None;
+        Ok(Some(status))
+    }
+}
+
+pub(super) fn spawn_supervised(command: Command) -> std::io::Result<SupervisedChild> {
+    let mut wrapped = CommandWrap::from(command);
+    wrapped.wrap(KillOnDrop);
+    #[cfg(unix)]
+    wrapped.wrap(ProcessGroup::leader());
+    #[cfg(windows)]
+    wrapped.wrap(JobObject);
+    wrapped.spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Stdio;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::process::Command;
+    use tokio::sync::Mutex;
+
+    use super::{AgentProcessSupervisor, SharedSupervisedChild, StopTarget, spawn_supervised};
+
+    #[tokio::test]
+    async fn shutdown_waits_for_active_start_and_rejects_new_starts() {
+        let supervisor =
+            AgentProcessSupervisor::new(Duration::from_millis(100), Duration::from_millis(100));
+        let start_permit = supervisor
+            .acquire_start_permit()
+            .await
+            .expect("acquire start permit");
+        let shutdown_supervisor = supervisor.clone();
+        let shutdown = tokio::spawn(async move {
+            let _guard = shutdown_supervisor.begin_shutdown().await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(!shutdown.is_finished());
+        drop(start_permit);
+        shutdown.await.expect("join shutdown gate");
+
+        assert!(supervisor.acquire_start_permit().await.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_all_force_kills_and_reaps_process_groups() {
+        let supervisor =
+            AgentProcessSupervisor::new(Duration::from_millis(100), Duration::from_secs(2));
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("trap '' TERM; sleep 60 & printf '%s\\n' \"$!\"; wait")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut process = spawn_supervised(command).expect("spawn supervised process group");
+        let stdout = process.stdout().take().expect("take child stdout");
+        let mut lines = BufReader::new(stdout).lines();
+        let descendant_pid = lines
+            .next_line()
+            .await
+            .expect("read descendant pid")
+            .expect("descendant pid line");
+        let child: SharedSupervisedChild = Arc::new(Mutex::new(Some(process)));
+
+        let started_at = Instant::now();
+        supervisor.processes.write().await.insert(
+            "session-1".to_string(),
+            StopTarget {
+                agent_id: "agent-1".to_string(),
+                session_id: "session-1".to_string(),
+                child,
+            },
+        );
+        supervisor.stop_all().await.expect("stop process group");
+        assert!(started_at.elapsed() >= Duration::from_millis(100));
+
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg("kill -0 \"$1\" 2>/dev/null")
+            .arg("agenthub-supervisor-test")
+            .arg(descendant_pid)
+            .status()
+            .await
+            .expect("probe descendant process");
+        assert!(!status.success(), "descendant process should be reaped");
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -191,11 +191,11 @@ async fn wait_for_shutdown_signal() {
 }
 
 async fn run_shutdown_cleanup(state: crate::state::AppState) {
-    tracing::warn!("shutdown signal received; marking running agents exited");
-    if let Err(err) = state.agents.mark_exited_on_shutdown().await {
+    tracing::warn!("shutdown signal received; stopping supervised agent processes");
+    if let Err(err) = state.agents.stop_all_on_shutdown().await {
         tracing::error!(
             error = %err,
-            "shutdown cleanup failed to mark running agents exited"
+            "shutdown cleanup failed to stop supervised agent processes"
         );
     }
 }


### PR DESCRIPTION
## What changed

- add a daemon-owned `AgentProcessSupervisor` registry for local agent children, including processes that are still in startup
- run Unix children in dedicated process groups and Windows children in Job Objects with kill-on-drop protection
- stop all registered process trees concurrently with `SIGTERM`, a bounded graceful deadline, force kill, and a final reap pass
- serialize daemon shutdown against in-flight local starts and reject starts after shutdown begins
- write explicit-stop and shutdown terminal database state only after supervised process exit is proven
- document the stable supervision contract, implementation checkpoint, and remaining daemon-reliability phases

## Why

Shutdown previously marked running sessions as exited without stopping their local children. Explicit stop also updated terminal state before killing only the direct Tokio child. That ordering could leave provider or tool descendants alive while SQLite reported that the runtime had already ended.

## Related issue

No dedicated issue. This is the first daemon-reliability follow-up to the two-binary runtime consolidation.

## Validation

Passed:

```text
cargo fmt --all -- --check
cargo check -p agenthub --lib
cargo clippy -p agenthub --lib -- -D warnings
cargo test -p agenthub agent::manager::supervisor::tests::shutdown_waits_for_active_start_and_rejects_new_starts -- --exact
cargo test -p agenthub agent::manager::supervisor::tests::stop_all_force_kills_process_groups_and_reaps_leaders -- --exact
cargo test -p agenthub agent::manager::runtime::tests::shutdown_marks_terminal_state_only_after_process_tree_exits -- --exact
cargo test -p agenthub agent::manager::runtime::tests::stop_agent_removes_idle_gc_state_even_when_exit_watcher_exits_early -- --exact
```

Broader library run:

```text
cargo test -p agenthub --lib
```

Result: 779 passed and 3 unrelated `state::tests::initialize_services_*` tests failed in the existing `lance-namespace-impls 8.0.0` directory-manifest old-version-cleanup assertion. Running those three serially produced the same assertion.

Bazel boundary:

```text
bazel build //:agenthub_lib
```

The build stopped in the existing `lance-file 8.0.0` build script because the Bazel sandbox could not find `protoc`; the host has `/opt/homebrew/bin/protoc`. No Bazel configuration was changed.

The first GitHub exact-head run passed the ordinary Bazel root/crate suites, Cargo, Clippy, distributed P2P, and web gates. Bazel coverage exposed a Linux-only assertion issue in the new process-tree test: `kill -0` also succeeds for an already terminated zombie that is waiting for the host init process to reap it. The test now distinguishes a live descendant from a zombie while retaining the direct-child `wait()` proof. The focused Cargo test passes locally; exact-head CI is rerunning.

## Follow-ups

- database-path plus node-ID daemon instance lock and generation fencing
- globally bounded start admission, timeouts, and spawn-failure backoff
- durable Team mailbox runtime delivery receipts
- unified cancellation-aware daemon task-group shutdown
