### PR TITLE
fix(runtime): fence daemon instance ownership

### DIFF
--- a/crates/agenthub-db/src/daemon_generation.rs
+++ b/crates/agenthub-db/src/daemon_generation.rs
@@ -1,0 +1,155 @@
+use anyhow::Context;
+use sqlx::SqlitePool;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonGeneration {
+    pub node_id: String,
+    pub generation: i64,
+    pub owner_id: String,
+    pub owner_pid: i64,
+    pub claimed_at: i64,
+}
+
+pub(crate) async fn ensure_schema(pool: &SqlitePool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS daemon_generations (
+            node_id TEXT PRIMARY KEY,
+            generation INTEGER NOT NULL CHECK(generation > 0),
+            owner_id TEXT NOT NULL,
+            owner_pid INTEGER NOT NULL,
+            claimed_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .context("create daemon_generations table")?;
+    Ok(())
+}
+
+pub async fn claim_daemon_generation(
+    pool: &SqlitePool,
+    node_id: &str,
+    owner_id: &str,
+    owner_pid: i64,
+    claimed_at: i64,
+) -> anyhow::Result<DaemonGeneration> {
+    ensure_schema(pool).await?;
+    let generation = sqlx::query_scalar::<_, i64>(
+        r#"
+        INSERT INTO daemon_generations (
+            node_id,
+            generation,
+            owner_id,
+            owner_pid,
+            claimed_at,
+            updated_at
+        )
+        VALUES (?1, 1, ?2, ?3, ?4, ?4)
+        ON CONFLICT(node_id) DO UPDATE SET
+            generation = daemon_generations.generation + 1,
+            owner_id = excluded.owner_id,
+            owner_pid = excluded.owner_pid,
+            claimed_at = excluded.claimed_at,
+            updated_at = excluded.updated_at
+        RETURNING generation
+        "#,
+    )
+    .bind(node_id)
+    .bind(owner_id)
+    .bind(owner_pid)
+    .bind(claimed_at)
+    .fetch_one(pool)
+    .await
+    .context("claim daemon generation")?;
+
+    Ok(DaemonGeneration {
+        node_id: node_id.to_string(),
+        generation,
+        owner_id: owner_id.to_string(),
+        owner_pid,
+        claimed_at,
+    })
+}
+
+pub async fn is_current_daemon_generation(
+    pool: &SqlitePool,
+    generation: &DaemonGeneration,
+) -> anyhow::Result<bool> {
+    let current = sqlx::query_as::<_, (i64, String)>(
+        r#"
+        SELECT generation, owner_id
+        FROM daemon_generations
+        WHERE node_id = ?1
+        "#,
+    )
+    .bind(&generation.node_id)
+    .fetch_optional(pool)
+    .await
+    .context("read current daemon generation")?;
+
+    Ok(matches!(
+        current,
+        Some((current_generation, current_owner_id))
+            if current_generation == generation.generation
+                && current_owner_id == generation.owner_id
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
+
+    use super::{claim_daemon_generation, ensure_schema, is_current_daemon_generation};
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory database");
+        ensure_schema(&pool).await.expect("create schema");
+        pool
+    }
+
+    #[tokio::test]
+    async fn claims_increment_per_node_and_fence_stale_owners() {
+        let pool = test_pool().await;
+
+        let first = claim_daemon_generation(&pool, "main", "owner-1", 101, 1_000)
+            .await
+            .expect("claim first generation");
+        let other_node = claim_daemon_generation(&pool, "node-east", "owner-2", 102, 1_001)
+            .await
+            .expect("claim other node generation");
+        assert_eq!(first.generation, 1);
+        assert_eq!(other_node.generation, 1);
+        assert!(
+            is_current_daemon_generation(&pool, &first)
+                .await
+                .expect("verify first generation")
+        );
+
+        let replacement = claim_daemon_generation(&pool, "main", "owner-3", 103, 1_002)
+            .await
+            .expect("claim replacement generation");
+        assert_eq!(replacement.generation, 2);
+        assert!(
+            !is_current_daemon_generation(&pool, &first)
+                .await
+                .expect("reject stale generation")
+        );
+        assert!(
+            is_current_daemon_generation(&pool, &replacement)
+                .await
+                .expect("verify replacement generation")
+        );
+        assert!(
+            is_current_daemon_generation(&pool, &other_node)
+                .await
+                .expect("other node remains current")
+        );
+    }
+}

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -16,6 +16,7 @@ use tokio::sync::Mutex;
 use anyhow::Context;
 
 pub mod control_store;
+mod daemon_generation;
 pub mod message_body_outbox;
 pub mod object_uploads;
 
@@ -23,6 +24,9 @@ pub use control_store::{
     AuditEvent, ControlStoreError, IdempotentReplay, SQLITE_CONSTRAINT_UNIQUE_CODE,
     is_unique_violation, next_fencing_generation, record_audit_event,
     require_guarded_write_applied, resolve_idempotent_replay,
+};
+pub use daemon_generation::{
+    DaemonGeneration, claim_daemon_generation, is_current_daemon_generation,
 };
 pub use object_uploads::{
     NewObjectUpload, NewObjectUploadSession, NewObjectUploadSessionPart,
@@ -290,6 +294,8 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
         );
         anyhow::anyhow!("failed to open db at {}: {}", db_path.display(), err)
     })?;
+
+    daemon_generation::ensure_schema(&pool).await?;
 
     sqlx::query(
         r#"
@@ -3134,6 +3140,7 @@ mod tests {
                 'team_member_continuity_state',
                 'team_context_artifacts',
                 'team_context_flush_checkpoint',
+                'daemon_generations',
                 'object_uploads',
                 'object_download_metrics',
                 'object_download_failure_metrics',
@@ -3145,7 +3152,7 @@ mod tests {
         .fetch_one(&pool)
         .await
         .expect("count tables");
-        assert_eq!(table_count, 18);
+        assert_eq!(table_count, 19);
 
         let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
             .fetch_one(&pool)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -103,6 +103,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/npm-binary-distribution.md`
 - `docs/features/debian-systemd-distribution.md`
 - `docs/features/two-binary-runtime.md`
+- `docs/features/daemon-instance-ownership.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`
 

--- a/docs/features/daemon-instance-ownership.md
+++ b/docs/features/daemon-instance-ownership.md
@@ -1,0 +1,109 @@
+# Daemon Instance Ownership
+
+## Problem
+
+Two daemon processes configured with the same logical node identity and SQLite database can both run
+startup recovery, serve requests, and publish shutdown state. SQLite serializes individual
+transactions, but it does not establish which process owns the runtime. A replacement process also
+needs a durable generation token so delayed work from an older owner can be rejected.
+
+## Scope
+
+- Define daemon ownership by canonical database path and effective node ID.
+- Acquire ownership before database-backed startup mutations.
+- Persist a monotonically increasing generation for each node ID.
+- Fence lifecycle writes when the caller no longer owns the current generation.
+- Keep lock metadata available for local diagnostics.
+
+## Non-Goals
+
+- Distributed leader election across hosts that do not share a lock-capable filesystem.
+- Replacing SQLite transaction isolation or entity-specific generation guards.
+- Allowing two processes to serve the same node identity for availability.
+- Deleting lock files during normal shutdown.
+
+## Architecture
+
+`agenthubd` canonicalizes the configured database path and acquires an operating-system advisory file
+lock before opening the application database. The lock file is stored beside the database and its name
+is a SHA-256 digest of the canonical database path and effective node ID. Different node IDs may share
+one database, while the same node ID may independently own different databases.
+
+After the database schema is ready, but before root-user creation, startup recovery, or background
+workers, the daemon atomically claims the next row in `daemon_generations`. The in-process guard owns
+both the locked file handle and the returned generation for the full server lifetime.
+
+The lock file contains diagnostic JSON with the canonical database path, node ID, owner UUID, process
+ID, start time, and claimed generation. The file is never removed on release: closing the handle
+releases the advisory lock, while retaining the inode prevents lock-file replacement races.
+
+## Contracts
+
+### Lock Scope
+
+- At most one live process owns a `(canonical database path, effective node ID)` pair.
+- Equivalent paths, including a symlinked parent on Unix, resolve to the same lock scope.
+- A conflicting process fails startup before database initialization or recovery writes.
+- Dropping the guard releases ownership through operating-system file-handle semantics.
+
+### Generation Claim
+
+- Each successful claim for a node ID increments its durable positive integer generation.
+- Node IDs maintain independent generation sequences in the shared database.
+- A generation token is current only when both its generation number and owner UUID match the
+  authoritative row.
+- Schema creation and generation claim complete before any daemon-owned startup mutation.
+
+### Fenced Lifecycle Writes
+
+- Server startup verifies that its claimed generation remains current before accepting the runtime
+  role.
+- Shutdown cleanup verifies the generation again before publishing terminal agent state.
+- A stale owner skips shutdown cleanup rather than overwriting state published by its replacement.
+- Normal coexistence prevention is provided by the held advisory lock; generation verification is the
+  durable defense for delayed lifecycle work and future fenced operations.
+
+### Diagnostics
+
+- Lock metadata contains ownership identifiers only and must not contain credentials or configuration
+  secrets.
+- Metadata is truncated and rewritten only after the process has acquired the advisory lock.
+- Lock files may remain after a crash; their existence alone does not indicate a live owner.
+
+## Validation Matrix
+
+| Boundary | Required evidence |
+| --- | --- |
+| Same identity | A second guard for the same database and node fails while the first is held. |
+| Scope separation | Different nodes on one database and one node on different databases both succeed. |
+| Canonical path | Real and symlinked parent paths collide on Unix. |
+| Release | Dropping the guard permits a replacement guard to acquire the same identity. |
+| Generation | Claims start at one, increment per node, and reject an older owner token. |
+| Ordering | Daemon initialization claims ownership before root creation and startup recovery. |
+| Shutdown fence | Cleanup checks the generation before publishing terminal runtime state. |
+| Quality gates | Focused tests, `cargo fmt`, `cargo check`, and `cargo clippy -D warnings` pass. |
+
+## Operational Notes
+
+- The database directory must support the platform's advisory file-lock implementation.
+- Operators diagnosing a startup conflict may inspect the JSON lock file, then confirm the recorded PID
+  independently; they must not delete the file to force ownership.
+- A crash releases the operating-system lock automatically. The next owner reuses the same file and
+  advances the database generation.
+- Main and node roles use their effective configured node IDs, so one shared database can support
+  distinct node processes without sharing an ownership identity.
+
+## Open Risks
+
+- Filesystems with missing or unreliable advisory-lock semantics are unsupported for co-located daemon
+  ownership and require an external singleton supervisor.
+- Generation checks currently fence daemon lifecycle boundaries. Entity-specific asynchronous work
+  should carry its own existing lease/generation or adopt this daemon token when cross-generation
+  publication becomes possible.
+- Process supervision, global spawn scheduling, durable delivery receipts, and unified task shutdown
+  remain separate runtime-hardening slices.
+
+## Source Journals
+
+- [Daemon instance ownership fencing](../journal/2026-08-28-daemon-instance-ownership.md)
+- [Two-binary runtime consolidation](../journal/2026-08-27-two-binary-runtime-consolidation.md)

--- a/docs/journal/2026-08-28-daemon-instance-ownership.md
+++ b/docs/journal/2026-08-28-daemon-instance-ownership.md
@@ -1,0 +1,63 @@
+# Daemon Instance Ownership Fencing
+
+## Summary
+
+Added an exclusive daemon ownership boundary keyed by canonical SQLite database path and effective
+node ID. Each owner now claims a durable generation before startup mutations, and shutdown cleanup
+refuses to publish state from a stale generation.
+
+## Scope
+
+- Added an operating-system advisory lock held for the daemon lifetime.
+- Added diagnostic lock metadata without credentials or configuration secrets.
+- Added the `daemon_generations` SQLite table and atomic per-node claim operation.
+- Reordered daemon initialization so generation claim precedes root creation and startup cleanup.
+- Added a generation check before server role startup and before shutdown cleanup.
+- Added focused lock-scope, canonical-path, release, metadata, increment, and stale-owner tests.
+
+## Key Decisions
+
+- Scope ownership by canonical database path plus node ID instead of listen address. Database-backed
+  recovery and runtime state are the protected authority.
+- Keep the lock file after release and hold the lock through the open file description. Removing a lock
+  file can let another process lock a replacement inode while an old owner is still active.
+- Use a full SHA-256 digest in the lock filename so arbitrary node IDs never become filesystem paths.
+- Use the operating-system lock as the primary coexistence guard and the database generation as a
+  durable fencing token for lifecycle writes.
+- Claim the generation inside daemon-specific state initialization, after schema setup but before any
+  application mutation or worker startup.
+
+## Validation
+
+The focused gates pass:
+
+```bash
+cargo fmt --all -- --check
+cargo check -p agenthub --lib
+cargo clippy -p agenthub --lib -- -D warnings
+cargo test -p agenthub daemon_instance::tests -- --nocapture
+cargo test -p agenthub-db daemon_generation -- --nocapture
+bazel test //crates/agenthub-db:agenthub_db_tests --test_output=errors
+git diff --check
+```
+
+The daemon lock suite has three passing tests. The database generation suite has one passing test that
+covers independent node sequences, atomic replacement, current-owner verification, and stale-owner
+rejection. The full `agenthub-db` Cargo and Bazel suites both pass with 51 tests. The existing main/node
+root-user setup regressions also pass after the initialization ordering change.
+
+The broader `cargo test -p agenthub --lib` run completed with 780 passing tests and two failures. Both
+failures are the existing `state::tests::initialize_services_*` panic in
+`lance-namespace-impls 8.0.0`'s directory-manifest old-version-cleanup assertion; neither reaches the
+daemon ownership code.
+
+`bazel build //:agenthub_lib` stops before compiling the root crate because the existing
+`lance-datafusion 8.0.0` build script cannot find `protoc` inside the local Bazel sandbox. The focused
+`agenthub-db` Bazel target proves the new schema module under Bazel. No Bazel configuration was
+changed.
+
+## Follow-Ups
+
+- Validate the exact change head through Bazel CI and supported release platforms.
+- Add the global agent-start scheduler, durable mailbox delivery receipts, and unified daemon task
+  shutdown as separate reviewable runtime slices.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -34,6 +34,7 @@ rg -n "Validation|Follow-Ups|Key Decisions" docs/journal/2026-06-*.md
 | Frontend, UI, and mobile surfaces | `docs/features/frontend-design.md`, `docs/features/workspace-unified-ia.md` | `*-web-*.md`, `*-frontend-*.md`, `*-mobile-*.md`, `*-ui-*.md` |
 | Agent nodes and distributed execution | `docs/features/agent-nodes.md`, `docs/features/distributed-node-architecture.md` | `*-node-*.md`, `*-distributed-*.md`, `*-p2p-*.md` |
 | Release, packaging, and install paths | `docs/features/two-binary-runtime.md`, `docs/features/npm-binary-distribution.md`, `docs/features/debian-systemd-distribution.md` | `*-release-*.md`, `*-binary-*.md`, `*-npm-*.md`, `*-debian-*.md`, `*-homebrew-*.md` |
+| Daemon lifecycle and ownership | `docs/features/daemon-instance-ownership.md` | `*-daemon-*.md`, `*-runtime-process-*.md` |
 | CI, Bazel, coverage, and dependencies | `docs/developer-setup.md` | `*-ci-*.md`, `*-bazel-*.md`, `*-codecov-*.md`, `*-dependabot-*.md` |
 | Access control, auth, and permissions | `docs/features/access-control-and-roles.md`, `docs/features/acp-runtime.md` | `*-auth-*.md`, `*-access-control-*.md`, `*-permission-*.md` |
 | Message archive, metadata, and object storage | `docs/features/logical-message-metadata-contract.md`, `docs/features/message-archive-lancedb.md`, `docs/features/object-storage-opendal.md` | `*-message-*.md`, `*-metadata-*.md`, `*-lancedb-*.md`, `*-object-storage-*.md` |
@@ -311,6 +312,7 @@ Start with:
 - `2026-08-19-safe-paths-removal.md`
 - `2026-08-24-official-codex-0-149-1-acp-multimodal-standalone-ui.md`
 - `2026-08-27-two-binary-runtime-consolidation.md`
+- `2026-08-28-daemon-instance-ownership.md`
 - `2026-08-27-official-codex-0-150-1-upgrade.md`
 
 ## Compaction Rules

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -138,6 +138,16 @@ Stable contracts:
 
 ## Maintenance Rules
 
+- [ ] `P0` Land and validate exact-head CI for process-tree supervision and ordered daemon shutdown in
+  PR #1084. Keep terminal database state behind proven child-process exit.
+- [ ] `P1` Add a global agent-start scheduler with bounded concurrency, queue/start deadlines, and
+  spawn-failure backoff. Stable ownership boundary:
+  [features/daemon-instance-ownership.md](features/daemon-instance-ownership.md).
+- [ ] `P1` Add durable runtime delivery receipts over the Team mailbox so accepted, delivered, and
+  applied outcomes survive daemon restarts and retries.
+- [ ] `P2` Unify daemon background work under cancellation-aware task groups and await registered tasks
+  before releasing instance ownership.
+
 - [ ] `P1` Complete two-binary rollout evidence: validate the exact change head with Cargo and Bazel,
   prove Linux cross-builds, and inspect generated Debian/npm packages for exactly `agenthub` and
   `agenthubd`. Stable contract: [features/two-binary-runtime.md](features/two-binary-runtime.md);

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,7 +190,17 @@ async fn wait_for_shutdown_signal() {
     }
 }
 
-async fn run_shutdown_cleanup(state: crate::state::AppState) {
+async fn run_shutdown_cleanup(
+    state: crate::state::AppState,
+    daemon_instance: &crate::daemon_instance::DaemonInstanceGuard,
+) {
+    if let Err(err) = daemon_instance.verify_current(&state.db).await {
+        tracing::error!(
+            error = %err,
+            "shutdown cleanup skipped because daemon ownership is stale"
+        );
+        return;
+    }
     tracing::warn!("shutdown signal received; marking running agents exited");
     if let Err(err) = state.agents.mark_exited_on_shutdown().await {
         tracing::error!(
@@ -220,6 +230,7 @@ async fn run_main_server(
     state: crate::state::AppState,
     config: &agenthub_config::AppConfig,
     web_dir: Option<&str>,
+    daemon_instance: &crate::daemon_instance::DaemonInstanceGuard,
 ) -> anyhow::Result<()> {
     let _internal_grpc = crate::internal::maybe_spawn_internal_grpc(state.clone(), config).await?;
     let api_router = crate::api::router(state.clone());
@@ -243,7 +254,7 @@ async fn run_main_server(
             result?;
         }
         _ = wait_for_shutdown_signal() => {
-            run_shutdown_cleanup(state).await;
+            run_shutdown_cleanup(state, daemon_instance).await;
             let _ = shutdown_tx.send(true);
             await_server_shutdown(server.as_mut()).await?;
         }
@@ -254,6 +265,7 @@ async fn run_main_server(
 async fn run_node_server(
     state: crate::state::AppState,
     config: &agenthub_config::AppConfig,
+    daemon_instance: &crate::daemon_instance::DaemonInstanceGuard,
 ) -> anyhow::Result<()> {
     tracing::info!(
         node_id = %config.server_node_id()?,
@@ -261,7 +273,7 @@ async fn run_node_server(
     );
     let _internal_grpc = crate::internal::maybe_spawn_internal_grpc(state.clone(), config).await?;
     wait_for_shutdown_signal().await;
-    run_shutdown_cleanup(state).await;
+    run_shutdown_cleanup(state, daemon_instance).await;
     Ok(())
 }
 
@@ -318,12 +330,21 @@ pub async fn run_daemon() -> anyhow::Result<()> {
         web_dir.as_deref(),
     );
     validate_startup_config(&config)?;
+    let node_id = config.server_node_id()?;
+    let mut daemon_instance = crate::daemon_instance::DaemonInstanceGuard::acquire(
+        &agenthub_db::default_db_path(),
+        &node_id,
+    )?;
     let _pyroscope =
         agenthub_pyroscope::maybe_start_from_env(pyroscope_bootstrap_options(config.server_role()));
-    let state = crate::state::AppState::init(config.clone()).await?;
+    let state =
+        crate::state::AppState::init_for_daemon(config.clone(), &mut daemon_instance).await?;
+    daemon_instance.verify_current(&state.db).await?;
     match config.server_role() {
-        ServerRole::Main => run_main_server(state, &config, web_dir.as_deref()).await,
-        ServerRole::Node => run_node_server(state, &config).await,
+        ServerRole::Main => {
+            run_main_server(state, &config, web_dir.as_deref(), &daemon_instance).await
+        }
+        ServerRole::Node => run_node_server(state, &config, &daemon_instance).await,
     }
 }
 

--- a/src/daemon_instance.rs
+++ b/src/daemon_instance.rs
@@ -1,0 +1,307 @@
+use std::{
+    fmt::Write as _,
+    fs::{File, OpenOptions, TryLockError},
+    io::{Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(crate) struct DaemonInstanceGuard {
+    lock_file: File,
+    lock_path: PathBuf,
+    db_path: PathBuf,
+    node_id: String,
+    owner_id: String,
+    owner_pid: i64,
+    started_at: i64,
+    generation: Option<agenthub_db::DaemonGeneration>,
+}
+
+#[derive(Serialize)]
+struct LockMetadata<'a> {
+    node_id: &'a str,
+    db_path: String,
+    owner_id: &'a str,
+    owner_pid: i64,
+    started_at: i64,
+    generation: Option<i64>,
+}
+
+impl DaemonInstanceGuard {
+    pub(crate) fn acquire(db_path: &Path, node_id: &str) -> anyhow::Result<Self> {
+        let db_path = canonicalize_db_path(db_path)?;
+        let lock_path = lock_path_for(&db_path, node_id)?;
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            // Truncation must happen only after this process owns the lock.
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("open daemon instance lock {}", lock_path.display()))?;
+
+        match lock_file.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                anyhow::bail!(
+                    "daemon instance already owns node {node_id:?} for database {}; lock: {}",
+                    db_path.display(),
+                    lock_path.display()
+                );
+            }
+            Err(TryLockError::Error(error)) => {
+                return Err(error).with_context(|| {
+                    format!("acquire daemon instance lock {}", lock_path.display())
+                });
+            }
+        }
+
+        let mut guard = Self {
+            lock_file,
+            lock_path,
+            db_path,
+            node_id: node_id.to_string(),
+            owner_id: Uuid::new_v4().to_string(),
+            owner_pid: i64::from(std::process::id()),
+            started_at: chrono::Utc::now().timestamp(),
+            generation: None,
+        };
+        guard.write_metadata()?;
+        Ok(guard)
+    }
+
+    pub(crate) async fn claim_generation(&mut self, pool: &SqlitePool) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.generation.is_none(),
+            "daemon generation has already been claimed"
+        );
+        let generation = agenthub_db::claim_daemon_generation(
+            pool,
+            &self.node_id,
+            &self.owner_id,
+            self.owner_pid,
+            self.started_at,
+        )
+        .await?;
+        self.generation = Some(generation);
+        self.write_metadata()?;
+
+        tracing::info!(
+            node_id = %self.node_id,
+            owner_id = %self.owner_id,
+            generation = self.generation().expect("generation was just claimed"),
+            db_path = %self.db_path.display(),
+            lock_path = %self.lock_path.display(),
+            "daemon instance ownership claimed"
+        );
+        Ok(())
+    }
+
+    pub(crate) async fn verify_current(&self, pool: &SqlitePool) -> anyhow::Result<()> {
+        let generation = self
+            .generation
+            .as_ref()
+            .context("daemon generation has not been claimed")?;
+        if !agenthub_db::is_current_daemon_generation(pool, generation).await? {
+            anyhow::bail!(
+                "daemon generation {} for node {:?} is no longer current",
+                generation.generation,
+                self.node_id
+            );
+        }
+        Ok(())
+    }
+
+    fn generation(&self) -> Option<i64> {
+        self.generation
+            .as_ref()
+            .map(|generation| generation.generation)
+    }
+
+    fn write_metadata(&mut self) -> anyhow::Result<()> {
+        let generation = self.generation();
+        self.lock_file
+            .set_len(0)
+            .with_context(|| format!("truncate daemon lock {}", self.lock_path.display()))?;
+        self.lock_file
+            .seek(SeekFrom::Start(0))
+            .with_context(|| format!("seek daemon lock {}", self.lock_path.display()))?;
+        serde_json::to_writer_pretty(
+            &mut self.lock_file,
+            &LockMetadata {
+                node_id: &self.node_id,
+                db_path: self.db_path.display().to_string(),
+                owner_id: &self.owner_id,
+                owner_pid: self.owner_pid,
+                started_at: self.started_at,
+                generation,
+            },
+        )
+        .with_context(|| format!("write daemon lock metadata {}", self.lock_path.display()))?;
+        self.lock_file
+            .write_all(b"\n")
+            .with_context(|| format!("finish daemon lock metadata {}", self.lock_path.display()))?;
+        self.lock_file
+            .sync_data()
+            .with_context(|| format!("sync daemon lock metadata {}", self.lock_path.display()))?;
+        Ok(())
+    }
+}
+
+fn canonicalize_db_path(db_path: &Path) -> anyhow::Result<PathBuf> {
+    if db_path.exists() {
+        return db_path
+            .canonicalize()
+            .with_context(|| format!("canonicalize database path {}", db_path.display()));
+    }
+
+    let file_name = db_path
+        .file_name()
+        .context("database path must include a file name")?;
+    let parent = db_path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("create database directory {}", parent.display()))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("canonicalize database directory {}", parent.display()))?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn lock_path_for(db_path: &Path, node_id: &str) -> anyhow::Result<PathBuf> {
+    let parent = db_path
+        .parent()
+        .context("canonical database path must include a parent directory")?;
+    let mut hasher = Sha256::new();
+    hasher.update(db_path.as_os_str().as_encoded_bytes());
+    hasher.update([0]);
+    hasher.update(node_id.as_bytes());
+    let mut digest = String::with_capacity(64);
+    for byte in hasher.finalize() {
+        write!(&mut digest, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(parent.join(format!(".agenthub-daemon-{digest}.lock")))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+    use uuid::Uuid;
+
+    use super::DaemonInstanceGuard;
+
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("agenthub-daemon-lock-{name}-{}", Uuid::new_v4()))
+    }
+
+    #[test]
+    fn lock_scope_is_database_and_node_and_drop_releases_it() {
+        let first_dir = unique_temp_dir("scope-first");
+        let second_dir = unique_temp_dir("scope-second");
+        let first_db = first_dir.join("agenthub.db");
+        let second_db = second_dir.join("agenthub.db");
+
+        let first = DaemonInstanceGuard::acquire(&first_db, "main").expect("acquire first lock");
+        let same_db_same_node = DaemonInstanceGuard::acquire(&first_db, "main")
+            .expect_err("same database and node must conflict");
+        assert!(same_db_same_node.to_string().contains("already owns node"));
+
+        let same_db_other_node = DaemonInstanceGuard::acquire(&first_db, "node-east")
+            .expect("different node can share database");
+        let same_node_other_db = DaemonInstanceGuard::acquire(&second_db, "main")
+            .expect("same node can use a different database");
+
+        let lock_path = first.lock_path.clone();
+        let metadata: Value = serde_json::from_slice(
+            &std::fs::read(&lock_path).expect("read diagnostic lock metadata"),
+        )
+        .expect("parse diagnostic lock metadata");
+        assert_eq!(metadata["node_id"], "main");
+        assert_eq!(metadata["generation"], Value::Null);
+        assert!(
+            metadata["owner_id"]
+                .as_str()
+                .is_some_and(|id| !id.is_empty())
+        );
+
+        drop(first);
+        let replacement =
+            DaemonInstanceGuard::acquire(&first_db, "main").expect("dropping guard releases lock");
+
+        drop((replacement, same_db_other_node, same_node_other_db));
+        std::fs::remove_dir_all(first_dir).expect("remove first temp directory");
+        std::fs::remove_dir_all(second_dir).expect("remove second temp directory");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_paths_share_the_same_lock_scope() {
+        use std::os::unix::fs::symlink;
+
+        let dir = unique_temp_dir("canonical");
+        let real_dir = dir.join("real");
+        let alias_dir = dir.join("alias");
+        std::fs::create_dir_all(&real_dir).expect("create real directory");
+        symlink(&real_dir, &alias_dir).expect("create directory symlink");
+
+        let first = DaemonInstanceGuard::acquire(&real_dir.join("agenthub.db"), "main")
+            .expect("acquire canonical lock");
+        DaemonInstanceGuard::acquire(&alias_dir.join("agenthub.db"), "main")
+            .expect_err("symlinked database path must conflict");
+
+        drop(first);
+        std::fs::remove_dir_all(dir).expect("remove temp directory");
+    }
+
+    #[tokio::test]
+    async fn claimed_generation_updates_metadata_and_rejects_stale_owner() {
+        let dir = unique_temp_dir("generation");
+        let db_path = dir.join("agenthub.db");
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory database");
+        let mut guard =
+            DaemonInstanceGuard::acquire(&db_path, "main").expect("acquire daemon lock");
+
+        guard
+            .claim_generation(&pool)
+            .await
+            .expect("claim daemon generation");
+        guard
+            .verify_current(&pool)
+            .await
+            .expect("claimed generation is current");
+
+        let metadata: Value = serde_json::from_slice(
+            &std::fs::read(&guard.lock_path).expect("read lock metadata after claim"),
+        )
+        .expect("parse lock metadata after claim");
+        assert_eq!(metadata["generation"], 1);
+
+        agenthub_db::claim_daemon_generation(
+            &pool,
+            "main",
+            "replacement-owner",
+            999,
+            guard.started_at + 1,
+        )
+        .await
+        .expect("simulate a replacement owner");
+        let stale_error = guard
+            .verify_current(&pool)
+            .await
+            .expect_err("old generation must be fenced");
+        assert!(stale_error.to_string().contains("is no longer current"));
+
+        drop(guard);
+        pool.close().await;
+        std::fs::remove_dir_all(dir).expect("remove temp directory");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod auth;
 mod cli;
 mod cli_error;
 mod daemon_binary;
+mod daemon_instance;
 mod diagnostics;
 mod doctor_cli;
 mod init_cli;

--- a/src/state/database.rs
+++ b/src/state/database.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use agenthub_config::ServerRole;
 use sqlx::SqlitePool;
 use uuid::Uuid;
@@ -5,14 +6,19 @@ use uuid::Uuid;
 use super::AppState;
 
 impl AppState {
+    #[cfg(test)]
     pub(super) async fn setup_database(
         config: &agenthub_config::AppConfig,
     ) -> anyhow::Result<SqlitePool> {
-        let db = agenthub_db::init_db().await?;
+        let db = Self::open_database().await?;
         if config.server_role() == ServerRole::Main {
             Self::ensure_root(&db).await?;
         }
         Ok(db)
+    }
+
+    pub(super) async fn open_database() -> anyhow::Result<SqlitePool> {
+        agenthub_db::init_db().await
     }
 
     pub(super) async fn ensure_root(db: &SqlitePool) -> anyhow::Result<()> {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -51,14 +51,28 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub async fn init(config: agenthub_config::AppConfig) -> anyhow::Result<Self> {
+    pub(crate) async fn init_for_daemon(
+        config: agenthub_config::AppConfig,
+        daemon_instance: &mut crate::daemon_instance::DaemonInstanceGuard,
+    ) -> anyhow::Result<Self> {
+        Self::init_inner(config, daemon_instance).await
+    }
+
+    async fn init_inner(
+        config: agenthub_config::AppConfig,
+        daemon_instance: &mut crate::daemon_instance::DaemonInstanceGuard,
+    ) -> anyhow::Result<Self> {
+        let db = Self::open_database().await?;
+        daemon_instance.claim_generation(&db).await?;
+        if config.server_role() == agenthub_config::ServerRole::Main {
+            Self::ensure_root(&db).await?;
+        }
         if let Err(error) = Self::ensure_global_gitignore_agenthubmemory() {
             tracing::warn!(
                 ?error,
                 "failed to ensure global gitignore entry for .agenthubmemory"
             );
         }
-        let db = Self::setup_database(&config).await?;
         let linker_http = crate::linkers::AppLinkerService::default_http_client();
         let event_dbs = agenthub_db::AgentEventDbRouter::with_default_base_dir();
 


### PR DESCRIPTION
## What changed

- acquire an OS advisory lock for the canonical SQLite database path and effective node ID before daemon database initialization
- retain diagnostic lock metadata while keeping the lock file inode stable across owner handoff
- add atomic per-node daemon generations with owner UUID verification
- claim the generation before root creation, global gitignore mutation, startup recovery, or worker startup
- verify the generation before entering the server role and before shutdown cleanup publishes terminal agent state
- document the stable ownership contract, validation evidence, and remaining runtime-hardening slices

## Why

SQLite serializes transactions but does not identify which daemon process owns runtime recovery and lifecycle writes. Two processes using the same database and node ID could both run startup cleanup or publish shutdown state. The file lock prevents concurrent ownership, while the durable generation token fences delayed lifecycle work from an older owner.

## Related issue

No dedicated issue. This is the daemon ownership follow-up to the two-binary runtime consolidation and process-supervision work in #1084.

## Validation

Passed:

```text
cargo fmt --all -- --check
cargo check -p agenthub --lib
cargo clippy -p agenthub --lib -- -D warnings
cargo test -p agenthub daemon_instance::tests -- --nocapture
cargo test -p agenthub state::tests::setup_database -- --nocapture
cargo test -p agenthub-db --lib
bazel test //crates/agenthub-db:agenthub_db_tests --test_output=errors
git diff --check
```

Focused results:

- daemon ownership: 3 passed
- main/node initialization ordering: 2 passed
- agenthub-db Cargo: 51 passed
- agenthub-db Bazel: 51 passed

Broader library run:

```text
cargo test -p agenthub --lib
```

Result: 780 passed and 2 unrelated `state::tests::initialize_services_*` tests failed in the existing `lance-namespace-impls 8.0.0` directory-manifest old-version-cleanup assertion.

Bazel boundary:

```text
bazel build //:agenthub_lib
```

The root build stopped before compiling AgentHub because the existing `lance-datafusion 8.0.0` build script could not find `protoc` inside the local Bazel sandbox. The focused `agenthub-db` Bazel suite passes. No Bazel configuration was changed.

## Follow-ups

- global agent-start scheduler with bounded concurrency, deadlines, and spawn backoff
- durable Team mailbox runtime delivery receipts
- cancellation-aware daemon task-group shutdown
