### PR TITLE
fix(team): persist runtime delivery receipts

### DIFF
--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -806,6 +806,32 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
 
     sqlx::query(
         r#"
+        CREATE TABLE IF NOT EXISTS team_runtime_delivery_receipts (
+            delivery_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            actor_id TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            state TEXT NOT NULL CHECK(state IN ('pending', 'in_flight', 'delivered')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK(attempt >= 0),
+            next_retry_at INTEGER,
+            lease_expires_at INTEGER,
+            last_error TEXT,
+            session_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            delivered_at INTEGER,
+            UNIQUE(run_id, message_id, actor_id),
+            FOREIGN KEY(run_id) REFERENCES team_runs(id),
+            FOREIGN KEY(message_id) REFERENCES team_actor_messages(id) ON DELETE CASCADE
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        r#"
         CREATE TABLE IF NOT EXISTS team_actor_thread_claims (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id TEXT NOT NULL,
@@ -1287,6 +1313,20 @@ async fn init_db_at_path(db_path: &std::path::Path) -> anyhow::Result<SqlitePool
     {
         tracing::warn!(
             "db init: failed to create idx_team_actor_messages_remote_pending: {}",
+            err
+        );
+    }
+    if let Err(err) = sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_team_runtime_delivery_receipts_due
+        ON team_runtime_delivery_receipts(state, next_retry_at, lease_expires_at, created_at);
+        "#,
+    )
+    .execute(&pool)
+    .await
+    {
+        tracing::warn!(
+            "db init: failed to create idx_team_runtime_delivery_receipts_due: {}",
             err
         );
     }
@@ -3129,6 +3169,7 @@ mod tests {
                 'team_conversations',
                 'team_conversation_messages',
                 'team_actor_messages',
+                'team_runtime_delivery_receipts',
                 'team_goal_leases',
                 'team_goal_forks',
                 'team_member_continuity_state',
@@ -3145,13 +3186,27 @@ mod tests {
         .fetch_one(&pool)
         .await
         .expect("count tables");
-        assert_eq!(table_count, 18);
+        assert_eq!(table_count, 19);
 
         let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
             .fetch_one(&pool)
             .await
             .expect("read pragma foreign_keys");
         assert_eq!(fk_enabled, 1);
+
+        let receipt_message_cascade: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM pragma_foreign_key_list('team_runtime_delivery_receipts')
+            WHERE "table" = 'team_actor_messages'
+              AND "from" = 'message_id'
+              AND on_delete = 'CASCADE'
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read runtime delivery receipt foreign key");
+        assert_eq!(receipt_message_cascade, 1);
 
         let fk_err = sqlx::query(
             r#"

--- a/crates/agenthub-db/src/lib.rs
+++ b/crates/agenthub-db/src/lib.rs
@@ -3193,7 +3193,7 @@ mod tests {
         .fetch_one(&pool)
         .await
         .expect("count tables");
-        assert_eq!(table_count, 19);
+        assert_eq!(table_count, 20);
 
         let fk_enabled: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
             .fetch_one(&pool)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -83,6 +83,7 @@ when adding or compacting specs so this directory stays navigable.
 - `docs/features/teams-collaboration-playbook.md`
 - `docs/features/actor-foundation.md`
 - `docs/features/team-mailbox-intake-and-ownership.md`
+- `docs/features/team-runtime-delivery-receipts.md`
 - `docs/features/team-conversation-event-bus.md`
 - `docs/features/backend-runtime-logic.md`
 - `docs/features/runtime-diagnostics.md`

--- a/docs/features/team-mailbox-intake-and-ownership.md
+++ b/docs/features/team-mailbox-intake-and-ownership.md
@@ -139,6 +139,11 @@ Allowed transitions:
 
 Delivery status must not imply that the target actor accepted, ignored, or completed the work.
 
+Runtime prompt submission is a separate delivery projection. Its stable identity, lease, retry, and
+session acknowledgement contracts are defined in
+[`team-runtime-delivery-receipts.md`](team-runtime-delivery-receipts.md). A runtime receipt must never
+advance `team_actor_messages.status` or handling disposition.
+
 ### 4) Handling Disposition Contract
 
 Handling disposition is separate from delivery status and models actor-level work decisions:
@@ -348,6 +353,8 @@ Rules:
   unread-discovery surface.
 - Existing `actor_receive` and `actor_ack` flows should be treated as compatibility behavior until
   explicit triage/claim commands replace them.
+- Runtime-hint retry and restart recovery should be diagnosed from
+  `team_runtime_delivery_receipts`, not inferred from mailbox acknowledgement state.
 
 ## Open Risks
 
@@ -367,3 +374,4 @@ Rules:
 - `docs/journal/2026-02-22-team-task-routing-user-actor-semantics.md`
 - `docs/journal/2026-03-05-team-mcp-enforcement-external-review.md`
 - `docs/journal/2026-05-21-team-spec-refresh-from-external-daemon-review.md`
+- `docs/journal/2026-08-28-team-runtime-delivery-receipts.md`

--- a/docs/features/team-runtime-delivery-receipts.md
+++ b/docs/features/team-runtime-delivery-receipts.md
@@ -1,0 +1,110 @@
+# Team Runtime Delivery Receipts
+
+## Problem
+
+Team mailbox rows are durable, but the prompt that wakes a running actor was previously best-effort.
+A daemon restart or transient runtime-input failure could leave a pending mailbox message without a
+corresponding retry. The mailbox row's `delivered` state cannot solve this because it records explicit
+consumer acknowledgement, not submission to an agent runtime.
+
+## Scope
+
+- Durable receipts for direct-message, coordinator-mention, and permission-review runtime hints.
+- Stable delivery identity across retries and daemon restarts.
+- Lease-based claiming, bounded exponential retry, and stale-attempt fencing.
+- Runtime session attribution after the input transport accepts a hint.
+
+## Non-Goals
+
+- Treating runtime submission as mailbox acknowledgement or completed actor work.
+- Exactly-once execution inside an external provider after a process crash.
+- Persisting periodic unread-summary hints, which remain advisory and reconstructable.
+- Changing actor mailbox triage, ownership, or reply-obligation semantics.
+
+## Architecture
+
+`team_actor_messages` remains the authoritative mailbox record. One
+`team_runtime_delivery_receipts` row is created for each `(run_id, message_id, actor_id)` hint target.
+The API and internal service persist the receipt before attempting an immediate delivery. A daemon
+worker scans due receipts and retries them after restart. Receipts are deleted with their parent
+mailbox message.
+
+The state machine is:
+
+```text
+pending -> in_flight -> delivered
+              |
+              +------> pending
+```
+
+An `in_flight` row carries a lease. Expired leases are claimable again. Each successful claim
+increments `attempt`; acknowledgement and retry updates must match that attempt so a stale worker
+cannot overwrite a newer claim.
+
+## Contracts
+
+### Delivery Identity
+
+- A mailbox hint ID is `team-mailbox:{run_id}:{message_id}:{actor_id}`.
+- Receipt insertion is idempotent on `(run_id, message_id, actor_id)`.
+- The stable ID is forwarded as the agent input message ID on transports that support message IDs
+  and remains unchanged across retries.
+
+### Delivery Meaning
+
+- `delivered` means the current actor runtime session accepted the prompt through its input
+  transport.
+- It does not mean the actor read, triaged, acknowledged, or completed the mailbox message.
+- `team_actor_messages.status` remains the explicit consumer-delivery/acknowledgement contract.
+
+### Retry And Recovery
+
+- A due `pending` receipt or expired `in_flight` receipt may be claimed by one worker.
+- An unavailable runtime or input failure returns the receipt to `pending` with exponential backoff,
+  capped at 60 seconds.
+- One input attempt is bounded by the receipt lease, preventing a blocked runtime transport from
+  stopping the entire delivery worker.
+- Runtime availability is session-fenced. The receipt's mailbox run does not need to equal the
+  runtime's active run because permission review may use a shared mailbox run.
+- Startup recovery requires no special reset: expired leases become due through the normal query.
+
+### Delivery Guarantee
+
+Runtime hints are at-least-once. A crash after the runtime accepts input but before the receipt is
+acknowledged may submit the same stable delivery ID again. Agent event persistence can identify the
+duplicate, but external providers are not assumed to provide exactly-once execution.
+
+## Validation Matrix
+
+- Database initialization creates the receipt table, constraints, foreign keys, and due index.
+- Worker tests cover stable IDs, transient failure, restart retry, and idempotent acknowledgement.
+- Lease tests cover active-lease exclusion, expired-lease recovery, and stale-attempt fencing.
+- Permission-review tests cover delivery to a current session when the message uses a shared mailbox
+  run.
+- Team message API tests cover stable delivery IDs in hint events and idempotent message replay.
+- Cargo check, clippy, focused tests, full library tests, and the existing Bazel boundary remain the
+  implementation validation gates.
+
+## Operational Notes
+
+- The worker polls every five seconds, claims at most 100 receipts per tick, and uses a 30-second
+  lease.
+- Offline actors are moved to a future retry time rather than remaining continuously due; this keeps
+  old offline receipts from starving newer work in the bounded batch.
+- `last_error`, `attempt`, `next_retry_at`, `lease_expires_at`, `session_id`, and `delivered_at` are
+  available for database-level diagnosis. Errors are truncated to 2,048 characters.
+- Periodic unread summaries use deterministic message IDs for event correlation but remain
+  non-durable because the unread worker can reconstruct them from mailbox state.
+
+## Open Risks
+
+- Receipts for runs whose actor never returns remain pending indefinitely; retention or terminal
+  abandonment policy is intentionally deferred.
+- Stable IDs expose duplicate submissions for diagnosis but cannot force third-party providers to
+  deduplicate execution.
+- The worker is currently started as a detached Tokio task; ordered cancellation and bounded join
+  belong to the daemon task-group contract.
+
+## Source Journals
+
+- `docs/journal/2026-08-28-team-runtime-delivery-receipts.md`

--- a/docs/journal/2026-08-28-team-runtime-delivery-receipts.md
+++ b/docs/journal/2026-08-28-team-runtime-delivery-receipts.md
@@ -1,0 +1,63 @@
+# Team Runtime Delivery Receipts
+
+## Summary
+
+Replaced best-effort Team runtime hints with durable, restart-recoverable delivery receipts while
+preserving mailbox acknowledgement and handling as separate actor-owned state.
+
+## Background
+
+Direct actor messages, coordinator mentions, and permission reviews wrote durable mailbox rows but
+then attempted a one-shot runtime prompt. A transport error or daemon restart after the mailbox write
+could strand the prompt indefinitely. Reusing `team_actor_messages.status` would have collapsed
+runtime submission into explicit actor acknowledgement and broken the mailbox ownership contract.
+
+## Scope
+
+- Added `team_runtime_delivery_receipts` with stable IDs, retry state, leases, session attribution,
+  and a due index.
+- Persisted receipts before direct-message, coordinator-mention, and permission-review hint delivery.
+- Added an immediate dispatcher and a startup retry worker using the same claim path.
+- Forwarded the stable delivery ID into local and remote agent input submission.
+- Added attempt fencing so expired workers cannot acknowledge or retry a newer lease.
+- Kept unread-summary hints reconstructable, while assigning deterministic event IDs.
+
+## Key Decisions
+
+- Kept mailbox delivery/acknowledgement independent from runtime input submission.
+- Defined runtime delivery as input-transport acceptance by a specific session, not actor handling.
+- Used at-least-once delivery because a process can crash between transport acceptance and database
+  acknowledgement.
+- Allowed the current runtime's active run to differ from the mailbox run. Permission-review routing
+  can target a running reviewer while storing the request in a shared mailbox run.
+- Applied retry delay to offline runtimes so a bounded due batch cannot be permanently occupied by
+  old unavailable actors.
+
+## Validation Coverage
+
+The implementation is covered by:
+
+```bash
+cargo fmt --all
+cargo check -p agenthub --lib
+cargo clippy -p agenthub --lib -- -D warnings
+cargo test -p agenthub-db --lib -- --nocapture
+cargo test -p agenthub --lib runtime_delivery_receipts -- --nocapture
+cargo test -p agenthub --lib team::permission_review::tests -- --nocapture
+cargo test -p agenthub --lib team_run_messages_api_chat_type_hints_repeat_while_other_types_still_suppress -- --nocapture
+cargo test -p agenthub --lib
+bazel build //crates/agenthub-db:all
+bazel build //:agenthub_lib
+```
+
+The focused receipt cases assert retry with the same delivery ID after worker reconstruction,
+idempotent acknowledgement, expired-lease recovery, and rejection of stale attempt updates. The
+permission-review cases retain shared-mailbox-run delivery, and the Team API case exposes stable
+delivery IDs in diagnostic run events.
+
+## Follow-Ups
+
+- Define retention or abandonment for receipts whose target actor never becomes available again.
+- Move this worker and the other daemon background workers into the unified cancellation-aware task
+  group.
+- Preserve exact-head Cargo, Bazel, and cross-platform CI evidence on the delivery PR.

--- a/docs/journal/summary.md
+++ b/docs/journal/summary.md
@@ -29,7 +29,7 @@ rg -n "Validation|Follow-Ups|Key Decisions" docs/journal/2026-06-*.md
 | --- | --- | --- |
 | ACP runtime and provider integration | `docs/features/acp-runtime.md` | `*-acp-*.md`, `*-codex-acp-*.md`, `*-claude-acp-*.md` |
 | Team collaboration, channels, and tasks | `docs/features/agents-teams.md`, `docs/features/team-channels-threads.md`, `docs/features/team-execution-vocabulary.md` | `*-team-*.md`, `*-teams-*.md` |
-| Team mailbox and actor runtime | `docs/features/team-mailbox-intake-and-ownership.md`, `docs/features/actor-foundation.md` | `*-team-mailbox-*.md`, `*-actor-*.md` |
+| Team mailbox and actor runtime | `docs/features/team-mailbox-intake-and-ownership.md`, `docs/features/team-runtime-delivery-receipts.md`, `docs/features/actor-foundation.md` | `*-team-mailbox-*.md`, `*-runtime-delivery-*.md`, `*-actor-*.md` |
 | Workspace memory and continuity | `docs/features/team-workspace-memory-contract.md`, `docs/features/workspace-unified-ia.md` | `*-workspace-*.md`, `*-context-*.md`, `*-memory-*.md` |
 | Frontend, UI, and mobile surfaces | `docs/features/frontend-design.md`, `docs/features/workspace-unified-ia.md` | `*-web-*.md`, `*-frontend-*.md`, `*-mobile-*.md`, `*-ui-*.md` |
 | Agent nodes and distributed execution | `docs/features/agent-nodes.md`, `docs/features/distributed-node-architecture.md` | `*-node-*.md`, `*-distributed-*.md`, `*-p2p-*.md` |
@@ -314,6 +314,7 @@ Start with:
 - `2026-08-27-two-binary-runtime-consolidation.md`
 - `2026-08-27-official-codex-0-150-1-upgrade.md`
 - `2026-08-28-daemon-process-supervision.md`
+- `2026-08-28-team-runtime-delivery-receipts.md`
 
 ## Compaction Rules
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -97,8 +97,6 @@ Stable contracts:
   process ownership contract: [features/daemon-process-supervision.md](features/daemon-process-supervision.md).
 - [ ] `P1` Add globally bounded local-start admission with queue timeout, spawn timeout, and
   failure-class backoff. Preserve the supervisor lifecycle gate and per-agent duplicate-start guard.
-- [ ] `P1` Add durable Team mailbox delivery receipts for runtime-bound messages, including stable
-  delivery IDs, idempotent acknowledgement, retry state, and restart recovery.
 - [ ] `P2` Move daemon background workers and runtime watchers into one cancellation-aware task group
   with ordered shutdown, bounded joins, and surfaced teardown failures.
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2324,11 +2324,12 @@ impl AgentManager {
         agent_id: &str,
         input: &str,
         expected_session_id: Option<&str>,
+        delivery_id: &str,
     ) -> anyhow::Result<()> {
         let agent = self.get_agent(agent_id).await?;
         if agent.target_node_id.is_some() {
             return self
-                .send_input(agent_id, input, None, expected_session_id)
+                .send_input(agent_id, input, Some(delivery_id), expected_session_id)
                 .await;
         }
 
@@ -2352,12 +2353,12 @@ impl AgentManager {
                     .acp_prompt_delivery_policy
                     .unwrap_or(AcpPromptDeliveryPolicy::StrictFifo);
                 if !acp_accepts_best_effort_hint(&diagnostics, prompt_delivery_policy) {
-                    anyhow::bail!("agent ACP input is busy; skip best-effort mailbox hint");
+                    anyhow::bail!("agent ACP input is busy; defer mailbox hint");
                 }
             }
         }
 
-        self.send_input(agent_id, input, None, expected_session_id)
+        self.send_input(agent_id, input, Some(delivery_id), expected_session_id)
             .await
     }
 

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -47,12 +47,11 @@ use crate::state::AppState;
 use crate::team::{
     TEAM_RUN_STATUS_VALUES, TeamActorMessageRecord, TeamActorMessageTransport, TeamChannelRecord,
     TeamConversationMessageRecord, TeamConversationRecord, TeamDefinitionConfig,
-    TeamDefinitionRecord, TeamMemoryFlushRequest, TeamReplyObligationRecord, TeamRunEventRecord,
-    TeamRunRecord, TeamRunStatus, TeamRuntimeRecord, TeamStepRecord, TeamStepStatus,
-    TeamTaskCreateInput, TeamTaskExecutionPlan, TeamTaskNoteRecord, TeamTaskPriority,
-    TeamTaskRecord, TeamTaskStepExecutionSpec, TeamThreadReplyRecord,
-    dispatch_actor_mailbox_immediate_hint, effective_team_member_skills,
-    ensure_team_runtime_started, force_team_member_new_session,
+    TeamDefinitionRecord, TeamMailboxRuntimeDeliveryWorker, TeamMemoryFlushRequest,
+    TeamReplyObligationRecord, TeamRunEventRecord, TeamRunRecord, TeamRunStatus, TeamRuntimeRecord,
+    TeamStepRecord, TeamStepStatus, TeamTaskCreateInput, TeamTaskExecutionPlan, TeamTaskNoteRecord,
+    TeamTaskPriority, TeamTaskRecord, TeamTaskStepExecutionSpec, TeamThreadReplyRecord,
+    effective_team_member_skills, ensure_team_runtime_started, force_team_member_new_session,
     normalize_optional_idempotency_key_input, parse_task_execution_plan,
     plan_actor_mailbox_immediate_hint, stop_team_runtime,
 };
@@ -2676,14 +2675,16 @@ async fn maybe_notify_actor_new_mailbox_message_type(
             "coordinator_channel_mention"
         }
     };
-    let delivery =
-        dispatch_actor_mailbox_immediate_hint(state.agents.as_ref(), run_id, &plan).await;
+    let delivery = TeamMailboxRuntimeDeliveryWorker::new(state.teams.clone(), state.agents.clone())
+        .enqueue_and_dispatch(run_id, send_result.message_id, &plan)
+        .await?;
     append_actor_mailbox_type_hint_event(
         state,
         run_id,
         serde_json::json!({
             "status": if delivery.failed_actor_ids.is_empty() { "sent" } else if delivery.sent_actor_ids.is_empty() { "send_failed" } else { "partial" },
             "message_id": send_result.message_id,
+            "delivery_ids": delivery.delivery_ids,
             "reason": reason_label,
             "target_actor_ids": plan.target_actor_ids,
             "sent_actor_ids": delivery.sent_actor_ids,

--- a/src/api/teams/tests.rs
+++ b/src/api/teams/tests.rs
@@ -1131,6 +1131,33 @@ async fn init_test_schema(db: &SqlitePool) {
 
     sqlx::query(
         r#"
+        CREATE TABLE team_runtime_delivery_receipts (
+            delivery_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            actor_id TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('pending', 'in_flight', 'delivered')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+            next_retry_at INTEGER,
+            lease_expires_at INTEGER,
+            last_error TEXT,
+            session_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            delivered_at INTEGER,
+            UNIQUE(run_id, message_id, actor_id),
+            FOREIGN KEY(run_id) REFERENCES team_runs(id),
+            FOREIGN KEY(message_id) REFERENCES team_actor_messages(id) ON DELETE CASCADE
+        );
+        "#,
+    )
+    .execute(db)
+    .await
+    .expect("create team_runtime_delivery_receipts");
+
+    sqlx::query(
+        r#"
         CREATE TABLE team_actor_thread_claims (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id TEXT NOT NULL,

--- a/src/api/teams/tests_core.rs
+++ b/src/api/teams/tests_core.rs
@@ -5438,6 +5438,13 @@ async fn team_run_messages_api_chat_type_hints_repeat_while_other_types_still_su
     );
     assert_eq!(first_hint.payload["reason"], json!("direct_agent_message"));
     assert_eq!(first_hint.payload["target_actor_ids"], json!(["reviewer"]));
+    assert_eq!(
+        first_hint.payload["delivery_ids"],
+        json!([format!(
+            "team-mailbox:{}:{}:reviewer",
+            run.id, first_chat.message_id
+        )])
+    );
 
     let second_hint = hint_events
         .iter()
@@ -5453,6 +5460,13 @@ async fn team_run_messages_api_chat_type_hints_repeat_while_other_types_still_su
     );
     assert_eq!(second_hint.payload["reason"], json!("direct_agent_message"));
     assert_eq!(second_hint.payload["target_actor_ids"], json!(["reviewer"]));
+    assert_eq!(
+        second_hint.payload["delivery_ids"],
+        json!([format!(
+            "team-mailbox:{}:{}:reviewer",
+            run.id, second_chat.message_id
+        )])
+    );
 
     let worker_status_hint = hint_events
         .iter()

--- a/src/internal/service/helpers.rs
+++ b/src/internal/service/helpers.rs
@@ -203,7 +203,9 @@ pub(super) async fn maybe_notify_actor_new_mailbox_message_type(
             "coordinator_channel_mention"
         }
     };
-    let delivery = dispatch_actor_mailbox_immediate_hint(deps.agents.as_ref(), run_id, &plan).await;
+    let delivery = TeamMailboxRuntimeDeliveryWorker::new(deps.teams.clone(), deps.agents.clone())
+        .enqueue_and_dispatch(run_id, send_result.message_id, &plan)
+        .await?;
     if let Err(err) = deps
         .teams
         .append_run_event(
@@ -212,6 +214,7 @@ pub(super) async fn maybe_notify_actor_new_mailbox_message_type(
             serde_json::json!({
                 "status": if delivery.failed_actor_ids.is_empty() { "sent" } else if delivery.sent_actor_ids.is_empty() { "send_failed" } else { "partial" },
                 "message_id": send_result.message_id,
+                "delivery_ids": delivery.delivery_ids,
                 "reason": reason_label,
                 "target_actor_ids": plan.target_actor_ids,
                 "sent_actor_ids": delivery.sent_actor_ids,

--- a/src/internal/service/mod.rs
+++ b/src/internal/service/mod.rs
@@ -25,10 +25,10 @@ pub(super) use crate::agent::{
     AgentConfig, AgentManager, AgentTimeTriggerCreateInput, AgentTimeTriggerManager,
 };
 pub(super) use crate::team::{
-    TEAM_TASK_DETAIL_MESSAGE_LIMIT_MAX, TeamContextLookupError, TeamManager, TeamStepRecord,
-    TeamStepStatus, TeamTaskAssignmentUpdate, TeamTaskContextPatch, TeamTaskCreateInput,
-    TeamTaskListQuery, TeamTaskNoteCreateInput, TeamTaskNoteKind, TeamTaskPriority, TeamTaskStatus,
-    TeamTaskUpdateWithNoteInput, dispatch_actor_mailbox_immediate_hint,
+    TEAM_TASK_DETAIL_MESSAGE_LIMIT_MAX, TeamContextLookupError, TeamMailboxRuntimeDeliveryWorker,
+    TeamManager, TeamStepRecord, TeamStepStatus, TeamTaskAssignmentUpdate, TeamTaskContextPatch,
+    TeamTaskCreateInput, TeamTaskListQuery, TeamTaskNoteCreateInput, TeamTaskNoteKind,
+    TeamTaskPriority, TeamTaskStatus, TeamTaskUpdateWithNoteInput,
     plan_actor_mailbox_immediate_hint,
 };
 

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1888,8 +1888,9 @@ mod tests {
     async fn output_stream_emits_events_from_forwarders() {
         use futures::StreamExt;
 
+        let agent_id = format!("agent-forwarder-{}", Uuid::new_v4());
         let (tx, rx) = tokio::sync::broadcast::channel(8);
-        let mut stream = std::pin::pin!(super::output_stream(vec![("agent-x".to_string(), rx)]));
+        let mut stream = std::pin::pin!(super::output_stream(vec![(agent_id.clone(), rx)]));
 
         let first = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
             .await
@@ -1898,8 +1899,9 @@ mod tests {
             .expect("stream event should be ok");
         assert!(format!("{first:?}").contains("heartbeat"));
 
-        tx.send(sample_output(OutputStream::Stdout))
-            .expect("send broadcast output");
+        let mut output = sample_output(OutputStream::Stdout);
+        output.agent_id = agent_id.clone();
+        tx.send(output).expect("send broadcast output");
         let _second = tokio::time::timeout(std::time::Duration::from_millis(500), stream.next())
             .await
             .expect("receive second event")
@@ -1907,7 +1909,7 @@ mod tests {
             .expect("stream event should be ok");
         #[cfg(debug_assertions)]
         {
-            let diagnostics = super::agent_sse_diagnostics("agent-x")
+            let diagnostics = super::agent_sse_diagnostics(&agent_id)
                 .expect("agent sse diagnostics should exist");
             assert_eq!(diagnostics.last_forwarded_event_id, Some(42));
             assert_eq!(diagnostics.last_emitted_event_id, Some(42));

--- a/src/state/startup.rs
+++ b/src/state/startup.rs
@@ -5,7 +5,10 @@ use sqlx::SqlitePool;
 use crate::agent::{
     AgentManager, AgentTimeTriggerManager, AgentTimeTriggerWorker, AgentTimeTriggerWorkerSettings,
 };
-use crate::team::{TeamMailboxUnreadHintWorker, TeamMailboxUnreadHintWorkerSettings, TeamManager};
+use crate::team::{
+    TeamMailboxRuntimeDeliveryWorker, TeamMailboxRuntimeDeliveryWorkerSettings,
+    TeamMailboxUnreadHintWorker, TeamMailboxUnreadHintWorkerSettings, TeamManager,
+};
 
 use super::AppState;
 
@@ -36,6 +39,9 @@ impl AppState {
         }
         let _mailbox_hint_handle = TeamMailboxUnreadHintWorker::new(teams.clone(), agents.clone())
             .spawn(TeamMailboxUnreadHintWorkerSettings::default());
+        let _mailbox_delivery_handle =
+            TeamMailboxRuntimeDeliveryWorker::new(teams.clone(), agents.clone())
+                .spawn(TeamMailboxRuntimeDeliveryWorkerSettings::default());
         let trigger_manager = Arc::new(AgentTimeTriggerManager::new(db.clone()));
         let recovered_dispatching = trigger_manager.reset_inflight_on_startup().await?;
         if recovered_dispatching > 0 {

--- a/src/team/mailbox_hint/delivery.rs
+++ b/src/team/mailbox_hint/delivery.rs
@@ -1,0 +1,244 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::prompts::build_actor_mailbox_immediate_hint_prompt;
+use super::types::{
+    ActorMailboxImmediateHintDelivery, ActorMailboxImmediateHintPlan, TeamMailboxHintAgentNudger,
+};
+use crate::team::{TeamManager, TeamRuntimeDeliveryReceipt};
+
+#[derive(Debug, Clone, Copy)]
+pub struct TeamMailboxRuntimeDeliveryWorkerSettings {
+    pub poll_interval: Duration,
+    pub batch_size: i64,
+    pub lease_seconds: i64,
+}
+
+impl Default for TeamMailboxRuntimeDeliveryWorkerSettings {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(5),
+            batch_size: 100,
+            lease_seconds: 30,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TeamMailboxRuntimeDeliveryWorker {
+    teams: Arc<TeamManager>,
+    agent_nudger: Arc<dyn TeamMailboxHintAgentNudger>,
+}
+
+impl TeamMailboxRuntimeDeliveryWorker {
+    pub fn new(teams: Arc<TeamManager>, agents: Arc<crate::agent::AgentManager>) -> Self {
+        Self::with_agent_nudger(teams, agents)
+    }
+
+    pub fn with_agent_nudger(
+        teams: Arc<TeamManager>,
+        agent_nudger: Arc<dyn TeamMailboxHintAgentNudger>,
+    ) -> Self {
+        Self {
+            teams,
+            agent_nudger,
+        }
+    }
+
+    pub fn spawn(
+        self,
+        settings: TeamMailboxRuntimeDeliveryWorkerSettings,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(settings.poll_interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                if let Err(error) = self.dispatch_once(settings).await {
+                    tracing::warn!(error = %error, "team mailbox runtime delivery tick failed");
+                }
+            }
+        })
+    }
+
+    pub(crate) async fn enqueue_and_dispatch(
+        &self,
+        run_id: &str,
+        message_id: i64,
+        plan: &ActorMailboxImmediateHintPlan,
+    ) -> anyhow::Result<ActorMailboxImmediateHintDelivery> {
+        let prompt = build_actor_mailbox_immediate_hint_prompt(run_id, plan.reason);
+        self.enqueue_prompt(run_id, message_id, &plan.target_actor_ids, &prompt)
+            .await
+    }
+
+    pub(crate) async fn enqueue_prompt(
+        &self,
+        run_id: &str,
+        message_id: i64,
+        actor_ids: &[String],
+        prompt: &str,
+    ) -> anyhow::Result<ActorMailboxImmediateHintDelivery> {
+        let now = chrono::Utc::now().timestamp();
+        let receipts = self
+            .teams
+            .ensure_mailbox_runtime_deliveries(run_id, message_id, actor_ids, prompt, now)
+            .await?;
+        self.dispatch_receipts(
+            receipts,
+            now,
+            TeamMailboxRuntimeDeliveryWorkerSettings::default(),
+        )
+        .await
+    }
+
+    pub async fn dispatch_once(
+        &self,
+        settings: TeamMailboxRuntimeDeliveryWorkerSettings,
+    ) -> anyhow::Result<ActorMailboxImmediateHintDelivery> {
+        let now = chrono::Utc::now().timestamp();
+        self.dispatch_once_at(settings, now).await
+    }
+
+    pub(crate) async fn dispatch_once_at(
+        &self,
+        settings: TeamMailboxRuntimeDeliveryWorkerSettings,
+        now: i64,
+    ) -> anyhow::Result<ActorMailboxImmediateHintDelivery> {
+        let receipts = self
+            .teams
+            .list_due_mailbox_runtime_deliveries(now, settings.batch_size)
+            .await?;
+        self.dispatch_receipts(receipts, now, settings).await
+    }
+
+    async fn dispatch_receipts(
+        &self,
+        receipts: Vec<TeamRuntimeDeliveryReceipt>,
+        now: i64,
+        settings: TeamMailboxRuntimeDeliveryWorkerSettings,
+    ) -> anyhow::Result<ActorMailboxImmediateHintDelivery> {
+        let mut delivery_ids = Vec::with_capacity(receipts.len());
+        let mut sent_actor_ids = Vec::new();
+        let mut failed_actor_ids = Vec::new();
+        for receipt in receipts {
+            delivery_ids.push(receipt.delivery_id.clone());
+            if self
+                .dispatch_receipt(receipt.clone(), now, settings)
+                .await?
+            {
+                sent_actor_ids.push(receipt.actor_id);
+            } else {
+                failed_actor_ids.push(receipt.actor_id);
+            }
+        }
+        Ok(ActorMailboxImmediateHintDelivery {
+            delivery_ids,
+            sent_actor_ids,
+            failed_actor_ids,
+        })
+    }
+
+    async fn dispatch_receipt(
+        &self,
+        receipt: TeamRuntimeDeliveryReceipt,
+        now: i64,
+        settings: TeamMailboxRuntimeDeliveryWorkerSettings,
+    ) -> anyhow::Result<bool> {
+        let Some(claimed) = self
+            .teams
+            .claim_mailbox_runtime_delivery(&receipt.delivery_id, now, settings.lease_seconds)
+            .await?
+        else {
+            return Ok(receipt.state == "delivered");
+        };
+        let Some(runtime) = self
+            .agent_nudger
+            .running_actor_runtime(&claimed.actor_id)
+            .await
+        else {
+            self.schedule_retry(&claimed, now, "actor runtime is not running")
+                .await?;
+            return Ok(false);
+        };
+        let delivery_timeout = Duration::from_secs(settings.lease_seconds.max(1) as u64);
+        match tokio::time::timeout(
+            delivery_timeout,
+            self.agent_nudger.nudge_mailbox_prompt(
+                &claimed.actor_id,
+                Some(&runtime.session_id),
+                &claimed.delivery_id,
+                &claimed.prompt,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                let acknowledged = self
+                    .teams
+                    .acknowledge_mailbox_runtime_delivery(
+                        &claimed.delivery_id,
+                        claimed.attempt,
+                        &runtime.session_id,
+                        now,
+                    )
+                    .await?;
+                if !acknowledged {
+                    tracing::debug!(
+                        delivery_id = %claimed.delivery_id,
+                        attempt = claimed.attempt,
+                        "team mailbox runtime delivery acknowledgement lost its attempt fence"
+                    );
+                }
+                Ok(acknowledged)
+            }
+            Ok(Err(error)) => {
+                self.schedule_retry(&claimed, now, &error.to_string())
+                    .await?;
+                Ok(false)
+            }
+            Err(_) => {
+                self.schedule_retry(&claimed, now, "runtime input delivery timed out")
+                    .await?;
+                Ok(false)
+            }
+        }
+    }
+
+    async fn schedule_retry(
+        &self,
+        claimed: &TeamRuntimeDeliveryReceipt,
+        now: i64,
+        error: &str,
+    ) -> anyhow::Result<()> {
+        let delay = crate::team::runtime_delivery_retry_delay_seconds(claimed.attempt);
+        let scheduled = self
+            .teams
+            .retry_mailbox_runtime_delivery(
+                &claimed.delivery_id,
+                claimed.attempt,
+                now,
+                now.saturating_add(delay),
+                error,
+            )
+            .await?;
+        if !scheduled {
+            tracing::debug!(
+                delivery_id = %claimed.delivery_id,
+                attempt = claimed.attempt,
+                "team mailbox runtime delivery retry lost its attempt fence"
+            );
+            return Ok(());
+        }
+        tracing::debug!(
+            delivery_id = %claimed.delivery_id,
+            run_id = %claimed.run_id,
+            actor_id = %claimed.actor_id,
+            attempt = claimed.attempt,
+            retry_delay_seconds = delay,
+            error,
+            "team mailbox runtime delivery scheduled for retry"
+        );
+        Ok(())
+    }
+}

--- a/src/team/mailbox_hint/immediate.rs
+++ b/src/team/mailbox_hint/immediate.rs
@@ -3,10 +3,8 @@ use std::collections::BTreeSet;
 use agenthub_team_actor::{ActorIdentityKind, ActorSendResponse};
 use serde_json::Value;
 
-use super::prompts::build_actor_mailbox_immediate_hint_prompt;
 use super::types::{
-    ActorMailboxImmediateHintDelivery, ActorMailboxImmediateHintPlan,
-    ActorMailboxImmediateHintReason, ActorMailboxPriorityClass, TeamMailboxHintAgentNudger,
+    ActorMailboxImmediateHintPlan, ActorMailboxImmediateHintReason, ActorMailboxPriorityClass,
 };
 use crate::team::TeamManager;
 
@@ -89,38 +87,6 @@ pub(crate) async fn plan_actor_mailbox_immediate_hint(
             .await?
             .immediate_hint,
     )
-}
-
-pub(crate) async fn dispatch_actor_mailbox_immediate_hint(
-    nudger: &dyn TeamMailboxHintAgentNudger,
-    run_id: &str,
-    plan: &ActorMailboxImmediateHintPlan,
-) -> ActorMailboxImmediateHintDelivery {
-    let prompt = build_actor_mailbox_immediate_hint_prompt(run_id, plan.reason);
-    let mut sent_actor_ids = Vec::new();
-    let mut failed_actor_ids = Vec::new();
-    for target_actor_id in &plan.target_actor_ids {
-        match nudger
-            .nudge_mailbox_prompt(target_actor_id, None, prompt.as_str())
-            .await
-        {
-            Ok(()) => sent_actor_ids.push(target_actor_id.clone()),
-            Err(err) => {
-                tracing::debug!(
-                    run_id = %run_id,
-                    actor_id = %target_actor_id,
-                    reason = ?plan.reason,
-                    "skip mailbox hint push because agent input is unavailable: {}",
-                    err
-                );
-                failed_actor_ids.push(target_actor_id.clone());
-            }
-        }
-    }
-    ActorMailboxImmediateHintDelivery {
-        sent_actor_ids,
-        failed_actor_ids,
-    }
 }
 
 fn is_channel_payload(payload: &Value) -> bool {

--- a/src/team/mailbox_hint/mod.rs
+++ b/src/team/mailbox_hint/mod.rs
@@ -1,11 +1,13 @@
+mod delivery;
 mod immediate;
 mod prompts;
 mod types;
 mod worker;
 
-pub(crate) use immediate::{
-    dispatch_actor_mailbox_immediate_hint, plan_actor_mailbox_immediate_hint,
+pub(crate) use delivery::{
+    TeamMailboxRuntimeDeliveryWorker, TeamMailboxRuntimeDeliveryWorkerSettings,
 };
+pub(crate) use immediate::plan_actor_mailbox_immediate_hint;
 #[cfg(test)]
 pub(crate) use prompts::build_actor_mailbox_immediate_hint_prompt;
 #[allow(unused_imports)]

--- a/src/team/mailbox_hint/tests.rs
+++ b/src/team/mailbox_hint/tests.rs
@@ -1,4 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
 
 use agenthub_team_actor::{
     ACTOR_MAIN_PEER_ID, ActorMessageRecord, ActorMessageStatus, ActorMessageTransport,
@@ -13,8 +15,12 @@ use super::types::{
     RunningActorRuntime, TeamMailboxHintAgentNudger, actor_mailbox_priority_label,
 };
 use super::worker::{IdleUnreadHintState, actor_mailbox_is_idle, decide_idle_unread_hint_action};
-use super::{build_actor_mailbox_immediate_hint_prompt, dispatch_actor_mailbox_immediate_hint};
+use super::{
+    TeamMailboxRuntimeDeliveryWorker, TeamMailboxRuntimeDeliveryWorkerSettings,
+    build_actor_mailbox_immediate_hint_prompt,
+};
 use crate::team::mailbox_hint::prompts::build_actor_mailbox_unread_summary_prompt;
+use crate::team::{TeamManager, mailbox_runtime_delivery_id};
 
 fn is_user_message_payload(message: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(message)
@@ -30,23 +36,48 @@ fn is_user_message_payload(message: &str) -> bool {
 
 #[derive(Default)]
 struct RecordingNudger {
-    sent: Mutex<Vec<String>>,
+    runtimes: HashMap<String, RunningActorRuntime>,
+    sent: Mutex<Vec<(String, String)>>,
     failed: Mutex<HashSet<String>>,
+    blocked: HashSet<String>,
 }
 
 impl RecordingNudger {
     fn failing(targets: impl IntoIterator<Item = &'static str>) -> Self {
         Self {
+            runtimes: HashMap::from([
+                (
+                    "idle-worker".to_string(),
+                    RunningActorRuntime {
+                        session_id: "session-idle".to_string(),
+                        current_run_id: Some("run-1".to_string()),
+                    },
+                ),
+                (
+                    "busy-worker".to_string(),
+                    RunningActorRuntime {
+                        session_id: "session-busy".to_string(),
+                        current_run_id: Some("run-1".to_string()),
+                    },
+                ),
+            ]),
             sent: Mutex::default(),
             failed: Mutex::new(targets.into_iter().map(str::to_string).collect()),
+            blocked: HashSet::new(),
         }
+    }
+
+    fn blocking(target: &'static str) -> Self {
+        let mut nudger = Self::failing([]);
+        nudger.blocked.insert(target.to_string());
+        nudger
     }
 }
 
 #[async_trait]
 impl TeamMailboxHintAgentNudger for RecordingNudger {
-    async fn running_actor_runtime(&self, _actor_id: &str) -> Option<RunningActorRuntime> {
-        None
+    async fn running_actor_runtime(&self, actor_id: &str) -> Option<RunningActorRuntime> {
+        self.runtimes.get(actor_id).cloned()
     }
 
     async fn mailbox_idle_anchor_ts(
@@ -61,14 +92,126 @@ impl TeamMailboxHintAgentNudger for RecordingNudger {
         &self,
         actor_id: &str,
         _expected_session_id: Option<&str>,
+        delivery_id: &str,
         _prompt: &str,
     ) -> anyhow::Result<()> {
+        if self.blocked.contains(actor_id) {
+            std::future::pending::<()>().await;
+        }
         if self.failed.lock().await.contains(actor_id) {
             anyhow::bail!("busy");
         }
-        self.sent.lock().await.push(actor_id.to_string());
+        self.sent
+            .lock()
+            .await
+            .push((actor_id.to_string(), delivery_id.to_string()));
         Ok(())
     }
+}
+
+async fn setup_runtime_delivery_manager() -> Arc<TeamManager> {
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(":memory:")
+        .create_if_missing(true)
+        .foreign_keys(true);
+    let db = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .expect("connect runtime delivery test database");
+    for statement in [
+        r#"
+        CREATE TABLE team_definitions (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            spec_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        "#,
+        r#"
+        CREATE TABLE team_runs (
+            id TEXT PRIMARY KEY,
+            team_id TEXT NOT NULL,
+            context_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            input_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY(team_id) REFERENCES team_definitions(id)
+        )
+        "#,
+        r#"
+        CREATE TABLE team_actor_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            from_actor_id TEXT NOT NULL,
+            to_actor_id TEXT NOT NULL,
+            channel TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES team_runs(id)
+        )
+        "#,
+        r#"
+        CREATE TABLE team_runtime_delivery_receipts (
+            delivery_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            actor_id TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('pending', 'in_flight', 'delivered')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+            next_retry_at INTEGER,
+            lease_expires_at INTEGER,
+            last_error TEXT,
+            session_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            delivered_at INTEGER,
+            UNIQUE(run_id, message_id, actor_id),
+            FOREIGN KEY(run_id) REFERENCES team_runs(id),
+            FOREIGN KEY(message_id) REFERENCES team_actor_messages(id) ON DELETE CASCADE
+        )
+        "#,
+    ] {
+        sqlx::query(statement)
+            .execute(&db)
+            .await
+            .expect("create runtime delivery test schema");
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO team_definitions (id, name, spec_json, created_at, updated_at)
+        VALUES ('team-1', 'Runtime Delivery Team', '{}', 100, 100)
+        "#,
+    )
+    .execute(&db)
+    .await
+    .expect("insert runtime delivery team");
+    sqlx::query(
+        r#"
+        INSERT INTO team_runs (id, team_id, context_id, status, input_json, created_at)
+        VALUES ('run-1', 'team-1', 'ctx-1', 'running', '{}', 100)
+        "#,
+    )
+    .execute(&db)
+    .await
+    .expect("insert runtime delivery run");
+    sqlx::query(
+        r#"
+        INSERT INTO team_actor_messages (
+            id, run_id, from_actor_id, to_actor_id, channel, transport, payload_json, status,
+            created_at
+        )
+        VALUES (11, 'run-1', 'planner', 'idle-worker', 'default', 'local', '{}', 'pending', 100)
+        "#,
+    )
+    .execute(&db)
+    .await
+    .expect("insert runtime delivery mailbox message");
+    Arc::new(TeamManager::new(db))
 }
 
 fn actor_send_response(
@@ -234,16 +377,174 @@ fn direct_agent_message_shape_matches_immediate_contract() {
 }
 
 #[tokio::test]
-async fn immediate_mailbox_hint_dispatch_uses_best_effort_nudger() {
-    let nudger = RecordingNudger::failing(["busy-worker"]);
+async fn runtime_delivery_receipts_retry_with_stable_ids_after_restart() {
+    let teams = setup_runtime_delivery_manager().await;
+    let nudger = Arc::new(RecordingNudger::failing(["busy-worker"]));
+    let worker = TeamMailboxRuntimeDeliveryWorker::with_agent_nudger(teams.clone(), nudger.clone());
     let plan = ActorMailboxImmediateHintPlan {
         target_actor_ids: vec!["idle-worker".to_string(), "busy-worker".to_string()],
         reason: ActorMailboxImmediateHintReason::DirectAgentMessage,
     };
 
-    let delivery = dispatch_actor_mailbox_immediate_hint(&nudger, "run-1", &plan).await;
+    let delivery = worker
+        .enqueue_and_dispatch("run-1", 11, &plan)
+        .await
+        .expect("enqueue runtime deliveries");
 
     assert_eq!(delivery.sent_actor_ids, vec!["idle-worker".to_string()]);
     assert_eq!(delivery.failed_actor_ids, vec!["busy-worker".to_string()]);
-    assert_eq!(*nudger.sent.lock().await, vec!["idle-worker".to_string()]);
+    let idle_delivery_id = mailbox_runtime_delivery_id("run-1", 11, "idle-worker");
+    let busy_delivery_id = mailbox_runtime_delivery_id("run-1", 11, "busy-worker");
+    assert_eq!(
+        *nudger.sent.lock().await,
+        vec![("idle-worker".to_string(), idle_delivery_id.clone())]
+    );
+    let delivered = teams
+        .mailbox_runtime_delivery_for_test(&idle_delivery_id)
+        .await
+        .expect("read delivered receipt");
+    assert_eq!(delivered.state, "delivered");
+    assert_eq!(delivered.session_id.as_deref(), Some("session-idle"));
+    let pending = teams
+        .mailbox_runtime_delivery_for_test(&busy_delivery_id)
+        .await
+        .expect("read retry receipt");
+    assert_eq!(pending.state, "pending");
+    assert_eq!(pending.attempt, 1);
+    assert!(pending.next_retry_at.is_some());
+
+    nudger.failed.lock().await.remove("busy-worker");
+    let restarted =
+        TeamMailboxRuntimeDeliveryWorker::with_agent_nudger(teams.clone(), nudger.clone());
+    let retried = restarted
+        .dispatch_once_at(
+            TeamMailboxRuntimeDeliveryWorkerSettings {
+                poll_interval: Duration::from_millis(10),
+                batch_size: 10,
+                lease_seconds: 30,
+            },
+            pending.next_retry_at.expect("retry deadline"),
+        )
+        .await
+        .expect("dispatch recovered receipt");
+    assert_eq!(retried.delivery_ids, vec![busy_delivery_id.clone()]);
+    assert_eq!(retried.sent_actor_ids, vec!["busy-worker".to_string()]);
+    let recovered = teams
+        .mailbox_runtime_delivery_for_test(&busy_delivery_id)
+        .await
+        .expect("read recovered receipt");
+    assert_eq!(recovered.state, "delivered");
+    assert_eq!(recovered.attempt, 2);
+    assert_eq!(recovered.session_id.as_deref(), Some("session-busy"));
+    assert!(
+        !teams
+            .acknowledge_mailbox_runtime_delivery(
+                &busy_delivery_id,
+                recovered.attempt,
+                "different-session",
+                recovered.delivered_at.expect("delivered timestamp") + 1,
+            )
+            .await
+            .expect("idempotent runtime acknowledgement")
+    );
+}
+
+#[tokio::test]
+async fn runtime_delivery_receipts_fence_stale_attempts_after_lease_expiry() {
+    let teams = setup_runtime_delivery_manager().await;
+    let actor_ids = vec!["idle-worker".to_string()];
+    let receipts = teams
+        .ensure_mailbox_runtime_deliveries("run-1", 11, &actor_ids, "prompt", 100)
+        .await
+        .expect("persist runtime delivery");
+    let delivery_id = receipts[0].delivery_id.clone();
+    let first = teams
+        .claim_mailbox_runtime_delivery(&delivery_id, 100, 30)
+        .await
+        .expect("claim first attempt")
+        .expect("first attempt is due");
+    assert!(
+        teams
+            .claim_mailbox_runtime_delivery(&delivery_id, 129, 30)
+            .await
+            .expect("check active lease")
+            .is_none()
+    );
+    let second = teams
+        .claim_mailbox_runtime_delivery(&delivery_id, 130, 30)
+        .await
+        .expect("reclaim expired delivery")
+        .expect("expired lease is due");
+    assert_eq!(second.attempt, first.attempt + 1);
+    assert!(
+        !teams
+            .retry_mailbox_runtime_delivery(&delivery_id, first.attempt, 131, 132, "stale failure",)
+            .await
+            .expect("fence stale retry")
+    );
+    assert!(
+        !teams
+            .acknowledge_mailbox_runtime_delivery(
+                &delivery_id,
+                first.attempt,
+                "stale-session",
+                131,
+            )
+            .await
+            .expect("fence stale acknowledgement")
+    );
+    assert!(
+        teams
+            .acknowledge_mailbox_runtime_delivery(
+                &delivery_id,
+                second.attempt,
+                "current-session",
+                132,
+            )
+            .await
+            .expect("acknowledge current attempt")
+    );
+    let delivered = teams
+        .mailbox_runtime_delivery_for_test(&delivery_id)
+        .await
+        .expect("read fenced receipt");
+    assert_eq!(delivered.state, "delivered");
+    assert_eq!(delivered.session_id.as_deref(), Some("current-session"));
+}
+
+#[tokio::test]
+async fn runtime_delivery_receipts_timeout_blocked_input_and_retry() {
+    let teams = setup_runtime_delivery_manager().await;
+    let actor_ids = vec!["idle-worker".to_string()];
+    let receipts = teams
+        .ensure_mailbox_runtime_deliveries("run-1", 11, &actor_ids, "prompt", 100)
+        .await
+        .expect("persist runtime delivery");
+    let delivery_id = receipts[0].delivery_id.clone();
+    let nudger = Arc::new(RecordingNudger::blocking("idle-worker"));
+    let worker = TeamMailboxRuntimeDeliveryWorker::with_agent_nudger(teams.clone(), nudger);
+
+    let delivery = worker
+        .dispatch_once_at(
+            TeamMailboxRuntimeDeliveryWorkerSettings {
+                poll_interval: Duration::from_millis(10),
+                batch_size: 10,
+                lease_seconds: 1,
+            },
+            100,
+        )
+        .await
+        .expect("bound blocked runtime input");
+
+    assert_eq!(delivery.failed_actor_ids, vec!["idle-worker".to_string()]);
+    let pending = teams
+        .mailbox_runtime_delivery_for_test(&delivery_id)
+        .await
+        .expect("read timed out receipt");
+    assert_eq!(pending.state, "pending");
+    assert_eq!(pending.attempt, 1);
+    assert_eq!(
+        pending.last_error.as_deref(),
+        Some("runtime input delivery timed out")
+    );
 }

--- a/src/team/mailbox_hint/types.rs
+++ b/src/team/mailbox_hint/types.rs
@@ -25,6 +25,7 @@ pub(crate) struct ActorMailboxImmediateHintPlan {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ActorMailboxImmediateHintDelivery {
+    pub delivery_ids: Vec<String>,
     pub sent_actor_ids: Vec<String>,
     pub failed_actor_ids: Vec<String>,
 }
@@ -71,6 +72,7 @@ pub trait TeamMailboxHintAgentNudger: Send + Sync {
         &self,
         actor_id: &str,
         expected_session_id: Option<&str>,
+        delivery_id: &str,
         prompt: &str,
     ) -> anyhow::Result<()>;
 }
@@ -101,9 +103,10 @@ impl TeamMailboxHintAgentNudger for AgentManager {
         &self,
         actor_id: &str,
         expected_session_id: Option<&str>,
+        delivery_id: &str,
         prompt: &str,
     ) -> anyhow::Result<()> {
-        self.send_mailbox_hint_input(actor_id, prompt, expected_session_id)
+        self.send_mailbox_hint_input(actor_id, prompt, expected_session_id, delivery_id)
             .await
     }
 }

--- a/src/team/mailbox_hint/worker.rs
+++ b/src/team/mailbox_hint/worker.rs
@@ -114,11 +114,20 @@ impl TeamMailboxUnreadHintWorker {
 
             let prompt =
                 build_actor_mailbox_unread_summary_prompt(&record.run_id, record.unread_count);
+            let delivery_id = format!(
+                "team-mailbox-summary:{}:{}:{}:{}:{}",
+                record.run_id,
+                record.actor_id,
+                runtime.session_id,
+                action.idle_anchor_ts,
+                action.unread_count
+            );
             match self
                 .agent_nudger
                 .nudge_mailbox_prompt(
                     record.actor_id.as_str(),
                     Some(runtime.session_id.as_str()),
+                    &delivery_id,
                     prompt.as_str(),
                 )
                 .await

--- a/src/team/manager.rs
+++ b/src/team/manager.rs
@@ -76,6 +76,7 @@ mod run_queries;
 mod run_summary;
 mod run_task_status_sync;
 mod runtime_context_lookup;
+mod runtime_delivery;
 mod runtime_run_members;
 mod runtime_team_runtime;
 mod runtime_view_builders;
@@ -150,6 +151,11 @@ use self::payload_utils::{
     filter_visible_team_runs, merge_json_value, redact_sensitive_json, resolve_task_context_patch,
 };
 use self::run_task_status_sync::load_linked_task_ids_for_runs;
+#[cfg(test)]
+pub(crate) use self::runtime_delivery::mailbox_runtime_delivery_id;
+pub(crate) use self::runtime_delivery::{
+    TeamRuntimeDeliveryReceipt, runtime_delivery_retry_delay_seconds,
+};
 use self::runtime_views::TeamMemberSpecView;
 use self::runtime_views::parse_team_member_specs;
 use self::support::maybe_attach_context_artifact_pointer;

--- a/src/team/manager/runtime_delivery.rs
+++ b/src/team/manager/runtime_delivery.rs
@@ -1,0 +1,316 @@
+use sqlx::Row;
+
+use super::TeamManager;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TeamRuntimeDeliveryReceipt {
+    pub delivery_id: String,
+    pub run_id: String,
+    pub message_id: i64,
+    pub actor_id: String,
+    pub prompt: String,
+    pub state: String,
+    pub attempt: i64,
+    pub next_retry_at: Option<i64>,
+    pub lease_expires_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub session_id: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub delivered_at: Option<i64>,
+}
+
+pub(crate) fn mailbox_runtime_delivery_id(run_id: &str, message_id: i64, actor_id: &str) -> String {
+    format!("team-mailbox:{run_id}:{message_id}:{actor_id}")
+}
+
+impl TeamManager {
+    pub(crate) async fn ensure_mailbox_runtime_deliveries(
+        &self,
+        run_id: &str,
+        message_id: i64,
+        actor_ids: &[String],
+        prompt: &str,
+        now: i64,
+    ) -> anyhow::Result<Vec<TeamRuntimeDeliveryReceipt>> {
+        let mut tx = self.db.begin().await?;
+        let mut receipts = Vec::with_capacity(actor_ids.len());
+        for actor_id in actor_ids {
+            let delivery_id = mailbox_runtime_delivery_id(run_id, message_id, actor_id);
+            sqlx::query(
+                r#"
+                INSERT OR IGNORE INTO team_runtime_delivery_receipts (
+                    delivery_id,
+                    run_id,
+                    message_id,
+                    actor_id,
+                    prompt,
+                    state,
+                    attempt,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 0, ?6, ?6)
+                "#,
+            )
+            .bind(&delivery_id)
+            .bind(run_id)
+            .bind(message_id)
+            .bind(actor_id)
+            .bind(prompt)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            let row = sqlx::query(
+                r#"
+                SELECT
+                    delivery_id,
+                    run_id,
+                    message_id,
+                    actor_id,
+                    prompt,
+                    state,
+                    attempt,
+                    next_retry_at,
+                    lease_expires_at,
+                    last_error,
+                    session_id,
+                    created_at,
+                    updated_at,
+                    delivered_at
+                FROM team_runtime_delivery_receipts
+                WHERE delivery_id = ?1
+                "#,
+            )
+            .bind(&delivery_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            receipts.push(parse_runtime_delivery_receipt(&row));
+        }
+        tx.commit().await?;
+        Ok(receipts)
+    }
+
+    pub(crate) async fn list_due_mailbox_runtime_deliveries(
+        &self,
+        now: i64,
+        limit: i64,
+    ) -> anyhow::Result<Vec<TeamRuntimeDeliveryReceipt>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                delivery_id,
+                run_id,
+                message_id,
+                actor_id,
+                prompt,
+                state,
+                attempt,
+                next_retry_at,
+                lease_expires_at,
+                last_error,
+                session_id,
+                created_at,
+                updated_at,
+                delivered_at
+            FROM team_runtime_delivery_receipts
+            WHERE (
+                    state = 'pending'
+                    AND (next_retry_at IS NULL OR next_retry_at <= ?1)
+                  )
+               OR (
+                    state = 'in_flight'
+                    AND lease_expires_at IS NOT NULL
+                    AND lease_expires_at <= ?1
+                  )
+            ORDER BY created_at ASC, delivery_id ASC
+            LIMIT ?2
+            "#,
+        )
+        .bind(now)
+        .bind(limit.clamp(1, 1_000))
+        .fetch_all(&self.db)
+        .await?;
+        Ok(rows.iter().map(parse_runtime_delivery_receipt).collect())
+    }
+
+    pub(crate) async fn claim_mailbox_runtime_delivery(
+        &self,
+        delivery_id: &str,
+        now: i64,
+        lease_seconds: i64,
+    ) -> anyhow::Result<Option<TeamRuntimeDeliveryReceipt>> {
+        let row = sqlx::query(
+            r#"
+            UPDATE team_runtime_delivery_receipts
+            SET
+                state = 'in_flight',
+                attempt = attempt + 1,
+                next_retry_at = NULL,
+                lease_expires_at = ?2,
+                updated_at = ?1
+            WHERE delivery_id = ?3
+              AND (
+                    (
+                        state = 'pending'
+                        AND (next_retry_at IS NULL OR next_retry_at <= ?1)
+                    )
+                    OR (
+                        state = 'in_flight'
+                        AND lease_expires_at IS NOT NULL
+                        AND lease_expires_at <= ?1
+                    )
+                  )
+            RETURNING
+                delivery_id,
+                run_id,
+                message_id,
+                actor_id,
+                prompt,
+                state,
+                attempt,
+                next_retry_at,
+                lease_expires_at,
+                last_error,
+                session_id,
+                created_at,
+                updated_at,
+                delivered_at
+            "#,
+        )
+        .bind(now)
+        .bind(now.saturating_add(lease_seconds.max(1)))
+        .bind(delivery_id)
+        .fetch_optional(&self.db)
+        .await?;
+        Ok(row.as_ref().map(parse_runtime_delivery_receipt))
+    }
+
+    pub(crate) async fn acknowledge_mailbox_runtime_delivery(
+        &self,
+        delivery_id: &str,
+        attempt: i64,
+        session_id: &str,
+        now: i64,
+    ) -> anyhow::Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE team_runtime_delivery_receipts
+            SET
+                state = 'delivered',
+                session_id = COALESCE(session_id, ?2),
+                delivered_at = COALESCE(delivered_at, ?3),
+                next_retry_at = NULL,
+                lease_expires_at = NULL,
+                last_error = NULL,
+                updated_at = ?3
+            WHERE delivery_id = ?1
+              AND state = 'in_flight'
+              AND attempt = ?4
+            "#,
+        )
+        .bind(delivery_id)
+        .bind(session_id)
+        .bind(now)
+        .bind(attempt)
+        .execute(&self.db)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub(crate) async fn retry_mailbox_runtime_delivery(
+        &self,
+        delivery_id: &str,
+        attempt: i64,
+        now: i64,
+        next_retry_at: i64,
+        error: &str,
+    ) -> anyhow::Result<bool> {
+        let error = truncate_runtime_delivery_error(error);
+        let result = sqlx::query(
+            r#"
+            UPDATE team_runtime_delivery_receipts
+            SET
+                state = 'pending',
+                next_retry_at = ?2,
+                lease_expires_at = NULL,
+                last_error = ?3,
+                session_id = NULL,
+                updated_at = ?1
+            WHERE delivery_id = ?4
+              AND state = 'in_flight'
+              AND attempt = ?5
+            "#,
+        )
+        .bind(now)
+        .bind(next_retry_at.max(now))
+        .bind(error)
+        .bind(delivery_id)
+        .bind(attempt)
+        .execute(&self.db)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn mailbox_runtime_delivery_for_test(
+        &self,
+        delivery_id: &str,
+    ) -> anyhow::Result<TeamRuntimeDeliveryReceipt> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                delivery_id,
+                run_id,
+                message_id,
+                actor_id,
+                prompt,
+                state,
+                attempt,
+                next_retry_at,
+                lease_expires_at,
+                last_error,
+                session_id,
+                created_at,
+                updated_at,
+                delivered_at
+            FROM team_runtime_delivery_receipts
+            WHERE delivery_id = ?1
+            "#,
+        )
+        .bind(delivery_id)
+        .fetch_one(&self.db)
+        .await?;
+        Ok(parse_runtime_delivery_receipt(&row))
+    }
+}
+
+fn parse_runtime_delivery_receipt(row: &sqlx::sqlite::SqliteRow) -> TeamRuntimeDeliveryReceipt {
+    TeamRuntimeDeliveryReceipt {
+        delivery_id: row.get("delivery_id"),
+        run_id: row.get("run_id"),
+        message_id: row.get("message_id"),
+        actor_id: row.get("actor_id"),
+        prompt: row.get("prompt"),
+        state: row.get("state"),
+        attempt: row.get("attempt"),
+        next_retry_at: row.get("next_retry_at"),
+        lease_expires_at: row.get("lease_expires_at"),
+        last_error: row.get("last_error"),
+        session_id: row.get("session_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        delivered_at: row.get("delivered_at"),
+    }
+}
+
+fn truncate_runtime_delivery_error(error: &str) -> String {
+    const MAX_CHARS: usize = 2_048;
+    error.chars().take(MAX_CHARS).collect()
+}
+
+pub(crate) fn runtime_delivery_retry_delay_seconds(attempt: i64) -> i64 {
+    const MAX_DELAY_SECONDS: i64 = 60;
+    let exponent = attempt.saturating_sub(1).clamp(0, 30) as u32;
+    (1_i64 << exponent).min(MAX_DELAY_SECONDS)
+}

--- a/src/team/manager/tests_support.rs
+++ b/src/team/manager/tests_support.rs
@@ -586,6 +586,33 @@ async fn create_full_test_schema(pool: &SqlitePool) {
 
     sqlx::query(
         r#"
+        CREATE TABLE team_runtime_delivery_receipts (
+            delivery_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            actor_id TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('pending', 'in_flight', 'delivered')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+            next_retry_at INTEGER,
+            lease_expires_at INTEGER,
+            last_error TEXT,
+            session_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            delivered_at INTEGER,
+            UNIQUE(run_id, message_id, actor_id),
+            FOREIGN KEY(run_id) REFERENCES team_runs(id),
+            FOREIGN KEY(message_id) REFERENCES team_actor_messages(id) ON DELETE CASCADE
+        );
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create team_runtime_delivery_receipts");
+
+    sqlx::query(
+        r#"
         CREATE TABLE team_actor_thread_claims (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id TEXT NOT NULL,

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -27,11 +27,13 @@ pub(crate) use helpers::{
 #[cfg(test)]
 pub(crate) use mailbox_hint::build_actor_mailbox_immediate_hint_prompt;
 pub(crate) use mailbox_hint::{
-    ActorMailboxImmediateHintReason, TeamMailboxUnreadHintWorker,
-    TeamMailboxUnreadHintWorkerSettings, dispatch_actor_mailbox_immediate_hint,
-    plan_actor_mailbox_immediate_hint,
+    ActorMailboxImmediateHintReason, TeamMailboxRuntimeDeliveryWorker,
+    TeamMailboxRuntimeDeliveryWorkerSettings, TeamMailboxUnreadHintWorker,
+    TeamMailboxUnreadHintWorkerSettings, plan_actor_mailbox_immediate_hint,
 };
 pub(crate) use manager::TEAM_TASK_DETAIL_MESSAGE_LIMIT_MAX;
+#[cfg(test)]
+pub(crate) use manager::mailbox_runtime_delivery_id;
 #[allow(unused_imports)]
 pub use manager::{
     SendActorMessageInput, TeamContextLookupError, TeamContextRecord, TeamConversationStreamEvent,
@@ -43,7 +45,8 @@ pub use manager::{
     TeamspaceMemberRecord,
 };
 pub(crate) use manager::{
-    count_pending_conversation_body_migration, migrate_conversation_bodies_into_store,
+    TeamRuntimeDeliveryReceipt, count_pending_conversation_body_migration,
+    migrate_conversation_bodies_into_store, runtime_delivery_retry_delay_seconds,
 };
 pub use permission_review::{
     TeamPermissionReviewDispatcher, TeamPermissionReviewDispatcherSettings,

--- a/src/team/permission_review/dispatcher.rs
+++ b/src/team/permission_review/dispatcher.rs
@@ -11,7 +11,7 @@ use agenthub_team_actor::{
 use serde_json::{Value, json};
 
 use crate::agent::AgentManager;
-use crate::team::TeamManager;
+use crate::team::{TeamMailboxRuntimeDeliveryWorker, TeamManager};
 
 use super::payload::{
     build_permission_review_payload, build_permission_review_summary, extract_tool_name,
@@ -154,6 +154,7 @@ impl TeamPermissionReviewDispatcher {
         self.nudge_actor(
             review_target_actor_id.as_str(),
             &run_id,
+            response.message_id,
             TEAM_PERMISSION_REVIEW_PAYLOAD_TYPE,
         )
         .await;
@@ -171,16 +172,18 @@ impl TeamPermissionReviewDispatcher {
         });
     }
 
-    async fn nudge_actor(&self, actor_id: &str, run_id: &str, payload_type: &str) {
+    async fn nudge_actor(&self, actor_id: &str, run_id: &str, message_id: i64, payload_type: &str) {
         let priority_label =
             actor_mailbox_priority_label(ActorMailboxPriorityClass::PermissionReview);
         let hint = format!(
             "New {priority_label} mailbox message type '{payload_type}' is pending in run '{run_id}'. Use agenthub actor inbox --run-id \"{run_id}\" to inspect pending messages and batch-handle this type before ack."
         );
-        if let Err(err) = self
-            .agent_nudger
-            .nudge_mailbox_prompt(actor_id, None, &hint)
-            .await
+        if let Err(err) = TeamMailboxRuntimeDeliveryWorker::with_agent_nudger(
+            self.teams.clone(),
+            self.agent_nudger.clone(),
+        )
+        .enqueue_prompt(run_id, message_id, &[actor_id.to_string()], &hint)
+        .await
         {
             tracing::debug!(
                 actor_id = %actor_id,

--- a/src/team/permission_review/tests_support.rs
+++ b/src/team/permission_review/tests_support.rs
@@ -34,6 +34,7 @@ impl TeamMailboxHintAgentNudger for TestMailboxHintAgentNudger {
         &self,
         actor_id: &str,
         expected_session_id: Option<&str>,
+        _delivery_id: &str,
         prompt: &str,
     ) -> anyhow::Result<()> {
         self.prompts.lock().await.push((


### PR DESCRIPTION
## What changed

- add durable Team runtime delivery receipts with stable IDs, retry state, leases, session attribution, and mailbox-message cascade cleanup
- persist receipts before direct-message, coordinator-mention, and permission-review runtime hints
- recover due and expired deliveries through a daemon worker with bounded batches, exponential backoff, and per-attempt timeout
- fence acknowledgement and retry writes by claim attempt so stale workers cannot overwrite a newer lease
- forward stable delivery IDs through supported agent input transports without changing mailbox acknowledgement or triage semantics
- keep the database schema inventory test synchronized with the new receipt table
- isolate the SSE forwarder diagnostics assertion from process-global test diagnostics exposed by exact-head CI
- document the stable receipt contract, implementation checkpoint, and remaining task-group follow-up

## Why

Team mailbox rows were durable, but their runtime wake-up prompts were best-effort. A daemon restart,
offline actor, busy ACP transport, or blocked input could leave a pending mailbox message without a
retry. Reusing `team_actor_messages.status` would incorrectly conflate runtime submission with the
actor's explicit mailbox acknowledgement.

## Delivery contract

- `delivered` on a runtime receipt means a specific runtime session accepted the prompt through its input transport.
- Runtime delivery does not acknowledge, triage, claim, or complete the mailbox message.
- Delivery is at-least-once; the stable delivery ID identifies a duplicate if the daemon exits after transport acceptance but before receipt acknowledgement.
- A permission-review receipt may target the reviewer's current session even when the request is stored in a shared mailbox run.

## Related issue

No dedicated issue. This is the durable-delivery slice of the daemon reliability follow-up after #1084.

## Validation scope

```text
cargo fmt --all --check
cargo check -p agenthub --lib
cargo clippy -p agenthub --lib -- -D warnings
cargo test -p agenthub-db --lib
cargo test -p agenthub --lib runtime_delivery_receipts -- --nocapture
cargo test -p agenthub --lib team::permission_review::tests -- --nocapture
cargo test -p agenthub --lib team_run_messages_api_chat_type_hints_repeat_while_other_types_still_suppress -- --nocapture
cargo test -p agenthub --lib teams_router_http_contract -- --nocapture
cargo test -p agenthub --lib sse::tests::output_stream_emits_events_from_forwarders -- --exact
cargo test -p agenthub --lib --quiet
bazel test //crates/agenthub-db:agenthub_db_tests --test_output=errors
bazel test //:agenthub_unit_tests --test_output=errors
```

Focused coverage includes stable-ID retry after worker reconstruction, active and expired leases,
stale-attempt fencing, idempotent acknowledgement, blocked-input timeout, shared-mailbox permission
review delivery, API hint events, Team deletion with receipt cascade cleanup, and isolated SSE
diagnostics under parallel test execution.

The full library baseline retains three existing `state::tests::initialize_services_*` failures in
`lance-namespace-impls 8.0.0`'s directory-manifest old-version-cleanup assertion. The focused
`agenthub-db` Bazel target reaches the receipt schema, while the local root Bazel boundary remains
blocked before AgentHub compilation because the external `lance-datafusion 8.0.0` build script cannot
find `protoc` inside the macOS sandbox. No Bazel configuration is changed. Exact-head Linux CI remains
the repository-wide Bazel authority.

## Follow-ups

- define retention or terminal abandonment for receipts whose actors never return
- move daemon background workers and runtime watchers into the unified cancellation-aware task group
