### PR TITLE
fix(runtime): bound agent start scheduling

### DIFF
--- a/crates/agenthub-config/src/lib.rs
+++ b/crates/agenthub-config/src/lib.rs
@@ -9,6 +9,11 @@ const DEFAULT_CODEX_ACP_MODE: &str = "full-access";
 const DEFAULT_HISTORY_EVENT_RETENTION_DAYS: u32 = 5;
 const DEFAULT_HISTORY_DELETE_BATCH_SIZE: u32 = 10_000;
 const MAIN_SERVER_NODE_ID: &str = "main";
+const DEFAULT_AGENT_START_MAX_CONCURRENT: usize = 4;
+const DEFAULT_AGENT_START_QUEUE_TIMEOUT_SECONDS: u64 = 30;
+const DEFAULT_AGENT_START_TIMEOUT_SECONDS: u64 = 120;
+const DEFAULT_AGENT_SPAWN_BACKOFF_INITIAL_MILLIS: u64 = 250;
+const DEFAULT_AGENT_SPAWN_BACKOFF_MAX_MILLIS: u64 = 30_000;
 
 #[derive(Debug, Clone)]
 pub struct ConfigLoadInfo {
@@ -20,6 +25,7 @@ pub struct ConfigLoadInfo {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct AppConfig {
     pub server: Option<ServerConfig>,
+    pub agent_runtime: Option<AgentRuntimeConfig>,
     pub web: Option<WebConfig>,
     pub proxy: Option<ProxyConfig>,
     pub worktree: Option<WorktreeConfig>,
@@ -33,6 +39,15 @@ pub struct AppConfig {
     pub internal_grpc: Option<InternalGrpcConfig>,
     pub web_dir: Option<String>,
     pub log_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentRuntimeConfig {
+    pub start_max_concurrent: Option<usize>,
+    pub start_queue_timeout_seconds: Option<u64>,
+    pub start_timeout_seconds: Option<u64>,
+    pub spawn_backoff_initial_millis: Option<u64>,
+    pub spawn_backoff_max_millis: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -196,6 +211,55 @@ pub struct InternalGrpcBootstrapConfig {
 }
 
 impl AppConfig {
+    pub fn agent_start_max_concurrent(&self) -> usize {
+        self.agent_runtime
+            .as_ref()
+            .and_then(|config| config.start_max_concurrent)
+            .unwrap_or(DEFAULT_AGENT_START_MAX_CONCURRENT)
+            .clamp(1, 64)
+    }
+
+    pub fn agent_start_queue_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(
+            self.agent_runtime
+                .as_ref()
+                .and_then(|config| config.start_queue_timeout_seconds)
+                .unwrap_or(DEFAULT_AGENT_START_QUEUE_TIMEOUT_SECONDS)
+                .clamp(1, 300),
+        )
+    }
+
+    pub fn agent_start_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(
+            self.agent_runtime
+                .as_ref()
+                .and_then(|config| config.start_timeout_seconds)
+                .unwrap_or(DEFAULT_AGENT_START_TIMEOUT_SECONDS)
+                .clamp(1, 900),
+        )
+    }
+
+    pub fn agent_spawn_backoff_initial(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(
+            self.agent_runtime
+                .as_ref()
+                .and_then(|config| config.spawn_backoff_initial_millis)
+                .unwrap_or(DEFAULT_AGENT_SPAWN_BACKOFF_INITIAL_MILLIS)
+                .clamp(10, 60_000),
+        )
+    }
+
+    pub fn agent_spawn_backoff_max(&self) -> std::time::Duration {
+        let initial = self.agent_spawn_backoff_initial();
+        std::time::Duration::from_millis(
+            self.agent_runtime
+                .as_ref()
+                .and_then(|config| config.spawn_backoff_max_millis)
+                .unwrap_or(DEFAULT_AGENT_SPAWN_BACKOFF_MAX_MILLIS)
+                .clamp(initial.as_millis() as u64, 300_000),
+        )
+    }
+
     pub fn nowledge_mem_profile(&self, name: &str) -> anyhow::Result<NowledgeMemProfileConfig> {
         let name = name.trim();
         if name.is_empty() {
@@ -872,10 +936,62 @@ fn detect_env_overrides() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig, MessageBodyStoreConfig,
-        NowledgeMemConfig, NowledgeMemProfileConfig, NowledgeMemTeamBindingConfig,
-        ObjectStoreConfig, ServerConfig, ServerRole, WorktreeConfig,
+        AgentRuntimeConfig, AppConfig, CodexAcpConfig, HistoryConfig, MessageArchiveConfig,
+        MessageBodyStoreConfig, NowledgeMemConfig, NowledgeMemProfileConfig,
+        NowledgeMemTeamBindingConfig, ObjectStoreConfig, ServerConfig, ServerRole, WorktreeConfig,
     };
+
+    #[test]
+    fn agent_runtime_start_settings_use_bounded_defaults() {
+        let config = AppConfig::default();
+
+        assert_eq!(config.agent_start_max_concurrent(), 4);
+        assert_eq!(config.agent_start_queue_timeout().as_secs(), 30);
+        assert_eq!(config.agent_start_timeout().as_secs(), 120);
+        assert_eq!(config.agent_spawn_backoff_initial().as_millis(), 250);
+        assert_eq!(config.agent_spawn_backoff_max().as_millis(), 30_000);
+    }
+
+    #[test]
+    fn agent_runtime_start_settings_clamp_invalid_ranges() {
+        let config = AppConfig {
+            agent_runtime: Some(AgentRuntimeConfig {
+                start_max_concurrent: Some(0),
+                start_queue_timeout_seconds: Some(0),
+                start_timeout_seconds: Some(10_000),
+                spawn_backoff_initial_millis: Some(70_000),
+                spawn_backoff_max_millis: Some(10),
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(config.agent_start_max_concurrent(), 1);
+        assert_eq!(config.agent_start_queue_timeout().as_secs(), 1);
+        assert_eq!(config.agent_start_timeout().as_secs(), 900);
+        assert_eq!(config.agent_spawn_backoff_initial().as_millis(), 60_000);
+        assert_eq!(config.agent_spawn_backoff_max().as_millis(), 60_000);
+    }
+
+    #[test]
+    fn agent_runtime_start_settings_deserialize_from_toml() {
+        let config: AppConfig = toml::from_str(
+            r#"
+            [agent_runtime]
+            start_max_concurrent = 8
+            start_queue_timeout_seconds = 12
+            start_timeout_seconds = 45
+            spawn_backoff_initial_millis = 100
+            spawn_backoff_max_millis = 5000
+            "#,
+        )
+        .expect("deserialize agent runtime settings");
+
+        assert_eq!(config.agent_start_max_concurrent(), 8);
+        assert_eq!(config.agent_start_queue_timeout().as_secs(), 12);
+        assert_eq!(config.agent_start_timeout().as_secs(), 45);
+        assert_eq!(config.agent_spawn_backoff_initial().as_millis(), 100);
+        assert_eq!(config.agent_spawn_backoff_max().as_millis(), 5_000);
+    }
 
     #[test]
     fn message_body_store_is_opt_in() {

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -104,6 +104,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/debian-systemd-distribution.md`
 - `docs/features/two-binary-runtime.md`
 - `docs/features/daemon-process-supervision.md`
+- `docs/features/agent-start-scheduling.md`
 - `docs/features/app-linkers.md`
 - `docs/features/slock-oauth-linkers.md`
 

--- a/docs/features/agent-start-scheduling.md
+++ b/docs/features/agent-start-scheduling.md
@@ -1,0 +1,127 @@
+# Agent Start Scheduling
+
+## Problem
+
+Local agent starts can perform filesystem preparation, process spawning, ACP initialization, and
+session recovery. Without global admission control, a burst of starts can exhaust daemon resources.
+Without deadlines and failure backoff, blocked preparation or a repeatedly broken executable can
+hold callers indefinitely or create a tight retry loop.
+
+## Scope
+
+- Globally bound concurrent local starts within one daemon process.
+- Bound queue waiting separately from admitted start execution.
+- Bound the complete admitted local-start attempt, including workspace preparation and ACP startup.
+- Apply per-agent exponential backoff after process spawn failures.
+- Persist terminal failure state before releasing the per-agent start reservation after a timeout.
+- Cancel Git subprocesses when timed-out workspace preparation futures are dropped.
+
+## Non-Goals
+
+- Distributed admission control across multiple daemon instances.
+- Limiting remote forwarding performed by a main node. The destination node schedules its own local
+  process start.
+- Retrying a failed start automatically without a new caller request.
+- Defining a new public HTTP status-code contract for admission failures.
+- Applying spawn backoff to workspace, database, ACP protocol, or configuration failures.
+
+## Architecture
+
+`AgentManager` owns one clone-safe `AgentStartScheduler`. The scheduler contains a global semaphore
+and per-agent spawn-failure state. All `AgentManager` clones share both through `Arc` ownership.
+
+The local start sequence is:
+
+1. Reserve the agent ID with the existing duplicate-start guard.
+2. Reject an active per-agent spawn backoff.
+3. Wait for the global semaphore with the configured queue deadline.
+4. Recheck spawn backoff after admission.
+5. Acquire the process supervisor lifecycle permit.
+6. Run the complete local start under the configured start deadline.
+7. On timeout, stop the tracked supervised session, remove matching in-memory handles, persist the
+   failed session and agent state, and only then release the per-agent reservation.
+
+Queue waiting intentionally occurs before acquiring the supervisor lifecycle permit. Daemon
+shutdown can therefore close the lifecycle gate without waiting for queued starts. A waiter admitted
+after shutdown begins fails when it attempts to acquire that gate.
+
+Each start attempt publishes its generated session ID to a timeout cleanup tracker before workspace
+preparation begins. Resume fallback replaces the tracked ID before starting its next attempt, so
+cleanup always targets the current launch.
+
+## Contracts
+
+### Admission
+
+- The default concurrent local-start limit is 4.
+- The default queue timeout is 30 seconds.
+- The default admitted-start timeout is 120 seconds.
+- A queued request retains the existing per-agent start reservation, so another request for the same
+  agent fails instead of entering the queue.
+- Remote forwarding does not consume a main node's local-start permit.
+
+### Timeout Cleanup
+
+- A timeout response is not returned until process cleanup and durable failure-state persistence
+  complete.
+- Cleanup stops the current session through `AgentProcessSupervisor`, preserving process-tree
+  termination semantics.
+- A session row is inserted or updated to `failed` with `ended_at` populated.
+- The agent row is updated to `failed` after the supervised process has exited.
+- If process termination or failure-state persistence fails, the caller receives a cleanup error and
+  AgentHub does not falsely claim that an unconfirmed process is terminal.
+- A late timeout cannot remove an in-memory handle for a newer session because removal compares the
+  tracked session ID.
+
+### Spawn Failure Backoff
+
+- Only `AgentExecutor::spawn_process` failures increment backoff.
+- The default initial delay is 250 milliseconds and the default maximum is 30 seconds.
+- Delay doubles after each failed spawn and saturates at the configured maximum.
+- Failure count remains across elapsed retry windows and clears immediately after a successful spawn.
+- Admission checks backoff both before queueing and after acquiring a permit.
+
+### Configuration
+
+The optional `[agent_runtime]` section accepts:
+
+| Setting | Default | Accepted effective range |
+| --- | ---: | ---: |
+| `start_max_concurrent` | `4` | `1..=64` |
+| `start_queue_timeout_seconds` | `30` | `1..=300` |
+| `start_timeout_seconds` | `120` | `1..=900` |
+| `spawn_backoff_initial_millis` | `250` | `10..=60000` |
+| `spawn_backoff_max_millis` | `30000` | `initial..=300000` |
+
+Values outside these ranges are clamped. Effective values are logged during daemon startup.
+
+## Validation Matrix
+
+| Scenario | Expected result |
+| --- | --- |
+| One permit is held and another agent queues | The second request fails after the queue deadline |
+| A permit is released before the queue deadline | The next request is admitted |
+| A local executor never completes spawn | The start times out, reservation is released, and durable agent/session state is `failed` |
+| Spawn fails and the caller retries immediately | The retry is rejected without another spawn attempt |
+| Spawn fails again after the first delay | The next delay doubles up to the configured maximum |
+| Spawn succeeds after earlier failures | Backoff state is cleared |
+| Workspace Git preparation is canceled | Its Git subprocess is killed on drop |
+| Daemon shutdown begins while starts are queued | Queued starts do not hold the supervisor lifecycle gate |
+
+## Operational Notes
+
+- Repeated `agent spawn backoff active` errors usually indicate a missing or broken agent executable.
+- `agent start queue timed out` indicates local admission saturation; increase concurrency only after
+  checking CPU, memory, filesystem, and provider startup pressure.
+- `agent start timed out` covers the complete admitted local start, not only OS process creation.
+- Configuration changes take effect after daemon restart.
+
+## Open Risks
+
+- Backoff state is process-local and resets on daemon restart.
+- Admission errors currently use existing API error mapping rather than a dedicated overload status.
+- Non-Git workspace preparation code must independently preserve cancellation safety.
+
+## Source Journals
+
+- [2026-08-28 Agent Start Scheduler](../journal/2026-08-28-agent-start-scheduler.md)

--- a/docs/journal/2026-08-28-agent-start-scheduler.md
+++ b/docs/journal/2026-08-28-agent-start-scheduler.md
@@ -1,0 +1,45 @@
+# Agent Start Scheduler
+
+Date: 2026-08-28
+
+## Context
+
+The daemon process supervisor establishes process ownership and ordered termination, but start
+requests still needed resource admission, bounded waiting, an end-to-end deadline, and protection
+against repeated executable spawn failures.
+
+## Implementation
+
+- Added one shared local-start semaphore to `AgentManager`.
+- Kept queue waiting outside the supervisor lifecycle permit so shutdown is not coupled to queued
+  work.
+- Added separate queue and admitted-start deadlines.
+- Added timeout cleanup that stops the current supervised session before persisting terminal agent
+  and session failure state and releasing the per-agent reservation.
+- Added per-agent exponential spawn-failure backoff that clears only after a successful process spawn.
+- Made worktree Git preparation subprocesses kill-on-drop for cancellation safety.
+- Added bounded `[agent_runtime]` configuration and startup logging of effective values.
+
+## Validation Checklist
+
+```bash
+cargo test -p agenthub-config --lib agent_runtime_start_settings
+cargo test -p agenthub --lib agent::manager::start_scheduler::tests -- --nocapture
+cargo test -p agenthub --lib agent::manager::session::tests::start_timeout_persists_failure_before_releasing_reservation -- --exact --nocapture
+cargo test -p agenthub --lib agent::manager::session::tests::spawn_failure_backoff_rejects_immediate_retry_without_respawn -- --exact --nocapture
+cargo check -p agenthub --lib
+cargo clippy -p agenthub --lib -- -D warnings
+```
+
+The targeted cases cover global admission timeout, permit reuse, growing and capped spawn backoff,
+successful-spawn reset, durable timeout failure state, per-agent reservation release, and immediate
+retry rejection without a second spawn.
+
+## Follow-up
+
+- Add durable delivery receipts for Team mailbox messages that cross the runtime boundary.
+- Move remaining background workers and runtime watchers into one cancellation-aware task group.
+
+## Canonical Contract
+
+- [Agent Start Scheduling](../features/agent-start-scheduling.md)

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -314,6 +314,7 @@ Start with:
 - `2026-08-27-two-binary-runtime-consolidation.md`
 - `2026-08-27-official-codex-0-150-1-upgrade.md`
 - `2026-08-28-daemon-process-supervision.md`
+- `2026-08-28-agent-start-scheduler.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -95,8 +95,6 @@ Stable contracts:
 - [ ] `P0` Add an exclusive daemon instance lock scoped by canonical database path plus node ID, and
   persist a daemon generation so stale owners cannot publish runtime state after replacement. Stable
   process ownership contract: [features/daemon-process-supervision.md](features/daemon-process-supervision.md).
-- [ ] `P1` Add globally bounded local-start admission with queue timeout, spawn timeout, and
-  failure-class backoff. Preserve the supervisor lifecycle gate and per-agent duplicate-start guard.
 - [ ] `P1` Add durable Team mailbox delivery receipts for runtime-bound messages, including stable
   delivery IDs, idempotent acknowledgement, retry state, and restart recovery.
 - [ ] `P2` Move daemon background workers and runtime watchers into one cancellation-aware task group

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -6,6 +6,7 @@ mod process;
 mod runtime;
 mod session;
 mod start_plan;
+mod start_scheduler;
 mod store;
 mod supervisor;
 mod worktree;
@@ -33,6 +34,8 @@ use self::nodes::{
     delete_agent_node_record, get_agent_node_row, insert_agent_node_record, list_agent_node_rows,
     touch_agent_node_last_seen, update_agent_node_record,
 };
+use self::start_scheduler::AgentStartScheduler;
+pub(crate) use self::start_scheduler::AgentStartSchedulerSettings;
 use self::store::{
     AgentInsertRecord, AgentSchemaCaps, RemoteManagedAgentUpsert, decode_agent_record,
     get_agent_row, insert_agent_record, list_agent_rows, upsert_remote_managed_agent_record,
@@ -72,6 +75,7 @@ pub struct AgentManager {
     auth: Arc<AuthService>,
     local_executor: Arc<dyn AgentExecutor>,
     process_supervisor: AgentProcessSupervisor,
+    start_scheduler: AgentStartScheduler,
     codex_acp_binary: String,
     acp_default_mode: Option<String>,
     codex_acp_multi_agent_enabled: bool,
@@ -801,6 +805,7 @@ impl AgentManager {
                 process_supervisor.clone(),
             )),
             process_supervisor,
+            start_scheduler: AgentStartScheduler::default(),
             codex_acp_binary,
             acp_default_mode,
             codex_acp_multi_agent_enabled,
@@ -812,6 +817,14 @@ impl AgentManager {
             starting: Arc::new(Mutex::new(HashSet::new())),
             inner: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    pub(crate) fn with_start_scheduler_settings(
+        mut self,
+        settings: AgentStartSchedulerSettings,
+    ) -> Self {
+        self.start_scheduler = AgentStartScheduler::new(settings);
+        self
     }
 
     /// Attach the rebuildable message index store. Agent event reads use it only when the per-agent

--- a/src/agent/manager/session.rs
+++ b/src/agent/manager/session.rs
@@ -377,9 +377,42 @@ impl AgentManager {
                 agent,
                 actor_context,
             } => {
-                let _start_permit = self.process_supervisor.acquire_start_permit().await?;
                 self.reserve_agent_start(agent_id).await?;
-                let result = self.start_local_agent(agent, actor_context).await;
+                let result = async {
+                    let admission = self.start_scheduler.acquire(agent_id).await?;
+                    let session_tracker = Arc::new(Mutex::new(None));
+                    match tokio::time::timeout(
+                        admission.start_timeout(),
+                        async {
+                            let _start_permit =
+                                self.process_supervisor.acquire_start_permit().await?;
+                            self.start_local_agent(
+                                agent,
+                                actor_context,
+                                session_tracker.clone(),
+                            )
+                            .await
+                        },
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_) => {
+                            self.cleanup_timed_out_start(agent_id, &session_tracker)
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "agent start timed out and cleanup failed: agent_id={agent_id}"
+                                    )
+                                })?;
+                            anyhow::bail!(
+                                "agent start timed out: agent_id={agent_id} timeout_ms={}",
+                                admission.start_timeout().as_millis()
+                            );
+                        }
+                    }
+                }
+                .await;
                 self.release_agent_start(agent_id).await;
                 result
             }
@@ -407,8 +440,9 @@ impl AgentManager {
         &self,
         agent: crate::agent::AgentRecord,
         actor_context: Option<AcpActorSkillContext>,
+        session_tracker: Arc<Mutex<Option<String>>>,
     ) -> anyhow::Result<String> {
-        self.start_local_agent_with_resume_fallback(agent, actor_context, true)
+        self.start_local_agent_with_resume_fallback(agent, actor_context, true, session_tracker)
             .await
     }
 
@@ -417,10 +451,12 @@ impl AgentManager {
         agent: crate::agent::AgentRecord,
         actor_context: Option<AcpActorSkillContext>,
         allow_resume_retry: bool,
+        session_tracker: Arc<Mutex<Option<String>>>,
     ) -> anyhow::Result<String> {
         // This UUID tracks the current AgentHub runtime launch only. ACP/Codex continuity
         // can still resume a previously persisted provider session later in this method.
         let session_id = Uuid::new_v4().to_string();
+        *session_tracker.lock().await = Some(session_id.clone());
         let actor_context = actor_context.map(normalize_actor_context).transpose()?;
         let persisted_workdir = super::expand_tilde(&agent.workdir);
         let persisted_worktree_repo = agent.worktree_repo.as_deref().map(super::expand_tilde);
@@ -563,6 +599,7 @@ impl AgentManager {
         {
             Ok(execution) => execution,
             Err(err) => {
+                let backoff = self.start_scheduler.record_spawn_failure(&agent.id).await;
                 if let Err(record_err) = self
                     .record_failed_session(&agent.id, &session_id, &err.to_string())
                     .await
@@ -587,12 +624,14 @@ impl AgentManager {
                 }
                 tracing::error!("spawn failed: {} error={}", spawn_summary, err);
                 return Err(anyhow::anyhow!(
-                    "spawn failed: {} error={}",
+                    "spawn failed: {} error={} retry_after_ms={}",
                     spawn_summary,
-                    err
+                    err,
+                    backoff.as_millis()
                 ));
             }
         };
+        self.start_scheduler.clear_spawn_failures(&agent.id).await;
         let SpawnedLocalProcess {
             child,
             registration,
@@ -1047,12 +1086,60 @@ impl AgentManager {
                     agent,
                     actor_context,
                     false,
+                    session_tracker,
                 ))
                 .await;
             }
         }
 
         Ok(session_id)
+    }
+
+    async fn cleanup_timed_out_start(
+        &self,
+        agent_id: &str,
+        session_tracker: &Arc<Mutex<Option<String>>>,
+    ) -> anyhow::Result<()> {
+        let session_id = session_tracker.lock().await.clone();
+        if let Some(session_id) = session_id.as_deref() {
+            self.process_supervisor
+                .stop_session(session_id)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to stop timed-out agent process: agent_id={agent_id} session_id={session_id}"
+                    )
+                })?;
+            let removed = {
+                let mut guard = self.inner.write().await;
+                if Self::handle_matches_session(guard.get(agent_id), session_id) {
+                    guard.remove(agent_id)
+                } else {
+                    None
+                }
+            };
+            if let Some(handle) = removed
+                && let Some(controller) = handle.loop_controller
+            {
+                controller.stop();
+            }
+            self.record_failed_session(agent_id, session_id, "agent start timed out")
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to record timed-out agent start: agent_id={agent_id} session_id={session_id}"
+                    )
+                })?;
+        }
+        self.update_agent_status(agent_id, AgentStatus::Failed)
+            .await
+            .with_context(|| {
+                format!("failed to update agent status after start timeout: agent_id={agent_id}")
+            })?;
+        if let Some(idle_gc) = &self.idle_gc {
+            idle_gc.remove_agent(agent_id).await;
+        }
+        Ok(())
     }
 
     #[tracing::instrument(skip(self), fields(agent_id = %agent_id), err)]
@@ -1153,7 +1240,12 @@ impl AgentManager {
     ) -> anyhow::Result<()> {
         let now = Utc::now().timestamp();
         let seq = Uuid::now_v7().to_string();
-        if let Err(err) = sqlx::query(
+        let mut transaction = self.db.begin().await.with_context(|| {
+            format!(
+                "failed to begin failed-session transaction: agent_id={agent_id} session_id={session_id}"
+            )
+        })?;
+        sqlx::query(
             r#"
             INSERT OR IGNORE INTO agent_sessions (id, agent_id, status, started_at, ended_at)
             VALUES (?1, ?2, 'failed', ?3, ?4)
@@ -1163,17 +1255,14 @@ impl AgentManager {
         .bind(agent_id)
         .bind(now)
         .bind(now)
-        .execute(&self.db)
+        .execute(&mut *transaction)
         .await
-        {
-            tracing::warn!(
-                agent_id = %agent_id,
-                session_id = %session_id,
-                error = %err,
-                "failed to persist failed agent session row"
-            );
-        }
-        if let Err(err) = sqlx::query(
+        .with_context(|| {
+            format!(
+                "failed to insert failed agent session row: agent_id={agent_id} session_id={session_id}"
+            )
+        })?;
+        sqlx::query(
             r#"
             UPDATE agent_sessions
             SET status = 'failed', ended_at = ?1
@@ -1183,16 +1272,18 @@ impl AgentManager {
         .bind(now)
         .bind(session_id)
         .bind(agent_id)
-        .execute(&self.db)
+        .execute(&mut *transaction)
         .await
-        {
-            tracing::warn!(
-                agent_id = %agent_id,
-                session_id = %session_id,
-                error = %err,
-                "failed to update failed agent session row"
-            );
-        }
+        .with_context(|| {
+            format!(
+                "failed to update failed agent session row: agent_id={agent_id} session_id={session_id}"
+            )
+        })?;
+        transaction.commit().await.with_context(|| {
+            format!(
+                "failed to commit failed-session transaction: agent_id={agent_id} session_id={session_id}"
+            )
+        })?;
 
         let failure_message = format!("start failed: {}", message);
         if let Err(err) = persist_agent_event(
@@ -1221,6 +1312,12 @@ impl AgentManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use sqlx::Row;
+
     use super::{
         RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY, RESUMED_ACP_SESSION_GRACE_PERIOD,
         RESUMED_ACP_SESSION_POLL_INTERVAL, ResumedSessionStartupState,
@@ -1228,10 +1325,82 @@ mod tests {
         should_retry_resumed_acp_session,
     };
     use crate::agent::manager::supervisor::SharedSupervisedChild;
+    use crate::agent::manager::{
+        AgentManager, AgentStartSchedulerSettings,
+        executor::{AgentExecutor, LocalExecutionRequest, SpawnedLocalProcess},
+    };
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::process::Command;
     use tokio::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct HangingExecutor;
+
+    #[async_trait]
+    impl AgentExecutor for HangingExecutor {
+        async fn spawn_process(
+            &self,
+            _request: LocalExecutionRequest,
+        ) -> anyhow::Result<SpawnedLocalProcess> {
+            std::future::pending().await
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FailingExecutor {
+        attempts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl AgentExecutor for FailingExecutor {
+        async fn spawn_process(
+            &self,
+            _request: LocalExecutionRequest,
+        ) -> anyhow::Result<SpawnedLocalProcess> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("synthetic spawn failure")
+        }
+    }
+
+    async fn build_scheduled_test_manager(
+        executor: Arc<dyn AgentExecutor>,
+        settings: AgentStartSchedulerSettings,
+    ) -> (AgentManager, String) {
+        let state = crate::api::team_tests::build_test_state().await;
+        let mut agents = AgentManager::new(
+            state.db.clone(),
+            state.agents.event_dbs.clone(),
+            None,
+            state.push.clone(),
+            Vec::new(),
+            "agenthubd".to_string(),
+            None,
+            true,
+            state.acp_permissions.clone(),
+            state.auth.clone(),
+        )
+        .with_start_scheduler_settings(settings);
+        agents.local_executor = executor;
+
+        let agent_id = format!("scheduled-agent-{}", uuid::Uuid::new_v4());
+        let now = Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT INTO agents (
+                id, name, workdir, command, args, worktree_mode, status, created_at, updated_at
+            )
+            VALUES (?1, ?2, '/tmp', 'synthetic-agent', '[]', 'use_existing', 'stopped', ?3, ?3)
+            "#,
+        )
+        .bind(&agent_id)
+        .bind(&agent_id)
+        .bind(now)
+        .execute(&state.db)
+        .await
+        .expect("insert scheduled test agent");
+        (agents, agent_id)
+    }
 
     #[test]
     fn should_retry_resumed_acp_session_only_on_failed_matching_resume() {
@@ -1274,6 +1443,67 @@ mod tests {
         assert!(should_force_fresh_session_after_resume_failures(
             RESUMED_ACP_SESSION_FAILURES_BEFORE_FRESH_RETRY + 1
         ));
+    }
+
+    #[tokio::test]
+    async fn start_timeout_persists_failure_before_releasing_reservation() {
+        let settings = AgentStartSchedulerSettings {
+            max_concurrent_starts: 1,
+            queue_timeout: Duration::from_millis(100),
+            start_timeout: Duration::from_millis(25),
+            spawn_backoff_initial: Duration::from_millis(20),
+            spawn_backoff_max: Duration::from_millis(40),
+        };
+        let (agents, agent_id) =
+            build_scheduled_test_manager(Arc::new(HangingExecutor), settings).await;
+
+        let error = agents
+            .start_agent(&agent_id)
+            .await
+            .expect_err("hanging start must time out");
+        assert!(error.to_string().contains("agent start timed out"));
+        assert!(!agents.starting.lock().await.contains(&agent_id));
+
+        let agent_status: String = sqlx::query_scalar("SELECT status FROM agents WHERE id = ?1")
+            .bind(&agent_id)
+            .fetch_one(&agents.db)
+            .await
+            .expect("read timed-out agent status");
+        assert_eq!(agent_status, "failed");
+        let session = sqlx::query(
+            "SELECT status, ended_at FROM agent_sessions WHERE agent_id = ?1 ORDER BY started_at DESC LIMIT 1",
+        )
+        .bind(&agent_id)
+        .fetch_one(&agents.db)
+        .await
+        .expect("read timed-out session");
+        assert_eq!(session.get::<String, _>("status"), "failed");
+        assert!(session.get::<Option<i64>, _>("ended_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn spawn_failure_backoff_rejects_immediate_retry_without_respawn() {
+        let settings = AgentStartSchedulerSettings {
+            max_concurrent_starts: 1,
+            queue_timeout: Duration::from_millis(100),
+            start_timeout: Duration::from_secs(1),
+            spawn_backoff_initial: Duration::from_secs(1),
+            spawn_backoff_max: Duration::from_secs(2),
+        };
+        let executor = Arc::new(FailingExecutor::default());
+        let (agents, agent_id) = build_scheduled_test_manager(executor.clone(), settings).await;
+
+        let first_error = agents
+            .start_agent(&agent_id)
+            .await
+            .expect_err("synthetic spawn must fail");
+        assert!(first_error.to_string().contains("retry_after_ms"));
+        let retry_error = agents
+            .start_agent(&agent_id)
+            .await
+            .expect_err("immediate retry must hit spawn backoff");
+        assert!(retry_error.to_string().contains("spawn backoff active"));
+        assert_eq!(executor.attempts.load(Ordering::SeqCst), 1);
     }
 
     #[cfg(unix)]

--- a/src/agent/manager/start_scheduler.rs
+++ b/src/agent/manager/start_scheduler.rs
@@ -1,0 +1,217 @@
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+
+const DEFAULT_MAX_CONCURRENT_STARTS: usize = 4;
+const DEFAULT_QUEUE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_START_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_SPAWN_BACKOFF_INITIAL: Duration = Duration::from_millis(250);
+const DEFAULT_SPAWN_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AgentStartSchedulerSettings {
+    pub max_concurrent_starts: usize,
+    pub queue_timeout: Duration,
+    pub start_timeout: Duration,
+    pub spawn_backoff_initial: Duration,
+    pub spawn_backoff_max: Duration,
+}
+
+impl Default for AgentStartSchedulerSettings {
+    fn default() -> Self {
+        Self {
+            max_concurrent_starts: DEFAULT_MAX_CONCURRENT_STARTS,
+            queue_timeout: DEFAULT_QUEUE_TIMEOUT,
+            start_timeout: DEFAULT_START_TIMEOUT,
+            spawn_backoff_initial: DEFAULT_SPAWN_BACKOFF_INITIAL,
+            spawn_backoff_max: DEFAULT_SPAWN_BACKOFF_MAX,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AgentStartScheduler {
+    settings: AgentStartSchedulerSettings,
+    permits: Arc<Semaphore>,
+    spawn_failures: Arc<Mutex<HashMap<String, SpawnFailureState>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SpawnFailureState {
+    consecutive_failures: u32,
+    retry_at: Instant,
+}
+
+#[derive(Debug)]
+pub(super) struct AgentStartAdmission {
+    _permit: OwnedSemaphorePermit,
+    start_timeout: Duration,
+}
+
+impl AgentStartAdmission {
+    pub(super) fn start_timeout(&self) -> Duration {
+        self.start_timeout
+    }
+}
+
+impl AgentStartScheduler {
+    pub(super) fn new(settings: AgentStartSchedulerSettings) -> Self {
+        let max_concurrent_starts = settings.max_concurrent_starts.max(1);
+        let settings = AgentStartSchedulerSettings {
+            max_concurrent_starts,
+            spawn_backoff_max: settings
+                .spawn_backoff_max
+                .max(settings.spawn_backoff_initial),
+            ..settings
+        };
+        Self {
+            settings,
+            permits: Arc::new(Semaphore::new(max_concurrent_starts)),
+            spawn_failures: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub(super) async fn acquire(&self, agent_id: &str) -> anyhow::Result<AgentStartAdmission> {
+        self.reject_active_backoff(agent_id).await?;
+        let queued_at = Instant::now();
+        let permit = tokio::time::timeout(
+            self.settings.queue_timeout,
+            self.permits.clone().acquire_owned(),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "agent start queue timed out: agent_id={agent_id} timeout_ms={}",
+                self.settings.queue_timeout.as_millis()
+            )
+        })?
+        .map_err(|_| anyhow::anyhow!("agent start scheduler is closed"))?;
+        self.reject_active_backoff(agent_id).await?;
+
+        tracing::debug!(
+            agent_id,
+            queue_wait_ms = queued_at.elapsed().as_millis(),
+            max_concurrent_starts = self.settings.max_concurrent_starts,
+            "agent start admitted"
+        );
+        Ok(AgentStartAdmission {
+            _permit: permit,
+            start_timeout: self.settings.start_timeout,
+        })
+    }
+
+    pub(super) async fn record_spawn_failure(&self, agent_id: &str) -> Duration {
+        let mut failures = self.spawn_failures.lock().await;
+        let consecutive_failures = failures
+            .get(agent_id)
+            .map(|state| state.consecutive_failures.saturating_add(1))
+            .unwrap_or(1);
+        let exponent = consecutive_failures.saturating_sub(1).min(31);
+        let multiplier = 1_u32 << exponent;
+        let delay = self
+            .settings
+            .spawn_backoff_initial
+            .saturating_mul(multiplier)
+            .min(self.settings.spawn_backoff_max);
+        failures.insert(
+            agent_id.to_string(),
+            SpawnFailureState {
+                consecutive_failures,
+                retry_at: Instant::now() + delay,
+            },
+        );
+        delay
+    }
+
+    pub(super) async fn clear_spawn_failures(&self, agent_id: &str) {
+        self.spawn_failures.lock().await.remove(agent_id);
+    }
+
+    async fn reject_active_backoff(&self, agent_id: &str) -> anyhow::Result<()> {
+        let now = Instant::now();
+        let failures = self.spawn_failures.lock().await;
+        let Some(state) = failures.get(agent_id).copied() else {
+            return Ok(());
+        };
+        if state.retry_at <= now {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "agent spawn backoff active: agent_id={agent_id} retry_after_ms={} consecutive_failures={}",
+            state.retry_at.saturating_duration_since(now).as_millis(),
+            state.consecutive_failures
+        )
+    }
+}
+
+impl Default for AgentStartScheduler {
+    fn default() -> Self {
+        Self::new(AgentStartSchedulerSettings::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{AgentStartScheduler, AgentStartSchedulerSettings};
+
+    fn test_settings() -> AgentStartSchedulerSettings {
+        AgentStartSchedulerSettings {
+            max_concurrent_starts: 1,
+            queue_timeout: Duration::from_millis(25),
+            start_timeout: Duration::from_millis(50),
+            spawn_backoff_initial: Duration::from_millis(20),
+            spawn_backoff_max: Duration::from_millis(40),
+        }
+    }
+
+    #[tokio::test]
+    async fn bounds_concurrent_start_admission_and_times_out_queue_waiters() {
+        let scheduler = AgentStartScheduler::new(test_settings());
+        let first = scheduler.acquire("agent-1").await.expect("first admission");
+
+        let error = scheduler
+            .acquire("agent-2")
+            .await
+            .expect_err("second admission should time out");
+        assert!(error.to_string().contains("start queue timed out"));
+
+        drop(first);
+        let second = scheduler
+            .acquire("agent-2")
+            .await
+            .expect("permit released after first admission");
+        assert_eq!(second.start_timeout(), Duration::from_millis(50));
+    }
+
+    #[tokio::test]
+    async fn spawn_backoff_grows_caps_and_clears_after_success() {
+        let scheduler = AgentStartScheduler::new(test_settings());
+
+        assert_eq!(
+            scheduler.record_spawn_failure("agent-1").await,
+            Duration::from_millis(20)
+        );
+        assert!(scheduler.acquire("agent-1").await.is_err());
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            scheduler.record_spawn_failure("agent-1").await,
+            Duration::from_millis(40)
+        );
+        assert_eq!(
+            scheduler.record_spawn_failure("agent-1").await,
+            Duration::from_millis(40)
+        );
+
+        scheduler.clear_spawn_failures("agent-1").await;
+        scheduler
+            .acquire("agent-1")
+            .await
+            .expect("successful spawn clears backoff");
+    }
+}

--- a/src/agent/manager/worktree.rs
+++ b/src/agent/manager/worktree.rs
@@ -13,7 +13,12 @@ pub(super) struct GitWorktreeEntry {
 
 pub(super) fn git_command_without_fsmonitor() -> Command {
     let mut command = Command::new("git");
-    command.arg("-c").arg("core.fsmonitor=false");
+    command
+        .arg("-c")
+        .arg("core.fsmonitor=false")
+        // Start deadlines cancel preparation futures; their Git subprocesses
+        // must not outlive the canceled start attempt.
+        .kill_on_drop(true);
     command
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,8 +10,8 @@ pub use agenthub_agent_domain::{
     AgentConfig, AgentEvent, AgentNodeConfig, AgentNodeJoinBootstrapInfo, AgentNodeRecord,
     AgentNodeUpdate, AgentOutput, AgentRecord, AgentStatus, OutputStream, WorktreeMode,
 };
-pub(crate) use manager::derive_team_runtime_workdir;
 pub use manager::{AgentInputImage, AgentManager, AgentSendInputError};
+pub(crate) use manager::{AgentStartSchedulerSettings, derive_team_runtime_workdir};
 pub use triggers::{
     AgentTimeTriggerCreateInput, AgentTimeTriggerManager, AgentTimeTriggerRecord,
     AgentTimeTriggerWorker, AgentTimeTriggerWorkerSettings,

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,6 +97,26 @@ fn log_config_details(
         "config codex_acp_multi_agent_enabled: {}",
         config.codex_acp_multi_agent_enabled()
     );
+    tracing::info!(
+        "config agent_runtime.start_max_concurrent: {}",
+        config.agent_start_max_concurrent()
+    );
+    tracing::info!(
+        "config agent_runtime.start_queue_timeout_seconds: {}",
+        config.agent_start_queue_timeout().as_secs()
+    );
+    tracing::info!(
+        "config agent_runtime.start_timeout_seconds: {}",
+        config.agent_start_timeout().as_secs()
+    );
+    tracing::info!(
+        "config agent_runtime.spawn_backoff_initial_millis: {}",
+        config.agent_spawn_backoff_initial().as_millis()
+    );
+    tracing::info!(
+        "config agent_runtime.spawn_backoff_max_millis: {}",
+        config.agent_spawn_backoff_max().as_millis()
+    );
     if config.server_role() == ServerRole::Node {
         tracing::info!("config push settings: disabled in node mode");
     } else {

--- a/src/state/service_factories.rs
+++ b/src/state/service_factories.rs
@@ -4,7 +4,7 @@ use agenthub_config::ServerRole;
 use sqlx::SqlitePool;
 
 use crate::acp::AcpPermissionService;
-use crate::agent::AgentManager;
+use crate::agent::{AgentManager, AgentStartSchedulerSettings};
 use crate::auth::AuthService;
 use crate::push::PushService;
 use crate::team::TeamManager;
@@ -59,6 +59,13 @@ pub(super) fn build_agent_manager(args: AgentManagerBuildArgs<'_>) -> Arc<AgentM
             args.auth,
             args.internal_peer_client,
         )
+        .with_start_scheduler_settings(AgentStartSchedulerSettings {
+            max_concurrent_starts: args.config.agent_start_max_concurrent(),
+            queue_timeout: args.config.agent_start_queue_timeout(),
+            start_timeout: args.config.agent_start_timeout(),
+            spawn_backoff_initial: args.config.agent_spawn_backoff_initial(),
+            spawn_backoff_max: args.config.agent_spawn_backoff_max(),
+        })
         .with_message_index(args.message_index)
         .with_read_repair_scheduler(args.read_repair),
     )

--- a/userdocs/docs/getting-started/configuration-basics.md
+++ b/userdocs/docs/getting-started/configuration-basics.md
@@ -99,6 +99,31 @@ Worktree creation settings.
 |--------|------|---------|-------------|
 | `default_root` | string | `"~/.agenthub/worktrees"` | Base directory for new worktrees |
 
+### `[agent_runtime]` Section
+
+Local agent start admission and failure protection.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `start_max_concurrent` | integer | `4` | Maximum local starts admitted at once (1-64) |
+| `start_queue_timeout_seconds` | integer | `30` | Maximum wait for a local-start permit (1-300) |
+| `start_timeout_seconds` | integer | `120` | Maximum time for an admitted local start, including workspace and ACP setup (1-900) |
+| `spawn_backoff_initial_millis` | integer | `250` | Initial delay after an executable spawn failure (10-60000) |
+| `spawn_backoff_max_millis` | integer | `30000` | Maximum exponential spawn delay (initial-300000) |
+
+```toml
+[agent_runtime]
+start_max_concurrent = 4
+start_queue_timeout_seconds = 30
+start_timeout_seconds = 120
+spawn_backoff_initial_millis = 250
+spawn_backoff_max_millis = 30000
+```
+
+These limits apply independently on every daemon node. Remote starts consume capacity on the node
+that launches the process, not on the node that forwards the request. Out-of-range values are
+clamped and effective values are logged at startup.
+
 ### `[codex_acp]` Section
 
 ACP (Agent Control Protocol) provider settings.


### PR DESCRIPTION
## Summary

- bound concurrent local agent starts with one daemon-wide scheduler
- add separate queue and admitted-start deadlines with supervised timeout cleanup
- add per-agent exponential backoff for executable spawn failures
- expose bounded `[agent_runtime]` settings and effective startup logging
- document the scheduling contract and operator configuration

## Why

Agent starts include workspace preparation, process creation, ACP initialization, and resume
recovery. Bursts previously had no global admission bound, while stuck preparation and repeatedly
broken executables could hold callers or create tight retry loops.

The scheduler is local to each daemon node. Queue waiting stays outside the process supervisor
lifecycle gate so queued starts do not delay shutdown. Timeout cleanup confirms process termination
and commits terminal failure state before releasing the existing per-agent start reservation.

## Related issues

- No linked issue.

## Validation coverage

```bash
cargo test -p agenthub-config --lib agent_runtime_start_settings
cargo test -p agenthub --lib agent::manager::start_scheduler::tests -- --nocapture
cargo test -p agenthub --lib agent::manager::session::tests::start_timeout_persists_failure_before_releasing_reservation -- --exact --nocapture
cargo test -p agenthub --lib agent::manager::session::tests::spawn_failure_backoff_rejects_immediate_retry_without_respawn -- --exact --nocapture
cargo clippy -p agenthub --lib -- -D warnings
bazel test //crates/agenthub-config:agenthub_config_tests
```

The root Cargo suite is expected to retain its two known local Lance directory-manifest failures.
The root Bazel target may require a sandbox-visible `protoc`; CI remains the authoritative Bazel
boundary.
