### PR TITLE
fix(acp): omit null MCP tool timeout override

### DIFF
--- a/agenthub-codex-acp/src/app_server_thread.rs
+++ b/agenthub-codex-acp/src/app_server_thread.rs
@@ -3394,10 +3394,24 @@ fn config_request_overrides_from_config(
         // ACP-provided servers exist only in this process's merged Config. The
         // external app-server reloads its own config, so project the complete
         // effective map into the per-thread override.
-        overrides.insert(
-            "mcp_servers".to_string(),
-            serde_json::to_value(mcp_servers)?,
-        );
+        let mut mcp_server_overrides = serde_json::to_value(mcp_servers)?;
+        if let serde_json::Value::Object(servers) = &mut mcp_server_overrides {
+            for server in servers.values_mut() {
+                let Some(server) = server.as_object_mut() else {
+                    continue;
+                };
+
+                // Optional durations serialize as null, but the app-server's
+                // override loader coerces null into an invalid empty string.
+                if server
+                    .get("tool_timeout_sec")
+                    .is_some_and(serde_json::Value::is_null)
+                {
+                    server.remove("tool_timeout_sec");
+                }
+            }
+        }
+        overrides.insert("mcp_servers".to_string(), mcp_server_overrides);
     }
 
     Ok((!overrides.is_empty()).then_some(overrides))
@@ -4376,6 +4390,35 @@ mod tests {
         assert_eq!(
             config["mcp_servers"]["agenthub"]["args"],
             serde_json::json!(["actor", "mailbox"])
+        );
+        assert!(
+            config["mcp_servers"]["agenthub"]
+                .get("tool_timeout_sec")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn thread_start_config_preserves_explicit_mcp_tool_timeout() {
+        let mut state = test_state_with_active_turn(None).await;
+        let server = serde_json::from_value(serde_json::json!({
+            "command": "agenthub",
+            "tool_timeout_sec": 2.5
+        }))
+        .expect("deserialize MCP server config");
+        state
+            .config
+            .mcp_servers
+            .set(HashMap::from([("agenthub".to_string(), server)]))
+            .expect("set MCP server config");
+
+        let params =
+            thread_start_params_from_config(&state.config).expect("serialize thread config");
+        let config = params.config.expect("thread config overrides");
+
+        assert_eq!(
+            config["mcp_servers"]["agenthub"]["tool_timeout_sec"],
+            serde_json::json!(2.5)
         );
     }
 

--- a/docs/journal/2026-09-01-acp-install-proxy-recovery.md
+++ b/docs/journal/2026-09-01-acp-install-proxy-recovery.md
@@ -125,6 +125,43 @@ the external app-server boundary.
   matches the pre-existing local non-terminal module-resolution evidence in the
   two-binary rollout journal; exact-head Bazel CI remains an open gate.
 
+### Post-Merge Rollout — 2026-09-02
+
+- [PR #1104](https://github.com/hawkingrei/agenthub/pull/1104) merged as
+  `4b0b5c7f2e42f2521f2ca04c191ca81fdedc9f67`. Exact-head Release Prebuild run
+  `33574882090` produced the Linux amd64 `agenthub` and `agenthubd` artifacts;
+  the Debian package contained only those two AgentHub-owned executables.
+- The first production ACP smoke exposed a compatibility defect in the
+  per-thread MCP override projection. `McpServerConfig.tool_timeout_sec: None`
+  serialized as JSON `null`; the official app-server override loader coerced
+  that value to an empty string and then rejected it as an invalid `f64`.
+- The rollout hotfix omits only a null `tool_timeout_sec` from projected MCP
+  server overrides and preserves explicit numeric timeout values. Two focused
+  regressions cover both boundaries. The runtime library completed all 153
+  tests, and focused Clippy completed with warnings denied.
+- The release candidate completed `initialize`, `new_session`, and `prompt`
+  against `/usr/bin/codex` 0.150.1. A forced `code_mode_only` prompt launched a
+  new `/usr/bin/codex-code-mode-host` process, evaluated JavaScript, returned
+  `CODE_MODE_HOST_OK_42`, and ended normally.
+- Production was atomically restarted at `2026-09-02 09:41:45 CST`. The service
+  reported `active/running`, `Result=success`, and zero automatic restarts.
+  Local and public `/health` probes returned HTTP 200. The installed binaries
+  have SHA-256 digests
+  `9b681afff4abd4210298ecf31720ab40fae2b3c1bc347dc02f63fd696469b1bf`
+  (`agenthub`) and
+  `da1b604dc3a99fe6ff620c614ad07c7605b4eb971e685dd01929d19d31214646`
+  (`agenthubd`).
+- Post-install ACP validation returned `INSTALLED_ACP_OK`. Forced Code Mode
+  launched a new official host process, returned `INSTALLED_CODE_MODE_OK_42`,
+  and ended normally. The pre-hotfix merged binaries remain as `.prev`; the
+  pre-#1104 generation remains recoverable as `agenthub.pre-1104` and
+  `agenthubd.pre-1104`.
+- Exact-head workspace tests completed 799 tests before the `Rust (Coverage)`
+  job failed in its separate distributed P2P pipeline step because the
+  coverage target directory did not contain `agenthubd`. The dedicated
+  Distributed P2P Pipeline job passed, so this workflow-shape failure did not
+  block the runtime rollout.
+
 # Follow-Ups
 
 - Keep exact-head release, Debian, npm, and Bazel evidence under the existing


### PR DESCRIPTION
## Summary

- omit `tool_timeout_sec` from app-server MCP overrides when the effective value is `None`
- preserve explicit numeric MCP tool timeouts
- add focused regression coverage for both serialization paths
- record the post-#1104 production rollout and validation evidence

## Why

After #1104 moved Codex execution to the installed official app-server, the first production ACP smoke failed during `thread/start`. Codex's `McpServerConfig` serializes a missing `tool_timeout_sec` as JSON `null`; the app-server override loader coerces that value to an empty string and then rejects it as an invalid `f64`.

This change keeps the complete effective MCP server map crossing the process boundary while removing only the incompatible null field. Explicit timeout values remain unchanged.

## Related

- Follow-up to #1104
- No linked issue

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p agenthub-codex-acp-runtime thread_start_config_ --lib -- --nocapture` — 2 passed
- `cargo test --locked -p agenthub-codex-acp-runtime --lib` — 153 passed
- `cargo clippy --locked -p agenthub-codex-acp-runtime --all-targets -- -D warnings`
- production-feature `agenthubd` release build
- candidate and installed-path ACP `initialize -> new_session -> prompt` smokes completed with `EndTurn`
- forced `code_mode_only` smokes launched `/usr/bin/codex-code-mode-host` and returned the expected result
- local and public production `/health` probes returned HTTP 200 after the atomic restart

## Rollout

The hotfix is deployed on the user-level `agenthub.service`. The installed `agenthubd` SHA-256 is `da1b604dc3a99fe6ff620c614ad07c7605b4eb971e685dd01929d19d31214646`. The exact merged #1104 daemon remains as `.prev`, and the pre-#1104 generation remains available as `.pre-1104`.

The exact-head `Rust (Coverage)` workflow failure is unrelated to this change: all 799 workspace tests completed before its distributed P2P step looked for an `agenthubd` binary that the coverage target directory did not contain. The dedicated Distributed P2P Pipeline job passed.
